### PR TITLE
Initial tests and improvements to cam nplusone decoder

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,5 +184,4 @@ To run the unit tests:
 cd src/
 make clean
 make check
-./check
 ```

--- a/src/Makefile
+++ b/src/Makefile
@@ -57,7 +57,7 @@ check: tfi
 	./tfi
 
 coverage: check
-	./check
+	./tfi
 	gcovr -r .
 
 

--- a/src/config.h
+++ b/src/config.h
@@ -18,7 +18,6 @@ struct config {
   struct output_event events[MAX_EVENTS];
 
   /* Trigger setup */
-  trigger_type trigger;
   struct decoder decoder;
 
   /* Analog inputs */

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -357,6 +357,90 @@ START_TEST(check_cam_nplusone_startup_normal_then_die) {
 
 } END_TEST
 
+START_TEST(check_cam_nplusone_startup_normal_sustained) {
+  struct decoder_event cam_nplusone_startup_events[] = {
+    {1, 0, 18000, DECODER_NOSYNC, 0, 0},
+    {1, 0, 25000, DECODER_NOSYNC, 0, 0},
+    {1, 0, 50000, DECODER_NOSYNC, 0, 0},
+    {1, 0, 75000, DECODER_NOSYNC, 0, 0},
+    {1, 0, 100000, DECODER_RPM, 0, 0},
+    {0, 1, 100500, DECODER_SYNC, 1, 0}, /* sync */
+    {1, 0, 125000, DECODER_SYNC, 1, 0},
+    {1, 0, 150000, DECODER_SYNC, 1, 0},
+    {1, 0, 175000, DECODER_SYNC, 1, 0},
+    {1, 0, 200000, DECODER_SYNC, 1, 0},
+    {1, 0, 225000, DECODER_SYNC, 1, 0},
+    {1, 0, 250000, DECODER_SYNC, 1, 0},
+    {1, 0, 275000, DECODER_SYNC, 1, 0},
+    {1, 0, 300000, DECODER_SYNC, 1, 0},
+    {1, 0, 325000, DECODER_SYNC, 1, 0},
+    {1, 0, 350000, DECODER_SYNC, 1, 0},
+    {1, 0, 375000, DECODER_SYNC, 1, 0},
+    {1, 0, 400000, DECODER_SYNC, 1, 0},
+    {1, 0, 425000, DECODER_SYNC, 1, 0},
+    {1, 0, 450000, DECODER_SYNC, 1, 0},
+    {1, 0, 475000, DECODER_SYNC, 1, 0},
+    {1, 0, 500000, DECODER_SYNC, 1, 0},
+    {1, 0, 525000, DECODER_SYNC, 1, 0},
+    {1, 0, 550000, DECODER_SYNC, 1, 0},
+    {1, 0, 575000, DECODER_SYNC, 1, 0},
+    {1, 0, 600000, DECODER_SYNC, 1, 0},
+    {1, 0, 625000, DECODER_SYNC, 1, 0},
+    {1, 0, 650000, DECODER_SYNC, 1, 0},
+    {1, 0, 675000, DECODER_SYNC, 1, 0},
+    {1, 0, 700000, DECODER_SYNC, 1, 0},
+    {0, 1, 700500, DECODER_SYNC, 1, 0}, /* sync */
+    {1, 0, 725000, DECODER_SYNC, 1, 0},
+    {1, 0, 750000, DECODER_SYNC, 1, 0},
+  };
+
+  prepare_decoder(TOYOTA_24_1_CAS);
+  validate_decoder_sequence(cam_nplusone_startup_events, 33);
+  ck_assert_int_eq(config.decoder.last_trigger_angle, 60);
+
+} END_TEST
+
+START_TEST(check_cam_nplusone_startup_normal_no_second_trigger) {
+  struct decoder_event cam_nplusone_startup_events[] = {
+    {1, 0, 18000, DECODER_NOSYNC, 0, 0},
+    {1, 0, 25000, DECODER_NOSYNC, 0, 0},
+    {1, 0, 50000, DECODER_NOSYNC, 0, 0},
+    {1, 0, 75000, DECODER_NOSYNC, 0, 0},
+    {1, 0, 100000, DECODER_RPM, 0, 0},
+    {0, 1, 100500, DECODER_SYNC, 1, 0}, /* sync */
+    {1, 0, 125000, DECODER_SYNC, 1, 0},
+    {1, 0, 150000, DECODER_SYNC, 1, 0},
+    {1, 0, 175000, DECODER_SYNC, 1, 0},
+    {1, 0, 200000, DECODER_SYNC, 1, 0},
+    {1, 0, 225000, DECODER_SYNC, 1, 0},
+    {1, 0, 250000, DECODER_SYNC, 1, 0},
+    {1, 0, 275000, DECODER_SYNC, 1, 0},
+    {1, 0, 300000, DECODER_SYNC, 1, 0},
+    {1, 0, 325000, DECODER_SYNC, 1, 0},
+    {1, 0, 350000, DECODER_SYNC, 1, 0},
+    {1, 0, 375000, DECODER_SYNC, 1, 0},
+    {1, 0, 400000, DECODER_SYNC, 1, 0},
+    {1, 0, 425000, DECODER_SYNC, 1, 0},
+    {1, 0, 450000, DECODER_SYNC, 1, 0},
+    {1, 0, 475000, DECODER_SYNC, 1, 0},
+    {1, 0, 500000, DECODER_SYNC, 1, 0},
+    {1, 0, 525000, DECODER_SYNC, 1, 0},
+    {1, 0, 550000, DECODER_SYNC, 1, 0},
+    {1, 0, 575000, DECODER_SYNC, 1, 0},
+    {1, 0, 600000, DECODER_SYNC, 1, 0},
+    {1, 0, 625000, DECODER_SYNC, 1, 0},
+    {1, 0, 650000, DECODER_SYNC, 1, 0},
+    {1, 0, 675000, DECODER_SYNC, 1, 0},
+    {1, 0, 700000, DECODER_SYNC, 1, 0},
+    {1, 0, 725000, DECODER_NOSYNC, 0, DECODER_TRIGGERCOUNT_HIGH},
+    {1, 0, 750000, DECODER_NOSYNC, 0, DECODER_TRIGGERCOUNT_HIGH},
+  };
+
+  prepare_decoder(TOYOTA_24_1_CAS);
+  validate_decoder_sequence(cam_nplusone_startup_events, 32);
+
+} END_TEST
+
 TCase *setup_decoder_tests() {
   TCase *decoder_tests = tcase_create("decoder");
   tcase_add_test(decoder_tests, check_tfi_decoder_startup_normal);
@@ -364,6 +448,8 @@ TCase *setup_decoder_tests() {
   tcase_add_test(decoder_tests, check_tfi_decoder_syncloss_expire);
   tcase_add_test(decoder_tests, check_cam_nplusone_startup_normal);
   tcase_add_test(decoder_tests, check_cam_nplusone_startup_normal_then_die);
+  tcase_add_test(decoder_tests, check_cam_nplusone_startup_normal_sustained);
+  tcase_add_test(decoder_tests, check_cam_nplusone_startup_normal_no_second_trigger);
   return decoder_tests;
 }
 #endif

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -441,6 +441,23 @@ START_TEST(check_cam_nplusone_startup_normal_no_second_trigger) {
 
 } END_TEST
 
+START_TEST(check_nplusone_decoder_syncloss_expire) {
+  struct decoder_event cam_nplusone_startup_events[] = {
+    {1, 0, 18000, DECODER_NOSYNC, 0, 0},
+    {1, 0, 25000, DECODER_NOSYNC, 0, 0},
+    {1, 0, 50000, DECODER_NOSYNC, 0, 0},
+    {1, 0, 75000, DECODER_NOSYNC, 0, 0},
+    {1, 0, 100000, DECODER_RPM, 0, 0},
+    {0, 1, 100500, DECODER_SYNC, 1, 0},
+    {1, 0, 125000, DECODER_SYNC, 1, 0},
+  };
+  prepare_decoder(TOYOTA_24_1_CAS);
+  validate_decoder_sequence(cam_nplusone_startup_events, 7);
+
+  ck_assert_int_eq(config.decoder.expiration, 162500);
+
+} END_TEST
+
 TCase *setup_decoder_tests() {
   TCase *decoder_tests = tcase_create("decoder");
   tcase_add_test(decoder_tests, check_tfi_decoder_startup_normal);
@@ -450,6 +467,7 @@ TCase *setup_decoder_tests() {
   tcase_add_test(decoder_tests, check_cam_nplusone_startup_normal_then_die);
   tcase_add_test(decoder_tests, check_cam_nplusone_startup_normal_sustained);
   tcase_add_test(decoder_tests, check_cam_nplusone_startup_normal_no_second_trigger);
+  tcase_add_test(decoder_tests, check_nplusone_decoder_syncloss_expire);
   return decoder_tests;
 }
 #endif


### PR DESCRIPTION
- Fix setup for decoder tests
- Allow faster startup for nplusone (don't require two successive sync pulses if totally out of sync)
- Basic testing of cam N+1 decoder