### PR TITLE
Use TLC2543 over SPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,9 +2,9 @@
 An Ignition controller for gasoline spark ignition engines.
 
 Currently it supports the Ford EEC-IV Thin Film Integration module as a decoder
-and ignitor, using the STM32F4-Discovery Cortex-M4 Board from ST. It should be
-fairly generic to any engine, with any number of ignition outputs, 
-if a decoder is written.
+and ignitor, using the STM32F4-Discovery Cortex-M4 Board from ST, and a TLC2543
+ADC from TI. It should be fairly generic to any engine, with any number of
+ignition outputs, if a decoder is written.
 
 ## Decoding
 
@@ -90,7 +90,7 @@ value into a usable number:
 
 Member | Meaning
 --- | ---
-`pin` | pin to use (Autoconfigured, see platform source)
+`pin` | pin to use on TLC2543
 `process` | Processing function to use (see below)
 `method` | Type of sensor, currently supported are analog and frequency based.
 `params` | Union used to configure a sensor. Contains `range` used for calculated sensors, and `table` for table lookup sensors.
@@ -101,6 +101,9 @@ The process function can point to any function that takes a pointer to the
 sensor structure.  Currently the only provided ones are `sensor_process_linear`, which
 linearly interpolates between `min` and `max`, and `sensor_process_freq`, which 
 converts based on measured frequency.
+
+The onboard ADC is not used. Instead a TLC2543 external ADC should be connected
+to SPI2 (PB12-PB15).  Currently the first 10 inputs are supported.
 
 ### Table Configuration
 Tables can be up to 24x24 float values that are bilinearly interpolated. Use

--- a/src/config.c
+++ b/src/config.c
@@ -80,7 +80,7 @@ struct config config __attribute__((section(".configdata"))) = {
     [SENSOR_IAT] = {.pin=2, .method=SENSOR_ADC, .process=sensor_process_linear, 
       .params={.range={.min=-30.0, .max=120.0}}},
 #else
-    [SENSOR_MAP] = {.pin=7, .method=SENSOR_ADC, .process=sensor_process_linear,
+    [SENSOR_MAP] = {.pin=0, .method=SENSOR_ADC, .process=sensor_process_linear,
       .params={.range={.min=0, .max=100}}},
     [SENSOR_AAP] = {.method=SENSOR_CONST, .params={.fixed_value = 102.0}},
     [SENSOR_IAT] = {.method=SENSOR_CONST, .params={.fixed_value = 29.0}},

--- a/src/tfi.c
+++ b/src/tfi.c
@@ -64,6 +64,12 @@ int main() {
           schedule(&config.events[e]);
         }
       }
+
+      /* We want to continue adc sampling when the engine isn't spinning.
+       * TODO: do this more infrequently */
+      if (!config.decoder.valid) {
+        adc_gather();
+      }
     }
    
     console_process();


### PR DESCRIPTION
The onboard ADC is 3.3V reference, which is annoying.  From now on use an external ADC.  The TI TLC2543 (http://www.ti.com/product/TLC2543) was chosen because it supports 11 channel at 12 bits and can be set up to be easily sampled only using DMA.

SPI2 is used to communicate with the ADC, using DMA for RX and TX, the latter being triggered by TIM6.

Remove old ADC setup and glue.