### PR TITLE
Fix tests wrt decoder valid check

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -584,6 +584,7 @@ static void check_scheduler_setup() {
   config.decoder.last_trigger_time = 0;
   config.decoder.offset = 0;
   config.decoder.rpm = 6000;
+  config.decoder.valid = 1;
   config.num_events = 1;
   *oev = (struct output_event){
     .type = IGNITION_EVENT,


### PR DESCRIPTION
Previous PR added asserts that cause the tests to fail.  All tests emulate a valid decoder in setup, so just set it .