### PR TITLE
Decoder interface now allows list of events

### DIFF
--- a/TODO
+++ b/TODO
@@ -2,8 +2,6 @@
 - New frequency sensors that use DMA (TBD)
 
 + Trigger input DMA to circular buffer
-+ Refactor decoder trigger interface now that it is synchronous (also to move
-  handling of similtaneous triggers somewhere not platform-specific)
 + Refactor sensor interface now that it is synchronous
 + Dwell time vs BRV
 + Basic tasks

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -339,7 +339,7 @@ static void validate_decoder_sequence(struct decoder_event *ev) {
     }
 
     set_current_time(ev->time);
-    config.decoder.decode(&config.decoder);
+    decoder_update_scheduling(ev, 1);
     ck_assert_msg(config.decoder.state == ev->state, 
         "expected event at %d: (state=%d, valid=%d). Got (state=%d, valid=%d)",
         ev->time, ev->state, ev->valid, 

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -71,8 +71,20 @@ struct decoder {
   timeval_t times[MAX_TRIGGERS];
 };
 
+struct decoder_event {
+  unsigned int t0 : 1;
+  unsigned int t1 : 1;
+  timeval_t time;
+#ifdef UNITTEST
+  decoder_state state;
+  int valid;
+  decoder_loss_reason reason;
+  struct decoder_event *next;
+#endif
+}; 
+
 void decoder_init(struct decoder *);
-void decoder_update_scheduling(int trigger, timeval_t time);
+void decoder_update_scheduling(struct decoder_event *, unsigned int count);
 void enable_test_trigger(trigger_type t, unsigned int rpm);
 
 #ifdef UNITTEST

--- a/src/platforms/hosted.c
+++ b/src/platforms/hosted.c
@@ -221,13 +221,15 @@ static void hosted_platform_timer() {
     static uint32_t trigger_count = 0;
     if (curtime >= test_trigger_last + time_between) {
       test_trigger_last = curtime;
-      decoder_update_scheduling(0, curtime);
+      struct decoder_event ev = {.t0 = 1, .time = curtime};
+      decoder_update_scheduling(&ev, 1);
       trigger_count++;
 
       if ((config.decoder.type == TOYOTA_24_1_CAS) &&
           (trigger_count >= config.decoder.num_triggers)) {
         trigger_count = 0;
-        decoder_update_scheduling(1, curtime);
+        struct decoder_event ev = {.t1 = 1, .time = curtime};
+        decoder_update_scheduling(&ev, 1);
       }
     }
   }


### PR DESCRIPTION
Goal is to allow more than one trigger per interrupt, allowing
arbitrarily large decoder wheels with DMA