### PR TITLE
Better scheduling

### DIFF
--- a/TODO
+++ b/TODO
@@ -1,7 +1,2 @@
-- Implement fuel scheduling
-- Implement smarter scheduler_insert code
-  * Keep off interrupts for smaller period
-  * Allow scheduling next event while current still ongoing
-- Allow reschedule of ignition stop event while dwelling.
 - Allow saving of variables to flash
 - Evaluate converting to input capture for trigger

--- a/src/Makefile
+++ b/src/Makefile
@@ -10,12 +10,12 @@ CFLAGS+= -D TICKRATE=100000000 -DUNITTEST
 .else
 .if ${PLATFORM} == "stm32f4-discovery"
 CC=arm-none-eabi-gcc
-CFLAGS=  -I. -std=c99 -Wall -O0 -Wextra -g
+CFLAGS=  -I. -std=c99 -Wall -O3 -Wextra -g
 CFLAGS+= -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -mcpu=cortex-m4
 CFLAGS+= -I /opt/libopencm3/arm-none-eabi/include -DSTM32F4
-CFLAGS+= -D TICKRATE=84000000 -D FASTMATH
+CFLAGS+= -D TICKRATE=84000000 -D FASTMATH -flto
 LDFLAGS=  -L/opt/libopencm3/arm-none-eabi/lib
-LDFLAGS+= -lopencm3_stm32f4 -fno-use-linker-plugin -lc -lnosys
+LDFLAGS+= -lopencm3_stm32f4 -lc -lnosys -flto
 LDFLAGS+= -T platforms/stm32f4-discovery.ld -nostartfiles
 all: tfi
 

--- a/src/calculations.c
+++ b/src/calculations.c
@@ -21,7 +21,7 @@ void calculate_ignition() {
   calculated_values.timing_advance = 
     interpolate_table_twoaxis(config.timing, config.decoder.rpm, 
         config.sensors[SENSOR_MAP].processed_value);
-  switch (config.dwell) {
+  switch (config.ignition.dwell) {
     case DWELL_FIXED_DUTY:
       calculated_values.dwell_us = 
         time_from_rpm_diff(config.decoder.rpm, 45) / (TICKRATE / 1000000);

--- a/src/calculations.h
+++ b/src/calculations.h
@@ -17,6 +17,16 @@ struct fueling_config {
   float injector_dead_time;
 };
 
+typedef enum {
+  DWELL_FIXED_DUTY,
+} dwell_type;
+
+struct ignition_config {
+  dwell_type dwell;
+  float dwell_duty;
+  int min_fire_time_us;
+};
+
 struct calculated_values {
   float timing_advance;
   unsigned int fueling_us;

--- a/src/config.c
+++ b/src/config.c
@@ -103,6 +103,11 @@ struct config config = {
     .density_of_fuel = 0.755,
     .density_of_air_stp = 1.2754e-3,
   },
+  .ignition = {
+    .dwell = DWELL_FIXED_DUTY,
+    .dwell_duty = 0.5,
+    .min_fire_time_us = 1000,
+  },
   .console = {
     .baud = 115200,
     .stop_bits = 1,

--- a/src/config.h
+++ b/src/config.h
@@ -12,16 +12,10 @@
 
 #define MAX_EVENTS 24
 
-typedef enum {
-  DWELL_FIXED_DUTY,
-} dwell_type;
-
 struct config {
   /* Event list */
   unsigned int num_events;
   struct output_event events[MAX_EVENTS];
-  dwell_type dwell;
-  float dwell_duty;
 
   /* Trigger setup */
   trigger_type trigger;
@@ -40,6 +34,7 @@ struct config {
 
   /* Fuel information */
   struct fueling_config fueling;
+  struct ignition_config ignition;
 
   /* Cutoffs */
   unsigned int rpm_stop;

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -228,7 +228,7 @@ static void platform_init_usart() {
 void platform_init() {
 
   /* 168 Mhz clock */
-  rcc_clock_setup_hse_3v3(&hse_8mhz_3v3[CLOCK_3V3_168MHZ]);
+  rcc_clock_setup_hse_3v3(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_168MHZ]);
 
   /* Enable clocks for subsystems */
   rcc_periph_clock_enable(RCC_GPIOA);

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -398,10 +398,12 @@ void dma2_stream0_isr(void) {
 
 void enable_interrupts() {
   cm_enable_interrupts();
+  gpio_clear(GPIOD, GPIO2);
 }
 
 void disable_interrupts() {
   cm_disable_interrupts();
+  gpio_set(GPIOD, GPIO2);
 }
 
 int interrupts_enabled() {

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -163,6 +163,8 @@ static void platform_init_eventtimer() {
 static void platform_init_outputs() {
   /* IG1 out */
   gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO0);
+  gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO1);
+  gpio_mode_setup(GPIOD, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, GPIO2);
 }
 
 static void platform_init_adc() {

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -147,6 +147,11 @@ schedule_ignition_event(struct output_event *ev,
     time_from_rpm_diff(d->rpm, (degrees_t)firing_angle);
   start_time = stop_time - time_from_us(usecs_dwell);
 
+  if (event_has_fired(ev)) {
+    ev->start.fired = 0;
+    ev->stop.fired = 0;
+  }
+
   curtime = current_time();
 
   if (!event_is_active(ev)) {

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -238,6 +238,7 @@ schedule_adc_event(struct output_event *ev, struct decoder *d) {
 
   ev->stop.time = stop_time;
   ev->stop.callback = adc_gather;
+  curtime = current_time();
   disable_interrupts();
   schedule_insert(curtime, &ev->stop);
   enable_interrupts();

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -49,7 +49,8 @@ timeval_t schedule_insert(timeval_t, struct sched_entry *);
 
 void scheduler_execute();
 
-unsigned char event_is_active(struct output_event *);
+int event_is_active(struct output_event *);
+int event_has_fired(struct output_event *);
 void invalidate_scheduled_events(struct output_event *, int);
 
 #ifdef UNITTEST

--- a/src/test/check.c
+++ b/src/test/check.c
@@ -36,6 +36,11 @@ START_TEST(check_time_from_rpm_diff) {
   ck_assert(value_within(1, time_from_rpm_diff(6000, 45), 1250));
 } END_TEST
 
+START_TEST(check_time_from_us) {
+  ck_assert_int_eq(time_from_us(0), 0);
+  ck_assert_int_eq(time_from_us(1000), 1000 * (TICKRATE / 1000000));
+} END_TEST
+
 START_TEST(check_time_in_range) {
   timeval_t t1, t2, val;
 
@@ -63,6 +68,11 @@ START_TEST(check_time_in_range) {
   val = 0x2000;
   t2 = 0x1000;
   ck_assert_int_eq(time_in_range(val, t1, t2), 0);
+
+  t1 = 0x1000;
+  val = 0x1000;
+  t2 = 0x1000;
+  ck_assert_int_eq(time_in_range(val, t1, t2), 1);
 } END_TEST
 
 START_TEST(check_time_diff) {
@@ -214,7 +224,7 @@ START_TEST(check_calculate_ignition_fixedduty) {
     .data = { .two = { {10, 10}, {10, 10} } },
   };
   config.timing = &t;
-  config.dwell = DWELL_FIXED_DUTY;
+  config.ignition.dwell = DWELL_FIXED_DUTY;
   config.decoder.rpm = 6000;
 
   calculate_ignition();
@@ -240,6 +250,7 @@ int main(void) {
   tcase_add_test(util_tests, check_time_in_range);
   tcase_add_test(util_tests, check_time_diff);
   tcase_add_test(util_tests, check_clamp_angle);
+  tcase_add_test(util_tests, check_time_from_us);
 
   tcase_add_test(sensor_tests, check_sensor_process_linear);
   tcase_add_test(sensor_tests, check_sensor_process_freq);

--- a/src/test/check_scheduler.c
+++ b/src/test/check_scheduler.c
@@ -262,6 +262,31 @@ START_TEST(check_event_is_active) {
   ck_assert(!event_is_active(&oev));
 } END_TEST
 
+START_TEST(check_event_has_fired) {
+
+  /* Event has been scheduled, not fired, sets both fired=0, scheduled=1*/
+  oev.start.scheduled = 1;
+  oev.start.fired = 0;
+  oev.stop.scheduled = 1;
+  oev.stop.fired = 0;
+  ck_assert(!event_has_fired(&oev));
+
+  /* Event has been scheduled, started*/
+  oev.start.scheduled = 0;
+  oev.start.fired = 1;
+  oev.stop.scheduled = 1;
+  oev.stop.fired = 0;
+  ck_assert(!event_has_fired(&oev));
+
+  /* Event has been scheduled, started, stopped*/
+  oev.start.scheduled = 0;
+  oev.start.fired = 1;
+  oev.stop.scheduled = 0;
+  oev.stop.fired = 1;
+  ck_assert(event_has_fired(&oev));
+
+} END_TEST
+
 START_TEST(check_invalidate_events) {
   set_current_time(time_from_rpm_diff(6000, 270));
   schedule_ignition_event(&oev, &config.decoder, 10, 1000);
@@ -370,6 +395,7 @@ TCase *setup_scheduler_tests() {
   tcase_add_test(scheduler_tests, check_schedule_ignition_reschedule_active_earlier);
   tcase_add_test(scheduler_tests, check_schedule_ignition_reschedule_after_finished);
   tcase_add_test(scheduler_tests, check_event_is_active);
+  tcase_add_test(scheduler_tests, check_event_has_fired);
   tcase_add_test(scheduler_tests, check_invalidate_events);
   tcase_add_test(scheduler_tests, check_invalidate_events_when_active);
   tcase_add_test(scheduler_tests, check_deschedule_event);

--- a/src/test/check_scheduler.c
+++ b/src/test/check_scheduler.c
@@ -268,13 +268,18 @@ START_TEST(check_schedule_ignition_reschedule_after_finished) {
   scheduler_execute();
   ck_assert_int_eq(get_output(), 0);
 
+  ck_assert(!oev.start.scheduled);
+  ck_assert(!oev.stop.scheduled);
+  ck_assert(oev.start.fired);
+  ck_assert(oev.stop.fired);
+
   /* Reschedule 10* later */
   schedule_ignition_event(&oev, &config.decoder, 0, 1000);
 
   ck_assert(!oev.start.scheduled);
   ck_assert(!oev.stop.scheduled);
-  ck_assert(oev.start.fired);
-  ck_assert(oev.stop.fired);
+  ck_assert(!oev.start.fired);
+  ck_assert(!oev.stop.fired);
 
   ck_assert_int_eq(get_output(), 0);
   ck_assert_int_eq(get_event_timer(), 0); /*Disabled*/

--- a/src/test/check_scheduler.c
+++ b/src/test/check_scheduler.c
@@ -62,6 +62,38 @@ START_TEST(check_scheduler_inserts_sorted) {
 
 } END_TEST
 
+/* Different scenarios:
+ *   Event is not currently active:
+ * - Has min fire time passed? if not, do not schedule.
+ * - Reschedule completely into the future 
+ *    Schedule as normal
+ * - Reschedule completely earlier, but still in the future
+ *    Schedule as normal
+ * - Reschedule completely earlier, but entirely in the past
+ *    Schedule as normal, it'll never happen (looks like far future)
+ * - Reschedule partially earlier, where it has already started
+ *    schedule now->newstop 
+ *
+ *   Event has started already:
+ * - Reschedule with new stop time
+ *   (ignore new start time completely). 
+ *
+ * Interrupt-guarded insertion of event:
+ *  - Either a start or stop trigger for the old event can fire
+ *    between calculations and scheduling of start, or between
+ *    scheduling of start and scheduling of stop.
+ *  - Combination of event_has_fired and event_is_active to determine
+ *    if this has happened, do not reschedule the event if so.
+ *  - Relies on specific meanings of scheduled and fired:
+ *    * scheduled means the event is queued to fire
+ *    * fired is set by scheduler_execute only.
+ *      - if fired is set and scheduled is not, it means the event has fired
+ *        and a (successful) reschedule has not occured for the event yet
+ *      - useful for determining if the event fired since earlier in the
+ *        function, such as since calculations.
+ */
+ 
+
 START_TEST(check_schedule_ignition) {
 
   /* Set our current position at 270* for an event at 360* */

--- a/src/tfi.c
+++ b/src/tfi.c
@@ -25,8 +25,7 @@ static void schedule(struct output_event *ev) {
         return;
       }
       schedule_fuel_event(ev, &config.decoder, 
-//        calculated_values.fueling_us);
-          3800);
+        calculated_values.fueling_us);
       break;
 
     case ADC_EVENT:

--- a/src/tfi.c
+++ b/src/tfi.c
@@ -25,7 +25,8 @@ static void schedule(struct output_event *ev) {
         return;
       }
       schedule_fuel_event(ev, &config.decoder, 
-        calculated_values.fueling_us);
+//        calculated_values.fueling_us);
+          3800);
       break;
 
     case ADC_EVENT:
@@ -56,13 +57,11 @@ int main() {
     } else {
       /* Check to see if any events have fired. These should be rescheduled
        * now to allow 100% duty utilization */
-#if 0
       for (unsigned int e = 0; e < config.num_events; ++e) {
         if (event_has_fired(&config.events[e])) {
           schedule(&config.events[e]);
         }
       }
-#endif
     }
    
     console_process();

--- a/src/tfi.c
+++ b/src/tfi.c
@@ -7,6 +7,33 @@
 #include "sensors.h"
 #include "calculations.h"
 
+static void schedule(struct output_event *ev) {
+  switch(ev->type) {
+    case IGNITION_EVENT:
+      if (ignition_cut() || !config.decoder.valid) {
+        invalidate_scheduled_events(config.events, config.num_events);
+        return;
+      }
+      schedule_ignition_event(ev, &config.decoder, 
+          (degrees_t)calculated_values.timing_advance, 
+          calculated_values.dwell_us);
+      break;
+
+    case FUEL_EVENT:
+      if (fuel_cut() || !config.decoder.valid) {
+        invalidate_scheduled_events(config.events, config.num_events);
+        return;
+      }
+      schedule_fuel_event(ev, &config.decoder, 
+        calculated_values.fueling_us);
+      break;
+
+    case ADC_EVENT:
+      schedule_adc_event(ev, &config.decoder);
+      break;
+  }
+}
+
 int main() {
   decoder_init(&config.decoder);
   platform_init();
@@ -19,40 +46,27 @@ int main() {
       config.decoder.decode(&config.decoder);
 
       if (config.decoder.valid) {
-
         calculate_ignition();
         calculate_fueling();
-
         for (unsigned int e = 0; e < config.num_events; ++e) {
-          switch(config.events[e].type) {
-            case IGNITION_EVENT:
-              if (ignition_cut()) {
-                invalidate_scheduled_events(config.events, config.num_events);
-                continue;
-              }
-              schedule_ignition_event(&config.events[e], &config.decoder, 
-                  (degrees_t)calculated_values.timing_advance, 
-                  calculated_values.dwell_us);
-              break;
-
-            case FUEL_EVENT:
-              if (fuel_cut()) {
-                invalidate_scheduled_events(config.events, config.num_events);
-                continue;
-              }
-              schedule_fuel_event(&config.events[e], &config.decoder, 
-                calculated_values.fueling_us);
-              break;
-
-            case ADC_EVENT:
-              schedule_adc_event(&config.events[e], &config.decoder);
-              break;
-          }
-
+          schedule(&config.events[e]);
         }
       }
+
+    } else {
+      /* Check to see if any events have fired. These should be rescheduled
+       * now to allow 100% duty utilization */
+#if 0
+      for (unsigned int e = 0; e < config.num_events; ++e) {
+        if (event_has_fired(&config.events[e])) {
+          schedule(&config.events[e]);
+        }
+      }
+#endif
     }
+   
     console_process();
+
   }
 
   return 0;

--- a/src/util.c
+++ b/src/util.c
@@ -13,10 +13,15 @@ timeval_t time_from_rpm_diff(unsigned int rpm, degrees_t deg) {
   return ticks_per_degree * deg;
 }
 
+timeval_t time_from_us(unsigned int us) {
+  timeval_t ticks = us * (TICKRATE / 1000000);
+  return ticks;
+}
+
 int time_in_range(timeval_t val, timeval_t t1, timeval_t t2) {
   if (t2 >= t1) {
     /* No timer wrap */
-    if ((val >= t1) && (val < t2)) {
+    if ((val >= t1) && (val <= t2)) {
       return 1;
     }
   } else {

--- a/src/util.h
+++ b/src/util.h
@@ -4,6 +4,7 @@
 #include "platform.h"
 
 timeval_t time_diff(timeval_t t1, timeval_t t2);
+timeval_t time_from_us(unsigned int us);
 unsigned int rpm_from_time_diff(timeval_t t1, degrees_t degrees);
 timeval_t time_from_rpm_diff(unsigned int rpm, degrees_t degrees);
 int time_in_range(timeval_t val, timeval_t t1, timeval_t t2);


### PR DESCRIPTION
- Allow rescheduling of already active events safely
- Allow immediate rescheduling of a fired event, allowing for up to 100% duty on an output event
- Finer grained critical sections, bringing worst case critical time for 18 events to 2.5 us.
