### PR TITLE
Add stats for rate and time counting

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -29,7 +29,7 @@ all: tfi
 .endif
 
 
-OBJS=decoder.o util.o scheduler.o console.o calculations.o config.o table.o sensors.o
+OBJS=decoder.o util.o scheduler.o console.o calculations.o config.o table.o sensors.o stats.o
 
 tfi: ${OBJS} tfi.o platforms/${PLATFORM}.o
 	${CC} ${CFLAGS} -o tfi tfi.o ${OBJS} ${PLATFORM}.o  ${LDFLAGS}

--- a/src/calculations.c
+++ b/src/calculations.c
@@ -1,6 +1,6 @@
 #include "config.h"
 #include "calculations.h"
-
+#include "stats.h"
 struct calculated_values calculated_values;
 
 int ignition_cut() {
@@ -45,6 +45,7 @@ static float fuel_density(float fuel_celsius) {
 }
 
 void calculate_fueling() {
+  stats_start_timing(STATS_FUELCALC_TIME);
   float ve;
   float lambda;
   float idt;
@@ -92,4 +93,5 @@ void calculate_fueling() {
   config.fueling.injector_dead_time = idt;
 
   calculated_values.fueling_us = raw_pw_us + idt;
+  stats_finish_timing(STATS_FUELCALC_TIME);
 }

--- a/src/console.c
+++ b/src/console.c
@@ -3,6 +3,7 @@
 #include "config.h"
 #include "calculations.h"
 #include "decoder.h"
+#include "stats.h"
 
 #include <stdio.h>
 #include <stdlib.h>
@@ -295,12 +296,14 @@ static void console_process_rx() {
 
 void console_process() {
 
+  stats_start_timing(STATS_CONSOLE_TIME);
   if (usart_rx_ready()) {
     console_process_rx();
   }
 
   /*  if tx buffer is usable, print regular status update */
   if (!usart_tx_ready()) {
+    stats_finish_timing(STATS_CONSOLE_TIME);
     return;
   }
 
@@ -309,5 +312,5 @@ void console_process() {
     usart_tx(config.console.txbuffer, strlen(config.console.txbuffer));
   }
 
-
+  stats_finish_timing(STATS_CONSOLE_TIME);
 }

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -3,6 +3,7 @@
 #include "util.h"
 #include "scheduler.h"
 #include "config.h"
+#include "stats.h"
 
 #include <stdlib.h>
 
@@ -133,6 +134,7 @@ void cam_nplusone_decoder(struct decoder *d) {
 }
 
 void tfi_pip_decoder(struct decoder *d) {
+  stats_start_timing(STATS_DECODE_TIME);
   timeval_t t0;
   decoder_state oldstate = d->state;
 
@@ -161,6 +163,7 @@ void tfi_pip_decoder(struct decoder *d) {
       invalidate_decoder();
     }
   }
+  stats_finish_timing(STATS_DECODE_TIME);
 }
 
 void decoder_init(struct decoder *d) {

--- a/src/platform.h
+++ b/src/platform.h
@@ -16,6 +16,7 @@ typedef uint16_t degrees_t;
 /* timeval_t is gauranteed to be 32 bits */
 
 timeval_t current_time();
+timeval_t cycle_count();
 
 void set_event_timer(timeval_t);
 timeval_t get_event_timer();

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -4,6 +4,7 @@
 #include "platform.h"
 #include "scheduler.h"
 #include "config.h"
+#include "stats.h"
 
 #include <string.h>
 #include <assert.h>
@@ -223,6 +224,7 @@ void schedule_output_event_safely(struct output_event *ev,
                                  timeval_t newstop,
                                  int preserve_duration) {
 
+  stats_start_timing(STATS_SCHED_SINGLE_TIME);
   int success;
   
   timeval_t oldstart = ev->start.time;
@@ -247,6 +249,7 @@ void schedule_output_event_safely(struct output_event *ev,
         }
     }
     enable_interrupts();
+    stats_finish_timing(STATS_SCHED_SINGLE_TIME);
     return;
   }
 
@@ -282,6 +285,7 @@ void schedule_output_event_safely(struct output_event *ev,
   }
 
   enable_interrupts();
+  stats_finish_timing(STATS_SCHED_SINGLE_TIME);
 
 }
 

--- a/src/stats.c
+++ b/src/stats.c
@@ -1,0 +1,122 @@
+#include "platform.h"
+#include "stats.h"
+#include <stdio.h>
+
+struct stats_entry entries[] __attribute__((externally_visible)) = {
+	[STATS_INT_RATE] = {
+		.name = "interrupt_rate",
+	},
+	[STATS_INT_PWM_RATE] = {
+		.name = "pwm interrupt_rate",
+	},
+	[STATS_INT_USART_RATE] = {
+		.name = "usart interrupt_rate",
+	},
+	[STATS_INT_EVENTTIMER_RATE] = {
+		.name = "event timer interrupt_rate",
+	},
+	[STATS_INT_BUFFERSWAP_RATE] = {
+		.name = "buffer swap interrupt_rate",
+	},
+	[STATS_CONSOLE_TIME] = {
+		.name = "console processing time",
+	},
+	[STATS_MAINLOOP_RATE] = {
+		.name = "main loop rate",
+	},
+	[STATS_INT_DISABLE_TIME] = {
+		.name = "interrupt_disabled_time",
+	},
+	[STATS_INT_BUFFERSWAP_TIME] = {
+		.name = "output buffer reload time",
+	},
+	[STATS_SCHED_TOTAL_TIME] = {
+		.name = "total scheduling time after decode",
+	},
+	[STATS_SCHED_FIRED_TIME] = {
+		.name = "total scheduling of just-fired events",
+	},
+	[STATS_SCHED_SINGLE_TIME] = {
+		.name = "individual event scheduling time",
+	},
+	[STATS_DECODE_TIME] = {
+		.name = "decode_time",
+	},
+	[STATS_FUELCALC_TIME] = {
+		.name = "fuelcalc_time",
+	},
+  [STATS_INT_TOTAL_TIME] = {
+    .name = "total interrupt time",
+    .is_interrupt = 1,
+  },
+	[STATS_LAST] = {},
+};
+
+static timeval_t ticks_per_sec;
+static timeval_t interrupt_time;
+
+void stats_init(timeval_t ticks) {
+  ticks_per_sec = ticks;
+
+  for (int i = 0; i < STATS_LAST; ++i) {
+    entries[i].min = (timeval_t)-1;
+    entries[i].max = 0;
+    entries[i].avg = 0;
+    entries[i].counter = 0;
+    entries[i]._window = 0;
+    entries[i]._prev[0] = 0;
+    entries[i]._prev[1] = 0;
+    entries[i]._prev[2] = 0;
+    entries[i]._prev[3] = 0;
+  }
+}
+
+static void stats_update(stats_field_t type, timeval_t val) {
+  if (val < entries[type].min) {
+    entries[type].min = val;
+  }
+
+  if (val > entries[type].max) {
+    entries[type].max = val;
+  }
+
+  entries[type]._prev[3] = entries[type]._prev[2];
+  entries[type]._prev[2] = entries[type]._prev[1];
+  entries[type]._prev[1] = entries[type]._prev[0];
+  entries[type]._prev[0] = val;
+
+  timeval_t total = entries[type]._prev[3] + entries[type]._prev[2] +
+    entries[type]._prev[1] + entries[type]._prev[0];
+  entries[type].avg = total / 4;
+}
+
+void stats_start_timing(stats_field_t type) {
+  entries[type]._window = cycle_count();
+  entries[type].cur_interrupt_time = interrupt_time;
+}
+
+void stats_finish_timing(stats_field_t type) {
+  timeval_t time = cycle_count();
+  if (!entries[type].is_interrupt) {
+    printf("%u %u\n", (interrupt_time - entries[type].cur_interrupt_time),
+          time);
+//    time -= (interrupt_time - entries[type].cur_interrupt_time);
+  }
+  time -= entries[type]._window;
+  stats_update(type, time);
+
+  if (entries[type].is_interrupt) {
+    interrupt_time += time;
+  }
+}
+
+void stats_increment_counter(stats_field_t type) {
+
+  if (cycle_count() - entries[type]._window > ticks_per_sec) {
+    /* We've reached the window edge, calculate and reset */
+    stats_update(type, entries[type].counter);
+    entries[type].counter = 0;
+    entries[type]._window = cycle_count();
+  }
+  entries[type].counter++;
+}

--- a/src/stats.h
+++ b/src/stats.h
@@ -1,0 +1,45 @@
+#ifndef STATS_H
+#define STATS_H
+
+struct stats_entry {
+  const char *name;
+  timeval_t min;
+  timeval_t avg;
+  timeval_t max;
+  timeval_t counter;
+
+  timeval_t _prev[4];
+  timeval_t _window;
+
+  int is_interrupt;
+  timeval_t cur_interrupt_time;
+};
+
+typedef enum {
+  STATS_INT_RATE,
+  STATS_INT_BUFFERSWAP_TIME,
+  STATS_INT_EVENTTIMER_RATE,
+  STATS_INT_USART_RATE,
+  STATS_INT_PWM_RATE,
+  STATS_INT_BUFFERSWAP_RATE,
+  STATS_INT_DISABLE_TIME,
+  STATS_INT_TOTAL_TIME,
+  STATS_FUELCALC_TIME,
+  STATS_DECODE_TIME,
+  STATS_SCHED_TOTAL_TIME,
+  STATS_SCHED_FIRED_TIME,
+  STATS_SCHED_SINGLE_TIME,
+  STATS_CONSOLE_TIME,
+  STATS_MAINLOOP_RATE,
+  STATS_LAST,
+} stats_field_t;
+
+
+void stats_init(timeval_t ticks_per_us);
+
+void stats_increment_counter(stats_field_t type);
+void stats_start_timing(stats_field_t type);
+void stats_finish_timing(stats_field_t type);
+
+#endif
+

--- a/src/test/check_platform.c
+++ b/src/test/check_platform.c
@@ -28,6 +28,10 @@ timeval_t current_time() {
   return curtime;
 }
 
+timeval_t cycle_count() {
+  return 0;
+}
+
 void set_current_time(timeval_t t) {
   timeval_t c = curtime;
   curtime = t;

--- a/src/tfi.c
+++ b/src/tfi.c
@@ -1,3 +1,4 @@
+#include <stdio.h>
 #include "platform.h"
 #include "util.h"
 #include "decoder.h"
@@ -6,6 +7,7 @@
 #include "table.h"
 #include "sensors.h"
 #include "calculations.h"
+#include "stats.h"
 
 static void schedule(struct output_event *ev) {
   switch(ev->type) {
@@ -40,9 +42,10 @@ int main(int argc, char *argv[]) {
   platform_init(argc, argv);
   initialize_scheduler();
 
-  enable_test_trigger(FORD_TFI, 300);
+  enable_test_trigger(FORD_TFI, 3000);
 
   while (1) {                   
+    stats_increment_counter(STATS_MAINLOOP_RATE);
 
     sensors_process();
     if (config.decoder.needs_decoding_t0 || config.decoder.needs_decoding_t1) {
@@ -51,19 +54,23 @@ int main(int argc, char *argv[]) {
       if (config.decoder.valid) {
         calculate_ignition();
         calculate_fueling();
+        stats_start_timing(STATS_SCHED_TOTAL_TIME);
         for (unsigned int e = 0; e < config.num_events; ++e) {
           schedule(&config.events[e]);
         }
+        stats_finish_timing(STATS_SCHED_TOTAL_TIME);
       }
 
     } else {
       /* Check to see if any events have fired. These should be rescheduled
        * now to allow 100% duty utilization */
+      stats_start_timing(STATS_SCHED_FIRED_TIME);
       for (unsigned int e = 0; e < config.num_events; ++e) {
         if (config.decoder.valid && event_has_fired(&config.events[e])) {
           schedule(&config.events[e]);
         }
       }
+      stats_finish_timing(STATS_SCHED_FIRED_TIME);
 
       /* We want to continue adc sampling when the engine isn't spinning.
        * TODO: do this more infrequently */


### PR DESCRIPTION
Adds a little framework for counting rates of things, and how long things take.

Added specific counters for:
 * Interrupt rates (total and invididual)
* Time spent in interrupts
* Time spent with interrupts disabled
* Decode time
* Calculation time
* Console time

No support for pulling data from console yet