### PR TITLE
New scheduler architecture

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ CFLAGS!=pkg-config --cflags check
 LDFLAGS!=pkg-config --libs check
 CC=gcc
 CFLAGS+= -I. -Itest -std=c99 -Wall -O0 -g
-CFLAGS+= -D TICKRATE=100000000 -DUNITTEST
+CFLAGS+= -D TICKRATE=4000000 -DUNITTEST
 
 .else
 .if ${PLATFORM} == "stm32f4-discovery"

--- a/src/Makefile
+++ b/src/Makefile
@@ -13,7 +13,7 @@ CC=arm-none-eabi-gcc
 CFLAGS=  -I. -std=c99 -Wall -O3 -Wextra -g
 CFLAGS+= -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -mcpu=cortex-m4
 CFLAGS+= -I /opt/libopencm3/arm-none-eabi/include -DSTM32F4
-CFLAGS+= -D TICKRATE=84000000 -D FASTMATH -flto
+CFLAGS+= -D TICKRATE=4000000 -D FASTMATH -flto
 LDFLAGS=  -L/opt/libopencm3/arm-none-eabi/lib
 LDFLAGS+= -lopencm3_stm32f4 -lc -lnosys -flto
 LDFLAGS+= -T platforms/stm32f4-discovery.ld -nostartfiles

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,11 +1,12 @@
 PLATFORM?=stm32f4-discovery
 
-.ifmake check
+.ifmake check || coverage
 CFLAGS!=pkg-config --cflags check
 LDFLAGS!=pkg-config --libs check
 CC=gcc
 CFLAGS+= -I. -Itest -std=c99 -Wall -O0 -g
 CFLAGS+= -D TICKRATE=4000000 -DUNITTEST
+CFLAGS+= -fprofile-arcs -ftest-coverage 
 
 .else
 .if ${PLATFORM} == "stm32f4-discovery"
@@ -37,6 +38,10 @@ tfi: ${OBJS} tfi.o platforms/${PLATFORM}.o
 
 check: ${OBJS} test/check.o test/check_platform.o test/check_scheduler.o test/check_decoder.o
 	${CC} ${CFLAGS} -o check check.o check_platform.o check_scheduler.o check_decoder.o  ${OBJS} ${LDFLAGS}
+
+coverage: check
+	./check
+	gcovr -r .
 
 
 clean:

--- a/src/Makefile
+++ b/src/Makefile
@@ -35,8 +35,8 @@ tfi: ${OBJS} tfi.o platforms/${PLATFORM}.o
 	${CC} ${CFLAGS} -o tfi tfi.o ${OBJS} ${PLATFORM}.o  ${LDFLAGS}
 
 
-check: ${OBJS} test/check.o test/check_platform.o test/check_decoder.o test/check_scheduler.o
-	${CC} ${CFLAGS} -o check check.o check_platform.o check_decoder.o check_scheduler.o ${OBJS} ${LDFLAGS}
+check: ${OBJS} test/check.o test/check_platform.o test/check_scheduler.o test/check_decoder.o
+	${CC} ${CFLAGS} -o check check.o check_platform.o check_scheduler.o check_decoder.o  ${OBJS} ${LDFLAGS}
 
 
 clean:

--- a/src/calculations.c
+++ b/src/calculations.c
@@ -14,7 +14,7 @@ int ignition_cut() {
 }
 
 int fuel_cut() {
-  return 0;
+  return ignition_cut();
 }
 
 void calculate_ignition() {

--- a/src/calculations.c
+++ b/src/calculations.c
@@ -26,6 +26,9 @@ void calculate_ignition() {
       calculated_values.dwell_us = 
         time_from_rpm_diff(config.decoder.rpm, 45) / (TICKRATE / 1000000);
       break;
+    case DWELL_FIXED_TIME:
+      calculated_values.dwell_us = config.ignition.dwell_us;
+      break;
   }
 }
 

--- a/src/calculations.h
+++ b/src/calculations.h
@@ -19,11 +19,13 @@ struct fueling_config {
 
 typedef enum {
   DWELL_FIXED_DUTY,
+  DWELL_FIXED_TIME,
 } dwell_type;
 
 struct ignition_config {
   dwell_type dwell;
   float dwell_duty;
+  float dwell_us;
   int min_fire_time_us;
 };
 

--- a/src/config.c
+++ b/src/config.c
@@ -103,8 +103,9 @@ struct config config __attribute__((section(".configdata"))) = {
     .density_of_air_stp = 1.2754e-3,
   },
   .ignition = {
-    .dwell = DWELL_FIXED_DUTY,
+    .dwell = DWELL_FIXED_TIME,
     .dwell_duty = 0.5,
+    .dwell_us = 1000,
     .min_fire_time_us = 100,
   },
   .console = {

--- a/src/config.c
+++ b/src/config.c
@@ -44,19 +44,19 @@ struct table injector_dead_time __attribute__((section(".configdata"))) = {
 };
 
 struct config config __attribute__((section(".configdata"))) = {
-  .num_events = 16,
+  .num_events = 18,
   .events = {
     {.type=IGNITION_EVENT, .angle=0, .output_id=12, .inverted=1},
     {.type=IGNITION_EVENT, .angle=90, .output_id=13, .inverted=1},
     {.type=IGNITION_EVENT, .angle=180, .output_id=14, .inverted=1},
     {.type=IGNITION_EVENT, .angle=270, .output_id=15, .inverted=1},
- //   {.type=ADC_EVENT, .angle=270},
+    {.type=ADC_EVENT, .angle=270},
 
     {.type=IGNITION_EVENT, .angle=360, .output_id=12, .inverted=1},
     {.type=IGNITION_EVENT, .angle=450, .output_id=13, .inverted=1},
     {.type=IGNITION_EVENT, .angle=540, .output_id=14, .inverted=1},
     {.type=IGNITION_EVENT, .angle=630, .output_id=15, .inverted=1},
-//    {.type=ADC_EVENT, .angle=630},
+    {.type=ADC_EVENT, .angle=630},
 
     {.type=FUEL_EVENT, .angle=90, .output_id=0},
     {.type=FUEL_EVENT, .angle=90,   .output_id=1},

--- a/src/config.c
+++ b/src/config.c
@@ -44,28 +44,28 @@ struct table injector_dead_time __attribute__((section(".configdata"))) = {
 };
 
 struct config config __attribute__((section(".configdata"))) = {
-  .num_events = 9,
+  .num_events = 16,
   .events = {
     {.type=IGNITION_EVENT, .angle=0, .output_id=12, .inverted=1},
-    {.type=IGNITION_EVENT, .angle=90, .output_id=12, .inverted=1},
-    {.type=IGNITION_EVENT, .angle=180, .output_id=12, .inverted=1},
-    {.type=IGNITION_EVENT, .angle=270, .output_id=12, .inverted=1},
+    {.type=IGNITION_EVENT, .angle=90, .output_id=13, .inverted=1},
+    {.type=IGNITION_EVENT, .angle=180, .output_id=14, .inverted=1},
+    {.type=IGNITION_EVENT, .angle=270, .output_id=15, .inverted=1},
  //   {.type=ADC_EVENT, .angle=270},
 
     {.type=IGNITION_EVENT, .angle=360, .output_id=12, .inverted=1},
-    {.type=IGNITION_EVENT, .angle=450, .output_id=12, .inverted=1},
-    {.type=IGNITION_EVENT, .angle=540, .output_id=12, .inverted=1},
-    {.type=IGNITION_EVENT, .angle=630, .output_id=12, .inverted=1},
+    {.type=IGNITION_EVENT, .angle=450, .output_id=13, .inverted=1},
+    {.type=IGNITION_EVENT, .angle=540, .output_id=14, .inverted=1},
+    {.type=IGNITION_EVENT, .angle=630, .output_id=15, .inverted=1},
 //    {.type=ADC_EVENT, .angle=630},
 
-    {.type=FUEL_EVENT, .angle=90, .output_id=13},
-//    {.type=FUEL_EVENT, .angle=90,   .output_id=6},
-//    {.type=FUEL_EVENT, .angle=90,  .output_id=7},
-//    {.type=FUEL_EVENT, .angle=90, .output_id=8},
-//    {.type=FUEL_EVENT, .angle=90, .output_id=9},
-//    {.type=FUEL_EVENT, .angle=90, .output_id=10},
-//    {.type=FUEL_EVENT, .angle=90, .output_id=11},
-//    {.type=FUEL_EVENT, .angle=90, .output_id=12},
+    {.type=FUEL_EVENT, .angle=90, .output_id=0},
+    {.type=FUEL_EVENT, .angle=90,   .output_id=1},
+    {.type=FUEL_EVENT, .angle=90,  .output_id=2},
+    {.type=FUEL_EVENT, .angle=90, .output_id=3},
+    {.type=FUEL_EVENT, .angle=450, .output_id=0},
+    {.type=FUEL_EVENT, .angle=450, .output_id=1},
+    {.type=FUEL_EVENT, .angle=450, .output_id=2},
+    {.type=FUEL_EVENT, .angle=450, .output_id=3},
   },
   .trigger = FORD_TFI,
   .decoder = {

--- a/src/config.c
+++ b/src/config.c
@@ -44,29 +44,28 @@ struct table injector_dead_time __attribute__((section(".configdata"))) = {
 };
 
 struct config config __attribute__((section(".configdata"))) = {
-  .num_events = 17,
+  .num_events = 9,
   .events = {
-    {.type=IGNITION_EVENT, .angle=0, .output_id=0, .inverted=1},
-    {.type=IGNITION_EVENT, .angle=90, .output_id=0, .inverted=1},
-    {.type=IGNITION_EVENT, .angle=180, .output_id=0, .inverted=1},
-    {.type=IGNITION_EVENT, .angle=270, .output_id=0, .inverted=1},
-    {.type=IGNITION_EVENT, .angle=270, .output_id=2, .inverted=1},
-    {.type=ADC_EVENT, .angle=270},
+    {.type=IGNITION_EVENT, .angle=0, .output_id=12, .inverted=1},
+    {.type=IGNITION_EVENT, .angle=90, .output_id=12, .inverted=1},
+    {.type=IGNITION_EVENT, .angle=180, .output_id=12, .inverted=1},
+    {.type=IGNITION_EVENT, .angle=270, .output_id=12, .inverted=1},
+ //   {.type=ADC_EVENT, .angle=270},
 
-    {.type=IGNITION_EVENT, .angle=360, .output_id=0, .inverted=1},
-    {.type=IGNITION_EVENT, .angle=450, .output_id=0, .inverted=1},
-    {.type=IGNITION_EVENT, .angle=540, .output_id=0, .inverted=1},
-    {.type=IGNITION_EVENT, .angle=630, .output_id=0, .inverted=1},
-    {.type=ADC_EVENT, .angle=630},
+    {.type=IGNITION_EVENT, .angle=360, .output_id=12, .inverted=1},
+    {.type=IGNITION_EVENT, .angle=450, .output_id=12, .inverted=1},
+    {.type=IGNITION_EVENT, .angle=540, .output_id=12, .inverted=1},
+    {.type=IGNITION_EVENT, .angle=630, .output_id=12, .inverted=1},
+//    {.type=ADC_EVENT, .angle=630},
 
-    {.type=FUEL_EVENT, .angle=90, .output_id=1},
-    {.type=FUEL_EVENT, .angle=90,   .output_id=6},
-    {.type=FUEL_EVENT, .angle=90,  .output_id=7},
-    {.type=FUEL_EVENT, .angle=90, .output_id=8},
-    {.type=FUEL_EVENT, .angle=90, .output_id=9},
-    {.type=FUEL_EVENT, .angle=90, .output_id=10},
-    {.type=FUEL_EVENT, .angle=90, .output_id=11},
-    {.type=FUEL_EVENT, .angle=90, .output_id=12},
+    {.type=FUEL_EVENT, .angle=90, .output_id=13},
+//    {.type=FUEL_EVENT, .angle=90,   .output_id=6},
+//    {.type=FUEL_EVENT, .angle=90,  .output_id=7},
+//    {.type=FUEL_EVENT, .angle=90, .output_id=8},
+//    {.type=FUEL_EVENT, .angle=90, .output_id=9},
+//    {.type=FUEL_EVENT, .angle=90, .output_id=10},
+//    {.type=FUEL_EVENT, .angle=90, .output_id=11},
+//    {.type=FUEL_EVENT, .angle=90, .output_id=12},
   },
   .trigger = FORD_TFI,
   .decoder = {
@@ -106,7 +105,7 @@ struct config config __attribute__((section(".configdata"))) = {
   .ignition = {
     .dwell = DWELL_FIXED_DUTY,
     .dwell_duty = 0.5,
-    .min_fire_time_us = 1000,
+    .min_fire_time_us = 100,
   },
   .console = {
     .baud = 115200,

--- a/src/console.c
+++ b/src/console.c
@@ -199,34 +199,9 @@ void console_set_test_trigger() {
 
 
 static void console_status() {
-  int min = 10000;
-  int max = -10000;
-  float mean = 0;
-  int n = 0;
   
-  int i;
-  for (i = 0; i < config.num_events; ++i) {
-    if (config.events[i].type == ADC_EVENT)
-      continue;
-    if (config.events[i].stop.jitter > max) 
-      max = config.events[i].stop.jitter;
-    if (config.events[i].stop.jitter < min) 
-      min = config.events[i].stop.jitter;
-    if (config.events[i].start.jitter > max) 
-      max = config.events[i].start.jitter;
-    if (config.events[i].start.jitter < min) 
-      min = config.events[i].start.jitter;
-    mean += config.events[i].stop.jitter;
-    mean += config.events[i].start.jitter;
-    n += 2;
-  }
-  if (n == 0)
-    mean = 0;
-  else
-    mean = mean / n;
-
   snprintf(config.console.txbuffer, CONSOLE_BUFFER_SIZE,
-      "* rpm=%d sync=%d loss=%d variance=%1.3f t0_count=%d t1_count=%d map=%3.1f adv=%2.1f dwell_us=%d pw_us=%d jit=%d/%d/%d\r\n",
+      "* rpm=%d sync=%d loss=%d variance=%1.3f t0_count=%d t1_count=%d map=%3.1f adv=%2.1f dwell_us=%d pw_us=%d\r\n",
       config.decoder.rpm,
       config.decoder.valid,
       config.decoder.loss,
@@ -236,8 +211,7 @@ static void console_status() {
       config.sensors[SENSOR_MAP].processed_value,
       calculated_values.timing_advance,
       calculated_values.dwell_us,
-      calculated_values.fueling_us,
-      min, max, (int)mean);
+      calculated_values.fueling_us);
 }
 
 

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -12,6 +12,7 @@ static void invalidate_decoder() {
   config.decoder.valid = 0;
   config.decoder.state = DECODER_NOSYNC;
   config.decoder.current_triggers_rpm = 0;
+  config.decoder.triggers_since_last_sync = 0;
   invalidate_scheduled_events(config.events, config.num_events);
 }
 

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -6,7 +6,7 @@
 
 #include <stdlib.h>
 
-static struct sched_entry expire_event;
+static struct timed_callback expire_event;
 
 static void invalidate_decoder() {
   config.decoder.valid = 0;
@@ -21,10 +21,7 @@ static void handle_decoder_expire() {
 }
 
 static void set_expire_event(timeval_t t) {
-  disable_interrupts();
-  expire_event.time = t;
-//  schedule_insert(current_time(), &expire_event);
-  enable_interrupts();
+  schedule_callback(&expire_event, t);
 }
 
 static void push_time(struct decoder *d, timeval_t t) {

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -23,7 +23,7 @@ static void handle_decoder_expire() {
 static void set_expire_event(timeval_t t) {
   disable_interrupts();
   expire_event.time = t;
-  schedule_insert(current_time(), &expire_event);
+//  schedule_insert(current_time(), &expire_event);
   enable_interrupts();
 }
 

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -34,7 +34,7 @@ struct decoder {
 
   /* Safe, only handled in main loop */
   decoder_func decode;
-  unsigned char valid;
+  volatile unsigned char valid;
   unsigned int rpm;
   timeval_t last_trigger_time;
   degrees_t last_trigger_angle;

--- a/src/platform.h
+++ b/src/platform.h
@@ -30,6 +30,7 @@ void enable_interrupts();
 int interrupts_enabled();
 
 void set_output(int output, char value);
+int get_output(int output);
 void set_gpio(int output, char value);
 void set_pwm(int output, float value);
 void adc_gather();
@@ -41,6 +42,10 @@ void usart_tx(char *, unsigned short);
 
 void platform_load_config();
 void platform_save_config();
+
+timeval_t init_output_thread(uint32_t *buf0, uint32_t *buf1, uint32_t len);
+int current_output_buffer();
+int current_output_slot();
 
 #endif
 

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -536,7 +536,7 @@ void adc_gather() {
 void tim2_isr() {
   if (timer_get_flag(TIM2, TIM_SR_CC1IF)) {
     timer_clear_flag(TIM2, TIM_SR_CC1IF);
-    //scheduler_execute();
+    scheduler_callback_timer_execute();
   }
   if (timer_get_flag(TIM2, TIM_SR_CC2IF)) {
     timer_clear_flag(TIM2, TIM_SR_CC2IF);

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -152,21 +152,21 @@ static void platform_init_eventtimer() {
   timer_set_oc_slow_mode(TIM2, TIM_OC1);
   timer_set_oc_mode(TIM2, TIM_OC1, TIM_OCM_FROZEN);
   /* Setup input captures for CH2-4 Triggers */
-  gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO3);
+  gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_PULLDOWN, GPIO3);
   gpio_set_af(GPIOB, GPIO_AF1, GPIO3);
   timer_ic_set_input(TIM2, TIM_IC2, TIM_IC_IN_TI2);
   timer_ic_set_filter(TIM2, TIM_IC2, TIM_IC_CK_INT_N_2);
   timer_ic_set_polarity(TIM2, TIM_IC2, TIM_IC_FALLING);
   timer_ic_enable(TIM2, TIM_IC2);
 
-  gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO10);
+  gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_PULLDOWN, GPIO10);
   gpio_set_af(GPIOB, GPIO_AF1, GPIO10);
   timer_ic_set_input(TIM2, TIM_IC3, TIM_IC_IN_TI3);
   timer_ic_set_filter(TIM2, TIM_IC3, TIM_IC_CK_INT_N_2);
   timer_ic_set_polarity(TIM2, TIM_IC3, TIM_IC_FALLING);
   timer_ic_enable(TIM2, TIM_IC3);
 
-  gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO11);
+  gpio_mode_setup(GPIOB, GPIO_MODE_AF, GPIO_PUPD_PULLDOWN, GPIO11);
   gpio_set_af(GPIOB, GPIO_AF1, GPIO11);
   timer_ic_set_input(TIM2, TIM_IC4, TIM_IC_IN_TI4);
   timer_ic_set_filter(TIM2, TIM_IC4, TIM_IC_CK_INT_N_2);
@@ -235,6 +235,7 @@ timeval_t init_output_thread(uint32_t *buf0, uint32_t *buf1, uint32_t len) {
   timer_enable_counter(TIM8);
 
   nvic_enable_irq(NVIC_DMA2_STREAM1_IRQ);
+  nvic_set_priority(NVIC_DMA2_STREAM1_IRQ, 32);
 
   return start;
 }
@@ -327,7 +328,7 @@ void set_pwm(int output, float value) {
 
 static void platform_init_scheduled_outputs() {
   gpio_clear(GPIOD, 0xFFFF);
-  int i;
+  unsigned int i;
   for (i = 0; i < config.num_events; ++i) {
     if (config.events[i].inverted && config.events[i].type) {
       set_output(config.events[i].output_id, 1);

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -178,7 +178,7 @@ static void platform_init_eventtimer() {
   timer_enable_irq(TIM2, TIM_DIER_CC3IE);
   timer_enable_irq(TIM2, TIM_DIER_CC4IE);
   nvic_enable_irq(NVIC_TIM2_IRQ);
-  nvic_set_priority(NVIC_TIM2_IRQ, 0);
+  nvic_set_priority(NVIC_TIM2_IRQ, 32);
 
   /* Set debug unit to stop the timer on halt */
   *((volatile uint32_t *)0xE0042008) |= 9; /*TIM2 and TIM5 */
@@ -534,6 +534,12 @@ void adc_gather() {
   adc_start_conversion_injected(ADC1);
 }
 
+/* This can be set as a higher priority interrupt than the swap_buffers
+ * interrupt once it is verified there are no races between the descheduling
+ * callback and the buffer swaps.  Its not an urgent fix as currently the swap
+ * takes 13 uS, which means we might be delayed up to about a degree in
+ * recording decoder information.  This isn't an issue until we're dealing with
+ * more than 100 teeth on a wheel */
 void tim2_isr() {
   if (timer_get_flag(TIM2, TIM_SR_CC1IF)) {
     timer_clear_flag(TIM2, TIM_SR_CC1IF);

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -200,10 +200,12 @@ void schedule_output_event_safely(struct output_event *ev,
   if (!ev->start.scheduled && !ev->stop.scheduled) {
     disable_interrupts();
     ev->stop.time = newstop;
-    schedule_insert(&ev->stop, newstop);
-
-    ev->start.time = newstart;
-    schedule_insert(&ev->start, newstart);
+    if (schedule_insert(&ev->stop, newstop)) {
+      ev->start.time = newstart;
+      if (!schedule_insert(&ev->start, newstart)) {
+        schedule_remove(&ev->stop, newstop);
+      }
+    }
     enable_interrupts();
     return;
   }
@@ -221,9 +223,9 @@ void schedule_output_event_safely(struct output_event *ev,
     if (success && (oldstart != newstart)) {
       schedule_remove(&ev->start, oldstart);
     }
-    if (success || preserve_duration) {
+//    if (success || preserve_duration) {
       reschedule_end(&ev->stop, oldstop, newstop);
-    }
+ //   }
   }
   else {
     success = schedule_remove(&ev->start, oldstart);
@@ -375,19 +377,199 @@ initialize_scheduler() {
 }
 
 #ifdef UNITTEST
-int introspect_buffer(timeval_t t, uint16_t *on, uint16_t *off) {
-  struct output_buffer *buf = buffer_for_time(t);
-  if (!buf) {
-    return 0;
-  }
-  if (on) {
-    *on = buf->slots[t - buf->start].on_mask;
-  }
-  if (off) {
-    *off = buf->slots[t - buf->start].off_mask;
-  }
-  return 1;
-}
+#include <check.h>
+#include "check_platform.h"
 
+START_TEST(check_buffer_insert_totally_after) {
+  struct output_event oev = {0};
+
+  schedule_output_event_safely(&oev, 20, 40, 0); 
+
+  schedule_output_event_safely(&oev, 80, 100, 0); 
+  ck_assert_int_eq(output_buffers[0].slots[20].on_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[40].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[80].on_mask, 1);
+  ck_assert_int_eq(output_buffers[0].slots[100].off_mask, 1);
+
+  schedule_output_event_safely(&oev, 100, 150, 1); 
+  ck_assert_int_eq(output_buffers[0].slots[80].on_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[100].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[100].on_mask, 1);
+  ck_assert_int_eq(output_buffers[0].slots[150].off_mask, 1);
+} END_TEST
+
+START_TEST(check_buffer_insert_totally_before) {
+  struct output_event oev = {0};
+
+  schedule_output_event_safely(&oev, 80, 100, 0); 
+
+  schedule_output_event_safely(&oev, 20, 40, 0); 
+  ck_assert_int_eq(output_buffers[0].slots[80].on_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[100].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[20].on_mask, 1);
+  ck_assert_int_eq(output_buffers[0].slots[40].off_mask, 1);
+
+  schedule_output_event_safely(&oev, 10, 15, 1); 
+  ck_assert_int_eq(output_buffers[0].slots[20].on_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[40].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[10].on_mask, 1);
+  ck_assert_int_eq(output_buffers[0].slots[15].off_mask, 1);
+} END_TEST
+
+START_TEST(check_buffer_insert_totally_inside) {
+  struct output_event oev = {0};
+
+  schedule_output_event_safely(&oev, 20, 100, 0); 
+
+  schedule_output_event_safely(&oev, 30, 90, 0); 
+  ck_assert_int_eq(output_buffers[0].slots[20].on_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[100].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 1);
+  ck_assert_int_eq(output_buffers[0].slots[90].off_mask, 1);
+
+  schedule_output_event_safely(&oev, 30, 80, 0); 
+  ck_assert_int_eq(output_buffers[0].slots[90].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 1);
+  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 1);
+
+  schedule_output_event_safely(&oev, 40, 80, 0); 
+  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[40].on_mask, 1);
+  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 1);
+
+} END_TEST
+
+START_TEST(check_buffer_insert_totally_outside) {
+  struct output_event oev = {0};
+
+  schedule_output_event_safely(&oev, 40, 80, 0); 
+
+  schedule_output_event_safely(&oev, 30, 90, 0); 
+  ck_assert_int_eq(output_buffers[0].slots[40].on_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 1);
+  ck_assert_int_eq(output_buffers[0].slots[90].off_mask, 1);
+
+  schedule_output_event_safely(&oev, 30, 100, 0); 
+  ck_assert_int_eq(output_buffers[0].slots[90].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 1);
+  ck_assert_int_eq(output_buffers[0].slots[100].off_mask, 1);
+
+  schedule_output_event_safely(&oev, 20, 100, 0); 
+  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[20].on_mask, 1);
+  ck_assert_int_eq(output_buffers[0].slots[100].off_mask, 1);
+
+} END_TEST
+
+START_TEST(check_buffer_insert_partially_later) {
+  struct output_event oev = {0};
+
+  schedule_output_event_safely(&oev, 40, 80, 0); 
+
+  schedule_output_event_safely(&oev, 50, 90, 0); 
+  ck_assert_int_eq(output_buffers[0].slots[40].on_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[50].on_mask, 1);
+  ck_assert_int_eq(output_buffers[0].slots[90].off_mask, 1);
+
+} END_TEST
+
+START_TEST(check_buffer_insert_partially_earlier) {
+  struct output_event oev = {0};
+
+  schedule_output_event_safely(&oev, 40, 80, 0); 
+
+  schedule_output_event_safely(&oev, 30, 70, 0); 
+  ck_assert_int_eq(output_buffers[0].slots[40].on_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 1);
+  ck_assert_int_eq(output_buffers[0].slots[70].off_mask, 1);
+
+} END_TEST
+
+START_TEST(check_buffer_insert_active_later) {
+  struct output_event oev = {0};
+
+  schedule_output_event_safely(&oev, 40, 80, 0); 
+
+  set_current_time(50);
+  /* If we don't preserve duration, it'll stay fired through */
+  schedule_output_event_safely(&oev, 100, 120, 0); 
+  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[120].off_mask, 1);
+
+} END_TEST
+
+START_TEST(check_buffer_insert_active_later_preserve_duration) {
+  struct output_event oev = {0};
+
+  schedule_output_event_safely(&oev, 40, 80, 0); 
+
+  set_current_time(50);
+  /* We want to preserve the pulse width at the expense
+   * of end time */
+  schedule_output_event_safely(&oev, 100, 120, 1); 
+  ck_assert_int_eq(output_buffers[0].slots[60].off_mask, 1);
+  ck_assert_int_eq(output_buffers[0].slots[100].on_mask, 0);
+
+} END_TEST
+
+START_TEST(check_buffer_insert_active_earlier) {
+  struct output_event oev = {0};
+
+  schedule_output_event_safely(&oev, 40, 80, 0); 
+
+  set_current_time(50); 
+  /* Currently in this situation we give up, leave it the same.
+   * The naive fix to this causes errors in other situations */
+  schedule_output_event_safely(&oev, 30, 70, 0); 
+  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[70].off_mask, 1);
+
+} END_TEST
+
+START_TEST(check_buffer_insert_active_earlier_not_yet_started) {
+  struct output_event oev = {0};
+
+  schedule_output_event_safely(&oev, 40, 80, 0); 
+
+  set_current_time(50); 
+  schedule_output_event_safely(&oev, 60, 70, 0); 
+  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[70].off_mask, 1);
+
+} END_TEST
+
+START_TEST(check_buffer_insert_active_earlier_preserve_duration) {
+  struct output_event oev = {0};
+
+  schedule_output_event_safely(&oev, 40, 80, 0); 
+
+  set_current_time(50);
+  /* We want to preserve the pulse width at the expense
+   * of end time */
+  schedule_output_event_safely(&oev, 30, 60, 1); 
+  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[60].off_mask, 0);
+  ck_assert_int_eq(output_buffers[0].slots[70].off_mask, 1);
+
+} END_TEST
+
+
+void check_add_buffer_tests(TCase *tc) {
+  tcase_add_test(tc, check_buffer_insert_totally_after);
+  tcase_add_test(tc, check_buffer_insert_totally_before);
+  tcase_add_test(tc, check_buffer_insert_totally_inside);
+  tcase_add_test(tc, check_buffer_insert_totally_outside);
+  tcase_add_test(tc, check_buffer_insert_partially_later);
+  tcase_add_test(tc, check_buffer_insert_partially_earlier);
+
+  tcase_add_test(tc, check_buffer_insert_active_later);
+  tcase_add_test(tc, check_buffer_insert_active_later_preserve_duration);
+  tcase_add_test(tc, check_buffer_insert_active_earlier);
+  tcase_add_test(tc, check_buffer_insert_active_earlier_not_yet_started);
+  tcase_add_test(tc, check_buffer_insert_active_earlier_preserve_duration);
+}
 #endif
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -5,45 +5,110 @@
 #include "scheduler.h"
 #include "config.h"
 
-static struct scheduler_head schedule = LIST_HEAD_INITIALIZER(schedule);
+#include <string.h>
+#include <assert.h>
+
+#define OUTPUT_BUFFER_LEN (512)
+struct output_buffer {
+  timeval_t start;
+  struct output_slot {
+    uint16_t on_mask;   /* On little endian arch, most-significant */
+    uint16_t off_mask;  /* are last in struct */
+  } __attribute__((packed)) slots[OUTPUT_BUFFER_LEN];
+} output_buffers[2];
+
+
+static int sched_entry_has_fired(struct sched_entry *en) {
+  int ret = 0;
+  disable_interrupts();
+  if (en->buffer) {
+    if (time_in_range(en->time, en->buffer->start, current_time())) {
+      ret = 1;
+    }
+  }
+  if (en->fired) {
+    ret = 1;
+  }
+  enable_interrupts();
+  return ret;
+}
 
 int event_is_active(struct output_event *ev) {
-  return (ev->start.fired && !ev->stop.fired);
+  return (sched_entry_has_fired(&ev->start) && 
+          !sched_entry_has_fired(&ev->stop));
 }
+
 
 int event_has_fired(struct output_event *ev) {
-  return ((!ev->stop.scheduled && ev->stop.fired) &&
-          (!ev->start.scheduled && ev->start.fired));
+  return (sched_entry_has_fired(&ev->start) &&
+          sched_entry_has_fired(&ev->stop));
 }
 
-static timeval_t reschedule_head(timeval_t new, timeval_t old) {
-  /* Did we miss an event when interrupts were off? */
-  set_event_timer(new);
-  if (time_in_range(new, old, current_time())) {
-    scheduler_execute();
+static struct output_buffer *buffer_for_time(timeval_t time) {
+  struct output_buffer *buf = NULL;
+  if (time_in_range(time, output_buffers[0].start, 
+        output_buffers[0].start + OUTPUT_BUFFER_LEN - 1)) {
+    buf = &output_buffers[0];
+  } else if (time_in_range(time, output_buffers[1].start, 
+        output_buffers[1].start + OUTPUT_BUFFER_LEN - 1)) {
+    buf = &output_buffers[1];
   }
-  return new;
+  /* Make sure we're not selecting an expired buffer */
+  if (buf && time_before(buf->start, output_buffers[current_output_buffer()].start)) {
+    buf = NULL;
+  }
+  return buf;
 }
+
+int schedule_remove(struct sched_entry *s, timeval_t time) {
+  int success = 1;
+  struct output_buffer *buf = buffer_for_time(time);
+
+  if (buf) {
+    int slot = time - buf->start;
+    uint16_t *addr = s->output_val ? &buf->slots[slot].on_mask : 
+                                     &buf->slots[slot].off_mask;
+    uint16_t value = *addr &= ~(1 << s->output_id);
+
+    struct output_buffer *curbuf = &output_buffers[current_output_buffer()];
+    int before_slot = current_output_slot();
+    *addr = value;
+    int after_slot = current_output_slot();
+    struct output_buffer *otherbuf = &output_buffers[current_output_buffer()];
+
+  /* This depends on at most one slot passing during the write */
+    if (((curbuf == buf) || (otherbuf == buf)) && 
+        ((before_slot == slot) || (after_slot == slot))) {
+      set_output(s->output_id, s->output_val);
+      success = 0;
+    }
+    if (time_before(time, curbuf->start + before_slot)) {
+      success = 0;
+    }
+  }
+  if (s->fired) {
+    success = 0;
+  }
+  if (time == s->time) {
+    s->scheduled = 0;
+    s->buffer = NULL;
+    s->fired = s->fired || !success;
+  }
+  return success;
+}
+
 
 void deschedule_event(struct output_event *ev) {
-  if (ev->start.scheduled) {
-    ev->start.scheduled = 0;
-    LIST_REMOVE(&ev->start, entries);
+  int desched_failure;
+  desched_failure = schedule_remove(&ev->start, ev->start.time);
+  if (!desched_failure) {
+    ev->start.fired = 0;
+    schedule_remove(&ev->stop, ev->stop.time);
+    ev->stop.fired = 0;
   }
-  ev->start.fired = 0;
-
-  if (ev->stop.scheduled) {
-    ev->stop.scheduled = 0;
-    LIST_REMOVE(&ev->stop, entries);
-  }
-  ev->stop.fired = 0;
 }
 
 void invalidate_scheduled_events(struct output_event *evs, int n) {
-  timeval_t t;
-  int int_on = interrupts_enabled();
-  disable_interrupts();
-  t = current_time();
   for (int i = 0; i < n; ++i) {
     switch(evs[i].type) {
       case IGNITION_EVENT:
@@ -55,77 +120,136 @@ void invalidate_scheduled_events(struct output_event *evs, int n) {
         break;
     }
   }
-  if (LIST_EMPTY(&schedule)) {
-    disable_event_timer();
-  } else {
-    reschedule_head(LIST_FIRST(&schedule)->time, t);
-  }
-  if (int_on) {
-    enable_interrupts();
-  }
 }
 
-timeval_t
-schedule_insert(timeval_t curtime, struct sched_entry *en) {
-  struct sched_entry *cur;
 
-  /* If the entry is already in here somewhere, remove it first */
-  if (en->scheduled) {
-    LIST_REMOVE(en, entries);
+
+static int buffer_insert(struct output_buffer *obuf, struct sched_entry *en, timeval_t time) {
+
+  int slot = time - obuf->start;
+  int success = 1;
+
+  assert((slot >= 0) && (slot < 512));
+  uint16_t *addr = en->output_val ? &obuf->slots[slot].on_mask : 
+                                    &obuf->slots[slot].off_mask;
+  uint16_t value = *addr |= (1 << en->output_id);
+  struct output_buffer *curbuf = &output_buffers[current_output_buffer()];
+  int before_slot = current_output_slot();
+  *addr = value;
+  int after_slot = current_output_slot();
+  struct output_buffer *otherbuf = &output_buffers[current_output_buffer()];
+
+  /* This depends on at most one slot passing during the write */
+  if (((curbuf == obuf) || (otherbuf == obuf)) && 
+      ((before_slot == slot) || (after_slot == slot))) {
+    set_output(en->output_id, en->output_val);
+  }
+  if (time_before(time, curbuf->start + before_slot)) {
+    success = 0;
+  }
+  if (success && (en->time == time)) {
+    en->buffer = obuf;
+  }
+  return success;
+}
+
+
+static int
+schedule_insert(struct sched_entry *en, timeval_t newtime) {
+  int desched_fail;
+  struct output_buffer *buf = NULL;
+  int success = 0;
+
+
+  buf = buffer_for_time(newtime);
+  if (buf) {
+    success = buffer_insert(buf, en, newtime);
+  } else {
+    success = !time_before(newtime, output_buffers[current_output_buffer()].start);
+  }
+  if (en->time == newtime) {
+    en->scheduled = success;
   }
 
-  if (LIST_EMPTY(&schedule)) {
-    LIST_INSERT_HEAD(&schedule, en, entries);
-    en->scheduled = 1;
-    en->fired = 0;
-    return reschedule_head(en->time, curtime);
-  }
+  return success;
+}
 
-  /* Find where to insert the entry */
-  LIST_FOREACH(cur, &schedule, entries) {
-    if (time_in_range(en->time, curtime, cur->time)) {
-      LIST_INSERT_BEFORE(cur, en, entries);
-      en->scheduled = 1;
-      en->fired = 0;
-      return reschedule_head(LIST_FIRST(&schedule)->time, curtime);
-    }
-    if (LIST_NEXT(cur, entries) == NULL) {
-      /* This is the last entry in the list, insert here */
-      LIST_INSERT_AFTER(cur, en, entries);
-      en->scheduled = 1;
-      en->fired = 0;
-      return reschedule_head(LIST_FIRST(&schedule)->time, curtime);
-    }
-  }
 
-  return reschedule_head(LIST_FIRST(&schedule)->time, curtime);
+static void reschedule_end(struct sched_entry *s, timeval_t old, timeval_t new) {
+  if (new == old) return;
+
+  int success;
+  s->time = new;
+  success = schedule_insert(s, new);
+  if (success) {
+    success = schedule_remove(s, old);
+    if (!success) {
+      s->time = old;
+      schedule_remove(s, new);
+    } 
+  }
 }
 
 /* Schedules an output event in a hazard-free manner, assuming 
  * that the start and stop times occur at least after curtime
  */
 void schedule_output_event_safely(struct output_event *ev,
-                                 timeval_t start,
-                                 timeval_t stop,
-                                 timeval_t curtime) {
+                                 timeval_t newstart,
+                                 timeval_t newstop,
+                                 int preserve_duration) {
+
+  int success;
+  
+  timeval_t oldstart = ev->start.time;
+  timeval_t oldstop = ev->stop.time;
+ 
+  ev->start.output_id = ev->output_id;
+  ev->start.output_val = ev->inverted ? 0 : 1;
+  ev->stop.output_id = ev->output_id;
+  ev->stop.output_val = ev->inverted ? 1 : 0;
+
+  if (!ev->start.scheduled && !ev->stop.scheduled) {
+    disable_interrupts();
+    ev->stop.time = newstop;
+    schedule_insert(&ev->stop, newstop);
+
+    ev->start.time = newstart;
+    schedule_insert(&ev->start, newstart);
+    enable_interrupts();
+    return;
+  }
 
   disable_interrupts();
-  if (!event_is_active(ev) && !event_has_fired(ev)) {
-    ev->start.time = start;
-    ev->start.output_id = ev->output_id;
-    ev->start.output_val = ev->inverted ? 0 : 1;
-    schedule_insert(curtime, &ev->start);
-  } 
-  enable_interrupts();
-  /* It is safe to let events occur here */
-  disable_interrupts();
-  if (!event_has_fired(ev)) {
-    ev->stop.time = stop;
-    ev->stop.output_id = ev->output_id;
-    ev->stop.output_val = ev->inverted ? 1 : 0;
-    schedule_insert(curtime, &ev->stop);
+  if ((oldstart == newstart) || time_before(newstart, oldstart)) {
+    ev->start.time = newstart;
+    success = schedule_insert(&ev->start, newstart);
+    if (!success && preserve_duration) {
+      newstop += oldstart - newstart;
+    }
+    if (!success) {
+      ev->start.time = oldstart;
+    }
+    if (success && (oldstart != newstart)) {
+      schedule_remove(&ev->start, oldstart);
+    }
+    if (success || preserve_duration) {
+      reschedule_end(&ev->stop, oldstop, newstop);
+    }
   }
+  else {
+    success = schedule_remove(&ev->start, oldstart);
+    if (!success && preserve_duration) {
+      newstop += oldstart - newstart;
+    }
+    reschedule_end(&ev->stop, oldstop, newstop);
+    if (success) {
+      ev->start.time = newstart;
+      schedule_insert(&ev->start, newstart);
+    }
+  }
+
   enable_interrupts();
+
 }
 
 int
@@ -136,7 +260,6 @@ schedule_ignition_event(struct output_event *ev,
   
   timeval_t stop_time;
   timeval_t start_time;
-  timeval_t curtime;
   int firing_angle;
 
   firing_angle = clamp_angle(ev->angle - advance - 
@@ -146,32 +269,20 @@ schedule_ignition_event(struct output_event *ev,
     time_from_rpm_diff(d->rpm, (degrees_t)firing_angle);
   start_time = stop_time - time_from_us(usecs_dwell);
 
-  if (event_has_fired(ev)) {
+  if (ev->start.fired && ev->stop.fired) {
     ev->start.fired = 0;
     ev->stop.fired = 0;
+    ev->start.scheduled = 0;
+    ev->stop.scheduled = 0;
   }
 
-  curtime = current_time();
-
-  if (!event_is_active(ev)) {
-    if (time_in_range(curtime, start_time, stop_time)) {
-      /* New event is already upon us */
-      start_time = curtime;
-    }
-    if (time_diff(start_time, ev->stop.time) < 
+  if (time_diff(start_time, ev->stop.time) < 
       time_from_us(config.ignition.min_fire_time_us)) {
-      /* Too little time since last fire */
-      return 0;
-    }
-  } else {
-    /* If an active event stops earlier than now, make a 
-     * best effort to fire asap */
-    if (time_in_range(stop_time, ev->start.time, curtime)) {
-      stop_time = curtime;
-    }
+    /* Too little time since last fire */
+    return 0;
   }
   
-  schedule_output_event_safely(ev, start_time, stop_time, curtime);
+  schedule_output_event_safely(ev, start_time, stop_time, 0);
 
   return 1;
 }
@@ -183,7 +294,6 @@ schedule_fuel_event(struct output_event *ev,
 
   timeval_t stop_time;
   timeval_t start_time;
-  timeval_t curtime;
   int firing_angle;
 
 
@@ -193,28 +303,15 @@ schedule_fuel_event(struct output_event *ev,
   stop_time = d->last_trigger_time + time_from_rpm_diff(d->rpm, firing_angle);
   start_time = stop_time - (TICKRATE / 1000000) * usecs_pw;
 
-  if (event_has_fired(ev)) {
+  if (ev->start.fired && ev->stop.fired) {
     ev->start.fired = 0;
     ev->stop.fired = 0;
+    ev->start.scheduled = 0;
+    ev->stop.scheduled = 0;
   }
 
-  curtime = current_time();
 
-  if (!event_is_active(ev)) {
-    if (time_in_range(curtime, start_time, stop_time)) {
-      /* New event is already upon us, try to preserve pw */
-      stop_time += time_diff(curtime, start_time);
-      start_time = curtime;
-    }
-  } else {
-    /* If an active event stops earlier than now, make a 
-     * best effort to fire asap */
-    if (time_in_range(stop_time, ev->start.time, curtime)) {
-      stop_time = curtime;
-    }
-  }
-
-  schedule_output_event_safely(ev, start_time, stop_time, curtime);
+  schedule_output_event_safely(ev, start_time, stop_time, 1);
 
   return 1;
 }
@@ -238,47 +335,55 @@ schedule_adc_event(struct output_event *ev, struct decoder *d) {
   ev->stop.time = stop_time;
   ev->stop.callback = adc_gather;
   curtime = current_time();
-  disable_interrupts();
-  schedule_insert(curtime, &ev->stop);
-  enable_interrupts();
   return 1;
 }
 
+void scheduler_buffer_swap() {
+  int newbuf = (current_output_buffer() + 1) % 2;
+  struct output_buffer *obuf = &output_buffers[newbuf];
+
+  memset(obuf->slots, 0, sizeof(struct output_slot) * OUTPUT_BUFFER_LEN);
+  obuf->start += 2 * OUTPUT_BUFFER_LEN;  
+
+  timeval_t end = obuf->start + OUTPUT_BUFFER_LEN - 1;
+
+  struct output_event *oev;
+  int i;
+  for (i = 0; i < MAX_EVENTS; ++i) {
+    oev = &config.events[i];
+
+    /* OEVs that were in the old buffer are no longer */
+    if (oev->start.buffer == obuf) {
+      oev->start.buffer = NULL;
+      oev->start.fired = 1;
+    }
+    if (oev->stop.buffer == obuf) {
+      oev->stop.buffer = NULL;
+      oev->stop.fired = 1;
+    }
+
+    /* Is this an event that is scheduled for this time window? */
+    if (oev->start.scheduled && 
+        time_in_range(oev->start.time, obuf->start, end)) {
+      buffer_insert(obuf, &oev->start, oev->start.time);
+    }
+    if (oev->stop.scheduled && 
+        time_in_range(oev->stop.time, obuf->start, end)) {
+      buffer_insert(obuf, &oev->stop, oev->stop.time);
+    }
+  }
+}
 
 void
-scheduler_execute() {
+initialize_scheduler() {
+  memset(&output_buffers, 0, sizeof(output_buffers));
 
-  timeval_t schedtime = get_event_timer();
-  timeval_t cur;
-  struct sched_entry *en = LIST_FIRST(&schedule);
-  do {
-    clear_event_timer();
-    if (en->scheduled) {
-      en->scheduled = 0;
-      LIST_REMOVE(en, entries);
-      if (en->callback) {
-        en->callback();
-      } else{
-        set_output(en->output_id, en->output_val);
-        en->jitter = current_time() - en->time;
-      }
-    }
-    en->fired = 1;
-    en = LIST_FIRST(&schedule);
-    if (en == NULL) {
-      disable_event_timer();
-      break;
-    }
-
-    set_event_timer(en->time);
-    /* Has that time already passed? */
-    cur = current_time();
-  } while (time_in_range(en->time, schedtime, cur));
+  output_buffers[0].start = init_output_thread(
+      (uint32_t *)output_buffers[0].slots,
+      (uint32_t *)output_buffers[1].slots,
+      OUTPUT_BUFFER_LEN);
+  output_buffers[1].start = output_buffers[0].start + OUTPUT_BUFFER_LEN;
 }
 
-#ifdef UNITTEST
-struct scheduler_head *check_get_schedule() {
-  return &schedule;
-}
-#endif
+
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -269,6 +269,15 @@ schedule_ignition_event(struct output_event *ev,
     ev->stop.scheduled = 0;
   }
 
+  /* Don't let the stop time move more than 90* 
+   * forward once it is scheduled */
+  if (ev->stop.scheduled &&
+      time_before(ev->stop.time, stop_time) &&
+      ((time_diff(stop_time, ev->stop.time) > 
+       time_from_rpm_diff(d->rpm, 90)))) {
+    return 0;
+  }
+
   if (time_diff(start_time, ev->stop.time) < 
       time_from_us(config.ignition.min_fire_time_us)) {
     /* Too little time since last fire */

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -713,18 +713,18 @@ START_TEST(check_buffer_insert_active_earlier_repeated) {
   ck_assert_int_eq(output_buffers[0].slots[40].off_mask, 0);
   ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
   ck_assert_int_eq(output_buffers[0].slots[70].off_mask, 1);
-//  ck_assert_int_eq(oev.stop.scheduled, 1);
+  ck_assert_int_eq(oev.stop.scheduled, 1);
 
   set_current_time(55); 
   schedule_output_event_safely(&oev, 30, 60, 0); 
   ck_assert_int_eq(output_buffers[0].slots[70].off_mask, 0);
   ck_assert_int_eq(output_buffers[0].slots[60].off_mask, 1);
- // ck_assert_int_eq(oev.stop.scheduled, 1);
+  ck_assert_int_eq(oev.stop.scheduled, 1);
 
   set_current_time(58); 
   schedule_output_event_safely(&oev, 30, 55, 0); 
   ck_assert_int_eq(output_buffers[0].slots[60].off_mask, 1);
-  //ck_assert_int_eq(oev.stop.scheduled, 1);
+  ck_assert_int_eq(oev.stop.scheduled, 1);
 
 } END_TEST
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -9,7 +9,7 @@
 #include <assert.h>
 
 #define OUTPUT_BUFFER_LEN (512)
-struct output_buffer {
+static struct output_buffer {
   timeval_t start;
   struct output_slot {
     uint16_t on_mask;   /* On little endian arch, most-significant */
@@ -146,7 +146,6 @@ static int buffer_insert(struct output_buffer *obuf, struct sched_entry *en, tim
 
 static int
 schedule_insert(struct sched_entry *en, timeval_t newtime) {
-  int desched_fail;
   struct output_buffer *buf = NULL;
   int success = 0;
 
@@ -375,5 +374,20 @@ initialize_scheduler() {
   output_buffers[1].start = output_buffers[0].start + OUTPUT_BUFFER_LEN;
 }
 
+#ifdef UNITTEST
+int introspect_buffer(timeval_t t, uint16_t *on, uint16_t *off) {
+  struct output_buffer *buf = buffer_for_time(t);
+  if (!buf) {
+    return 0;
+  }
+  if (on) {
+    *on = buf->slots[t - buf->start].on_mask;
+  }
+  if (off) {
+    *off = buf->slots[t - buf->start].off_mask;
+  }
+  return 1;
+}
 
+#endif
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -226,7 +226,7 @@ void schedule_output_event_safely(struct output_event *ev,
     if (success && (oldstart != newstart)) {
       schedule_remove(&ev->start, oldstart);
     }
-    if (success || preserve_duration) {
+    if (time_before(ev->start.time, newstop) || preserve_duration) {
       reschedule_end(&ev->stop, oldstop, newstop);
     }
   }

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -60,7 +60,9 @@ void scheduler_buffer_swap();
 int event_is_active(struct output_event *);
 int event_has_fired(struct output_event *);
 void invalidate_scheduled_events(struct output_event *, int);
+
 #ifdef UNITTEST
+int introspect_buffer(timeval_t t, uint16_t *on, uint16_t *off);
 #endif
 
 #endif 

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -14,9 +14,6 @@ typedef enum {
 struct sched_entry {
   /* scheduled time of an event */
   timeval_t time;
-  int32_t jitter;
-  /* Treat event as a callback */
-  void (*callback)();
 
   /* Otherwise an output change */
   unsigned char output_id;
@@ -35,6 +32,13 @@ struct sched_entry {
  *     1     |      0      |  event fired, not meaningful
  */
 
+struct timed_callback {
+  void (*callback)(void *);
+  void *data;
+  timeval_t time;
+  int scheduled;
+};
+
 struct output_event {
   event_type_t type;
   degrees_t angle;
@@ -43,7 +47,9 @@ struct output_event {
 
   struct sched_entry start;
   struct sched_entry stop;
+  struct timed_callback callback;
 };
+
 
 int schedule_ignition_event(struct output_event *, struct decoder *d, 
     degrees_t advance, unsigned int usecs_dwell);
@@ -51,9 +57,10 @@ int schedule_fuel_event(struct output_event *, struct decoder *d,
     unsigned int usecs_pw);
 int schedule_adc_event(struct output_event *, struct decoder *);
 void deschedule_event(struct output_event *);
-//timeval_t schedule_insert(timeval_t, timeval_t, struct sched_entry *);
 
-void scheduler_execute();
+int schedule_callback(struct timed_callback *tcb, timeval_t time);
+
+void scheduler_callback_timer_execute();
 void initialize_scheduler();
 void scheduler_buffer_swap();
 

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -23,10 +23,17 @@ struct sched_entry {
   unsigned char output_val;
 
   volatile unsigned char fired;
-  volatile unsigned char scheduled;
-  LIST_ENTRY(sched_entry) entries;
+  volatile unsigned char scheduled; /* current time is valid */
+  struct output_buffer *buffer;
 };
-LIST_HEAD(scheduler_head, sched_entry);
+
+/* Meaning of scheduled/fired:
+ *   fired   |  scheduled  |  meaning
+ *     0     |      0      |  new event
+ *     1     |      1      |  event fired, time not updated since
+ *     0     |      1      |  time updated, waiting to fire
+ *     1     |      0      |  event fired, not meaningful
+ */
 
 struct output_event {
   event_type_t type;
@@ -44,16 +51,16 @@ int schedule_fuel_event(struct output_event *, struct decoder *d,
     unsigned int usecs_pw);
 int schedule_adc_event(struct output_event *, struct decoder *);
 void deschedule_event(struct output_event *);
-timeval_t schedule_insert(timeval_t, struct sched_entry *);
+//timeval_t schedule_insert(timeval_t, timeval_t, struct sched_entry *);
 
 void scheduler_execute();
+void initialize_scheduler();
+void scheduler_buffer_swap();
 
 int event_is_active(struct output_event *);
 int event_has_fired(struct output_event *);
 void invalidate_scheduled_events(struct output_event *, int);
-
 #ifdef UNITTEST
-struct scheduler_head *check_get_schedule();
 #endif
 
 #endif 

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -62,7 +62,8 @@ int event_has_fired(struct output_event *);
 void invalidate_scheduled_events(struct output_event *, int);
 
 #ifdef UNITTEST
-int introspect_buffer(timeval_t t, uint16_t *on, uint16_t *off);
+#include <check.h>
+void check_add_buffer_tests(TCase *);
 #endif
 
 #endif 

--- a/src/test/check.c
+++ b/src/test/check.c
@@ -129,7 +129,6 @@ START_TEST(check_sensor_process_freq) {
 
   si.raw_value = 1000.0;
   sensor_process_freq(&si); 
-  printf("%f\n", si.processed_value);
   ck_assert(value_within(1, si.processed_value, 0.976562));
 
   si.raw_value = 0.0;

--- a/src/test/check.c
+++ b/src/test/check.c
@@ -22,10 +22,10 @@ static int value_within(int percent, float value, float target) {
 
 START_TEST(check_rpm_from_time_diff) {
   /* 360 degrees for 0.005 s is 6000 rpm */
-  ck_assert(value_within(1, rpm_from_time_diff(500000, 180), 6000));
+  ck_assert(value_within(1, rpm_from_time_diff(2000, 180), 6000));
 
   /* 90 degrees for 0.00125 s is 6000 rpm */
-  ck_assert(value_within(1, rpm_from_time_diff(125000, 45), 6000));
+  ck_assert(value_within(1, rpm_from_time_diff(5000, 45), 6000));
 } END_TEST
 
 START_TEST(check_time_from_rpm_diff) {
@@ -125,11 +125,12 @@ START_TEST(check_sensor_process_freq) {
 
   si.raw_value = 100.0;
   sensor_process_freq(&si);  
-  ck_assert(si.processed_value == 244.140625);
+  ck_assert(value_within(1, si.processed_value, 9.765625));
 
   si.raw_value = 1000.0;
   sensor_process_freq(&si); 
-  ck_assert(si.processed_value == 24.4140625);
+  printf("%f\n", si.processed_value);
+  ck_assert(value_within(1, si.processed_value, 0.976562));
 
   si.raw_value = 0.0;
   sensor_process_freq(&si);  

--- a/src/test/check_platform.c
+++ b/src/test/check_platform.c
@@ -10,7 +10,6 @@ static int int_on = 1;
 static int output_state = 0;
 
 void check_platform_reset() {
-  LIST_INIT(check_get_schedule());
   curtime = 0;
 }
 
@@ -54,7 +53,7 @@ void set_output(int output, char value) {
   output_state = value;  
 }
 
-int get_output() {
+int get_output(int output) {
   return output_state;
 }
 
@@ -73,6 +72,14 @@ void usart_rx_reset() {
 }
 
 void usart_tx(char *s, unsigned short len) {
+}
+
+int current_output_buffer() {
+  return 0;
+}
+
+timeval_t init_output_thread(uint32_t *b0, uint32_t *b1, uint32_t len) {
+  return 0;
 }
 
 

--- a/src/test/check_platform.c
+++ b/src/test/check_platform.c
@@ -32,7 +32,7 @@ void set_current_time(timeval_t t) {
   curtime = t;
 
   /* Swap buffers until we're at time t */
-  while (c < t) {
+  while (c < ((t / 512) * 512)) {
     current_buffer = (current_buffer + 1) % 2;
     scheduler_buffer_swap();
     c += 512;

--- a/src/test/check_platform.c
+++ b/src/test/check_platform.c
@@ -12,6 +12,7 @@ static int current_buffer = 0;
 
 void check_platform_reset() {
   curtime = 0;
+  current_buffer = 0;
   initialize_scheduler();
 }
 

--- a/src/test/check_scheduler.c
+++ b/src/test/check_scheduler.c
@@ -145,10 +145,7 @@ START_TEST(check_invalidate_events_when_active) {
  
   invalidate_scheduled_events(&oev, 1);
 
-  ck_assert(!oev.start.scheduled);
   ck_assert(oev.stop.scheduled);
-  ck_assert(oev.start.fired);
-  ck_assert(!oev.stop.fired);
 
 } END_TEST
 

--- a/src/test/check_scheduler.c
+++ b/src/test/check_scheduler.c
@@ -118,6 +118,24 @@ START_TEST(check_schedule_ignition_reschedule_active_later) {
 
 } END_TEST
 
+/* Special case where rescheduling before last trigger is
+ * reinterpretted as future */
+START_TEST(check_schedule_ignition_reschedule_active_too_early) {
+  oev.angle = 40;
+  set_current_time(time_from_rpm_diff(6000, 0));
+  schedule_ignition_event(&oev, &config.decoder, 0, 1000);
+  /* Emulate firing of the event */
+  set_current_time(oev.start.time + 5);
+
+  timeval_t old_stop = oev.stop.time;
+  /* Reschedule 45* earlier, now in past*/
+  schedule_ignition_event(&oev, &config.decoder, 45, 1000);
+
+  ck_assert(oev.stop.scheduled);
+  ck_assert_int_eq(oev.stop.time, old_stop);
+
+} END_TEST
+
 START_TEST(check_event_is_active) {
   ck_assert(!event_is_active(&oev));
 
@@ -162,6 +180,7 @@ TCase *setup_scheduler_tests() {
   tcase_add_test(scheduler_tests, check_schedule_ignition_reschedule_completely_earlier_still_future);
   tcase_add_test(scheduler_tests, check_schedule_ignition_reschedule_onto_now);
   tcase_add_test(scheduler_tests, check_schedule_ignition_reschedule_active_later);
+  tcase_add_test(scheduler_tests, check_schedule_ignition_reschedule_active_too_early);
   tcase_add_test(scheduler_tests, check_event_is_active);
   tcase_add_test(scheduler_tests, check_event_has_fired);
   tcase_add_test(scheduler_tests, check_invalidate_events_when_active);

--- a/src/test/check_scheduler.c
+++ b/src/test/check_scheduler.c
@@ -6,15 +6,17 @@
 #include <check.h>
 #include <stdio.h>
 
-static struct output_event oev;
+static struct output_event *oev = &config.events[0];
 
 static void check_scheduler_setup() {
+  decoder_init(&config.decoder);
   check_platform_reset();
   config.decoder.last_trigger_angle = 0;
   config.decoder.last_trigger_time = 0;
   config.decoder.offset = 0;
   config.decoder.rpm = 6000;
-  oev = (struct output_event){
+  config.num_events = 1;
+  *oev = (struct output_event){
     .type = IGNITION_EVENT,
     .angle = 360,
     .output_id = 0,
@@ -26,94 +28,90 @@ START_TEST(check_schedule_ignition) {
 
   /* Set our current position at 270* for an event at 360* */
   set_current_time(time_from_rpm_diff(6000, 270));
-  schedule_ignition_event(&oev, &config.decoder, 10, 1000);
-  ck_assert(oev.start.scheduled);
-  ck_assert(oev.stop.scheduled);
-  ck_assert(!oev.start.fired);
-  ck_assert(!oev.stop.fired);
+  schedule_ignition_event(oev, &config.decoder, 10, 1000);
+  ck_assert(oev->start.scheduled);
+  ck_assert(oev->stop.scheduled);
+  ck_assert(!oev->start.fired);
+  ck_assert(!oev->stop.fired);
 
-  ck_assert_int_eq(oev.stop.time - oev.start.time, 
+  ck_assert_int_eq(oev->stop.time - oev->start.time, 
     1000 * (TICKRATE / 1000000));
-  ck_assert_int_eq(oev.stop.time, 
+  ck_assert_int_eq(oev->stop.time, 
     time_from_rpm_diff(config.decoder.rpm, 
-    oev.angle + config.decoder.offset - 10));
+    oev->angle + config.decoder.offset - 10));
 } END_TEST
 
 START_TEST(check_schedule_ignition_reschedule_completely_later) {
 
-  timeval_t old_start, old_stop;
-
   set_current_time(time_from_rpm_diff(6000, 270));
-  schedule_ignition_event(&oev, &config.decoder, 10, 1000);
+  schedule_ignition_event(oev, &config.decoder, 10, 1000);
 
-  set_current_time(oev.start.time - 100);
+  set_current_time(oev->start.time - 100);
 
   /* Reschedule 10 degrees later */
-  old_start = oev.start.time;
-  old_stop = oev.stop.time;
-  schedule_ignition_event(&oev, &config.decoder, 0, 1000);
+  schedule_ignition_event(oev, &config.decoder, 0, 1000);
 
-  ck_assert(oev.start.scheduled);
-  ck_assert(oev.stop.scheduled);
-  ck_assert(!oev.start.fired);
-  ck_assert(!oev.stop.fired);
+  ck_assert(oev->start.scheduled);
+  ck_assert(oev->stop.scheduled);
+  ck_assert(!oev->start.fired);
+  ck_assert(!oev->stop.fired);
 
-  ck_assert_int_eq(oev.stop.time - oev.start.time, 
+  ck_assert_int_eq(oev->stop.time - oev->start.time, 
     1000 * (TICKRATE / 1000000));
-  ck_assert_int_eq(oev.stop.time, 
+  ck_assert_int_eq(oev->stop.time, 
     time_from_rpm_diff(config.decoder.rpm, 
-    oev.angle + config.decoder.offset));
+    oev->angle + config.decoder.offset));
 
 } END_TEST
 
 START_TEST(check_schedule_ignition_reschedule_completely_earlier_still_future) {
 
   set_current_time(time_from_rpm_diff(6000, 180));
-  schedule_ignition_event(&oev, &config.decoder, 10, 1000);
+  schedule_ignition_event(oev, &config.decoder, 10, 1000);
   /* Reschedule 10 earlier later */
-  schedule_ignition_event(&oev, &config.decoder, 50, 1000);
+  schedule_ignition_event(oev, &config.decoder, 50, 1000);
 
-  ck_assert(oev.start.scheduled);
-  ck_assert(oev.stop.scheduled);
-  ck_assert(!oev.start.fired);
-  ck_assert(!oev.stop.fired);
+  ck_assert(oev->start.scheduled);
+  ck_assert(oev->stop.scheduled);
+  ck_assert(!oev->start.fired);
+  ck_assert(!oev->stop.fired);
 
-  ck_assert_int_eq(oev.stop.time - oev.start.time, 
+  ck_assert_int_eq(oev->stop.time - oev->start.time, 
     1000 * (TICKRATE / 1000000));
-  ck_assert_int_eq(oev.stop.time, 
+  ck_assert_int_eq(oev->stop.time, 
     time_from_rpm_diff(config.decoder.rpm, 
-    oev.angle + config.decoder.offset - 50));
+    oev->angle + config.decoder.offset - 50));
 
 } END_TEST
 
 START_TEST(check_schedule_ignition_reschedule_onto_now) {
 
   set_current_time(time_from_rpm_diff(6000, 340));
-  schedule_ignition_event(&oev, &config.decoder, 15, 1000);
+  schedule_ignition_event(oev, &config.decoder, 15, 1000);
 
   /* Start would fail, stop should schedule */
-  ck_assert(!oev.start.scheduled);
-  ck_assert(!oev.stop.scheduled); 
-  ck_assert(!oev.start.fired);
-  ck_assert(!oev.stop.fired);
+  ck_assert(!oev->start.scheduled);
+  ck_assert(!oev->stop.scheduled); 
+  ck_assert(!oev->start.fired);
+  ck_assert(!oev->stop.fired);
 
 } END_TEST
 
 START_TEST(check_schedule_ignition_reschedule_active_later) {
 
   set_current_time(time_from_rpm_diff(6000, 270));
-  schedule_ignition_event(&oev, &config.decoder, 10, 1000);
+  schedule_ignition_event(oev, &config.decoder, 10, 1000);
 
   /* Emulate firing of the event */
-  set_current_time(oev.start.time + 1);
+  set_current_time(oev->start.time + 1);
 
   /* Reschedule 10* later */
-  schedule_ignition_event(&oev, &config.decoder, 0, 1000);
+  schedule_ignition_event(oev, &config.decoder, 0, 1000);
 
-  ck_assert(oev.stop.scheduled);
-  ck_assert_int_eq(oev.stop.time, 
+  ck_assert(oev->stop.scheduled);
+  ck_assert_int_eq(oev->stop.time, 
     time_from_rpm_diff(config.decoder.rpm, 
-    oev.angle + config.decoder.offset));
+    oev->angle + config.decoder.offset));
 
 
 } END_TEST
@@ -121,32 +119,32 @@ START_TEST(check_schedule_ignition_reschedule_active_later) {
 /* Special case where rescheduling before last trigger is
  * reinterpretted as future */
 START_TEST(check_schedule_ignition_reschedule_active_too_early) {
-  oev.angle = 40;
+  oev->angle = 40;
   set_current_time(time_from_rpm_diff(6000, 0));
-  schedule_ignition_event(&oev, &config.decoder, 0, 1000);
+  schedule_ignition_event(oev, &config.decoder, 0, 1000);
   /* Emulate firing of the event */
-  set_current_time(oev.start.time + 5);
+  set_current_time(oev->start.time + 5);
 
-  timeval_t old_stop = oev.stop.time;
+  timeval_t old_stop = oev->stop.time;
   /* Reschedule 45* earlier, now in past*/
-  schedule_ignition_event(&oev, &config.decoder, 45, 1000);
+  schedule_ignition_event(oev, &config.decoder, 45, 1000);
 
-  ck_assert(oev.stop.scheduled);
-  ck_assert_int_eq(oev.stop.time, old_stop);
+  ck_assert(oev->stop.scheduled);
+  ck_assert_int_eq(oev->stop.time, old_stop);
 
 } END_TEST
 
 START_TEST(check_event_is_active) {
-  ck_assert(!event_is_active(&oev));
+  ck_assert(!event_is_active(oev));
 
-  oev.start.fired = 1;
-  ck_assert(event_is_active(&oev));
+  oev->start.fired = 1;
+  ck_assert(event_is_active(oev));
 
-  oev.stop.fired = 1;
-  ck_assert(!event_is_active(&oev));
+  oev->stop.fired = 1;
+  ck_assert(!event_is_active(oev));
 
-  oev.start.fired = 0;
-  ck_assert(!event_is_active(&oev));
+  oev->start.fired = 0;
+  ck_assert(!event_is_active(oev));
 } END_TEST
 
 START_TEST(check_event_has_fired) {
@@ -157,13 +155,12 @@ START_TEST(check_event_has_fired) {
 START_TEST(check_invalidate_events_when_active) {
   /* Schedule an event, get in the middle of it */
   set_current_time(time_from_rpm_diff(6000, 270));
-  schedule_ignition_event(&oev, &config.decoder, 10, 1000);
-  set_current_time(time_from_rpm_diff(6000, 
-    oev.angle + config.decoder.offset - 10) - 500 * (TICKRATE/1000000));
+  schedule_ignition_event(oev, &config.decoder, 10, 1000);
+  set_current_time(oev->start.time + 500);
  
-  invalidate_scheduled_events(&oev, 1);
+  invalidate_scheduled_events(oev, 1);
 
-  ck_assert(oev.stop.scheduled);
+  ck_assert(oev->stop.scheduled);
 
 } END_TEST
 

--- a/src/tfi.c
+++ b/src/tfi.c
@@ -7,9 +7,6 @@
 #include "sensors.h"
 #include "calculations.h"
 
-#include <libopencm3/stm32/gpio.h>
-#include <libopencm3/stm32/timer.h>
-
 static void schedule(struct output_event *ev) {
   switch(ev->type) {
     case IGNITION_EVENT:

--- a/src/tfi.c
+++ b/src/tfi.c
@@ -43,7 +43,7 @@ int main() {
   platform_init();
   initialize_scheduler();
 
-  enable_test_trigger(FORD_TFI, 5100);
+  enable_test_trigger(FORD_TFI, 300);
 
   while (1) {                   
 

--- a/src/util.c
+++ b/src/util.c
@@ -17,6 +17,13 @@ timeval_t time_from_us(unsigned int us) {
   timeval_t ticks = us * (TICKRATE / 1000000);
   return ticks;
 }
+
+/* True if n is before x */
+int time_before(timeval_t n, timeval_t x) {
+  signed int res = n - x;
+  return (res < 0);
+}
+
 int time_in_range(timeval_t val, timeval_t t1, timeval_t t2) {
   if (t2 >= t1) {
     /* No timer wrap */

--- a/src/util.h
+++ b/src/util.h
@@ -4,6 +4,7 @@
 #include "platform.h"
 
 timeval_t time_diff(timeval_t t1, timeval_t t2);
+int time_before(timeval_t n, timeval_t x);
 timeval_t time_from_us(unsigned int us);
 unsigned int rpm_from_time_diff(timeval_t t1, degrees_t degrees);
 timeval_t time_from_rpm_diff(unsigned int rpm, degrees_t degrees);


### PR DESCRIPTION
The old scheduler has issues:
- Cannot accurately schedule events on top of each other without at minimum of 400 nS between events
  - Best case jitter at 1 uS
  - Extremely slow insert time that could make worst case jitter upwards of 10 uS

The new architecture uses DMA to drive GPIO, quantizing all outputs to 250 nS updates, and requiring no interrupts to drive them.  This allows all 16 outputs to be scheduled with 250 nS accuracy, even if all 16 are at the same time.
