### PR TITLE
Add a clang-format config and reformat the code

### DIFF
--- a/src/.clang-format
+++ b/src/.clang-format
@@ -68,7 +68,7 @@ IncludeCategories:
   - Regex:           '.*'
     Priority:        1
 IncludeIsMainRegex: '(Test)?$'
-IndentCaseLabels: true
+IndentCaseLabels: false
 IndentPPDirectives: None
 IndentWidth:     2
 IndentWrappedFunctionNames: false

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -91,7 +91,7 @@ PenaltyBreakString: 1000
 PenaltyBreakTemplateDeclaration: 10
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
-PointerAlignment: Left
+PointerAlignment: Right
 ReflowComments:  true
 SortIncludes:    true
 SortUsingDeclarations: true

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -14,8 +14,7 @@ AllowShortCaseLabelsOnASingleLine: false
 AllowShortFunctionsOnASingleLine: Inline
 AllowShortIfStatementsOnASingleLine: false
 AllowShortLoopsOnASingleLine: false
-AlwaysBreakAfterDefinitionReturnType: TopLevel
-AlwaysBreakAfterReturnType: TopLevel
+AlwaysBreakAfterReturnType: None
 AlwaysBreakBeforeMultilineStrings: false
 AlwaysBreakTemplateDeclarations: Yes
 BinPackArguments: false

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -1,0 +1,118 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Mozilla
+AccessModifierOffset: -2
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlines: Right
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: false
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: TopLevel
+AlwaysBreakAfterReturnType: TopLevel
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: Yes
+BinPackArguments: false
+BinPackParameters: false
+BraceWrapping:   
+  AfterClass:      true
+  AfterControlStatement: false
+  AfterEnum:       true
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  AfterExternBlock: true
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+  SplitEmptyFunction: true
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: true
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Custom
+BreakBeforeInheritanceComma: false
+BreakInheritanceList: BeforeComma
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakConstructorInitializers: BeforeComma
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: false
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 2
+ContinuationIndentWidth: 2
+Cpp11BracedListStyle: false
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+FixNamespaceComments: false
+ForEachMacros:   
+  - foreach
+  - Q_FOREACH
+  - BOOST_FOREACH
+IncludeBlocks:   Preserve
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|gmock|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IncludeIsMainRegex: '(Test)?$'
+IndentCaseLabels: true
+IndentPPDirectives: None
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: true
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBinPackProtocolList: Auto
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: true
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakAssignment: 2
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyBreakTemplateDeclaration: 10
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SortUsingDeclarations: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeCpp11BracedList: false
+SpaceBeforeCtorInitializerColon: true
+SpaceBeforeInheritanceColon: true
+SpaceBeforeParens: ControlStatements
+SpaceBeforeRangeBasedForLoopColon: true
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 1
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
+...
+

--- a/src/.clang-format
+++ b/src/.clang-format
@@ -23,12 +23,12 @@ BinPackParameters: false
 BraceWrapping:   
   AfterClass:      true
   AfterControlStatement: false
-  AfterEnum:       true
+  AfterEnum:       false
   AfterFunction:   false
   AfterNamespace:  false
   AfterObjCDeclaration: false
-  AfterStruct:     true
-  AfterUnion:      true
+  AfterStruct:     false
+  AfterUnion:      false
   AfterExternBlock: true
   BeforeCatch:     false
   BeforeElse:      false

--- a/src/Makefile
+++ b/src/Makefile
@@ -61,6 +61,9 @@ coverage: check
 	./viaems
 	gcovr -r .
 
+format:
+	clang-format -i *.c platforms/*.c
+
 
 clean:
 	-rm *.o *.a

--- a/src/Makefile
+++ b/src/Makefile
@@ -62,7 +62,7 @@ coverage: check
 	gcovr -r .
 
 format:
-	clang-format -i *.c platforms/*.c
+	clang-format -i *.c *.h platforms/*.c
 
 
 clean:

--- a/src/calculations.c
+++ b/src/calculations.c
@@ -98,8 +98,7 @@ calculate_fuel_volume(float airmass, float frt) {
 /* Returns mm^3 of fuel per cycle to add */
 static float
 calculate_tipin_enrichment(float tps, float tpsrate, int rpm) {
-  static struct
-  {
+  static struct {
     timeval_t time;
     timeval_t length;
     float amount;

--- a/src/calculations.c
+++ b/src/calculations.c
@@ -1,18 +1,21 @@
 #include <math.h>
 
-#include "config.h"
 #include "calculations.h"
+#include "config.h"
 #include "stats.h"
 struct calculated_values calculated_values;
 
-static int fuel_overduty() {
+static int
+fuel_overduty() {
   /* Maximum pulse width */
-  timeval_t max_pw = time_from_rpm_diff(config.decoder.rpm, 720) / config.fueling.injections_per_cycle;
+  timeval_t max_pw = time_from_rpm_diff(config.decoder.rpm, 720) /
+                     config.fueling.injections_per_cycle;
 
   return time_from_us(calculated_values.fueling_us) >= max_pw;
 }
 
-static int rpm_limit() {
+static int
+rpm_limit() {
   if (config.decoder.rpm >= config.rpm_stop) {
     calculated_values.rpm_limit_cut = 1;
   }
@@ -22,25 +25,31 @@ static int rpm_limit() {
   return calculated_values.rpm_limit_cut;
 }
 
-int boost_cut() {
-  return (config.sensors[SENSOR_MAP].processed_value > config.boost_control.overboost);
+int
+boost_cut() {
+  return (config.sensors[SENSOR_MAP].processed_value >
+          config.boost_control.overboost);
 }
 
-int ignition_cut() {
+int
+ignition_cut() {
   return rpm_limit() || fuel_overduty() || boost_cut();
 }
 
-int fuel_cut() {
+int
+fuel_cut() {
   return ignition_cut();
 }
 
-void calculate_ignition() {
-  calculated_values.timing_advance = 
-    interpolate_table_twoaxis(config.timing, config.decoder.rpm, 
-        config.sensors[SENSOR_MAP].processed_value);
+void
+calculate_ignition() {
+  calculated_values.timing_advance =
+    interpolate_table_twoaxis(config.timing,
+                              config.decoder.rpm,
+                              config.sensors[SENSOR_MAP].processed_value);
   switch (config.ignition.dwell) {
     case DWELL_FIXED_DUTY:
-      calculated_values.dwell_us = 
+      calculated_values.dwell_us =
         time_from_rpm_diff(config.decoder.rpm, 45) / (TICKRATE / 1000000);
       break;
     case DWELL_FIXED_TIME:
@@ -49,33 +58,37 @@ void calculate_ignition() {
   }
 }
 
-static float air_density(float iat_celsius, float atmos_kpa) {
+static float
+air_density(float iat_celsius, float atmos_kpa) {
   const float kelvin_offset = 273.15;
-  float temp_factor =  kelvin_offset / (iat_celsius + kelvin_offset);
+  float temp_factor = kelvin_offset / (iat_celsius + kelvin_offset);
   return (atmos_kpa / 100) * config.fueling.density_of_air_stp * temp_factor;
 }
 
-static float fuel_density(float fuel_celsius) {
+static float
+fuel_density(float fuel_celsius) {
   const float beta = 950.0; /* Gasoline 10^-6/K */
   float delta_temp = fuel_celsius - 15.0;
   return config.fueling.density_of_fuel - (delta_temp * beta / 1000000.0);
 }
 
 /* Returns mass of air injested into a cylinder */
-static float calculate_airmass(float ve, float map, float aap, float iat) {
+static float
+calculate_airmass(float ve, float map, float aap, float iat) {
 
-  float injested_air_volume_per_cycle = (ve / 100.0) * 
-    (map / aap) * 
-    config.fueling.cylinder_cc;
+  float injested_air_volume_per_cycle =
+    (ve / 100.0) * (map / aap) * config.fueling.cylinder_cc;
 
-  float injested_air_mass_per_cycle = injested_air_volume_per_cycle *
-    air_density(iat, aap);
+  float injested_air_mass_per_cycle =
+    injested_air_volume_per_cycle * air_density(iat, aap);
 
   return injested_air_mass_per_cycle;
 }
 
-/* Given an airmass and a fuel temperature, returns stoich amount of fuel volume */
-static float calculate_fuel_volume(float airmass, float frt) {
+/* Given an airmass and a fuel temperature, returns stoich amount of fuel volume
+ */
+static float
+calculate_fuel_volume(float airmass, float frt) {
   float fuel_mass = airmass / config.fueling.fuel_stoich_ratio;
   float fuel_volume = fuel_mass / fuel_density(frt);
 
@@ -83,34 +96,35 @@ static float calculate_fuel_volume(float airmass, float frt) {
 }
 
 /* Returns mm^3 of fuel per cycle to add */
-static float calculate_tipin_enrichment(float tps, float tpsrate, int rpm) {
-  static struct {
+static float
+calculate_tipin_enrichment(float tps, float tpsrate, int rpm) {
+  static struct
+  {
     timeval_t time;
     timeval_t length;
     float amount;
     int active;
-  } current = {0};
+  } current = { 0 };
 
   if (!config.tipin_enrich_amount || !config.tipin_enrich_duration) {
     return 0.0;
   }
 
-  float new_tipin_amount = interpolate_table_twoaxis(config.tipin_enrich_amount, 
-      tpsrate, tps);
+  float new_tipin_amount =
+    interpolate_table_twoaxis(config.tipin_enrich_amount, tpsrate, tps);
 
   /* Update status flag */
-  if (current.active &&
-      !time_in_range(current_time(), current.time, current.time +
-        current.length)) {
+  if (current.active && !time_in_range(current_time(),
+                                       current.time,
+                                       current.time + current.length)) {
     current.active = 0;
   }
 
-  if ((new_tipin_amount > current.amount) ||
-       !current.active) {
-      /* Overwrite our event */
+  if ((new_tipin_amount > current.amount) || !current.active) {
+    /* Overwrite our event */
     current.time = current_time();
     current.length = time_from_us(
-        interpolate_table_oneaxis(config.tipin_enrich_duration, rpm) * 1000);
+      interpolate_table_oneaxis(config.tipin_enrich_duration, rpm) * 1000);
     current.amount = new_tipin_amount;
     current.active = 1;
   }
@@ -118,7 +132,8 @@ static float calculate_tipin_enrichment(float tps, float tpsrate, int rpm) {
   return current.amount;
 }
 
-void calculate_fueling() {
+void
+calculate_fueling() {
   stats_start_timing(STATS_FUELCALC_TIME);
 
   float ve;
@@ -144,8 +159,8 @@ void calculate_fueling() {
   }
 
   if (config.commanded_lambda) {
-    lambda = interpolate_table_twoaxis(config.commanded_lambda, 
-      config.decoder.rpm, map);
+    lambda = interpolate_table_twoaxis(
+      config.commanded_lambda, config.decoder.rpm, map);
   } else {
     lambda = 1.0;
   }
@@ -162,20 +177,21 @@ void calculate_fueling() {
     ete = 1.0;
   }
 
-  calculated_values.tipin = calculate_tipin_enrichment(tps, tpsrate, 
-      config.decoder.rpm);
+  calculated_values.tipin =
+    calculate_tipin_enrichment(tps, tpsrate, config.decoder.rpm);
 
   calculated_values.airmass_per_cycle = calculate_airmass(ve, map, aap, iat);
 
-  float fuel_vol_at_stoich = calculate_fuel_volume(
-      calculated_values.airmass_per_cycle,
-      frt);
+  float fuel_vol_at_stoich =
+    calculate_fuel_volume(calculated_values.airmass_per_cycle, frt);
 
   calculated_values.fuelvol_per_cycle = fuel_vol_at_stoich / lambda;
 
-  float raw_pw_us = (calculated_values.fuelvol_per_cycle + 
-      (calculated_values.tipin / 1000)) / /* Tipin unit is mm^3 */
-    config.fueling.injector_cc_per_minute * 60000000 / /* uS per minute */
+  float raw_pw_us =
+    (calculated_values.fuelvol_per_cycle +
+     (calculated_values.tipin / 1000)) / /* Tipin unit is mm^3 */
+    config.fueling.injector_cc_per_minute *
+    60000000 /                           /* uS per minute */
     config.fueling.injections_per_cycle; /* This many pulses */
 
   calculated_values.ete = ete;
@@ -197,13 +213,14 @@ START_TEST(check_air_density) {
   ck_assert_float_eq_tol(air_density(0.0, 100), 1.2754e-3, 0.000001);
 
   ck_assert_float_eq_tol(air_density(20, 101.325), 1.2041e-3, 0.000001);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_fuel_density) {
   ck_assert_float_eq_tol(fuel_density(15), 0.755, 0.001);
   ck_assert_float_eq_tol(fuel_density(50), 0.721, 0.001);
-} END_TEST
-
+}
+END_TEST
 
 START_TEST(check_calculate_airmass) {
 
@@ -211,17 +228,18 @@ START_TEST(check_calculate_airmass) {
   float airmass = calculate_airmass(100, 100, 100, 0);
 
   /* 70 MAP should be 70% of previous airmass */
-  ck_assert_float_eq_tol(calculate_airmass(100, 70, 100, 0), 
-      0.7 * airmass, 0.001);
+  ck_assert_float_eq_tol(
+    calculate_airmass(100, 70, 100, 0), 0.7 * airmass, 0.001);
 
   /* 80 VE should be 80% of first airmass */
-  ck_assert_float_eq_tol(calculate_airmass(80, 100, 100, 0), 
-      0.8 * airmass, 0.001);
+  ck_assert_float_eq_tol(
+    calculate_airmass(80, 100, 100, 0), 0.8 * airmass, 0.001);
 
   /* 70 MAP when aap is 70 as well should be the same as 70 %*/
-  ck_assert_float_eq_tol(calculate_airmass(100, 70, 70, 0), 
-      0.7 * airmass, 0.001);
-} END_TEST
+  ck_assert_float_eq_tol(
+    calculate_airmass(100, 70, 70, 0), 0.7 * airmass, 0.001);
+}
+END_TEST
 
 START_TEST(check_fuel_overduty) {
 
@@ -234,7 +252,6 @@ START_TEST(check_fuel_overduty) {
   calculated_values.fueling_us = 21000;
   ck_assert(fuel_overduty());
 
-
   /* Test batch injection */
   config.fueling.injections_per_cycle = 2;
   calculated_values.fueling_us = 11000;
@@ -242,8 +259,8 @@ START_TEST(check_fuel_overduty) {
 
   calculated_values.fueling_us = 8000;
   ck_assert(!fuel_overduty());
-
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_calculate_ignition_cut) {
   config.rpm_stop = 5000;
@@ -268,38 +285,41 @@ START_TEST(check_calculate_ignition_cut) {
   config.decoder.rpm = 5500;
   ck_assert_int_eq(ignition_cut(), 1);
   ck_assert_int_eq(calculated_values.rpm_limit_cut, 1);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_calculate_ignition_fixedduty) {
-  struct table t = { 
+  struct table t = {
     .num_axis = 2,
-    .axis = { { .num = 2, .values = {5, 10} }, { .num = 2, .values = {5, 10}} },
-    .data = { .two = { {10, 10}, {10, 10} } },
+    .axis = { { .num = 2, .values = { 5, 10 } },
+              { .num = 2, .values = { 5, 10 } } },
+    .data = { .two = { { 10, 10 }, { 10, 10 } } },
   };
   config.timing = &t;
   config.ignition.dwell = DWELL_FIXED_DUTY;
   config.decoder.rpm = 6000;
 
   calculate_ignition();
-  
+
   ck_assert(calculated_values.timing_advance == 10);
   /* 10 ms per rev, dwell should be 1/8 of rotation,
    * fuzzy estimate because math */
   ck_assert(abs(calculated_values.dwell_us - (10000 / 8)) < 5);
-} END_TEST
+}
+END_TEST
 
 static struct table tipin_amount = {
-    .num_axis = 2,
-    .axis = { { .num = 2, .values = {0, 100} }, { .num = 2, .values = {0, 100}} },
-    .data = { .two = { {0, 0}, {0, 2000} } },
+  .num_axis = 2,
+  .axis = { { .num = 2, .values = { 0, 100 } },
+            { .num = 2, .values = { 0, 100 } } },
+  .data = { .two = { { 0, 0 }, { 0, 2000 } } },
 };
 
 static struct table tipin_duration = {
-    .num_axis = 1,
-    .axis = { { .num = 2, .values = {100, 6000}}},
-    .data = { .one = {1.0, 5.0}},
+  .num_axis = 1,
+  .axis = { { .num = 2, .values = { 100, 6000 } } },
+  .data = { .one = { 1.0, 5.0 } },
 };
-
 
 START_TEST(check_calculate_tipin_newevent) {
 
@@ -309,15 +329,16 @@ START_TEST(check_calculate_tipin_newevent) {
   set_current_time(0);
 
   ck_assert_float_eq_tol(calculate_tipin_enrichment(0, 0, 100), 0, 0.001);
-  ck_assert_float_eq_tol(calculate_tipin_enrichment(100, 100, 100), 2000.0, 0.001);
+  ck_assert_float_eq_tol(
+    calculate_tipin_enrichment(100, 100, 100), 2000.0, 0.001);
   /* At 100 rpm, should last 1 ms */
 
   set_current_time(time_from_us(900));
   ck_assert_float_eq_tol(calculate_tipin_enrichment(0, 0, 100), 2000.0, 0.001);
   set_current_time(time_from_us(1005));
   ck_assert_float_eq_tol(calculate_tipin_enrichment(0, 0, 100), 0.0, 0.001);
-
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_calculate_tipin_overriding_event) {
 
@@ -343,7 +364,7 @@ START_TEST(check_calculate_tipin_overriding_event) {
   set_current_time(time_from_us(1500));
   /* New tipin should override, since its higher */
   ck_assert_float_eq_tol(calculate_tipin_enrichment(100, 50, 100), 1000, 0.001);
-  
+
   /* and should still be ongoing for the full time */
   set_current_time(time_from_us(2400));
   ck_assert_float_eq_tol(calculate_tipin_enrichment(0, 0, 100), 1000, 0.001);
@@ -351,11 +372,12 @@ START_TEST(check_calculate_tipin_overriding_event) {
   /*and now finished */
   set_current_time(time_from_us(2600));
   ck_assert_float_eq_tol(calculate_tipin_enrichment(0, 0, 100), 0.0, 0.001);
+}
+END_TEST
 
-} END_TEST
-
-TCase *setup_calculations_tests() {
-  TCase *tc = tcase_create("calculations");
+TCase*
+setup_calculations_tests() {
+  TCase* tc = tcase_create("calculations");
   tcase_add_test(tc, check_air_density);
   tcase_add_test(tc, check_fuel_density);
   tcase_add_test(tc, check_calculate_airmass);
@@ -368,4 +390,3 @@ TCase *setup_calculations_tests() {
   return tc;
 }
 #endif
-

--- a/src/calculations.c
+++ b/src/calculations.c
@@ -362,8 +362,8 @@ START_TEST(check_calculate_tipin_overriding_event) {
 }
 END_TEST
 
-TCase* setup_calculations_tests() {
-  TCase* tc = tcase_create("calculations");
+TCase *setup_calculations_tests() {
+  TCase *tc = tcase_create("calculations");
   tcase_add_test(tc, check_air_density);
   tcase_add_test(tc, check_fuel_density);
   tcase_add_test(tc, check_calculate_airmass);

--- a/src/calculations.c
+++ b/src/calculations.c
@@ -5,8 +5,7 @@
 #include "stats.h"
 struct calculated_values calculated_values;
 
-static int
-fuel_overduty() {
+static int fuel_overduty() {
   /* Maximum pulse width */
   timeval_t max_pw = time_from_rpm_diff(config.decoder.rpm, 720) /
                      config.fueling.injections_per_cycle;
@@ -14,8 +13,7 @@ fuel_overduty() {
   return time_from_us(calculated_values.fueling_us) >= max_pw;
 }
 
-static int
-rpm_limit() {
+static int rpm_limit() {
   if (config.decoder.rpm >= config.rpm_stop) {
     calculated_values.rpm_limit_cut = 1;
   }
@@ -25,24 +23,20 @@ rpm_limit() {
   return calculated_values.rpm_limit_cut;
 }
 
-int
-boost_cut() {
+int boost_cut() {
   return (config.sensors[SENSOR_MAP].processed_value >
           config.boost_control.overboost);
 }
 
-int
-ignition_cut() {
+int ignition_cut() {
   return rpm_limit() || fuel_overduty() || boost_cut();
 }
 
-int
-fuel_cut() {
+int fuel_cut() {
   return ignition_cut();
 }
 
-void
-calculate_ignition() {
+void calculate_ignition() {
   calculated_values.timing_advance =
     interpolate_table_twoaxis(config.timing,
                               config.decoder.rpm,
@@ -58,23 +52,20 @@ calculate_ignition() {
   }
 }
 
-static float
-air_density(float iat_celsius, float atmos_kpa) {
+static float air_density(float iat_celsius, float atmos_kpa) {
   const float kelvin_offset = 273.15;
   float temp_factor = kelvin_offset / (iat_celsius + kelvin_offset);
   return (atmos_kpa / 100) * config.fueling.density_of_air_stp * temp_factor;
 }
 
-static float
-fuel_density(float fuel_celsius) {
+static float fuel_density(float fuel_celsius) {
   const float beta = 950.0; /* Gasoline 10^-6/K */
   float delta_temp = fuel_celsius - 15.0;
   return config.fueling.density_of_fuel - (delta_temp * beta / 1000000.0);
 }
 
 /* Returns mass of air injested into a cylinder */
-static float
-calculate_airmass(float ve, float map, float aap, float iat) {
+static float calculate_airmass(float ve, float map, float aap, float iat) {
 
   float injested_air_volume_per_cycle =
     (ve / 100.0) * (map / aap) * config.fueling.cylinder_cc;
@@ -87,8 +78,7 @@ calculate_airmass(float ve, float map, float aap, float iat) {
 
 /* Given an airmass and a fuel temperature, returns stoich amount of fuel volume
  */
-static float
-calculate_fuel_volume(float airmass, float frt) {
+static float calculate_fuel_volume(float airmass, float frt) {
   float fuel_mass = airmass / config.fueling.fuel_stoich_ratio;
   float fuel_volume = fuel_mass / fuel_density(frt);
 
@@ -96,8 +86,7 @@ calculate_fuel_volume(float airmass, float frt) {
 }
 
 /* Returns mm^3 of fuel per cycle to add */
-static float
-calculate_tipin_enrichment(float tps, float tpsrate, int rpm) {
+static float calculate_tipin_enrichment(float tps, float tpsrate, int rpm) {
   static struct {
     timeval_t time;
     timeval_t length;
@@ -131,8 +120,7 @@ calculate_tipin_enrichment(float tps, float tpsrate, int rpm) {
   return current.amount;
 }
 
-void
-calculate_fueling() {
+void calculate_fueling() {
   stats_start_timing(STATS_FUELCALC_TIME);
 
   float ve;
@@ -374,8 +362,7 @@ START_TEST(check_calculate_tipin_overriding_event) {
 }
 END_TEST
 
-TCase*
-setup_calculations_tests() {
+TCase* setup_calculations_tests() {
   TCase* tc = tcase_create("calculations");
   tcase_add_test(tc, check_air_density);
   tcase_add_test(tc, check_fuel_density);

--- a/src/calculations.c
+++ b/src/calculations.c
@@ -42,13 +42,13 @@ void calculate_ignition() {
                               config.decoder.rpm,
                               config.sensors[SENSOR_MAP].processed_value);
   switch (config.ignition.dwell) {
-    case DWELL_FIXED_DUTY:
-      calculated_values.dwell_us =
-        time_from_rpm_diff(config.decoder.rpm, 45) / (TICKRATE / 1000000);
-      break;
-    case DWELL_FIXED_TIME:
-      calculated_values.dwell_us = config.ignition.dwell_us;
-      break;
+  case DWELL_FIXED_DUTY:
+    calculated_values.dwell_us =
+      time_from_rpm_diff(config.decoder.rpm, 45) / (TICKRATE / 1000000);
+    break;
+  case DWELL_FIXED_TIME:
+    calculated_values.dwell_us = config.ignition.dwell_us;
+    break;
   }
 }
 

--- a/src/calculations.h
+++ b/src/calculations.h
@@ -53,7 +53,7 @@ int fuel_cut();
 
 #ifdef UNITTEST
 #include <check.h>
-TCase* setup_calculations_tests();
+TCase *setup_calculations_tests();
 #endif
 
 #endif

--- a/src/calculations.h
+++ b/src/calculations.h
@@ -4,13 +4,13 @@
 struct fueling_config {
   float injector_cc_per_minute;
   float cylinder_cc;
-  float fuel_stoich_ratio; 
+  float fuel_stoich_ratio;
   unsigned int injections_per_cycle; /* fuel quantity per shot divisor */
   unsigned int fuel_pump_pin;
 
   /* Constants */
   float density_of_air_stp; /* g/cc at 0C 100 kpa */
-  float density_of_fuel; /* At 15 C */
+  float density_of_fuel;    /* At 15 C */
 
   /* Intermediate values for debugging below */
 };
@@ -46,14 +46,19 @@ struct calculated_values {
 
 extern struct calculated_values calculated_values;
 
-void calculate_ignition();
-void calculate_fueling();
-int ignition_cut();
-int fuel_cut();
+void
+calculate_ignition();
+void
+calculate_fueling();
+int
+ignition_cut();
+int
+fuel_cut();
 
 #ifdef UNITTEST
 #include <check.h>
-TCase *setup_calculations_tests();
+TCase*
+setup_calculations_tests();
 #endif
 
 #endif

--- a/src/calculations.h
+++ b/src/calculations.h
@@ -46,19 +46,14 @@ struct calculated_values {
 
 extern struct calculated_values calculated_values;
 
-void
-calculate_ignition();
-void
-calculate_fueling();
-int
-ignition_cut();
-int
-fuel_cut();
+void calculate_ignition();
+void calculate_fueling();
+int ignition_cut();
+int fuel_cut();
 
 #ifdef UNITTEST
 #include <check.h>
-TCase*
-setup_calculations_tests();
+TCase* setup_calculations_tests();
 #endif
 
 #endif

--- a/src/config.c
+++ b/src/config.c
@@ -265,8 +265,7 @@ struct config config __attribute__((section(".configdata"))) = {
   },
 };
 
-int
-config_valid() {
+int config_valid() {
   if (config.ve && !table_valid(config.ve)) {
     return 0;
   }

--- a/src/config.c
+++ b/src/config.c
@@ -88,7 +88,6 @@ struct table ve_vs_rpm_and_map __attribute__((section(".configdata"))) = {
   },
 };
 
-
 struct table lambda_vs_rpm_and_map __attribute__((section(".configdata"))) = {
   .title = "lambda", .num_axis = 2,
   .axis = { { 
@@ -155,7 +154,6 @@ struct table timing_vs_rpm_and_map __attribute__((section(".configdata"))) = {
     },
   },
 };
-
 
 struct table injector_dead_time __attribute__((section(".configdata"))) = {
   .title = "dead_time", .num_axis = 1,
@@ -267,7 +265,8 @@ struct config config __attribute__((section(".configdata"))) = {
   },
 };
 
-int config_valid() {
+int
+config_valid() {
   if (config.ve && !table_valid(config.ve)) {
     return 0;
   }
@@ -276,7 +275,8 @@ int config_valid() {
     return 0;
   }
 
-  if (config.injector_pw_compensation && !table_valid(config.injector_pw_compensation)) {
+  if (config.injector_pw_compensation &&
+      !table_valid(config.injector_pw_compensation)) {
     return 0;
   }
 
@@ -288,7 +288,8 @@ int config_valid() {
     return 0;
   }
 
-  if (config.tipin_enrich_duration && !table_valid(config.tipin_enrich_duration)) {
+  if (config.tipin_enrich_duration &&
+      !table_valid(config.tipin_enrich_duration)) {
     return 0;
   }
 

--- a/src/config.h
+++ b/src/config.h
@@ -1,15 +1,15 @@
 #ifndef _CONFIG_H
 #define _CONFIG_H
 
-#include "platform.h"
-#include "decoder.h"
-#include "util.h"
-#include "scheduler.h"
-#include "table.h"
-#include "console.h"
-#include "sensors.h"
 #include "calculations.h"
+#include "console.h"
+#include "decoder.h"
+#include "platform.h"
+#include "scheduler.h"
+#include "sensors.h"
+#include "table.h"
 #include "tasks.h"
+#include "util.h"
 
 #define MAX_EVENTS 24
 
@@ -25,15 +25,15 @@ struct config {
   struct sensor_input sensors[NUM_SENSORS];
 
   /* Tables */
-  struct table *timing;
-  struct table *iat_timing_adjust;
-  struct table *clt_timing_adjust;
-  struct table *ve;
-  struct table *commanded_lambda;
-  struct table *injector_pw_compensation;
-  struct table *engine_temp_enrich;
-  struct table *tipin_enrich_amount;
-  struct table *tipin_enrich_duration;
+  struct table* timing;
+  struct table* iat_timing_adjust;
+  struct table* clt_timing_adjust;
+  struct table* ve;
+  struct table* commanded_lambda;
+  struct table* injector_pw_compensation;
+  struct table* engine_temp_enrich;
+  struct table* tipin_enrich_amount;
+  struct table* tipin_enrich_duration;
 
   /* Fuel information */
   struct fueling_config fueling;
@@ -60,6 +60,7 @@ extern struct table tipin_vs_tpsrate_and_tps;
 extern struct table tipin_duration_vs_rpm;
 extern struct table boost_control_pwm;
 
-int config_valid();
+int
+config_valid();
 
 #endif

--- a/src/config.h
+++ b/src/config.h
@@ -25,15 +25,15 @@ struct config {
   struct sensor_input sensors[NUM_SENSORS];
 
   /* Tables */
-  struct table* timing;
-  struct table* iat_timing_adjust;
-  struct table* clt_timing_adjust;
-  struct table* ve;
-  struct table* commanded_lambda;
-  struct table* injector_pw_compensation;
-  struct table* engine_temp_enrich;
-  struct table* tipin_enrich_amount;
-  struct table* tipin_enrich_duration;
+  struct table *timing;
+  struct table *iat_timing_adjust;
+  struct table *clt_timing_adjust;
+  struct table *ve;
+  struct table *commanded_lambda;
+  struct table *injector_pw_compensation;
+  struct table *engine_temp_enrich;
+  struct table *tipin_enrich_amount;
+  struct table *tipin_enrich_duration;
 
   /* Fuel information */
   struct fueling_config fueling;

--- a/src/config.h
+++ b/src/config.h
@@ -60,7 +60,6 @@ extern struct table tipin_vs_tpsrate_and_tps;
 extern struct table tipin_duration_vs_rpm;
 extern struct table boost_control_pwm;
 
-int
-config_valid();
+int config_valid();
 
 #endif

--- a/src/console.c
+++ b/src/console.c
@@ -18,22 +18,22 @@
 #include <strings.h>
 
 struct console_config_node {
-  const char* name;
-  void (*get)(const struct console_config_node* self,
-              char* dest,
-              char* remaining);
-  void (*set)(const struct console_config_node* self, char* remaining);
-  void* val;
+  const char *name;
+  void (*get)(const struct console_config_node *self,
+              char *dest,
+              char *remaining);
+  void (*set)(const struct console_config_node *self, char *remaining);
+  void *val;
 };
 
-static const struct console_config_node* console_search_node(
-  const struct console_config_node* nodes,
-  const char* var) {
+static const struct console_config_node *console_search_node(
+  const struct console_config_node *nodes,
+  const char *var) {
 
   if (!var) {
     return NULL;
   }
-  const struct console_config_node* n;
+  const struct console_config_node *n;
   for (n = nodes; n->name; n++) {
     if (!strcmp(n->name, var)) {
       return n;
@@ -44,23 +44,23 @@ static const struct console_config_node* console_search_node(
 
 static struct console_feed_config {
   size_t n_nodes;
-  const struct console_config_node* nodes[64];
+  const struct console_config_node *nodes[64];
 } console_feed_config = {
   .n_nodes = 0,
   .nodes = { 0 },
 };
 
 static struct console_config_node console_config_nodes[];
-static void console_set_feed(const struct console_config_node* self,
-                             char* remaining) {
+static void console_set_feed(const struct console_config_node *self,
+                             char *remaining) {
   assert(self);
   assert(self->val);
 
   unsigned int cur_entry = 0;
-  struct console_feed_config* c = self->val;
-  const char* cur_var = strtok(remaining, ",");
+  struct console_feed_config *c = self->val;
+  const char *cur_var = strtok(remaining, ",");
   while (cur_var) {
-    const struct console_config_node* n =
+    const struct console_config_node *n =
       console_search_node(console_config_nodes, cur_var);
     if (n) {
       c->nodes[cur_entry] = n;
@@ -71,13 +71,13 @@ static void console_set_feed(const struct console_config_node* self,
   c->n_nodes = cur_entry;
 }
 
-static void console_get_feed(const struct console_config_node* self,
-                             char* dest,
-                             char* remaining __attribute__((unused))) {
+static void console_get_feed(const struct console_config_node *self,
+                             char *dest,
+                             char *remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  struct console_feed_config* c = self->val;
+  struct console_feed_config *c = self->val;
   unsigned int i;
   if (!c->n_nodes) {
     strcat(dest, "");
@@ -90,55 +90,55 @@ static void console_get_feed(const struct console_config_node* self,
   strcat(dest, c->nodes[i]->name);
 }
 
-static void console_get_time(const struct console_config_node* self
+static void console_get_time(const struct console_config_node *self
                              __attribute__((unused)),
-                             char* dest,
-                             char* remaining __attribute__((unused))) {
+                             char *dest,
+                             char *remaining __attribute__((unused))) {
   sprintf(dest, "%u", (unsigned int)current_time());
 }
 
-static void console_get_float(const struct console_config_node* self,
-                              char* dest,
-                              char* remaining __attribute__((unused))) {
-  float* v = self->val;
+static void console_get_float(const struct console_config_node *self,
+                              char *dest,
+                              char *remaining __attribute__((unused))) {
+  float *v = self->val;
   sprintf(dest, "%.4f", *v);
 }
 
-static void console_set_float(const struct console_config_node* self,
-                              char* remaining) {
-  float* v = self->val;
+static void console_set_float(const struct console_config_node *self,
+                              char *remaining) {
+  float *v = self->val;
   *v = atof(remaining);
 }
 
-static void console_get_uint(const struct console_config_node* self,
-                             char* dest,
-                             char* remaining __attribute__((unused))) {
-  unsigned int* v = self->val;
+static void console_get_uint(const struct console_config_node *self,
+                             char *dest,
+                             char *remaining __attribute__((unused))) {
+  unsigned int *v = self->val;
   sprintf(dest, "%u", *v);
 }
 
-static void console_set_uint(const struct console_config_node* self,
-                             char* remaining) {
-  unsigned int* v = self->val;
+static void console_set_uint(const struct console_config_node *self,
+                             char *remaining) {
+  unsigned int *v = self->val;
   *v = (unsigned int)atoi(remaining);
 }
 
-static void console_get_fuel_cut(const struct console_config_node* self
+static void console_get_fuel_cut(const struct console_config_node *self
                                  __attribute__((unused)),
-                                 char* dest,
-                                 char* remaining __attribute__((unused))) {
+                                 char *dest,
+                                 char *remaining __attribute__((unused))) {
   sprintf(dest, "%u", fuel_cut());
 }
 
-static void console_get_ignition_cut(const struct console_config_node* self
+static void console_get_ignition_cut(const struct console_config_node *self
                                      __attribute__((unused)),
-                                     char* dest,
-                                     char* remaining __attribute__((unused))) {
+                                     char *dest,
+                                     char *remaining __attribute__((unused))) {
   sprintf(dest, "%u", ignition_cut());
 }
 
-static int parse_keyval_pair(char** key, char** val, char** str) {
-  char* saveptr;
+static int parse_keyval_pair(char **key, char **val, char **str) {
+  char *saveptr;
   *key = strtok_r(*str, "=", &saveptr);
   if (!*key) {
     return 0;
@@ -151,7 +151,7 @@ static int parse_keyval_pair(char** key, char** val, char** str) {
   return 1;
 }
 
-static int console_set_table_element(struct table* t, const char* k, float v) {
+static int console_set_table_element(struct table *t, const char *k, float v) {
   unsigned int row, col;
   int n_parsed = sscanf(k, "[%d][%d]", &row, &col);
   if ((t->num_axis == 1) && (n_parsed == 1) && (row < t->axis[0].num)) {
@@ -165,9 +165,9 @@ static int console_set_table_element(struct table* t, const char* k, float v) {
   return 0;
 }
 
-static int console_get_table_element(const struct table* t,
-                                     const char* k,
-                                     float* v) {
+static int console_get_table_element(const struct table *t,
+                                     const char *k,
+                                     float *v) {
   int row, col;
   int n_parsed = sscanf(k, "[%d][%d]", &row, &col);
   if ((t->num_axis == 1) && (n_parsed == 1) && (row < t->axis[0].num)) {
@@ -181,14 +181,14 @@ static int console_get_table_element(const struct table* t,
   return 0;
 }
 
-static void console_set_table_axis_labels(struct table_axis* t, char* list) {
+static void console_set_table_axis_labels(struct table_axis *t, char *list) {
   unsigned int cur = 0;
   if ((list[0] != '[') || (list[strlen(list) - 1] != ']')) {
     return;
   }
 
-  char* saveptr;
-  char* curlabel = list;
+  char *saveptr;
+  char *curlabel = list;
   curlabel = strtok_r(list, "[,]", &saveptr);
   while (curlabel) {
     if ((cur >= t->num) || (cur >= MAX_AXIS_SIZE)) {
@@ -200,13 +200,13 @@ static void console_set_table_axis_labels(struct table_axis* t, char* list) {
   }
 }
 
-static void console_set_table(const struct console_config_node* self,
-                              char* remaining) {
+static void console_set_table(const struct console_config_node *self,
+                              char *remaining) {
   assert(self);
   assert(self->val);
   assert(remaining);
 
-  struct table* t = self->val;
+  struct table *t = self->val;
 
   char *k, *v;
   while (parse_keyval_pair(&k, &v, &remaining)) {
@@ -231,8 +231,8 @@ static void console_set_table(const struct console_config_node* self,
     }
   }
 }
-static void console_get_table_axis_labels(const struct table_axis* t,
-                                          char* dest) {
+static void console_get_table_axis_labels(const struct table_axis *t,
+                                          char *dest) {
   char buf[32];
   strcat(dest, "[");
   for (int i = 0; i < t->num; ++i) {
@@ -245,9 +245,9 @@ static void console_get_table_axis_labels(const struct table_axis* t,
   strcat(dest, "]");
 }
 
-static void console_get_table(const struct console_config_node* self,
-                              char* dest,
-                              char* remaining) {
+static void console_get_table(const struct console_config_node *self,
+                              char *dest,
+                              char *remaining) {
   assert(self);
 
   if (!self->val) {
@@ -255,11 +255,11 @@ static void console_get_table(const struct console_config_node* self,
     return;
   }
 
-  const struct table* t = self->val;
+  const struct table *t = self->val;
   if (remaining && (remaining[0] == '[')) {
     float val;
-    char* saveptr;
-    char* element = strtok_r(remaining, " ", &saveptr);
+    char *saveptr;
+    char *element = strtok_r(remaining, " ", &saveptr);
     do {
       if (console_get_table_element(t, element, &val)) {
         dest += sprintf(dest, "%s%.2f", (element == remaining) ? "" : " ", val);
@@ -286,28 +286,28 @@ static void console_get_table(const struct console_config_node* self,
   }
 }
 
-static void console_save_to_flash(const struct console_config_node* self
+static void console_save_to_flash(const struct console_config_node *self
                                   __attribute__((unused)),
-                                  char* rem __attribute__((unused))) {
+                                  char *rem __attribute__((unused))) {
   platform_save_config();
 }
 
-static void console_bootloader(const struct console_config_node* self
+static void console_bootloader(const struct console_config_node *self
                                __attribute__((unused)),
-                               char* dest __attribute__((unused)),
-                               char* rem __attribute__((unused))) {
+                               char *dest __attribute__((unused)),
+                               char *rem __attribute__((unused))) {
   platform_reset_into_bootloader();
 }
 
-static void console_get_sensor(const struct console_config_node* self,
-                               char* dest,
-                               char* remaining __attribute__((unused))) {
+static void console_get_sensor(const struct console_config_node *self,
+                               char *dest,
+                               char *remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  const struct sensor_input* s = self->val;
+  const struct sensor_input *s = self->val;
 
-  const char* source = "";
+  const char *source = "";
   switch (s->source) {
     case SENSOR_NONE:
       source = "disabled";
@@ -329,7 +329,7 @@ static void console_get_sensor(const struct console_config_node* self,
       break;
   }
 
-  const char* method = "";
+  const char *method = "";
   switch (s->method) {
     case METHOD_LINEAR:
       method = "linear";
@@ -368,7 +368,7 @@ static void console_get_sensor(const struct console_config_node* self,
           s->lag);
 }
 
-static sensor_source console_sensor_source_from_str(const char* str) {
+static sensor_source console_sensor_source_from_str(const char *str) {
   if (!strcmp("disabled", str)) {
     return SENSOR_NONE;
   } else if (!strcmp("adc", str)) {
@@ -385,7 +385,7 @@ static sensor_source console_sensor_source_from_str(const char* str) {
   return SENSOR_NONE;
 }
 
-static sensor_method console_sensor_method_from_str(const char* str) {
+static sensor_method console_sensor_method_from_str(const char *str) {
   if (!strcmp("linear", str)) {
     return METHOD_LINEAR;
   } else if (!strcmp("table", str)) {
@@ -396,13 +396,13 @@ static sensor_method console_sensor_method_from_str(const char* str) {
   return METHOD_TABLE;
 }
 
-static void console_set_sensor(const struct console_config_node* self,
-                               char* remaining) {
+static void console_set_sensor(const struct console_config_node *self,
+                               char *remaining) {
   assert(self);
   assert(self->val);
   assert(remaining);
 
-  struct sensor_input* s = self->val;
+  struct sensor_input *s = self->val;
 
   char *k, *v;
   while (parse_keyval_pair(&k, &v, &remaining)) {
@@ -438,11 +438,11 @@ static void console_set_sensor(const struct console_config_node* self,
   }
 }
 
-static void console_get_sensor_fault(const struct console_config_node* self,
-                                     char* dest,
-                                     char* remaining __attribute__((unused))) {
-  const struct sensor_input* t = self->val;
-  const char* result;
+static void console_get_sensor_fault(const struct console_config_node *self,
+                                     char *dest,
+                                     char *remaining __attribute__((unused))) {
+  const struct sensor_input *t = self->val;
+  const char *result;
 
   switch (t->fault) {
     case FAULT_RANGE:
@@ -459,14 +459,14 @@ static void console_get_sensor_fault(const struct console_config_node* self,
 }
 
 static void console_get_decoder_loss_reason(
-  const struct console_config_node* self,
-  char* dest,
-  char* remaining __attribute__((unused))) {
+  const struct console_config_node *self,
+  char *dest,
+  char *remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  const decoder_loss_reason* s = self->val;
-  const char* result = "";
+  const decoder_loss_reason *s = self->val;
+  const char *result = "";
 
   switch (*s) {
     case DECODER_NO_LOSS:
@@ -488,14 +488,14 @@ static void console_get_decoder_loss_reason(
   strcat(dest, result);
 }
 
-static void console_get_decoder_state(const struct console_config_node* self,
-                                      char* dest,
-                                      char* remaining __attribute__((unused))) {
+static void console_get_decoder_state(const struct console_config_node *self,
+                                      char *dest,
+                                      char *remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  const decoder_state* s = self->val;
-  const char* result = "";
+  const decoder_state *s = self->val;
+  const char *result = "";
 
   switch (*s) {
     case DECODER_NOSYNC:
@@ -511,14 +511,14 @@ static void console_get_decoder_state(const struct console_config_node* self,
   strcat(dest, result);
 }
 
-static void console_get_trigger(const struct console_config_node* self,
-                                char* dest,
-                                char* remaining __attribute__((unused))) {
+static void console_get_trigger(const struct console_config_node *self,
+                                char *dest,
+                                char *remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  const trigger_type* t = self->val;
-  const char* result = "";
+  const trigger_type *t = self->val;
+  const char *result = "";
 
   switch (*t) {
     case FORD_TFI:
@@ -531,12 +531,12 @@ static void console_get_trigger(const struct console_config_node* self,
   strcat(dest, result);
 }
 
-static void console_set_trigger(const struct console_config_node* self,
-                                char* remaining __attribute__((unused))) {
+static void console_set_trigger(const struct console_config_node *self,
+                                char *remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  trigger_type* t = self->val;
+  trigger_type *t = self->val;
   if (!strcmp("tfi", remaining)) {
     *t = FORD_TFI;
   } else if (!strcmp("cam24+1", remaining)) {
@@ -544,14 +544,14 @@ static void console_set_trigger(const struct console_config_node* self,
   }
 }
 
-static void console_get_dwell_type(const struct console_config_node* self,
-                                   char* dest,
-                                   char* remaining __attribute__((unused))) {
+static void console_get_dwell_type(const struct console_config_node *self,
+                                   char *dest,
+                                   char *remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  const dwell_type* t = self->val;
-  const char* result = "";
+  const dwell_type *t = self->val;
+  const char *result = "";
 
   switch (*t) {
     case DWELL_FIXED_DUTY:
@@ -564,12 +564,12 @@ static void console_get_dwell_type(const struct console_config_node* self,
   strcat(dest, result);
 }
 
-static void console_set_dwell_type(const struct console_config_node* self,
-                                   char* remaining __attribute__((unused))) {
+static void console_set_dwell_type(const struct console_config_node *self,
+                                   char *remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  dwell_type* t = self->val;
+  dwell_type *t = self->val;
   if (!strcmp("fixed-duty", remaining)) {
     *t = DWELL_FIXED_DUTY;
   } else if (!strcmp("fixed-time", remaining)) {
@@ -577,12 +577,12 @@ static void console_set_dwell_type(const struct console_config_node* self,
   }
 }
 
-static void console_get_stats(const struct console_config_node* self
+static void console_get_stats(const struct console_config_node *self
                               __attribute((unused)),
-                              char* dest,
-                              char* remaining __attribute__((unused))) {
+                              char *dest,
+                              char *remaining __attribute__((unused))) {
 
-  const struct stats_entry* e;
+  const struct stats_entry *e;
   for (e = &stats_entries[0]; e != &stats_entries[STATS_LAST]; ++e) {
     dest += sprintf(dest,
                     "  %s min/avg/max (uS) = %u/%u/%u\r\n",
@@ -593,10 +593,10 @@ static void console_get_stats(const struct console_config_node* self
   }
 }
 
-static void console_get_events(const struct console_config_node* self
+static void console_get_events(const struct console_config_node *self
                                __attribute__((unused)),
-                               char* dest,
-                               char* remaining) {
+                               char *dest,
+                               char *remaining) {
 
   if (!remaining || !strcmp("", remaining)) {
     sprintf(dest, "num_events=%d", config.num_events);
@@ -604,8 +604,8 @@ static void console_get_events(const struct console_config_node* self
   }
   unsigned int ev_n = atoi(strtok(remaining, " "));
   if (ev_n < config.num_events) {
-    const struct output_event* ev = &config.events[ev_n];
-    const char* ev_type = "";
+    const struct output_event *ev = &config.events[ev_n];
+    const char *ev_type = "";
     switch (ev->type) {
       case FUEL_EVENT:
         ev_type = "fuel";
@@ -631,12 +631,12 @@ static void console_get_events(const struct console_config_node* self
   }
 }
 
-static void console_set_events(const struct console_config_node* self
+static void console_set_events(const struct console_config_node *self
                                __attribute__((unused)),
-                               char* remaining) {
+                               char *remaining) {
 
   char *k, *v;
-  char* saveptr;
+  char *saveptr;
 
   if (!remaining) {
     return;
@@ -652,7 +652,7 @@ static void console_set_events(const struct console_config_node* self
   if (ev_n >= config.num_events) {
     return;
   }
-  struct output_event* ev = &config.events[ev_n];
+  struct output_event *ev = &config.events[ev_n];
 
   remaining = saveptr;
   while (parse_keyval_pair(&k, &v, &remaining)) {
@@ -708,22 +708,22 @@ void console_record_event(struct logged_event ev) {
 }
 
 static struct timed_callback trig_cb = { 0 };
-static void console_fire_trigger_callback(void* _a) {
+static void console_fire_trigger_callback(void *_a) {
   (void)_a;
 
   decoder_update_scheduling(0, trig_cb.time);
 }
 
-static void console_set_trigger_callback(const struct console_config_node* self,
-                                         char* remaining) {
+static void console_set_trigger_callback(const struct console_config_node *self,
+                                         char *remaining) {
   (void)self;
   timeval_t stoptime = atoi(remaining);
   trig_cb.callback = console_fire_trigger_callback;
   schedule_callback(&trig_cb, stoptime);
 }
 
-static void console_set_event_logging(const struct console_config_node* self,
-                                      char* remaining) {
+static void console_set_event_logging(const struct console_config_node *self,
+                                      char *remaining) {
   (void)self;
 
   if (!strncmp(remaining, "on", 2)) {
@@ -735,14 +735,14 @@ static void console_set_event_logging(const struct console_config_node* self,
   }
 }
 
-static void console_set_freeze(const struct console_config_node* self,
-                               char* remaining) {
+static void console_set_freeze(const struct console_config_node *self,
+                               char *remaining) {
   (void)self;
   (void)remaining;
 }
 
-static void console_set_test_trigger(const struct console_config_node* self,
-                                     char* remaining) {
+static void console_set_test_trigger(const struct console_config_node *self,
+                                     char *remaining) {
   (void)self;
 
   uint32_t rpm = atoi(remaining);
@@ -1038,11 +1038,11 @@ static struct console_config_node console_config_nodes[] = {
 };
 
 /* Lists all immediate prefixes in node list nodes */
-static void console_list_prefix(const struct console_config_node* nodes,
-                                char* dest,
-                                const char* prefix) {
+static void console_list_prefix(const struct console_config_node *nodes,
+                                char *dest,
+                                const char *prefix) {
 
-  const struct console_config_node* node;
+  const struct console_config_node *node;
   for (node = nodes; node->name; node++) {
     /* If prefix doesn't match */
     if (prefix && strlen(prefix) &&
@@ -1054,17 +1054,17 @@ static void console_list_prefix(const struct console_config_node* nodes,
   }
 }
 
-int console_parse_request(char* dest, char* line) {
-  char* action = strtok(line, " ");
-  char* var = strtok(NULL, " ");
-  char* rem = strtok(NULL, "\0");
+int console_parse_request(char *dest, char *line) {
+  char *action = strtok(line, " ");
+  char *var = strtok(NULL, " ");
+  char *rem = strtok(NULL, "\0");
 
   if (!action) {
     strcat(dest, "invalid action");
     return 0;
   }
 
-  const struct console_config_node* node =
+  const struct console_config_node *node =
     console_search_node(console_config_nodes, var);
   if (!strcmp("list", action)) {
     console_list_prefix(console_config_nodes, dest, var);
@@ -1097,7 +1097,7 @@ int console_parse_request(char* dest, char* line) {
 }
 
 void console_init() {
-  const char* console_feed_defaults[] = {
+  const char *console_feed_defaults[] = {
     "status.current_time",
     "status.decoder.state",
     "status.decoder.rpm",
@@ -1133,13 +1133,13 @@ void console_init() {
   console_feed_config.n_nodes = count;
 }
 
-static void console_feed_line(char* dest) {
+static void console_feed_line(char *dest) {
 
   unsigned int i;
   char temp[64];
   char empty[1] = "";
   for (i = 0; i < console_feed_config.n_nodes; i++) {
-    const struct console_config_node* node = console_feed_config.nodes[i];
+    const struct console_config_node *node = console_feed_config.nodes[i];
     strcpy(temp, "");
     if (!node->get) {
       continue;
@@ -1157,15 +1157,15 @@ struct {
   struct {
     int in_progress;
     size_t max;
-    const char* src;
-    char* ptr;
+    const char *src;
+    char *ptr;
   } rx, tx;
 } console_state = {
   .tx = { .src = config.console.txbuffer, .in_progress = 0 },
   .rx = { .src = config.console.rxbuffer, .in_progress = 0 },
 };
 
-int console_read_full(char* buf, size_t max) {
+int console_read_full(char *buf, size_t max) {
   if (console_state.rx.in_progress) {
     size_t r = console_state.rx.max - 1 -
                (size_t)(console_state.rx.ptr - console_state.rx.src);
@@ -1197,7 +1197,7 @@ int console_read_full(char* buf, size_t max) {
   return 0;
 }
 
-int console_write_full(char* buf, size_t max) {
+int console_write_full(char *buf, size_t max) {
   if (console_state.tx.in_progress) {
     size_t r = console_state.tx.max -
                (size_t)(console_state.tx.ptr - console_state.tx.src);
@@ -1220,9 +1220,9 @@ int console_write_full(char* buf, size_t max) {
 }
 
 static void console_process_rx() {
-  char* out = config.console.txbuffer;
-  char* in = strtok(config.console.rxbuffer, "\r\n");
-  char* response = out + 2; /* Allow for status character */
+  char *out = config.console.txbuffer;
+  char *in = strtok(config.console.rxbuffer, "\r\n");
+  char *response = out + 2; /* Allow for status character */
   strcpy(response, "");
 
   if (!in) {
@@ -1413,8 +1413,8 @@ START_TEST(check_console_set_uint) {
 END_TEST
 
 START_TEST(check_parse_keyval_pair) {
-  char* buf = malloc(64);
-  char* orig = buf;
+  char *buf = malloc(64);
+  char *orig = buf;
 
   strcpy(buf, "");
   char *k = NULL, *v = NULL;
@@ -1804,8 +1804,8 @@ START_TEST(check_console_set_events) {
 }
 END_TEST
 
-TCase* setup_console_tests() {
-  TCase* console_tests = tcase_create("console");
+TCase *setup_console_tests() {
+  TCase *console_tests = tcase_create("console");
   tcase_add_test(console_tests, check_console_search_node);
   tcase_add_test(console_tests, check_console_list_prefix);
   tcase_add_test(console_tests, check_console_get_time);

--- a/src/console.c
+++ b/src/console.c
@@ -26,8 +26,9 @@ struct console_config_node {
   void* val;
 };
 
-static const struct console_config_node*
-console_search_node(const struct console_config_node* nodes, const char* var) {
+static const struct console_config_node* console_search_node(
+  const struct console_config_node* nodes,
+  const char* var) {
 
   if (!var) {
     return NULL;
@@ -50,8 +51,8 @@ static struct console_feed_config {
 };
 
 static struct console_config_node console_config_nodes[];
-static void
-console_set_feed(const struct console_config_node* self, char* remaining) {
+static void console_set_feed(const struct console_config_node* self,
+                             char* remaining) {
   assert(self);
   assert(self->val);
 
@@ -70,10 +71,9 @@ console_set_feed(const struct console_config_node* self, char* remaining) {
   c->n_nodes = cur_entry;
 }
 
-static void
-console_get_feed(const struct console_config_node* self,
-                 char* dest,
-                 char* remaining __attribute__((unused))) {
+static void console_get_feed(const struct console_config_node* self,
+                             char* dest,
+                             char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
@@ -90,59 +90,54 @@ console_get_feed(const struct console_config_node* self,
   strcat(dest, c->nodes[i]->name);
 }
 
-static void
-console_get_time(const struct console_config_node* self __attribute__((unused)),
-                 char* dest,
-                 char* remaining __attribute__((unused))) {
+static void console_get_time(const struct console_config_node* self
+                             __attribute__((unused)),
+                             char* dest,
+                             char* remaining __attribute__((unused))) {
   sprintf(dest, "%u", (unsigned int)current_time());
 }
 
-static void
-console_get_float(const struct console_config_node* self,
-                  char* dest,
-                  char* remaining __attribute__((unused))) {
+static void console_get_float(const struct console_config_node* self,
+                              char* dest,
+                              char* remaining __attribute__((unused))) {
   float* v = self->val;
   sprintf(dest, "%.4f", *v);
 }
 
-static void
-console_set_float(const struct console_config_node* self, char* remaining) {
+static void console_set_float(const struct console_config_node* self,
+                              char* remaining) {
   float* v = self->val;
   *v = atof(remaining);
 }
 
-static void
-console_get_uint(const struct console_config_node* self,
-                 char* dest,
-                 char* remaining __attribute__((unused))) {
+static void console_get_uint(const struct console_config_node* self,
+                             char* dest,
+                             char* remaining __attribute__((unused))) {
   unsigned int* v = self->val;
   sprintf(dest, "%u", *v);
 }
 
-static void
-console_set_uint(const struct console_config_node* self, char* remaining) {
+static void console_set_uint(const struct console_config_node* self,
+                             char* remaining) {
   unsigned int* v = self->val;
   *v = (unsigned int)atoi(remaining);
 }
 
-static void
-console_get_fuel_cut(const struct console_config_node* self
-                     __attribute__((unused)),
-                     char* dest,
-                     char* remaining __attribute__((unused))) {
+static void console_get_fuel_cut(const struct console_config_node* self
+                                 __attribute__((unused)),
+                                 char* dest,
+                                 char* remaining __attribute__((unused))) {
   sprintf(dest, "%u", fuel_cut());
 }
 
-static void
-console_get_ignition_cut(const struct console_config_node* self
-                         __attribute__((unused)),
-                         char* dest,
-                         char* remaining __attribute__((unused))) {
+static void console_get_ignition_cut(const struct console_config_node* self
+                                     __attribute__((unused)),
+                                     char* dest,
+                                     char* remaining __attribute__((unused))) {
   sprintf(dest, "%u", ignition_cut());
 }
 
-static int
-parse_keyval_pair(char** key, char** val, char** str) {
+static int parse_keyval_pair(char** key, char** val, char** str) {
   char* saveptr;
   *key = strtok_r(*str, "=", &saveptr);
   if (!*key) {
@@ -156,8 +151,7 @@ parse_keyval_pair(char** key, char** val, char** str) {
   return 1;
 }
 
-static int
-console_set_table_element(struct table* t, const char* k, float v) {
+static int console_set_table_element(struct table* t, const char* k, float v) {
   unsigned int row, col;
   int n_parsed = sscanf(k, "[%d][%d]", &row, &col);
   if ((t->num_axis == 1) && (n_parsed == 1) && (row < t->axis[0].num)) {
@@ -171,8 +165,9 @@ console_set_table_element(struct table* t, const char* k, float v) {
   return 0;
 }
 
-static int
-console_get_table_element(const struct table* t, const char* k, float* v) {
+static int console_get_table_element(const struct table* t,
+                                     const char* k,
+                                     float* v) {
   int row, col;
   int n_parsed = sscanf(k, "[%d][%d]", &row, &col);
   if ((t->num_axis == 1) && (n_parsed == 1) && (row < t->axis[0].num)) {
@@ -186,8 +181,7 @@ console_get_table_element(const struct table* t, const char* k, float* v) {
   return 0;
 }
 
-static void
-console_set_table_axis_labels(struct table_axis* t, char* list) {
+static void console_set_table_axis_labels(struct table_axis* t, char* list) {
   unsigned int cur = 0;
   if ((list[0] != '[') || (list[strlen(list) - 1] != ']')) {
     return;
@@ -206,8 +200,8 @@ console_set_table_axis_labels(struct table_axis* t, char* list) {
   }
 }
 
-static void
-console_set_table(const struct console_config_node* self, char* remaining) {
+static void console_set_table(const struct console_config_node* self,
+                              char* remaining) {
   assert(self);
   assert(self->val);
   assert(remaining);
@@ -237,8 +231,8 @@ console_set_table(const struct console_config_node* self, char* remaining) {
     }
   }
 }
-static void
-console_get_table_axis_labels(const struct table_axis* t, char* dest) {
+static void console_get_table_axis_labels(const struct table_axis* t,
+                                          char* dest) {
   char buf[32];
   strcat(dest, "[");
   for (int i = 0; i < t->num; ++i) {
@@ -251,10 +245,9 @@ console_get_table_axis_labels(const struct table_axis* t, char* dest) {
   strcat(dest, "]");
 }
 
-static void
-console_get_table(const struct console_config_node* self,
-                  char* dest,
-                  char* remaining) {
+static void console_get_table(const struct console_config_node* self,
+                              char* dest,
+                              char* remaining) {
   assert(self);
 
   if (!self->val) {
@@ -293,25 +286,22 @@ console_get_table(const struct console_config_node* self,
   }
 }
 
-static void
-console_save_to_flash(const struct console_config_node* self
-                      __attribute__((unused)),
-                      char* rem __attribute__((unused))) {
+static void console_save_to_flash(const struct console_config_node* self
+                                  __attribute__((unused)),
+                                  char* rem __attribute__((unused))) {
   platform_save_config();
 }
 
-static void
-console_bootloader(const struct console_config_node* self
-                   __attribute__((unused)),
-                   char* dest __attribute__((unused)),
-                   char* rem __attribute__((unused))) {
+static void console_bootloader(const struct console_config_node* self
+                               __attribute__((unused)),
+                               char* dest __attribute__((unused)),
+                               char* rem __attribute__((unused))) {
   platform_reset_into_bootloader();
 }
 
-static void
-console_get_sensor(const struct console_config_node* self,
-                   char* dest,
-                   char* remaining __attribute__((unused))) {
+static void console_get_sensor(const struct console_config_node* self,
+                               char* dest,
+                               char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
@@ -378,8 +368,7 @@ console_get_sensor(const struct console_config_node* self,
           s->lag);
 }
 
-static sensor_source
-console_sensor_source_from_str(const char* str) {
+static sensor_source console_sensor_source_from_str(const char* str) {
   if (!strcmp("disabled", str)) {
     return SENSOR_NONE;
   } else if (!strcmp("adc", str)) {
@@ -396,8 +385,7 @@ console_sensor_source_from_str(const char* str) {
   return SENSOR_NONE;
 }
 
-static sensor_method
-console_sensor_method_from_str(const char* str) {
+static sensor_method console_sensor_method_from_str(const char* str) {
   if (!strcmp("linear", str)) {
     return METHOD_LINEAR;
   } else if (!strcmp("table", str)) {
@@ -408,8 +396,8 @@ console_sensor_method_from_str(const char* str) {
   return METHOD_TABLE;
 }
 
-static void
-console_set_sensor(const struct console_config_node* self, char* remaining) {
+static void console_set_sensor(const struct console_config_node* self,
+                               char* remaining) {
   assert(self);
   assert(self->val);
   assert(remaining);
@@ -450,10 +438,9 @@ console_set_sensor(const struct console_config_node* self, char* remaining) {
   }
 }
 
-static void
-console_get_sensor_fault(const struct console_config_node* self,
-                         char* dest,
-                         char* remaining __attribute__((unused))) {
+static void console_get_sensor_fault(const struct console_config_node* self,
+                                     char* dest,
+                                     char* remaining __attribute__((unused))) {
   const struct sensor_input* t = self->val;
   const char* result;
 
@@ -471,10 +458,10 @@ console_get_sensor_fault(const struct console_config_node* self,
   strcat(dest, result);
 }
 
-static void
-console_get_decoder_loss_reason(const struct console_config_node* self,
-                                char* dest,
-                                char* remaining __attribute__((unused))) {
+static void console_get_decoder_loss_reason(
+  const struct console_config_node* self,
+  char* dest,
+  char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
@@ -501,10 +488,9 @@ console_get_decoder_loss_reason(const struct console_config_node* self,
   strcat(dest, result);
 }
 
-static void
-console_get_decoder_state(const struct console_config_node* self,
-                          char* dest,
-                          char* remaining __attribute__((unused))) {
+static void console_get_decoder_state(const struct console_config_node* self,
+                                      char* dest,
+                                      char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
@@ -525,10 +511,9 @@ console_get_decoder_state(const struct console_config_node* self,
   strcat(dest, result);
 }
 
-static void
-console_get_trigger(const struct console_config_node* self,
-                    char* dest,
-                    char* remaining __attribute__((unused))) {
+static void console_get_trigger(const struct console_config_node* self,
+                                char* dest,
+                                char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
@@ -546,9 +531,8 @@ console_get_trigger(const struct console_config_node* self,
   strcat(dest, result);
 }
 
-static void
-console_set_trigger(const struct console_config_node* self,
-                    char* remaining __attribute__((unused))) {
+static void console_set_trigger(const struct console_config_node* self,
+                                char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
@@ -560,10 +544,9 @@ console_set_trigger(const struct console_config_node* self,
   }
 }
 
-static void
-console_get_dwell_type(const struct console_config_node* self,
-                       char* dest,
-                       char* remaining __attribute__((unused))) {
+static void console_get_dwell_type(const struct console_config_node* self,
+                                   char* dest,
+                                   char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
@@ -581,9 +564,8 @@ console_get_dwell_type(const struct console_config_node* self,
   strcat(dest, result);
 }
 
-static void
-console_set_dwell_type(const struct console_config_node* self,
-                       char* remaining __attribute__((unused))) {
+static void console_set_dwell_type(const struct console_config_node* self,
+                                   char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
@@ -595,10 +577,10 @@ console_set_dwell_type(const struct console_config_node* self,
   }
 }
 
-static void
-console_get_stats(const struct console_config_node* self __attribute((unused)),
-                  char* dest,
-                  char* remaining __attribute__((unused))) {
+static void console_get_stats(const struct console_config_node* self
+                              __attribute((unused)),
+                              char* dest,
+                              char* remaining __attribute__((unused))) {
 
   const struct stats_entry* e;
   for (e = &stats_entries[0]; e != &stats_entries[STATS_LAST]; ++e) {
@@ -611,11 +593,10 @@ console_get_stats(const struct console_config_node* self __attribute((unused)),
   }
 }
 
-static void
-console_get_events(const struct console_config_node* self
-                   __attribute__((unused)),
-                   char* dest,
-                   char* remaining) {
+static void console_get_events(const struct console_config_node* self
+                               __attribute__((unused)),
+                               char* dest,
+                               char* remaining) {
 
   if (!remaining || !strcmp("", remaining)) {
     sprintf(dest, "num_events=%d", config.num_events);
@@ -650,10 +631,9 @@ console_get_events(const struct console_config_node* self
   }
 }
 
-static void
-console_set_events(const struct console_config_node* self
-                   __attribute__((unused)),
-                   char* remaining) {
+static void console_set_events(const struct console_config_node* self
+                               __attribute__((unused)),
+                               char* remaining) {
 
   char *k, *v;
   char* saveptr;
@@ -703,8 +683,7 @@ static struct {
   int write;
 } event_log;
 
-static struct logged_event
-platform_get_logged_event() {
+static struct logged_event platform_get_logged_event() {
   if (!event_log.enabled || (event_log.read == event_log.write)) {
     return (struct logged_event){ .type = EVENT_NONE };
   }
@@ -714,8 +693,7 @@ platform_get_logged_event() {
   return ret;
 }
 
-void
-console_record_event(struct logged_event ev) {
+void console_record_event(struct logged_event ev) {
   if (!event_log.enabled) {
     return;
   }
@@ -730,25 +708,22 @@ console_record_event(struct logged_event ev) {
 }
 
 static struct timed_callback trig_cb = { 0 };
-static void
-console_fire_trigger_callback(void* _a) {
+static void console_fire_trigger_callback(void* _a) {
   (void)_a;
 
   decoder_update_scheduling(0, trig_cb.time);
 }
 
-static void
-console_set_trigger_callback(const struct console_config_node* self,
-                             char* remaining) {
+static void console_set_trigger_callback(const struct console_config_node* self,
+                                         char* remaining) {
   (void)self;
   timeval_t stoptime = atoi(remaining);
   trig_cb.callback = console_fire_trigger_callback;
   schedule_callback(&trig_cb, stoptime);
 }
 
-static void
-console_set_event_logging(const struct console_config_node* self,
-                          char* remaining) {
+static void console_set_event_logging(const struct console_config_node* self,
+                                      char* remaining) {
   (void)self;
 
   if (!strncmp(remaining, "on", 2)) {
@@ -760,15 +735,14 @@ console_set_event_logging(const struct console_config_node* self,
   }
 }
 
-static void
-console_set_freeze(const struct console_config_node* self, char* remaining) {
+static void console_set_freeze(const struct console_config_node* self,
+                               char* remaining) {
   (void)self;
   (void)remaining;
 }
 
-static void
-console_set_test_trigger(const struct console_config_node* self,
-                         char* remaining) {
+static void console_set_test_trigger(const struct console_config_node* self,
+                                     char* remaining) {
   (void)self;
 
   uint32_t rpm = atoi(remaining);
@@ -1064,10 +1038,9 @@ static struct console_config_node console_config_nodes[] = {
 };
 
 /* Lists all immediate prefixes in node list nodes */
-static void
-console_list_prefix(const struct console_config_node* nodes,
-                    char* dest,
-                    const char* prefix) {
+static void console_list_prefix(const struct console_config_node* nodes,
+                                char* dest,
+                                const char* prefix) {
 
   const struct console_config_node* node;
   for (node = nodes; node->name; node++) {
@@ -1081,8 +1054,7 @@ console_list_prefix(const struct console_config_node* nodes,
   }
 }
 
-int
-console_parse_request(char* dest, char* line) {
+int console_parse_request(char* dest, char* line) {
   char* action = strtok(line, " ");
   char* var = strtok(NULL, " ");
   char* rem = strtok(NULL, "\0");
@@ -1124,8 +1096,7 @@ console_parse_request(char* dest, char* line) {
   return 0;
 }
 
-void
-console_init() {
+void console_init() {
   const char* console_feed_defaults[] = {
     "status.current_time",
     "status.decoder.state",
@@ -1162,8 +1133,7 @@ console_init() {
   console_feed_config.n_nodes = count;
 }
 
-static void
-console_feed_line(char* dest) {
+static void console_feed_line(char* dest) {
 
   unsigned int i;
   char temp[64];
@@ -1195,8 +1165,7 @@ struct {
   .rx = { .src = config.console.rxbuffer, .in_progress = 0 },
 };
 
-int
-console_read_full(char* buf, size_t max) {
+int console_read_full(char* buf, size_t max) {
   if (console_state.rx.in_progress) {
     size_t r = console_state.rx.max - 1 -
                (size_t)(console_state.rx.ptr - console_state.rx.src);
@@ -1228,8 +1197,7 @@ console_read_full(char* buf, size_t max) {
   return 0;
 }
 
-int
-console_write_full(char* buf, size_t max) {
+int console_write_full(char* buf, size_t max) {
   if (console_state.tx.in_progress) {
     size_t r = console_state.tx.max -
                (size_t)(console_state.tx.ptr - console_state.tx.src);
@@ -1251,8 +1219,7 @@ console_write_full(char* buf, size_t max) {
   return 0;
 }
 
-static void
-console_process_rx() {
+static void console_process_rx() {
   char* out = config.console.txbuffer;
   char* in = strtok(config.console.rxbuffer, "\r\n");
   char* response = out + 2; /* Allow for status character */
@@ -1270,8 +1237,7 @@ console_process_rx() {
   console_write_full(out, strlen(out));
 }
 
-static void
-console_output_events() {
+static void console_output_events() {
   struct logged_event ev = platform_get_logged_event();
   switch (ev.type) {
     case EVENT_OUTPUT:
@@ -1307,8 +1273,7 @@ console_output_events() {
   }
 }
 
-void
-console_process() {
+void console_process() {
 
   static int pending_request = 0;
   stats_start_timing(STATS_CONSOLE_TIME);
@@ -1839,8 +1804,7 @@ START_TEST(check_console_set_events) {
 }
 END_TEST
 
-TCase*
-setup_console_tests() {
+TCase* setup_console_tests() {
   TCase* console_tests = tcase_create("console");
   tcase_add_test(console_tests, check_console_search_node);
   tcase_add_test(console_tests, check_console_list_prefix);

--- a/src/console.c
+++ b/src/console.c
@@ -309,37 +309,37 @@ static void console_get_sensor(const struct console_config_node *self,
 
   const char *source = "";
   switch (s->source) {
-    case SENSOR_NONE:
-      source = "disabled";
-      break;
-    case SENSOR_ADC:
-      source = "adc";
-      break;
-    case SENSOR_FREQ:
-      source = "freq";
-      break;
-    case SENSOR_DIGITAL:
-      source = "digital";
-      break;
-    case SENSOR_PWM:
-      source = "pwm";
-      break;
-    case SENSOR_CONST:
-      source = "const";
-      break;
+  case SENSOR_NONE:
+    source = "disabled";
+    break;
+  case SENSOR_ADC:
+    source = "adc";
+    break;
+  case SENSOR_FREQ:
+    source = "freq";
+    break;
+  case SENSOR_DIGITAL:
+    source = "digital";
+    break;
+  case SENSOR_PWM:
+    source = "pwm";
+    break;
+  case SENSOR_CONST:
+    source = "const";
+    break;
   }
 
   const char *method = "";
   switch (s->method) {
-    case METHOD_LINEAR:
-      method = "linear";
-      break;
-    case METHOD_TABLE:
-      method = "table";
-      break;
-    case METHOD_THERM:
-      method = "therm";
-      break;
+  case METHOD_LINEAR:
+    method = "linear";
+    break;
+  case METHOD_TABLE:
+    method = "table";
+    break;
+  case METHOD_THERM:
+    method = "therm";
+    break;
   }
 
   dest += sprintf(dest, "source=%s method=%s pin=%d ", source, method, s->pin);
@@ -445,15 +445,15 @@ static void console_get_sensor_fault(const struct console_config_node *self,
   const char *result;
 
   switch (t->fault) {
-    case FAULT_RANGE:
-      result = "range";
-      break;
-    case FAULT_CONN:
-      result = "connection";
-      break;
-    default:
-      result = "-";
-      break;
+  case FAULT_RANGE:
+    result = "range";
+    break;
+  case FAULT_CONN:
+    result = "connection";
+    break;
+  default:
+    result = "-";
+    break;
   }
   strcat(dest, result);
 }
@@ -469,21 +469,21 @@ static void console_get_decoder_loss_reason(
   const char *result = "";
 
   switch (*s) {
-    case DECODER_NO_LOSS:
-      result = "none";
-      break;
-    case DECODER_VARIATION:
-      result = "variation";
-      break;
-    case DECODER_TRIGGERCOUNT_HIGH:
-      result = "triggers+";
-      break;
-    case DECODER_TRIGGERCOUNT_LOW:
-      result = "triggers-";
-      break;
-    case DECODER_EXPIRED:
-      result = "expired";
-      break;
+  case DECODER_NO_LOSS:
+    result = "none";
+    break;
+  case DECODER_VARIATION:
+    result = "variation";
+    break;
+  case DECODER_TRIGGERCOUNT_HIGH:
+    result = "triggers+";
+    break;
+  case DECODER_TRIGGERCOUNT_LOW:
+    result = "triggers-";
+    break;
+  case DECODER_EXPIRED:
+    result = "expired";
+    break;
   }
   strcat(dest, result);
 }
@@ -498,15 +498,15 @@ static void console_get_decoder_state(const struct console_config_node *self,
   const char *result = "";
 
   switch (*s) {
-    case DECODER_NOSYNC:
-      result = "none";
-      break;
-    case DECODER_RPM:
-      result = "rpm";
-      break;
-    case DECODER_SYNC:
-      result = "full";
-      break;
+  case DECODER_NOSYNC:
+    result = "none";
+    break;
+  case DECODER_RPM:
+    result = "rpm";
+    break;
+  case DECODER_SYNC:
+    result = "full";
+    break;
   }
   strcat(dest, result);
 }
@@ -521,12 +521,12 @@ static void console_get_trigger(const struct console_config_node *self,
   const char *result = "";
 
   switch (*t) {
-    case FORD_TFI:
-      result = "tfi";
-      break;
-    case TOYOTA_24_1_CAS:
-      result = "cam24+1";
-      break;
+  case FORD_TFI:
+    result = "tfi";
+    break;
+  case TOYOTA_24_1_CAS:
+    result = "cam24+1";
+    break;
   }
   strcat(dest, result);
 }
@@ -554,12 +554,12 @@ static void console_get_dwell_type(const struct console_config_node *self,
   const char *result = "";
 
   switch (*t) {
-    case DWELL_FIXED_DUTY:
-      result = "fixed-duty";
-      break;
-    case DWELL_FIXED_TIME:
-      result = "fixed-time";
-      break;
+  case DWELL_FIXED_DUTY:
+    result = "fixed-duty";
+    break;
+  case DWELL_FIXED_TIME:
+    result = "fixed-time";
+    break;
   }
   strcat(dest, result);
 }
@@ -607,18 +607,18 @@ static void console_get_events(const struct console_config_node *self
     const struct output_event *ev = &config.events[ev_n];
     const char *ev_type = "";
     switch (ev->type) {
-      case FUEL_EVENT:
-        ev_type = "fuel";
-        break;
-      case IGNITION_EVENT:
-        ev_type = "ignition";
-        break;
-      case ADC_EVENT:
-        ev_type = "adc";
-        break;
-      default:
-        ev_type = "disabled";
-        break;
+    case FUEL_EVENT:
+      ev_type = "fuel";
+      break;
+    case IGNITION_EVENT:
+      ev_type = "ignition";
+      break;
+    case ADC_EVENT:
+      ev_type = "adc";
+      break;
+    default:
+      ev_type = "disabled";
+      break;
     }
     sprintf(dest,
             "type=%s angle=%.0f output=%d inverted=%d",
@@ -1240,36 +1240,36 @@ static void console_process_rx() {
 static void console_output_events() {
   struct logged_event ev = platform_get_logged_event();
   switch (ev.type) {
-    case EVENT_OUTPUT:
-      sprintf(config.console.txbuffer,
-              "# OUTPUTS %lu %2x\r\n",
-              (unsigned long)ev.time,
-              ev.value);
-      console_write_full(config.console.txbuffer,
-                         strlen(config.console.txbuffer));
-      break;
-    case EVENT_GPIO:
-      sprintf(config.console.txbuffer,
-              "# GPIO %lu %2x\r\n",
-              (unsigned long)ev.time,
-              ev.value);
-      console_write_full(config.console.txbuffer,
-                         strlen(config.console.txbuffer));
-      break;
-    case EVENT_TRIGGER0:
-      sprintf(
-        config.console.txbuffer, "# TRIGGER0 %lu\r\n", (unsigned long)ev.time);
-      console_write_full(config.console.txbuffer,
-                         strlen(config.console.txbuffer));
-      break;
-    case EVENT_TRIGGER1:
-      sprintf(
-        config.console.txbuffer, "# TRIGGER1 %lu\r\n", (unsigned long)ev.time);
-      console_write_full(config.console.txbuffer,
-                         strlen(config.console.txbuffer));
-      break;
-    default:
-      break;
+  case EVENT_OUTPUT:
+    sprintf(config.console.txbuffer,
+            "# OUTPUTS %lu %2x\r\n",
+            (unsigned long)ev.time,
+            ev.value);
+    console_write_full(config.console.txbuffer,
+                       strlen(config.console.txbuffer));
+    break;
+  case EVENT_GPIO:
+    sprintf(config.console.txbuffer,
+            "# GPIO %lu %2x\r\n",
+            (unsigned long)ev.time,
+            ev.value);
+    console_write_full(config.console.txbuffer,
+                       strlen(config.console.txbuffer));
+    break;
+  case EVENT_TRIGGER0:
+    sprintf(
+      config.console.txbuffer, "# TRIGGER0 %lu\r\n", (unsigned long)ev.time);
+    console_write_full(config.console.txbuffer,
+                       strlen(config.console.txbuffer));
+    break;
+  case EVENT_TRIGGER1:
+    sprintf(
+      config.console.txbuffer, "# TRIGGER1 %lu\r\n", (unsigned long)ev.time);
+    console_write_full(config.console.txbuffer,
+                       strlen(config.console.txbuffer));
+    break;
+  default:
+    break;
   }
 }
 

--- a/src/console.c
+++ b/src/console.c
@@ -17,8 +17,7 @@
 #include <string.h>
 #include <strings.h>
 
-struct console_config_node
-{
+struct console_config_node {
   const char* name;
   void (*get)(const struct console_config_node* self,
               char* dest,
@@ -42,8 +41,7 @@ console_search_node(const struct console_config_node* nodes, const char* var) {
   return NULL;
 }
 
-static struct console_feed_config
-{
+static struct console_feed_config {
   size_t n_nodes;
   const struct console_config_node* nodes[64];
 } console_feed_config = {
@@ -698,8 +696,7 @@ console_set_events(const struct console_config_node* self
   }
 }
 
-static struct
-{
+static struct {
   int enabled;
   struct logged_event events[32];
   int read;
@@ -1186,10 +1183,8 @@ console_feed_line(char* dest) {
   strcat(dest, "\r\n");
 }
 
-struct
-{
-  struct
-  {
+struct {
+  struct {
     int in_progress;
     size_t max;
     const char* src;

--- a/src/console.c
+++ b/src/console.c
@@ -3,11 +3,11 @@
 #define _POSIX_C_SOURCE 1
 #endif
 
-#include "platform.h"
 #include "console.h"
-#include "config.h"
 #include "calculations.h"
+#include "config.h"
 #include "decoder.h"
+#include "platform.h"
 #include "sensors.h"
 #include "stats.h"
 
@@ -17,22 +17,23 @@
 #include <string.h>
 #include <strings.h>
 
-
-struct console_config_node {
-  const char *name;
-  void (*get)(const struct console_config_node *self, char *dest, char *remaining);
-  void (*set)(const struct console_config_node *self, char *remaining);
-  void *val;
+struct console_config_node
+{
+  const char* name;
+  void (*get)(const struct console_config_node* self,
+              char* dest,
+              char* remaining);
+  void (*set)(const struct console_config_node* self, char* remaining);
+  void* val;
 };
 
-static const struct console_config_node *console_search_node(
-    const struct console_config_node *nodes,
-    const char *var) {
+static const struct console_config_node*
+console_search_node(const struct console_config_node* nodes, const char* var) {
 
   if (!var) {
     return NULL;
   }
-  const struct console_config_node *n;
+  const struct console_config_node* n;
   for (n = nodes; n->name; n++) {
     if (!strcmp(n->name, var)) {
       return n;
@@ -41,24 +42,27 @@ static const struct console_config_node *console_search_node(
   return NULL;
 }
 
-static struct console_feed_config {
+static struct console_feed_config
+{
   size_t n_nodes;
-  const struct console_config_node *nodes[64];
+  const struct console_config_node* nodes[64];
 } console_feed_config = {
   .n_nodes = 0,
-  .nodes = {0},
+  .nodes = { 0 },
 };
 
 static struct console_config_node console_config_nodes[];
-static void console_set_feed(const struct console_config_node *self, char *remaining) {
+static void
+console_set_feed(const struct console_config_node* self, char* remaining) {
   assert(self);
   assert(self->val);
 
   unsigned int cur_entry = 0;
-  struct console_feed_config *c = self->val;
-  const char *cur_var = strtok(remaining, ",");
+  struct console_feed_config* c = self->val;
+  const char* cur_var = strtok(remaining, ",");
   while (cur_var) {
-    const struct console_config_node *n = console_search_node(console_config_nodes, cur_var);
+    const struct console_config_node* n =
+      console_search_node(console_config_nodes, cur_var);
     if (n) {
       c->nodes[cur_entry] = n;
       cur_entry++;
@@ -68,12 +72,14 @@ static void console_set_feed(const struct console_config_node *self, char *remai
   c->n_nodes = cur_entry;
 }
 
-static void console_get_feed(const struct console_config_node *self, 
-    char *dest, char *remaining __attribute__((unused))) {
+static void
+console_get_feed(const struct console_config_node* self,
+                 char* dest,
+                 char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  struct console_feed_config *c = self->val;
+  struct console_feed_config* c = self->val;
   unsigned int i;
   if (!c->n_nodes) {
     strcat(dest, "");
@@ -86,50 +92,60 @@ static void console_get_feed(const struct console_config_node *self,
   strcat(dest, c->nodes[i]->name);
 }
 
-
-static void console_get_time(
-    const struct console_config_node *self __attribute__((unused)),
-    char *dest,
-    char *remaining __attribute__((unused))) {
+static void
+console_get_time(const struct console_config_node* self __attribute__((unused)),
+                 char* dest,
+                 char* remaining __attribute__((unused))) {
   sprintf(dest, "%u", (unsigned int)current_time());
 }
 
-static void console_get_float(const struct console_config_node *self, 
-    char *dest, char *remaining __attribute__((unused))) {
-  float *v = self->val;
+static void
+console_get_float(const struct console_config_node* self,
+                  char* dest,
+                  char* remaining __attribute__((unused))) {
+  float* v = self->val;
   sprintf(dest, "%.4f", *v);
 }
 
-static void console_set_float(const struct console_config_node *self, char *remaining) {
-  float *v = self->val;
+static void
+console_set_float(const struct console_config_node* self, char* remaining) {
+  float* v = self->val;
   *v = atof(remaining);
 }
 
-static void console_get_uint(const struct console_config_node *self, 
-    char *dest, char *remaining __attribute__((unused))) {
-  unsigned int *v = self->val;
+static void
+console_get_uint(const struct console_config_node* self,
+                 char* dest,
+                 char* remaining __attribute__((unused))) {
+  unsigned int* v = self->val;
   sprintf(dest, "%u", *v);
 }
 
-static void console_set_uint(const struct console_config_node *self, char *remaining) {
-  unsigned int *v = self->val;
+static void
+console_set_uint(const struct console_config_node* self, char* remaining) {
+  unsigned int* v = self->val;
   *v = (unsigned int)atoi(remaining);
 }
 
-static void console_get_fuel_cut(
-    const struct console_config_node *self __attribute__((unused)), 
-    char *dest, char *remaining __attribute__((unused))) {
+static void
+console_get_fuel_cut(const struct console_config_node* self
+                     __attribute__((unused)),
+                     char* dest,
+                     char* remaining __attribute__((unused))) {
   sprintf(dest, "%u", fuel_cut());
 }
 
-static void console_get_ignition_cut(
-    const struct console_config_node *self __attribute__((unused)), 
-    char *dest, char *remaining __attribute__((unused))) {
+static void
+console_get_ignition_cut(const struct console_config_node* self
+                         __attribute__((unused)),
+                         char* dest,
+                         char* remaining __attribute__((unused))) {
   sprintf(dest, "%u", ignition_cut());
 }
 
-static int parse_keyval_pair(char **key, char **val, char **str) {
-  char *saveptr;
+static int
+parse_keyval_pair(char** key, char** val, char** str) {
+  char* saveptr;
   *key = strtok_r(*str, "=", &saveptr);
   if (!*key) {
     return 0;
@@ -142,47 +158,47 @@ static int parse_keyval_pair(char **key, char **val, char **str) {
   return 1;
 }
 
-
-static int console_set_table_element(struct table *t, const char *k, float v) {
+static int
+console_set_table_element(struct table* t, const char* k, float v) {
   unsigned int row, col;
   int n_parsed = sscanf(k, "[%d][%d]", &row, &col);
-  if ((t->num_axis == 1) && (n_parsed == 1) &&
-      (row < t->axis[0].num)) {
+  if ((t->num_axis == 1) && (n_parsed == 1) && (row < t->axis[0].num)) {
     t->data.one[row] = v;
     return 1;
-  } else if ((t->num_axis == 2) && (n_parsed == 2) &&
-      (row < t->axis[0].num) && (col < t->axis[1].num)) {
+  } else if ((t->num_axis == 2) && (n_parsed == 2) && (row < t->axis[0].num) &&
+             (col < t->axis[1].num)) {
     t->data.two[row][col] = v;
     return 1;
   }
   return 0;
 }
 
-static int console_get_table_element(const struct table *t, const char *k, float *v) {
+static int
+console_get_table_element(const struct table* t, const char* k, float* v) {
   int row, col;
   int n_parsed = sscanf(k, "[%d][%d]", &row, &col);
-  if ((t->num_axis == 1) && (n_parsed == 1) && 
-      (row < t->axis[0].num)) {
+  if ((t->num_axis == 1) && (n_parsed == 1) && (row < t->axis[0].num)) {
     *v = t->data.one[row];
     return 1;
-  } else if ((t->num_axis == 2) && (n_parsed == 2) &&
-      (row < t->axis[0].num) && (col < t->axis[1].num)) {
+  } else if ((t->num_axis == 2) && (n_parsed == 2) && (row < t->axis[0].num) &&
+             (col < t->axis[1].num)) {
     *v = t->data.two[row][col];
     return 1;
   }
   return 0;
 }
 
-static void console_set_table_axis_labels(struct table_axis *t, char *list) {
+static void
+console_set_table_axis_labels(struct table_axis* t, char* list) {
   unsigned int cur = 0;
   if ((list[0] != '[') || (list[strlen(list) - 1] != ']')) {
     return;
   }
 
-  char *saveptr;
-  char *curlabel = list;
+  char* saveptr;
+  char* curlabel = list;
   curlabel = strtok_r(list, "[,]", &saveptr);
-  while(curlabel) {
+  while (curlabel) {
     if ((cur >= t->num) || (cur >= MAX_AXIS_SIZE)) {
       return;
     }
@@ -192,15 +208,16 @@ static void console_set_table_axis_labels(struct table_axis *t, char *list) {
   }
 }
 
-static void console_set_table(const struct console_config_node *self, char *remaining) {
+static void
+console_set_table(const struct console_config_node* self, char* remaining) {
   assert(self);
   assert(self->val);
   assert(remaining);
 
-  struct table *t = self->val;
+  struct table* t = self->val;
 
   char *k, *v;
-  while(parse_keyval_pair(&k, &v, &remaining)) {
+  while (parse_keyval_pair(&k, &v, &remaining)) {
     if (!strcmp("naxis", k)) {
       t->num_axis = atoi(v);
     } else if (!strcmp("name", k)) {
@@ -222,7 +239,8 @@ static void console_set_table(const struct console_config_node *self, char *rema
     }
   }
 }
-static void console_get_table_axis_labels(const struct table_axis *t, char *dest) {
+static void
+console_get_table_axis_labels(const struct table_axis* t, char* dest) {
   char buf[32];
   strcat(dest, "[");
   for (int i = 0; i < t->num; ++i) {
@@ -235,7 +253,10 @@ static void console_get_table_axis_labels(const struct table_axis *t, char *dest
   strcat(dest, "]");
 }
 
-static void console_get_table(const struct console_config_node *self, char *dest, char *remaining) {
+static void
+console_get_table(const struct console_config_node* self,
+                  char* dest,
+                  char* remaining) {
   assert(self);
 
   if (!self->val) {
@@ -243,24 +264,28 @@ static void console_get_table(const struct console_config_node *self, char *dest
     return;
   }
 
-  const struct table *t = self->val;
+  const struct table* t = self->val;
   if (remaining && (remaining[0] == '[')) {
     float val;
-    char *saveptr;
-    char *element = strtok_r(remaining, " ", &saveptr);
+    char* saveptr;
+    char* element = strtok_r(remaining, " ", &saveptr);
     do {
       if (console_get_table_element(t, element, &val)) {
-        dest += sprintf(dest, "%s%.2f", (element == remaining) ? "": " ", val);
+        dest += sprintf(dest, "%s%.2f", (element == remaining) ? "" : " ", val);
       } else {
         strcpy(dest, "invalid");
       }
     } while ((element = strtok_r(NULL, " ", &saveptr)));
   } else {
-    dest += sprintf(dest, "name=%s naxis=%d rows=%d rowname=%s "
-        "cols=%d colname=%s ",
-        t->title, t->num_axis, 
-        t->axis[0].num, t->axis[0].name, 
-        t->axis[1].num, t->axis[1].name);
+    dest += sprintf(dest,
+                    "name=%s naxis=%d rows=%d rowname=%s "
+                    "cols=%d colname=%s ",
+                    t->title,
+                    t->num_axis,
+                    t->axis[0].num,
+                    t->axis[0].name,
+                    t->axis[1].num,
+                    t->axis[1].name);
 
     strcat(dest, "rowlabels=");
     console_get_table_axis_labels(&t->axis[0], dest);
@@ -268,31 +293,33 @@ static void console_get_table(const struct console_config_node *self, char *dest
     strcat(dest, " collabels=");
     console_get_table_axis_labels(&t->axis[1], dest);
   }
-
-
 }
 
-static void console_save_to_flash(
-    const struct console_config_node *self __attribute__((unused)), 
-    char *rem __attribute__((unused))) {
+static void
+console_save_to_flash(const struct console_config_node* self
+                      __attribute__((unused)),
+                      char* rem __attribute__((unused))) {
   platform_save_config();
 }
 
-static void console_bootloader(
-    const struct console_config_node *self __attribute__((unused)), 
-    char *dest __attribute__((unused)),
-    char *rem __attribute__((unused))) {
+static void
+console_bootloader(const struct console_config_node* self
+                   __attribute__((unused)),
+                   char* dest __attribute__((unused)),
+                   char* rem __attribute__((unused))) {
   platform_reset_into_bootloader();
 }
 
-static void console_get_sensor(const struct console_config_node *self, char *dest,
-    char *remaining __attribute__((unused))) {
+static void
+console_get_sensor(const struct console_config_node* self,
+                   char* dest,
+                   char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  const struct sensor_input *s = self->val;
-  
-  const char *source = "";
+  const struct sensor_input* s = self->val;
+
+  const char* source = "";
   switch (s->source) {
     case SENSOR_NONE:
       source = "disabled";
@@ -314,7 +341,7 @@ static void console_get_sensor(const struct console_config_node *self, char *des
       break;
   }
 
-  const char *method = "";
+  const char* method = "";
   switch (s->method) {
     case METHOD_LINEAR:
       method = "linear";
@@ -331,24 +358,30 @@ static void console_get_sensor(const struct console_config_node *self, char *des
   if (s->source == SENSOR_CONST) {
     dest += sprintf(dest, "fixed-val=%.2f ", s->params.fixed_value);
   } else if (s->method == METHOD_LINEAR) {
-    dest += sprintf(dest, "range-min=%.2f range-max=%.2f ", 
-        s->params.range.min, s->params.range.max);
+    dest += sprintf(dest,
+                    "range-min=%.2f range-max=%.2f ",
+                    s->params.range.min,
+                    s->params.range.max);
   } else if (s->method == METHOD_TABLE) {
     dest += sprintf(dest, "table=%s ", "unsupported");
   } else if (s->method == METHOD_THERM) {
-    dest += sprintf(dest, "therm-bias=%.2f therm-a=%e therm-b=%e therm-c=%e ", 
-        s->params.therm.bias, s->params.therm.a,
-        s->params.therm.b, s->params.therm.c);
+    dest += sprintf(dest,
+                    "therm-bias=%.2f therm-a=%e therm-b=%e therm-c=%e ",
+                    s->params.therm.bias,
+                    s->params.therm.a,
+                    s->params.therm.b,
+                    s->params.therm.c);
   }
-  sprintf(dest, "fault-min=%u fault-max=%u fault-val=%.2f lag=%f", 
-      (unsigned int)s->fault_config.min, 
-      (unsigned int)s->fault_config.max, 
-      s->fault_config.fault_value,
-      s->lag);
-
+  sprintf(dest,
+          "fault-min=%u fault-max=%u fault-val=%.2f lag=%f",
+          (unsigned int)s->fault_config.min,
+          (unsigned int)s->fault_config.max,
+          s->fault_config.fault_value,
+          s->lag);
 }
 
-static sensor_source console_sensor_source_from_str(const char *str) {
+static sensor_source
+console_sensor_source_from_str(const char* str) {
   if (!strcmp("disabled", str)) {
     return SENSOR_NONE;
   } else if (!strcmp("adc", str)) {
@@ -363,9 +396,10 @@ static sensor_source console_sensor_source_from_str(const char *str) {
     return SENSOR_CONST;
   }
   return SENSOR_NONE;
-}  
+}
 
-static sensor_method console_sensor_method_from_str(const char *str) {
+static sensor_method
+console_sensor_method_from_str(const char* str) {
   if (!strcmp("linear", str)) {
     return METHOD_LINEAR;
   } else if (!strcmp("table", str)) {
@@ -374,18 +408,18 @@ static sensor_method console_sensor_method_from_str(const char *str) {
     return METHOD_THERM;
   }
   return METHOD_TABLE;
-}  
+}
 
-static void console_set_sensor(const struct console_config_node *self,
-    char *remaining) {
+static void
+console_set_sensor(const struct console_config_node* self, char* remaining) {
   assert(self);
   assert(self->val);
   assert(remaining);
 
-  struct sensor_input *s = self->val;
+  struct sensor_input* s = self->val;
 
   char *k, *v;
-  while(parse_keyval_pair(&k, &v, &remaining)) {
+  while (parse_keyval_pair(&k, &v, &remaining)) {
     if (!strcmp("source", k)) {
       s->source = console_sensor_source_from_str(v);
     } else if (!strcmp("method", k)) {
@@ -416,13 +450,14 @@ static void console_set_sensor(const struct console_config_node *self,
       s->fault_config.fault_value = atof(v);
     }
   }
-
 }
 
-static void console_get_sensor_fault(const struct console_config_node *self, 
-    char *dest, char *remaining __attribute__((unused))) {
-  const struct sensor_input *t = self->val;
-  const char *result;
+static void
+console_get_sensor_fault(const struct console_config_node* self,
+                         char* dest,
+                         char* remaining __attribute__((unused))) {
+  const struct sensor_input* t = self->val;
+  const char* result;
 
   switch (t->fault) {
     case FAULT_RANGE:
@@ -438,13 +473,15 @@ static void console_get_sensor_fault(const struct console_config_node *self,
   strcat(dest, result);
 }
 
-static void console_get_decoder_loss_reason(const struct console_config_node *self, 
-    char *dest, char *remaining __attribute__((unused))) {
+static void
+console_get_decoder_loss_reason(const struct console_config_node* self,
+                                char* dest,
+                                char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  const decoder_loss_reason *s = self->val;
-  const char *result = "";
+  const decoder_loss_reason* s = self->val;
+  const char* result = "";
 
   switch (*s) {
     case DECODER_NO_LOSS:
@@ -466,13 +503,15 @@ static void console_get_decoder_loss_reason(const struct console_config_node *se
   strcat(dest, result);
 }
 
-static void console_get_decoder_state(const struct console_config_node *self, 
-    char *dest, char *remaining __attribute__((unused))) {
+static void
+console_get_decoder_state(const struct console_config_node* self,
+                          char* dest,
+                          char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  const decoder_state *s = self->val;
-  const char *result = "";
+  const decoder_state* s = self->val;
+  const char* result = "";
 
   switch (*s) {
     case DECODER_NOSYNC:
@@ -488,13 +527,15 @@ static void console_get_decoder_state(const struct console_config_node *self,
   strcat(dest, result);
 }
 
-static void console_get_trigger(const struct console_config_node *self, 
-    char *dest, char *remaining __attribute__((unused))) {
+static void
+console_get_trigger(const struct console_config_node* self,
+                    char* dest,
+                    char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  const trigger_type *t = self->val;
-  const char *result = "";
+  const trigger_type* t = self->val;
+  const char* result = "";
 
   switch (*t) {
     case FORD_TFI:
@@ -507,12 +548,13 @@ static void console_get_trigger(const struct console_config_node *self,
   strcat(dest, result);
 }
 
-static void console_set_trigger(const struct console_config_node *self, 
-    char *remaining __attribute__((unused))) {
+static void
+console_set_trigger(const struct console_config_node* self,
+                    char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  trigger_type *t = self->val;
+  trigger_type* t = self->val;
   if (!strcmp("tfi", remaining)) {
     *t = FORD_TFI;
   } else if (!strcmp("cam24+1", remaining)) {
@@ -520,13 +562,15 @@ static void console_set_trigger(const struct console_config_node *self,
   }
 }
 
-static void console_get_dwell_type(const struct console_config_node *self, 
-    char *dest, char *remaining __attribute__((unused))) {
+static void
+console_get_dwell_type(const struct console_config_node* self,
+                       char* dest,
+                       char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  const dwell_type *t = self->val;
-  const char *result = "";
+  const dwell_type* t = self->val;
+  const char* result = "";
 
   switch (*t) {
     case DWELL_FIXED_DUTY:
@@ -539,12 +583,13 @@ static void console_get_dwell_type(const struct console_config_node *self,
   strcat(dest, result);
 }
 
-static void console_set_dwell_type(const struct console_config_node *self, 
-    char *remaining __attribute__((unused))) {
+static void
+console_set_dwell_type(const struct console_config_node* self,
+                       char* remaining __attribute__((unused))) {
   assert(self);
   assert(self->val);
 
-  dwell_type *t = self->val;
+  dwell_type* t = self->val;
   if (!strcmp("fixed-duty", remaining)) {
     *t = DWELL_FIXED_DUTY;
   } else if (!strcmp("fixed-time", remaining)) {
@@ -552,25 +597,27 @@ static void console_set_dwell_type(const struct console_config_node *self,
   }
 }
 
-static void console_get_stats(
-    const struct console_config_node *self __attribute((unused)),
-    char *dest,
-    char *remaining __attribute__((unused))) {
+static void
+console_get_stats(const struct console_config_node* self __attribute((unused)),
+                  char* dest,
+                  char* remaining __attribute__((unused))) {
 
-  const struct stats_entry *e;
+  const struct stats_entry* e;
   for (e = &stats_entries[0]; e != &stats_entries[STATS_LAST]; ++e) {
-    dest += sprintf(dest, "  %s min/avg/max (uS) = %u/%u/%u\r\n",
-        e->name, 
-        (unsigned int)e->min, 
-        (unsigned int)e->avg, 
-        (unsigned int)e->max);
+    dest += sprintf(dest,
+                    "  %s min/avg/max (uS) = %u/%u/%u\r\n",
+                    e->name,
+                    (unsigned int)e->min,
+                    (unsigned int)e->avg,
+                    (unsigned int)e->max);
   }
 }
 
-static void console_get_events(
-    const struct console_config_node *self __attribute__((unused)), 
-    char *dest, 
-    char *remaining) {
+static void
+console_get_events(const struct console_config_node* self
+                   __attribute__((unused)),
+                   char* dest,
+                   char* remaining) {
 
   if (!remaining || !strcmp("", remaining)) {
     sprintf(dest, "num_events=%d", config.num_events);
@@ -578,8 +625,8 @@ static void console_get_events(
   }
   unsigned int ev_n = atoi(strtok(remaining, " "));
   if (ev_n < config.num_events) {
-    const struct output_event *ev = &config.events[ev_n];
-    const char *ev_type = "";
+    const struct output_event* ev = &config.events[ev_n];
+    const char* ev_type = "";
     switch (ev->type) {
       case FUEL_EVENT:
         ev_type = "fuel";
@@ -594,19 +641,24 @@ static void console_get_events(
         ev_type = "disabled";
         break;
     }
-    sprintf(dest, "type=%s angle=%.0f output=%d inverted=%d", 
-        ev_type, ev->angle, ev->pin, ev->inverted);
+    sprintf(dest,
+            "type=%s angle=%.0f output=%d inverted=%d",
+            ev_type,
+            ev->angle,
+            ev->pin,
+            ev->inverted);
   } else {
     strcpy(dest, "event out of range");
   }
 }
 
-static void console_set_events(
-    const struct console_config_node *self __attribute__((unused)), 
-    char *remaining) {
+static void
+console_set_events(const struct console_config_node* self
+                   __attribute__((unused)),
+                   char* remaining) {
 
   char *k, *v;
-  char *saveptr;
+  char* saveptr;
 
   if (!remaining) {
     return;
@@ -622,10 +674,10 @@ static void console_set_events(
   if (ev_n >= config.num_events) {
     return;
   }
-  struct output_event *ev = &config.events[ev_n];
+  struct output_event* ev = &config.events[ev_n];
 
   remaining = saveptr;
-  while(parse_keyval_pair(&k, &v, &remaining)) {
+  while (parse_keyval_pair(&k, &v, &remaining)) {
     if (!strcmp("type", k)) {
       if (!strcmp("fuel", v)) {
         ev->type = FUEL_EVENT;
@@ -646,23 +698,27 @@ static void console_set_events(
   }
 }
 
-static struct {
+static struct
+{
   int enabled;
   struct logged_event events[32];
   int read;
   int write;
 } event_log;
 
-static struct logged_event platform_get_logged_event() {
+static struct logged_event
+platform_get_logged_event() {
   if (!event_log.enabled || (event_log.read == event_log.write)) {
-    return (struct logged_event){.type = EVENT_NONE};
+    return (struct logged_event){ .type = EVENT_NONE };
   }
   struct logged_event ret = event_log.events[event_log.read];
-  event_log.read = (event_log.read + 1) % (sizeof(event_log.events) / sizeof(event_log.events[0]));
+  event_log.read = (event_log.read + 1) %
+                   (sizeof(event_log.events) / sizeof(event_log.events[0]));
   return ret;
 }
 
-void console_record_event(struct logged_event ev) {
+void
+console_record_event(struct logged_event ev) {
   if (!event_log.enabled) {
     return;
   }
@@ -676,23 +732,26 @@ void console_record_event(struct logged_event ev) {
   event_log.write = (event_log.write + 1) % size;
 }
 
-static struct timed_callback trig_cb = {0};
-static void console_fire_trigger_callback(void *_a) {
+static struct timed_callback trig_cb = { 0 };
+static void
+console_fire_trigger_callback(void* _a) {
   (void)_a;
- 
+
   decoder_update_scheduling(0, trig_cb.time);
 }
 
-static void console_set_trigger_callback(const struct console_config_node *self,
-    char *remaining) {
+static void
+console_set_trigger_callback(const struct console_config_node* self,
+                             char* remaining) {
   (void)self;
   timeval_t stoptime = atoi(remaining);
   trig_cb.callback = console_fire_trigger_callback;
   schedule_callback(&trig_cb, stoptime);
 }
 
-static void console_set_event_logging(const struct console_config_node *self,
-    char *remaining) {
+static void
+console_set_event_logging(const struct console_config_node* self,
+                          char* remaining) {
   (void)self;
 
   if (!strncmp(remaining, "on", 2)) {
@@ -704,215 +763,319 @@ static void console_set_event_logging(const struct console_config_node *self,
   }
 }
 
-static void console_set_freeze(const struct console_config_node *self,
-    char *remaining) {
+static void
+console_set_freeze(const struct console_config_node* self, char* remaining) {
   (void)self;
   (void)remaining;
 }
 
-static void console_set_test_trigger(const struct console_config_node *self,
-    char *remaining) {
-    (void)self;
+static void
+console_set_test_trigger(const struct console_config_node* self,
+                         char* remaining) {
+  (void)self;
 
-    uint32_t rpm = atoi(remaining);
-    enable_test_trigger(config.decoder.type, rpm);
+  uint32_t rpm = atoi(remaining);
+  enable_test_trigger(config.decoder.type, rpm);
 }
 
 static struct console_config_node console_config_nodes[] = {
   /* Config hierarchy */
-  {.name="config"},
-  {.name="config.feed", .get=console_get_feed, .set=console_set_feed, 
-    .val=&console_feed_config},
+  { .name = "config" },
+  { .name = "config.feed",
+    .get = console_get_feed,
+    .set = console_set_feed,
+    .val = &console_feed_config },
 
-  {.name="config.tables"},
-  {.name="config.tables.timing", .val=&timing_vs_rpm_and_map,
-   .get=console_get_table, .set=console_set_table},
-  {.name="config.tables.iat_timing_adjust",
-   .get=console_get_table, .set=console_set_table},
-  {.name="config.tables.clt_timing_adjust",
-   .get=console_get_table, .set=console_set_table},
-  {.name="config.tables.clt_pw_adjust",
-   .get=console_get_table, .set=console_set_table},
-  {.name="config.tables.ve", .val=&ve_vs_rpm_and_map,
-   .get=console_get_table, .set=console_set_table},
-  {.name="config.tables.commanded_lambda", .val=&lambda_vs_rpm_and_map,
-   .get=console_get_table, .set=console_set_table},
-  {.name="config.tables.injector_dead_time", .val=&injector_dead_time,
-   .get=console_get_table, .set=console_set_table},
-  {.name="config.tables.engine_temp_enrich", .val=&enrich_vs_temp_and_map,
-   .get=console_get_table, .set=console_set_table},
-  {.name="config.tables.tipin_enrich_amount", .val=&tipin_vs_tpsrate_and_tps,
-   .get=console_get_table, .set=console_set_table},
-  {.name="config.tables.tipin_enrich_duration", .val=&tipin_duration_vs_rpm,
-   .get=console_get_table, .set=console_set_table},
-  {.name="config.tables.boost_control", .val=&boost_control_pwm,
-   .get=console_get_table, .set=console_set_table},
+  { .name = "config.tables" },
+  { .name = "config.tables.timing",
+    .val = &timing_vs_rpm_and_map,
+    .get = console_get_table,
+    .set = console_set_table },
+  { .name = "config.tables.iat_timing_adjust",
+    .get = console_get_table,
+    .set = console_set_table },
+  { .name = "config.tables.clt_timing_adjust",
+    .get = console_get_table,
+    .set = console_set_table },
+  { .name = "config.tables.clt_pw_adjust",
+    .get = console_get_table,
+    .set = console_set_table },
+  { .name = "config.tables.ve",
+    .val = &ve_vs_rpm_and_map,
+    .get = console_get_table,
+    .set = console_set_table },
+  { .name = "config.tables.commanded_lambda",
+    .val = &lambda_vs_rpm_and_map,
+    .get = console_get_table,
+    .set = console_set_table },
+  { .name = "config.tables.injector_dead_time",
+    .val = &injector_dead_time,
+    .get = console_get_table,
+    .set = console_set_table },
+  { .name = "config.tables.engine_temp_enrich",
+    .val = &enrich_vs_temp_and_map,
+    .get = console_get_table,
+    .set = console_set_table },
+  { .name = "config.tables.tipin_enrich_amount",
+    .val = &tipin_vs_tpsrate_and_tps,
+    .get = console_get_table,
+    .set = console_set_table },
+  { .name = "config.tables.tipin_enrich_duration",
+    .val = &tipin_duration_vs_rpm,
+    .get = console_get_table,
+    .set = console_set_table },
+  { .name = "config.tables.boost_control",
+    .val = &boost_control_pwm,
+    .get = console_get_table,
+    .set = console_set_table },
 
   /* Decoding */
-  {.name="config.decoder"},
-  {.name="config.decoder.trigger", .val=&config.decoder.type,
-   .get=console_get_trigger, .set=console_set_trigger},
-  {.name="config.decoder.max_variance", .val=&config.decoder.trigger_cur_rpm_change,
-   .get=console_get_float, .set=console_set_float},
-  {.name="config.decoder.offset", .val=&config.decoder.offset,
-   .get=console_get_float, .set=console_set_float},
-  {.name="config.decoder.min_rpm", .val=&config.decoder.trigger_min_rpm,
-   .get=console_get_uint, .set=console_set_uint},
+  { .name = "config.decoder" },
+  { .name = "config.decoder.trigger",
+    .val = &config.decoder.type,
+    .get = console_get_trigger,
+    .set = console_set_trigger },
+  { .name = "config.decoder.max_variance",
+    .val = &config.decoder.trigger_cur_rpm_change,
+    .get = console_get_float,
+    .set = console_set_float },
+  { .name = "config.decoder.offset",
+    .val = &config.decoder.offset,
+    .get = console_get_float,
+    .set = console_set_float },
+  { .name = "config.decoder.min_rpm",
+    .val = &config.decoder.trigger_min_rpm,
+    .get = console_get_uint,
+    .set = console_set_uint },
 
   /* Fueling */
-  {.name="config.fueling"},
-  {.name="config.fueling.injector_cc", .val=&config.fueling.injector_cc_per_minute,
-   .get=console_get_float, .set=console_set_float},
-  {.name="config.fueling.cyclinder_cc", .val=&config.fueling.cylinder_cc,
-   .get=console_get_float, .set=console_set_float},
-  {.name="config.fueling.fuel_stoich_ratio", .val=&config.fueling.fuel_stoich_ratio,
-   .get=console_get_float, .set=console_set_float},
-  {.name="config.fueling.injections_per_cycle", .val=&config.fueling.injections_per_cycle,
-   .get=console_get_uint, .set=console_set_uint},
-  {.name="config.fueling.fuel_pump_pin", .val=&config.fueling.fuel_pump_pin,
-   .get=console_get_uint, .set=console_set_uint},
+  { .name = "config.fueling" },
+  { .name = "config.fueling.injector_cc",
+    .val = &config.fueling.injector_cc_per_minute,
+    .get = console_get_float,
+    .set = console_set_float },
+  { .name = "config.fueling.cyclinder_cc",
+    .val = &config.fueling.cylinder_cc,
+    .get = console_get_float,
+    .set = console_set_float },
+  { .name = "config.fueling.fuel_stoich_ratio",
+    .val = &config.fueling.fuel_stoich_ratio,
+    .get = console_get_float,
+    .set = console_set_float },
+  { .name = "config.fueling.injections_per_cycle",
+    .val = &config.fueling.injections_per_cycle,
+    .get = console_get_uint,
+    .set = console_set_uint },
+  { .name = "config.fueling.fuel_pump_pin",
+    .val = &config.fueling.fuel_pump_pin,
+    .get = console_get_uint,
+    .set = console_set_uint },
 
   /* Ignition */
-  {.name="config.ignition"},
-  {.name="config.ignition.dwell_type", .val=&config.ignition.dwell,
-   .get=console_get_dwell_type, .set=console_set_dwell_type},
-  {.name="config.ignition.dwell_duty", .val=&config.ignition.dwell_duty,
-   .get=console_get_float, .set=console_set_float},
-  {.name="config.ignition.dwell_us", .val=&config.ignition.dwell_us,
-   .get=console_get_float, .set=console_set_float},
-  {.name="config.ignition.min_fire_time_us", .val=&config.ignition.min_fire_time_us,
-   .get=console_get_uint, .set=console_set_uint},
+  { .name = "config.ignition" },
+  { .name = "config.ignition.dwell_type",
+    .val = &config.ignition.dwell,
+    .get = console_get_dwell_type,
+    .set = console_set_dwell_type },
+  { .name = "config.ignition.dwell_duty",
+    .val = &config.ignition.dwell_duty,
+    .get = console_get_float,
+    .set = console_set_float },
+  { .name = "config.ignition.dwell_us",
+    .val = &config.ignition.dwell_us,
+    .get = console_get_float,
+    .set = console_set_float },
+  { .name = "config.ignition.min_fire_time_us",
+    .val = &config.ignition.min_fire_time_us,
+    .get = console_get_uint,
+    .set = console_set_uint },
 
   /* Sensors */
-  {.name="config.sensors"},
-  {.name="config.sensors.map", .val=&config.sensors[SENSOR_MAP],
-   .get=console_get_sensor, .set=console_set_sensor},
-  {.name="config.sensors.iat", .val=&config.sensors[SENSOR_IAT],
-   .get=console_get_sensor, .set=console_set_sensor},
-  {.name="config.sensors.clt", .val=&config.sensors[SENSOR_CLT],
-   .get=console_get_sensor, .set=console_set_sensor},
-  {.name="config.sensors.brv", .val=&config.sensors[SENSOR_BRV],
-   .get=console_get_sensor, .set=console_set_sensor},
-  {.name="config.sensors.tps", .val=&config.sensors[SENSOR_TPS],
-   .get=console_get_sensor, .set=console_set_sensor},
-  {.name="config.sensors.aap", .val=&config.sensors[SENSOR_AAP],
-   .get=console_get_sensor, .set=console_set_sensor},
-  {.name="config.sensors.frt", .val=&config.sensors[SENSOR_FRT],
-   .get=console_get_sensor, .set=console_set_sensor},
-  {.name="config.sensors.ego", .val=&config.sensors[SENSOR_EGO],
-   .get=console_get_sensor, .set=console_set_sensor},
+  { .name = "config.sensors" },
+  { .name = "config.sensors.map",
+    .val = &config.sensors[SENSOR_MAP],
+    .get = console_get_sensor,
+    .set = console_set_sensor },
+  { .name = "config.sensors.iat",
+    .val = &config.sensors[SENSOR_IAT],
+    .get = console_get_sensor,
+    .set = console_set_sensor },
+  { .name = "config.sensors.clt",
+    .val = &config.sensors[SENSOR_CLT],
+    .get = console_get_sensor,
+    .set = console_set_sensor },
+  { .name = "config.sensors.brv",
+    .val = &config.sensors[SENSOR_BRV],
+    .get = console_get_sensor,
+    .set = console_set_sensor },
+  { .name = "config.sensors.tps",
+    .val = &config.sensors[SENSOR_TPS],
+    .get = console_get_sensor,
+    .set = console_set_sensor },
+  { .name = "config.sensors.aap",
+    .val = &config.sensors[SENSOR_AAP],
+    .get = console_get_sensor,
+    .set = console_set_sensor },
+  { .name = "config.sensors.frt",
+    .val = &config.sensors[SENSOR_FRT],
+    .get = console_get_sensor,
+    .set = console_set_sensor },
+  { .name = "config.sensors.ego",
+    .val = &config.sensors[SENSOR_EGO],
+    .get = console_get_sensor,
+    .set = console_set_sensor },
 
-  {.name="config.events", .get=console_get_events, .set=console_set_events},
+  { .name = "config.events",
+    .get = console_get_events,
+    .set = console_set_events },
 
   /* Tasks */
-  {.name="config.tasks"},
-  {.name="config.tasks.boost_control.overboost", .val=&config.boost_control.overboost,
-   .get=console_get_float, .set=console_set_float},
-  {.name="config.tasks.boost_control.pin", .val=&config.boost_control.pin,
-   .get=console_get_uint, .set=console_set_uint},
-  {.name="config.tasks.boost_control.threshold", .val=&config.boost_control.threshhold_kpa,
-   .get=console_get_float, .set=console_set_float},
+  { .name = "config.tasks" },
+  { .name = "config.tasks.boost_control.overboost",
+    .val = &config.boost_control.overboost,
+    .get = console_get_float,
+    .set = console_set_float },
+  { .name = "config.tasks.boost_control.pin",
+    .val = &config.boost_control.pin,
+    .get = console_get_uint,
+    .set = console_set_uint },
+  { .name = "config.tasks.boost_control.threshold",
+    .val = &config.boost_control.threshhold_kpa,
+    .get = console_get_float,
+    .set = console_set_float },
 
   /* Hardware config */
-  {.name="config.hardware"},
-  {.name="config.hardware.freq"},
-  {.name="config.hardware.pwm"},
+  { .name = "config.hardware" },
+  { .name = "config.hardware.freq" },
+  { .name = "config.hardware.pwm" },
 
-  {.name="status"},
-  {.name="status.current_time", .get=console_get_time},
+  { .name = "status" },
+  { .name = "status.current_time", .get = console_get_time },
 
-  {.name="status.decoder.state", .val=&config.decoder.state,
-   .get=console_get_decoder_state},
-  {.name="status.decoder.loss_reason", .val=&config.decoder.loss,
-   .get=console_get_decoder_loss_reason},
-  {.name="status.decoder.t0_count", .val=&config.decoder.t0_count,
-   .get=console_get_uint},
-  {.name="status.decoder.t1_count", .val=&config.decoder.t1_count,
-   .get=console_get_uint},
-  {.name="status.decoder.rpm", .val=&config.decoder.rpm,
-   .get=console_get_uint},
-  {.name="status.decoder.rpm_variance", .val=&config.decoder.trigger_cur_rpm_change,
-   .get=console_get_float},
+  { .name = "status.decoder.state",
+    .val = &config.decoder.state,
+    .get = console_get_decoder_state },
+  { .name = "status.decoder.loss_reason",
+    .val = &config.decoder.loss,
+    .get = console_get_decoder_loss_reason },
+  { .name = "status.decoder.t0_count",
+    .val = &config.decoder.t0_count,
+    .get = console_get_uint },
+  { .name = "status.decoder.t1_count",
+    .val = &config.decoder.t1_count,
+    .get = console_get_uint },
+  { .name = "status.decoder.rpm",
+    .val = &config.decoder.rpm,
+    .get = console_get_uint },
+  { .name = "status.decoder.rpm_variance",
+    .val = &config.decoder.trigger_cur_rpm_change,
+    .get = console_get_float },
 
-  {.name="status.fueling.cut", .get=console_get_fuel_cut},
-  {.name="status.fueling.pw_us", .val=&calculated_values.fueling_us,
-   .get=console_get_uint},
-  {.name="status.fueling.ete", .val=&calculated_values.ete,
-   .get=console_get_float},
-  {.name="status.fueling.ve", .val=&calculated_values.ve,
-   .get=console_get_float},
-  {.name="status.fueling.lambda", .val=&calculated_values.lambda,
-   .get=console_get_float},
-  {.name="status.fueling.idt", .val=&calculated_values.idt,
-   .get=console_get_float},
-  {.name="status.fueling.fuel_volume", .val=&calculated_values.fuelvol_per_cycle,
-   .get=console_get_float},
-  {.name="status.fueling.tipin", .val=&calculated_values.tipin,
-   .get=console_get_float},
+  { .name = "status.fueling.cut", .get = console_get_fuel_cut },
+  { .name = "status.fueling.pw_us",
+    .val = &calculated_values.fueling_us,
+    .get = console_get_uint },
+  { .name = "status.fueling.ete",
+    .val = &calculated_values.ete,
+    .get = console_get_float },
+  { .name = "status.fueling.ve",
+    .val = &calculated_values.ve,
+    .get = console_get_float },
+  { .name = "status.fueling.lambda",
+    .val = &calculated_values.lambda,
+    .get = console_get_float },
+  { .name = "status.fueling.idt",
+    .val = &calculated_values.idt,
+    .get = console_get_float },
+  { .name = "status.fueling.fuel_volume",
+    .val = &calculated_values.fuelvol_per_cycle,
+    .get = console_get_float },
+  { .name = "status.fueling.tipin",
+    .val = &calculated_values.tipin,
+    .get = console_get_float },
 
-  {.name="status.ignition.timing_advance", 
-    .val=&calculated_values.timing_advance, .get=console_get_float},
-  {.name="status.ignition.dwell_us", .val=&calculated_values.dwell_us,
-   .get=console_get_uint},
-  {.name="status.ignition.cut", .get=console_get_ignition_cut},
-  
+  { .name = "status.ignition.timing_advance",
+    .val = &calculated_values.timing_advance,
+    .get = console_get_float },
+  { .name = "status.ignition.dwell_us",
+    .val = &calculated_values.dwell_us,
+    .get = console_get_uint },
+  { .name = "status.ignition.cut", .get = console_get_ignition_cut },
+
   /* Sensor values */
-  {.name="status.sensors.map", .val=&config.sensors[SENSOR_MAP].processed_value,
-   .get=console_get_float},
-  {.name="status.sensors.map.fault", .val=&config.sensors[SENSOR_MAP].fault,
-   .get=console_get_sensor_fault},
-  {.name="status.sensors.iat", .val=&config.sensors[SENSOR_IAT].processed_value,
-   .get=console_get_float},
-  {.name="status.sensors.iat.fault", .val=&config.sensors[SENSOR_IAT].fault,
-   .get=console_get_sensor_fault},
-  {.name="status.sensors.clt", .val=&config.sensors[SENSOR_CLT].processed_value,
-   .get=console_get_float},
-  {.name="status.sensors.clt.fault", .val=&config.sensors[SENSOR_CLT].fault,
-   .get=console_get_sensor_fault},
-  {.name="status.sensors.brv", .val=&config.sensors[SENSOR_BRV].processed_value,
-   .get=console_get_float},
-  {.name="status.sensors.brv.fault", .val=&config.sensors[SENSOR_BRV].fault,
-   .get=console_get_sensor_fault},
-  {.name="status.sensors.tps", .val=&config.sensors[SENSOR_TPS].processed_value,
-   .get=console_get_float},
-  {.name="status.sensors.tps.fault", .val=&config.sensors[SENSOR_TPS].fault,
-   .get=console_get_sensor_fault},
-  {.name="status.sensors.aap", .val=&config.sensors[SENSOR_AAP].processed_value,
-   .get=console_get_float},
-  {.name="status.sensors.aap.fault", .val=&config.sensors[SENSOR_AAP].fault,
-   .get=console_get_sensor_fault},
-  {.name="status.sensors.frt", .val=&config.sensors[SENSOR_FRT].processed_value,
-   .get=console_get_float},
-  {.name="status.sensors.frt.fault", .val=&config.sensors[SENSOR_FRT].fault,
-   .get=console_get_sensor_fault},
-  {.name="status.sensors.ego", .val=&config.sensors[SENSOR_EGO].processed_value,
-   .get=console_get_float},
-  {.name="status.sensors.ego.fault", .val=&config.sensors[SENSOR_EGO].fault,
-   .get=console_get_sensor_fault},
+  { .name = "status.sensors.map",
+    .val = &config.sensors[SENSOR_MAP].processed_value,
+    .get = console_get_float },
+  { .name = "status.sensors.map.fault",
+    .val = &config.sensors[SENSOR_MAP].fault,
+    .get = console_get_sensor_fault },
+  { .name = "status.sensors.iat",
+    .val = &config.sensors[SENSOR_IAT].processed_value,
+    .get = console_get_float },
+  { .name = "status.sensors.iat.fault",
+    .val = &config.sensors[SENSOR_IAT].fault,
+    .get = console_get_sensor_fault },
+  { .name = "status.sensors.clt",
+    .val = &config.sensors[SENSOR_CLT].processed_value,
+    .get = console_get_float },
+  { .name = "status.sensors.clt.fault",
+    .val = &config.sensors[SENSOR_CLT].fault,
+    .get = console_get_sensor_fault },
+  { .name = "status.sensors.brv",
+    .val = &config.sensors[SENSOR_BRV].processed_value,
+    .get = console_get_float },
+  { .name = "status.sensors.brv.fault",
+    .val = &config.sensors[SENSOR_BRV].fault,
+    .get = console_get_sensor_fault },
+  { .name = "status.sensors.tps",
+    .val = &config.sensors[SENSOR_TPS].processed_value,
+    .get = console_get_float },
+  { .name = "status.sensors.tps.fault",
+    .val = &config.sensors[SENSOR_TPS].fault,
+    .get = console_get_sensor_fault },
+  { .name = "status.sensors.aap",
+    .val = &config.sensors[SENSOR_AAP].processed_value,
+    .get = console_get_float },
+  { .name = "status.sensors.aap.fault",
+    .val = &config.sensors[SENSOR_AAP].fault,
+    .get = console_get_sensor_fault },
+  { .name = "status.sensors.frt",
+    .val = &config.sensors[SENSOR_FRT].processed_value,
+    .get = console_get_float },
+  { .name = "status.sensors.frt.fault",
+    .val = &config.sensors[SENSOR_FRT].fault,
+    .get = console_get_sensor_fault },
+  { .name = "status.sensors.ego",
+    .val = &config.sensors[SENSOR_EGO].processed_value,
+    .get = console_get_float },
+  { .name = "status.sensors.ego.fault",
+    .val = &config.sensors[SENSOR_EGO].fault,
+    .get = console_get_sensor_fault },
 
   /* Misc commands */
-  {.name="flash", .set=console_save_to_flash},
-  {.name="stats", .get=console_get_stats},
-  {.name="bootloader", .get=console_bootloader},
+  { .name = "flash", .set = console_save_to_flash },
+  { .name = "stats", .get = console_get_stats },
+  { .name = "bootloader", .get = console_bootloader },
 
   /* Host commands */
-  {.name="sim"},
-  {.name="sim.trigger_time", .set=console_set_trigger_callback},
-  {.name="sim.test_trigger", .set=console_set_test_trigger},
-  {.name="sim.event_logging", .set=console_set_event_logging},
-  {.name="sim.freeze", .set=console_set_freeze},
-  {0},
+  { .name = "sim" },
+  { .name = "sim.trigger_time", .set = console_set_trigger_callback },
+  { .name = "sim.test_trigger", .set = console_set_test_trigger },
+  { .name = "sim.event_logging", .set = console_set_event_logging },
+  { .name = "sim.freeze", .set = console_set_freeze },
+  { 0 },
 };
 
 /* Lists all immediate prefixes in node list nodes */
-static void console_list_prefix(const struct console_config_node *nodes, 
-  char *dest, const char *prefix) {
+static void
+console_list_prefix(const struct console_config_node* nodes,
+                    char* dest,
+                    const char* prefix) {
 
-  const struct console_config_node *node;
+  const struct console_config_node* node;
   for (node = nodes; node->name; node++) {
     /* If prefix doesn't match */
-    if (prefix && 
-        strlen(prefix) && 
+    if (prefix && strlen(prefix) &&
         strncmp(node->name, prefix, strlen(prefix))) {
       continue;
     }
@@ -921,18 +1084,19 @@ static void console_list_prefix(const struct console_config_node *nodes,
   }
 }
 
-
-int console_parse_request(char *dest, char *line) {
-  char *action = strtok(line, " ");
-  char *var = strtok(NULL, " ");
-  char *rem = strtok(NULL, "\0");
+int
+console_parse_request(char* dest, char* line) {
+  char* action = strtok(line, " ");
+  char* var = strtok(NULL, " ");
+  char* rem = strtok(NULL, "\0");
 
   if (!action) {
     strcat(dest, "invalid action");
     return 0;
   }
 
-  const struct console_config_node *node = console_search_node(console_config_nodes, var);
+  const struct console_config_node* node =
+    console_search_node(console_config_nodes, var);
   if (!strcmp("list", action)) {
     console_list_prefix(console_config_nodes, dest, var);
     return 1;
@@ -956,15 +1120,16 @@ int console_parse_request(char *dest, char *line) {
       strcat(dest, "Config node ");
       strncat(dest, node->name, 64);
       strcat(dest, " does not support set");
-    } 
+    }
   } else {
     strcpy(dest, "invalid action");
   }
   return 0;
 }
 
-void console_init() {
-  const char *console_feed_defaults[] = {
+void
+console_init() {
+  const char* console_feed_defaults[] = {
     "status.current_time",
     "status.decoder.state",
     "status.decoder.rpm",
@@ -992,7 +1157,7 @@ void console_init() {
 
   int count = 0;
   while (console_feed_defaults[count]) {
-    console_feed_config.nodes[count] = 
+    console_feed_config.nodes[count] =
       console_search_node(console_config_nodes, console_feed_defaults[count]);
     assert(console_feed_config.nodes[count]);
     count++;
@@ -1000,13 +1165,14 @@ void console_init() {
   console_feed_config.n_nodes = count;
 }
 
-static void console_feed_line(char *dest) {
+static void
+console_feed_line(char* dest) {
 
   unsigned int i;
   char temp[64];
   char empty[1] = "";
   for (i = 0; i < console_feed_config.n_nodes; i++) {
-    const struct console_config_node *node = console_feed_config.nodes[i];
+    const struct console_config_node* node = console_feed_config.nodes[i];
     strcpy(temp, "");
     if (!node->get) {
       continue;
@@ -1020,22 +1186,25 @@ static void console_feed_line(char *dest) {
   strcat(dest, "\r\n");
 }
 
-struct {
-  struct {
+struct
+{
+  struct
+  {
     int in_progress;
     size_t max;
-    const char *src;
-    char *ptr;
+    const char* src;
+    char* ptr;
   } rx, tx;
 } console_state = {
-  .tx = { .src = config.console.txbuffer, .in_progress = 0},
-  .rx = { .src = config.console.rxbuffer, .in_progress = 0},
+  .tx = { .src = config.console.txbuffer, .in_progress = 0 },
+  .rx = { .src = config.console.rxbuffer, .in_progress = 0 },
 };
 
-int console_read_full(char *buf, size_t max) {
+int
+console_read_full(char* buf, size_t max) {
   if (console_state.rx.in_progress) {
     size_t r = console_state.rx.max - 1 -
-      (size_t)(console_state.rx.ptr - console_state.rx.src);
+               (size_t)(console_state.rx.ptr - console_state.rx.src);
     if (r == 0) {
       console_state.rx.in_progress = 0;
       return 0;
@@ -1043,10 +1212,12 @@ int console_read_full(char *buf, size_t max) {
     r = console_read(console_state.rx.ptr, r);
     if (r) {
       console_state.rx.ptr += r;
-      if (memchr(console_state.rx.src, '\r',
-            (uint16_t)(console_state.rx.ptr - console_state.rx.src)) ||
-          memchr(console_state.rx.src, '\n',
-            (uint16_t)(console_state.rx.ptr - console_state.rx.src))) {
+      if (memchr(console_state.rx.src,
+                 '\r',
+                 (uint16_t)(console_state.rx.ptr - console_state.rx.src)) ||
+          memchr(console_state.rx.src,
+                 '\n',
+                 (uint16_t)(console_state.rx.ptr - console_state.rx.src))) {
         console_state.rx.in_progress = 0;
         return 1;
       }
@@ -1062,11 +1233,11 @@ int console_read_full(char *buf, size_t max) {
   return 0;
 }
 
-
-int console_write_full(char *buf, size_t max) {
+int
+console_write_full(char* buf, size_t max) {
   if (console_state.tx.in_progress) {
     size_t r = console_state.tx.max -
-      (size_t)(console_state.tx.ptr - console_state.tx.src);
+               (size_t)(console_state.tx.ptr - console_state.tx.src);
     r = console_write(console_state.tx.ptr, r);
     if (r) {
       console_state.tx.ptr += r;
@@ -1085,10 +1256,11 @@ int console_write_full(char *buf, size_t max) {
   return 0;
 }
 
-static void console_process_rx() {
-  char *out = config.console.txbuffer;
-  char *in = strtok(config.console.rxbuffer, "\r\n");
-  char *response = out + 2; /* Allow for status character */
+static void
+console_process_rx() {
+  char* out = config.console.txbuffer;
+  char* in = strtok(config.console.rxbuffer, "\r\n");
+  char* response = out + 2; /* Allow for status character */
   strcpy(response, "");
 
   if (!in) {
@@ -1103,33 +1275,45 @@ static void console_process_rx() {
   console_write_full(out, strlen(out));
 }
 
-static void console_output_events() {
+static void
+console_output_events() {
   struct logged_event ev = platform_get_logged_event();
   switch (ev.type) {
-  case EVENT_OUTPUT:
-    sprintf(config.console.txbuffer, "# OUTPUTS %lu %2x\r\n",
-        (unsigned long)ev.time, ev.value);
-    console_write_full(config.console.txbuffer, strlen(config.console.txbuffer));
-    break;
-  case EVENT_GPIO:
-    sprintf(config.console.txbuffer, "# GPIO %lu %2x\r\n",
-        (unsigned long)ev.time, ev.value);
-    console_write_full(config.console.txbuffer, strlen(config.console.txbuffer));
-    break;
-  case EVENT_TRIGGER0:
-    sprintf(config.console.txbuffer, "# TRIGGER0 %lu\r\n", (unsigned long)ev.time);
-    console_write_full(config.console.txbuffer, strlen(config.console.txbuffer));
-    break;
-  case EVENT_TRIGGER1:
-    sprintf(config.console.txbuffer, "# TRIGGER1 %lu\r\n", (unsigned long)ev.time);
-    console_write_full(config.console.txbuffer, strlen(config.console.txbuffer));
-    break;
-  default:
-    break;
+    case EVENT_OUTPUT:
+      sprintf(config.console.txbuffer,
+              "# OUTPUTS %lu %2x\r\n",
+              (unsigned long)ev.time,
+              ev.value);
+      console_write_full(config.console.txbuffer,
+                         strlen(config.console.txbuffer));
+      break;
+    case EVENT_GPIO:
+      sprintf(config.console.txbuffer,
+              "# GPIO %lu %2x\r\n",
+              (unsigned long)ev.time,
+              ev.value);
+      console_write_full(config.console.txbuffer,
+                         strlen(config.console.txbuffer));
+      break;
+    case EVENT_TRIGGER0:
+      sprintf(
+        config.console.txbuffer, "# TRIGGER0 %lu\r\n", (unsigned long)ev.time);
+      console_write_full(config.console.txbuffer,
+                         strlen(config.console.txbuffer));
+      break;
+    case EVENT_TRIGGER1:
+      sprintf(
+        config.console.txbuffer, "# TRIGGER1 %lu\r\n", (unsigned long)ev.time);
+      console_write_full(config.console.txbuffer,
+                         strlen(config.console.txbuffer));
+      break;
+    default:
+      break;
   }
 }
 
-void console_process() {
+void
+console_process() {
 
   static int pending_request = 0;
   stats_start_timing(STATS_CONSOLE_TIME);
@@ -1155,7 +1339,8 @@ void console_process() {
   console_output_events();
   if (console_feed_config.n_nodes) {
     console_feed_line(config.console.txbuffer);
-    console_write_full(config.console.txbuffer, strlen(config.console.txbuffer));
+    console_write_full(config.console.txbuffer,
+                       strlen(config.console.txbuffer));
   }
 
   stats_finish_timing(STATS_CONSOLE_TIME);
@@ -1165,14 +1350,14 @@ void console_process() {
 #include <check.h>
 
 static struct console_config_node test_nodes[] = {
-  {.name="test1"},
-  {.name="test2"},
-  {.name="test2.testA"},
-  {.name="test3.testA"},
-  {.name="test3.testA.test1"},
-  {.name="test2.testB"},
-  {.name="test2.testB.test2"},
-  {0},
+  { .name = "test1" },
+  { .name = "test2" },
+  { .name = "test2.testA" },
+  { .name = "test3.testA" },
+  { .name = "test3.testA.test1" },
+  { .name = "test2.testB" },
+  { .name = "test2.testB.test2" },
+  { 0 },
 };
 
 START_TEST(check_console_search_node) {
@@ -1186,10 +1371,12 @@ START_TEST(check_console_search_node) {
 
   ck_assert_ptr_eq(console_search_node(test_nodes, "test1"), &test_nodes[0]);
   ck_assert_ptr_eq(console_search_node(test_nodes, "test2"), &test_nodes[1]);
-  ck_assert_ptr_eq(console_search_node(test_nodes, "test2.testA"), &test_nodes[2]);
-  ck_assert_ptr_eq(console_search_node(test_nodes, "test3.testA.test1"), &test_nodes[4]);
-
-} END_TEST
+  ck_assert_ptr_eq(console_search_node(test_nodes, "test2.testA"),
+                   &test_nodes[2]);
+  ck_assert_ptr_eq(console_search_node(test_nodes, "test3.testA.test1"),
+                   &test_nodes[4]);
+}
+END_TEST
 
 START_TEST(check_console_list_prefix) {
   char buf[128];
@@ -1205,13 +1392,15 @@ START_TEST(check_console_list_prefix) {
   strcpy(buf, "");
   console_list_prefix(test_nodes, buf, "test3");
   ck_assert_str_eq(buf, "test3.testA test3.testA.test1 ");
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_get_time) {
-  char buf[32] = {0};
+  char buf[32] = { 0 };
   console_get_time(NULL, buf, NULL);
   ck_assert(strlen(buf) != 0);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_get_float) {
   float v;
@@ -1223,7 +1412,8 @@ START_TEST(check_console_get_float) {
   char buf[32];
   console_get_float(&t, buf, NULL);
   ck_assert_str_eq(buf, "1.0000");
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_set_float) {
   float v;
@@ -1234,7 +1424,8 @@ START_TEST(check_console_set_float) {
   char buf[] = "1.00";
   console_set_float(&t, buf);
   ck_assert_float_eq(v, 1.00);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_get_uint) {
   unsigned int v;
@@ -1246,7 +1437,8 @@ START_TEST(check_console_get_uint) {
   char buf[32];
   console_get_uint(&t, buf, NULL);
   ck_assert_str_eq(buf, "200");
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_set_uint) {
   unsigned int v;
@@ -1257,11 +1449,12 @@ START_TEST(check_console_set_uint) {
   char buf[] = "200";
   console_set_uint(&t, buf);
   ck_assert_uint_eq(v, 200);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_parse_keyval_pair) {
-  char *buf = malloc(64);
-  char *orig = buf;
+  char* buf = malloc(64);
+  char* orig = buf;
 
   strcpy(buf, "");
   char *k = NULL, *v = NULL;
@@ -1270,25 +1463,30 @@ START_TEST(check_parse_keyval_pair) {
   ck_assert_ptr_null(k);
   ck_assert_ptr_null(v);
 
-  k = NULL; k = NULL;
+  k = NULL;
+  k = NULL;
   strcpy(buf, "");
   ck_assert_int_eq(parse_keyval_pair(&k, &v, &buf), 0);
 
-  k = NULL; k = NULL;
+  k = NULL;
+  k = NULL;
   strcpy(buf, "keywithnoval");
   ck_assert_int_eq(parse_keyval_pair(&k, &v, &buf), 0);
 
-  k = NULL; k = NULL;
+  k = NULL;
+  k = NULL;
   strcpy(buf, "keywithnoval=");
   ck_assert_int_eq(parse_keyval_pair(&k, &v, &buf), 0);
 
-  k = NULL; k = NULL;
+  k = NULL;
+  k = NULL;
   strcpy(buf, "keywithval=val");
   ck_assert_int_eq(parse_keyval_pair(&k, &v, &buf), 1);
   ck_assert_str_eq(k, "keywithval");
   ck_assert_str_eq(v, "val");
 
-  k = NULL; k = NULL;
+  k = NULL;
+  k = NULL;
   strcpy(buf, "keywithval=val anotherkey=anotherval");
   ck_assert_int_eq(parse_keyval_pair(&k, &v, &buf), 1);
   ck_assert_str_eq(k, "keywithval");
@@ -1299,7 +1497,8 @@ START_TEST(check_parse_keyval_pair) {
   ck_assert_str_eq(v, "anotherval");
 
   free(orig);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_set_table_element_oneaxis) {
   struct table t1 = {
@@ -1322,7 +1521,8 @@ START_TEST(check_console_set_table_element_oneaxis) {
 
   ck_assert_int_eq(console_set_table_element(&t1, "[3]", 1.0), 1);
   ck_assert_float_eq(t1.data.one[3], 1.0);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_set_table_element_twoaxis) {
   struct table t2 = {
@@ -1347,7 +1547,8 @@ START_TEST(check_console_set_table_element_twoaxis) {
 
   ck_assert_int_eq(console_set_table_element(&t2, "[3][2]", 1.0), 1);
   ck_assert_float_eq(t2.data.two[3][2], 1.0);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_get_table_element_oneaxis) {
   const struct table t1 = {
@@ -1380,7 +1581,8 @@ START_TEST(check_console_get_table_element_oneaxis) {
 
   ck_assert_int_eq(console_get_table_element(&t1, "[1][1]", &v), 1);
   ck_assert_float_eq(v, 13.0);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_get_table_element_twoaxis) {
   struct table t2 = {
@@ -1407,12 +1609,13 @@ START_TEST(check_console_get_table_element_twoaxis) {
 
   ck_assert_int_eq(console_set_table_element(&t2, "[3][2]", 1.0), 1);
   ck_assert_float_eq(t2.data.two[3][2], 1.0);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_set_table_axis_labels) {
   struct table_axis a = {
     .num = 4,
-    .values = {0},
+    .values = { 0 },
   };
   char buf[32];
 
@@ -1433,15 +1636,15 @@ START_TEST(check_console_set_table_axis_labels) {
   ck_assert_int_eq(a.values[0], 8);
   ck_assert_int_eq(a.values[1], 9);
   ck_assert_int_eq(a.values[2], 10);
-
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_set_table) {
-  struct table t = {0};
-  const struct console_config_node n = {.val = &t};
+  struct table t = { 0 };
+  const struct console_config_node n = { .val = &t };
 
   char buf[] = "name=test naxis=2 rows=3 cols=3 rowname=row colname=col "
-    "rowlabels=[1,2,3] collabels=[5,6,7.2] [0][0]=5.0";
+               "rowlabels=[1,2,3] collabels=[5,6,7.2] [0][0]=5.0";
 
   console_set_table(&n, buf);
   ck_assert_str_eq(t.title, "test");
@@ -1467,12 +1670,12 @@ START_TEST(check_console_set_table) {
   ck_assert_float_eq(t.data.two[0][1], 1.2);
   ck_assert_float_eq(t.data.two[0][2], 1.3);
   ck_assert_float_eq(t.data.two[1][0], 2.0);
-
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_get_table) {
   struct table t;
-  const struct console_config_node n = {.val = &t};
+  const struct console_config_node n = { .val = &t };
 
   char buf[512];
   t = (struct table){
@@ -1509,8 +1712,8 @@ START_TEST(check_console_get_table) {
   char cmd2[] = "[1][1]";
   console_get_table(&n, buf, cmd2);
   ck_assert_str_eq(buf, "6.00");
-
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_get_sensor) {
   struct sensor_input s_const = {
@@ -1524,7 +1727,7 @@ START_TEST(check_console_get_sensor) {
       .fault_value = 1.5,
     },
   };
-  struct console_config_node n = {.val = &s_const};
+  struct console_config_node n = { .val = &s_const };
   char buf[256];
   char cmd[] = "";
 
@@ -1558,14 +1761,15 @@ START_TEST(check_console_get_sensor) {
   ck_assert_ptr_nonnull(strstr(buf, "range-max=20.00"));
   ck_assert_ptr_nonnull(strstr(buf, "pin=1"));
   ck_assert_ptr_nonnull(strstr(buf, "lag=20.00"));
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_set_sensor) {
-  struct sensor_input s = {0};
-  const struct console_config_node n = {.val = &s};
+  struct sensor_input s = { 0 };
+  const struct console_config_node n = { .val = &s };
 
   char buf[] = "source=freq pin=2 method=linear lag=0.2 range-min=20.1 "
-    "range-max=100.1 fault-min=200 fault-max=400, fault-val=19.2";
+               "range-max=100.1 fault-min=200 fault-max=400, fault-val=19.2";
 
   console_set_sensor(&n, buf);
   ck_assert_int_eq(s.source, SENSOR_FREQ);
@@ -1582,8 +1786,8 @@ START_TEST(check_console_set_sensor) {
   console_set_sensor(&n, buf2);
   ck_assert_int_eq(s.source, SENSOR_CONST);
   ck_assert_float_eq(s.params.fixed_value, 101.1);
-
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_get_events) {
 
@@ -1594,7 +1798,7 @@ START_TEST(check_console_get_events) {
   console_get_events(NULL, buf, cmd);
   ck_assert_str_eq(buf, "num_events=4");
 
-  config.events[3] = (struct output_event) {
+  config.events[3] = (struct output_event){
     .type = FUEL_EVENT,
     .inverted = 1,
     .angle = 100,
@@ -1608,7 +1812,7 @@ START_TEST(check_console_get_events) {
   ck_assert_ptr_nonnull(strstr(buf, "output=5"));
   ck_assert_ptr_nonnull(strstr(buf, "inverted=1"));
 
-  config.events[3] = (struct output_event) {
+  config.events[3] = (struct output_event){
     .type = IGNITION_EVENT,
     .inverted = 0,
     .angle = 5,
@@ -1621,14 +1825,14 @@ START_TEST(check_console_get_events) {
   ck_assert_ptr_nonnull(strstr(buf, "angle=5"));
   ck_assert_ptr_nonnull(strstr(buf, "output=4"));
   ck_assert_ptr_nonnull(strstr(buf, "inverted=0"));
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_console_set_events) {
 
   char buf[] = "num_events=4";
   console_set_events(NULL, buf);
   ck_assert_int_eq(config.num_events, 4);
-
 
   char buf2[] = "2 type=fuel inverted=1 angle=12 output=6";
 
@@ -1637,11 +1841,12 @@ START_TEST(check_console_set_events) {
   ck_assert_int_eq(config.events[2].inverted, 1);
   ck_assert_int_eq(config.events[2].angle, 12);
   ck_assert_int_eq(config.events[2].pin, 6);
-} END_TEST
+}
+END_TEST
 
-
-TCase *setup_console_tests() {
-  TCase *console_tests = tcase_create("console");
+TCase*
+setup_console_tests() {
+  TCase* console_tests = tcase_create("console");
   tcase_add_test(console_tests, check_console_search_node);
   tcase_add_test(console_tests, check_console_list_prefix);
   tcase_add_test(console_tests, check_console_get_time);

--- a/src/console.h
+++ b/src/console.h
@@ -31,7 +31,7 @@ void console_record_event(struct logged_event);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase* setup_console_tests();
+TCase *setup_console_tests();
 #endif
 
 #endif

--- a/src/console.h
+++ b/src/console.h
@@ -1,6 +1,8 @@
 #ifndef _CONSOLE_H
 #define _CONSOLE_H
 
+#include "platform.h"
+
 #define CONSOLE_BUFFER_SIZE 2048
 
 struct console {

--- a/src/console.h
+++ b/src/console.h
@@ -22,14 +22,17 @@ struct logged_event {
   uint16_t value;
 };
 
-void console_init();
-void console_process();
+void
+console_init();
+void
+console_process();
 
 void console_record_event(struct logged_event);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase *setup_console_tests();
+TCase*
+setup_console_tests();
 #endif
 
 #endif

--- a/src/console.h
+++ b/src/console.h
@@ -24,17 +24,14 @@ struct logged_event {
   uint16_t value;
 };
 
-void
-console_init();
-void
-console_process();
+void console_init();
+void console_process();
 
 void console_record_event(struct logged_event);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase*
-setup_console_tests();
+TCase* setup_console_tests();
 #endif
 
 #endif

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -10,8 +10,7 @@
 
 static struct timed_callback expire_event;
 
-static void
-invalidate_decoder() {
+static void invalidate_decoder() {
   config.decoder.valid = 0;
   config.decoder.state = DECODER_NOSYNC;
   config.decoder.current_triggers_rpm = 0;
@@ -19,28 +18,24 @@ invalidate_decoder() {
   invalidate_scheduled_events(config.events, config.num_events);
 }
 
-static void
-handle_decoder_expire() {
+static void handle_decoder_expire() {
   config.decoder.loss = DECODER_EXPIRED;
   invalidate_decoder();
 }
 
-static void
-set_expire_event(timeval_t t) {
+static void set_expire_event(timeval_t t) {
   schedule_callback(&expire_event, t);
 }
 
-static void
-push_time(struct decoder* d, timeval_t t) {
+static void push_time(struct decoder* d, timeval_t t) {
   for (int i = MAX_TRIGGERS - 1; i > 0; --i) {
     d->times[i] = d->times[i - 1];
   }
   d->times[0] = t;
 }
 
-static unsigned int
-current_rpm_window_size(unsigned int current_triggers,
-                        unsigned int normal_window_size) {
+static unsigned int current_rpm_window_size(unsigned int current_triggers,
+                                            unsigned int normal_window_size) {
 
   /* Use the minimum of rpm_window_size and current previous triggers so that
    * rpm is valid in case our window size is larger than required trigger
@@ -53,8 +48,7 @@ current_rpm_window_size(unsigned int current_triggers,
 }
 
 /* Update rpm information and validate */
-static void
-trigger_update_rpm(struct decoder* d) {
+static void trigger_update_rpm(struct decoder* d) {
   timeval_t diff = d->times[0] - d->times[1];
   unsigned int slicerpm = rpm_from_time_diff(diff, d->degrees_per_trigger);
   unsigned int rpm_window_size =
@@ -92,8 +86,7 @@ trigger_update_rpm(struct decoder* d) {
   set_expire_event(d->expiration);
 }
 
-static void
-trigger_update(struct decoder* d, timeval_t t) {
+static void trigger_update(struct decoder* d, timeval_t t) {
   /* Bookkeeping */
   push_time(d, t);
   d->t0_count++;
@@ -122,8 +115,7 @@ trigger_update(struct decoder* d, timeval_t t) {
   }
 }
 
-static void
-sync_update(struct decoder* d) {
+static void sync_update(struct decoder* d) {
   d->t1_count++;
   if (d->state == DECODER_RPM) {
     d->state = DECODER_SYNC;
@@ -142,8 +134,7 @@ sync_update(struct decoder* d) {
   d->triggers_since_last_sync = 0;
 }
 
-void
-cam_nplusone_decoder(struct decoder* d) {
+void cam_nplusone_decoder(struct decoder* d) {
   timeval_t t0 = d->last_t0;
   decoder_state oldstate = d->state;
 
@@ -168,8 +159,7 @@ cam_nplusone_decoder(struct decoder* d) {
   }
 }
 
-void
-tfi_pip_decoder(struct decoder* d) {
+void tfi_pip_decoder(struct decoder* d) {
   stats_start_timing(STATS_DECODE_TIME);
   timeval_t t0;
   decoder_state oldstate = d->state;
@@ -194,8 +184,7 @@ tfi_pip_decoder(struct decoder* d) {
   stats_finish_timing(STATS_DECODE_TIME);
 }
 
-void
-decoder_init(struct decoder* d) {
+void decoder_init(struct decoder* d) {
   d->last_t0 = 0;
   d->last_t1 = 0;
   d->needs_decoding_t0 = 0;
@@ -234,8 +223,8 @@ decoder_init(struct decoder* d) {
 }
 
 /* When decoder has new information, reschedule everything */
-void
-decoder_update_scheduling(struct decoder_event* events, unsigned int count) {
+void decoder_update_scheduling(struct decoder_event* events,
+                               unsigned int count) {
   stats_start_timing(STATS_SCHEDULE_LATENCY);
 
   for (struct decoder_event* ev = events; count > 0; count--, ev++) {
@@ -274,25 +263,24 @@ decoder_update_scheduling(struct decoder_event* events, unsigned int count) {
 
 #include <check.h>
 
-static struct decoder_event*
-find_last_trigger_event(struct decoder_event** entries) {
+static struct decoder_event* find_last_trigger_event(
+  struct decoder_event** entries) {
   struct decoder_event* entry;
   for (entry = *entries; entry->next; entry = entry->next)
     ;
   return entry;
 }
 
-static void
-append_trigger_event(struct decoder_event* last, struct decoder_event new) {
+static void append_trigger_event(struct decoder_event* last,
+                                 struct decoder_event new) {
   last->next = malloc(sizeof(struct decoder_event));
   *(last->next) = new;
 }
 
-static void
-add_trigger_event(struct decoder_event** entries,
-                  timeval_t duration,
-                  unsigned int primary,
-                  unsigned int secondary) {
+static void add_trigger_event(struct decoder_event** entries,
+                              timeval_t duration,
+                              unsigned int primary,
+                              unsigned int secondary) {
 
   if (!*entries) {
     *entries = malloc(sizeof(struct decoder_event));
@@ -317,8 +305,7 @@ add_trigger_event(struct decoder_event** entries,
   append_trigger_event(last, new);
 }
 
-static void
-free_trigger_list(struct decoder_event* entries) {
+static void free_trigger_list(struct decoder_event* entries) {
   struct decoder_event* current = entries;
   struct decoder_event* next;
   while (current) {
@@ -328,11 +315,10 @@ free_trigger_list(struct decoder_event* entries) {
   }
 }
 
-static void
-add_trigger_event_transition_rpm(struct decoder_event** entries,
-                                 timeval_t duration,
-                                 unsigned int primary,
-                                 unsigned int secondary) {
+static void add_trigger_event_transition_rpm(struct decoder_event** entries,
+                                             timeval_t duration,
+                                             unsigned int primary,
+                                             unsigned int secondary) {
   ck_assert(*entries);
 
   struct decoder_event* last = find_last_trigger_event(entries);
@@ -347,11 +333,10 @@ add_trigger_event_transition_rpm(struct decoder_event** entries,
   append_trigger_event(last, new);
 }
 
-static void
-add_trigger_event_transition_sync(struct decoder_event** entries,
-                                  timeval_t duration,
-                                  unsigned int primary,
-                                  unsigned int secondary) {
+static void add_trigger_event_transition_sync(struct decoder_event** entries,
+                                              timeval_t duration,
+                                              unsigned int primary,
+                                              unsigned int secondary) {
   ck_assert(*entries);
 
   struct decoder_event* last = find_last_trigger_event(entries);
@@ -366,12 +351,11 @@ add_trigger_event_transition_sync(struct decoder_event** entries,
   append_trigger_event(last, new);
 }
 
-static void
-add_trigger_event_transition_loss(struct decoder_event** entries,
-                                  timeval_t duration,
-                                  unsigned int primary,
-                                  unsigned int secondary,
-                                  decoder_loss_reason reason) {
+static void add_trigger_event_transition_loss(struct decoder_event** entries,
+                                              timeval_t duration,
+                                              unsigned int primary,
+                                              unsigned int secondary,
+                                              decoder_loss_reason reason) {
   ck_assert(*entries);
 
   struct decoder_event* last = find_last_trigger_event(entries);
@@ -386,8 +370,7 @@ add_trigger_event_transition_loss(struct decoder_event** entries,
   append_trigger_event(last, new);
 }
 
-static void
-validate_decoder_sequence(struct decoder_event* ev) {
+static void validate_decoder_sequence(struct decoder_event* ev) {
   for (; ev; ev = ev->next) {
     if (ev->t0) {
       config.decoder.last_t0 = ev->time;
@@ -418,8 +401,7 @@ validate_decoder_sequence(struct decoder_event* ev) {
   }
 }
 
-static void
-prepare_decoder(trigger_type type) {
+static void prepare_decoder(trigger_type type) {
   config.decoder.type = type;
   decoder_init(&config.decoder);
 }
@@ -493,8 +475,8 @@ START_TEST(check_tfi_decoder_syncloss_expire) {
 END_TEST
 
 /* Gets decoder up to sync, plus an additional trigger */
-static void
-cam_nplusone_normal_startup_to_sync(struct decoder_event** entries) {
+static void cam_nplusone_normal_startup_to_sync(
+  struct decoder_event** entries) {
   /* Triggers to get RPM */
   for (int i = 0; i < config.decoder.required_triggers_rpm - 1; ++i) {
     add_trigger_event(entries, 25000, 1, 0);
@@ -713,8 +695,7 @@ START_TEST(check_update_rpm_window_smaller) {
 }
 END_TEST
 
-TCase*
-setup_decoder_tests() {
+TCase* setup_decoder_tests() {
   TCase* decoder_tests = tcase_create("decoder");
   tcase_add_test(decoder_tests, check_tfi_decoder_startup_normal);
   tcase_add_test(decoder_tests, check_tfi_decoder_syncloss_variation);

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -27,7 +27,7 @@ static void set_expire_event(timeval_t t) {
   schedule_callback(&expire_event, t);
 }
 
-static void push_time(struct decoder* d, timeval_t t) {
+static void push_time(struct decoder *d, timeval_t t) {
   for (int i = MAX_TRIGGERS - 1; i > 0; --i) {
     d->times[i] = d->times[i - 1];
   }
@@ -48,7 +48,7 @@ static unsigned int current_rpm_window_size(unsigned int current_triggers,
 }
 
 /* Update rpm information and validate */
-static void trigger_update_rpm(struct decoder* d) {
+static void trigger_update_rpm(struct decoder *d) {
   timeval_t diff = d->times[0] - d->times[1];
   unsigned int slicerpm = rpm_from_time_diff(diff, d->degrees_per_trigger);
   unsigned int rpm_window_size =
@@ -86,7 +86,7 @@ static void trigger_update_rpm(struct decoder* d) {
   set_expire_event(d->expiration);
 }
 
-static void trigger_update(struct decoder* d, timeval_t t) {
+static void trigger_update(struct decoder *d, timeval_t t) {
   /* Bookkeeping */
   push_time(d, t);
   d->t0_count++;
@@ -115,7 +115,7 @@ static void trigger_update(struct decoder* d, timeval_t t) {
   }
 }
 
-static void sync_update(struct decoder* d) {
+static void sync_update(struct decoder *d) {
   d->t1_count++;
   if (d->state == DECODER_RPM) {
     d->state = DECODER_SYNC;
@@ -134,7 +134,7 @@ static void sync_update(struct decoder* d) {
   d->triggers_since_last_sync = 0;
 }
 
-void cam_nplusone_decoder(struct decoder* d) {
+void cam_nplusone_decoder(struct decoder *d) {
   timeval_t t0 = d->last_t0;
   decoder_state oldstate = d->state;
 
@@ -159,7 +159,7 @@ void cam_nplusone_decoder(struct decoder* d) {
   }
 }
 
-void tfi_pip_decoder(struct decoder* d) {
+void tfi_pip_decoder(struct decoder *d) {
   stats_start_timing(STATS_DECODE_TIME);
   timeval_t t0;
   decoder_state oldstate = d->state;
@@ -184,7 +184,7 @@ void tfi_pip_decoder(struct decoder* d) {
   stats_finish_timing(STATS_DECODE_TIME);
 }
 
-void decoder_init(struct decoder* d) {
+void decoder_init(struct decoder *d) {
   d->last_t0 = 0;
   d->last_t1 = 0;
   d->needs_decoding_t0 = 0;
@@ -223,11 +223,11 @@ void decoder_init(struct decoder* d) {
 }
 
 /* When decoder has new information, reschedule everything */
-void decoder_update_scheduling(struct decoder_event* events,
+void decoder_update_scheduling(struct decoder_event *events,
                                unsigned int count) {
   stats_start_timing(STATS_SCHEDULE_LATENCY);
 
-  for (struct decoder_event* ev = events; count > 0; count--, ev++) {
+  for (struct decoder_event *ev = events; count > 0; count--, ev++) {
     assert(!(ev->t0 && ev->t1));
     if (ev->t0) {
       config.decoder.last_t0 = ev->time;
@@ -263,21 +263,21 @@ void decoder_update_scheduling(struct decoder_event* events,
 
 #include <check.h>
 
-static struct decoder_event* find_last_trigger_event(
-  struct decoder_event** entries) {
-  struct decoder_event* entry;
+static struct decoder_event *find_last_trigger_event(
+  struct decoder_event **entries) {
+  struct decoder_event *entry;
   for (entry = *entries; entry->next; entry = entry->next)
     ;
   return entry;
 }
 
-static void append_trigger_event(struct decoder_event* last,
+static void append_trigger_event(struct decoder_event *last,
                                  struct decoder_event new) {
   last->next = malloc(sizeof(struct decoder_event));
   *(last->next) = new;
 }
 
-static void add_trigger_event(struct decoder_event** entries,
+static void add_trigger_event(struct decoder_event **entries,
                               timeval_t duration,
                               unsigned int primary,
                               unsigned int secondary) {
@@ -293,7 +293,7 @@ static void add_trigger_event(struct decoder_event** entries,
     return;
   }
 
-  struct decoder_event* last = find_last_trigger_event(entries);
+  struct decoder_event *last = find_last_trigger_event(entries);
   struct decoder_event new = (struct decoder_event){
     .t0 = primary,
     .t1 = secondary,
@@ -305,9 +305,9 @@ static void add_trigger_event(struct decoder_event** entries,
   append_trigger_event(last, new);
 }
 
-static void free_trigger_list(struct decoder_event* entries) {
-  struct decoder_event* current = entries;
-  struct decoder_event* next;
+static void free_trigger_list(struct decoder_event *entries) {
+  struct decoder_event *current = entries;
+  struct decoder_event *next;
   while (current) {
     next = current->next;
     free(current);
@@ -315,13 +315,13 @@ static void free_trigger_list(struct decoder_event* entries) {
   }
 }
 
-static void add_trigger_event_transition_rpm(struct decoder_event** entries,
+static void add_trigger_event_transition_rpm(struct decoder_event **entries,
                                              timeval_t duration,
                                              unsigned int primary,
                                              unsigned int secondary) {
   ck_assert(*entries);
 
-  struct decoder_event* last = find_last_trigger_event(entries);
+  struct decoder_event *last = find_last_trigger_event(entries);
   struct decoder_event new = (struct decoder_event){
     .t0 = primary,
     .t1 = secondary,
@@ -333,13 +333,13 @@ static void add_trigger_event_transition_rpm(struct decoder_event** entries,
   append_trigger_event(last, new);
 }
 
-static void add_trigger_event_transition_sync(struct decoder_event** entries,
+static void add_trigger_event_transition_sync(struct decoder_event **entries,
                                               timeval_t duration,
                                               unsigned int primary,
                                               unsigned int secondary) {
   ck_assert(*entries);
 
-  struct decoder_event* last = find_last_trigger_event(entries);
+  struct decoder_event *last = find_last_trigger_event(entries);
   struct decoder_event new = (struct decoder_event){
     .t0 = primary,
     .t1 = secondary,
@@ -351,14 +351,14 @@ static void add_trigger_event_transition_sync(struct decoder_event** entries,
   append_trigger_event(last, new);
 }
 
-static void add_trigger_event_transition_loss(struct decoder_event** entries,
+static void add_trigger_event_transition_loss(struct decoder_event **entries,
                                               timeval_t duration,
                                               unsigned int primary,
                                               unsigned int secondary,
                                               decoder_loss_reason reason) {
   ck_assert(*entries);
 
-  struct decoder_event* last = find_last_trigger_event(entries);
+  struct decoder_event *last = find_last_trigger_event(entries);
   struct decoder_event new = (struct decoder_event){
     .t0 = primary,
     .t1 = secondary,
@@ -370,7 +370,7 @@ static void add_trigger_event_transition_loss(struct decoder_event** entries,
   append_trigger_event(last, new);
 }
 
-static void validate_decoder_sequence(struct decoder_event* ev) {
+static void validate_decoder_sequence(struct decoder_event *ev) {
   for (; ev; ev = ev->next) {
     if (ev->t0) {
       config.decoder.last_t0 = ev->time;
@@ -407,7 +407,7 @@ static void prepare_decoder(trigger_type type) {
 }
 
 START_TEST(check_tfi_decoder_startup_normal) {
-  struct decoder_event* entries = NULL;
+  struct decoder_event *entries = NULL;
   prepare_decoder(FORD_TFI);
 
   /* Triggers to get RPM */
@@ -426,7 +426,7 @@ START_TEST(check_tfi_decoder_startup_normal) {
 END_TEST
 
 START_TEST(check_tfi_decoder_syncloss_variation) {
-  struct decoder_event* entries = NULL;
+  struct decoder_event *entries = NULL;
   prepare_decoder(FORD_TFI);
 
   /* Triggers to get RPM */
@@ -447,7 +447,7 @@ START_TEST(check_tfi_decoder_syncloss_variation) {
 END_TEST
 
 START_TEST(check_tfi_decoder_syncloss_expire) {
-  struct decoder_event* entries = NULL;
+  struct decoder_event *entries = NULL;
   prepare_decoder(FORD_TFI);
 
   /* Triggers to get RPM */
@@ -476,7 +476,7 @@ END_TEST
 
 /* Gets decoder up to sync, plus an additional trigger */
 static void cam_nplusone_normal_startup_to_sync(
-  struct decoder_event** entries) {
+  struct decoder_event **entries) {
   /* Triggers to get RPM */
   for (int i = 0; i < config.decoder.required_triggers_rpm - 1; ++i) {
     add_trigger_event(entries, 25000, 1, 0);
@@ -493,7 +493,7 @@ static void cam_nplusone_normal_startup_to_sync(
 }
 
 START_TEST(check_cam_nplusone_startup_normal) {
-  struct decoder_event* entries = NULL;
+  struct decoder_event *entries = NULL;
   prepare_decoder(TOYOTA_24_1_CAS);
 
   cam_nplusone_normal_startup_to_sync(&entries);
@@ -512,7 +512,7 @@ START_TEST(check_cam_nplusone_startup_normal) {
 END_TEST
 
 START_TEST(check_cam_nplusone_startup_normal_then_early_sync) {
-  struct decoder_event* entries = NULL;
+  struct decoder_event *entries = NULL;
   prepare_decoder(TOYOTA_24_1_CAS);
 
   cam_nplusone_normal_startup_to_sync(&entries);
@@ -534,7 +534,7 @@ START_TEST(check_cam_nplusone_startup_normal_then_early_sync) {
 END_TEST
 
 START_TEST(check_cam_nplusone_startup_normal_sustained) {
-  struct decoder_event* entries = NULL;
+  struct decoder_event *entries = NULL;
   prepare_decoder(TOYOTA_24_1_CAS);
 
   cam_nplusone_normal_startup_to_sync(&entries);
@@ -557,14 +557,14 @@ START_TEST(check_cam_nplusone_startup_normal_sustained) {
 END_TEST
 
 START_TEST(check_bulk_decoder_updates) {
-  struct decoder_event* entries = NULL;
+  struct decoder_event *entries = NULL;
   prepare_decoder(TOYOTA_24_1_CAS);
 
   cam_nplusone_normal_startup_to_sync(&entries);
 
   /* Turn entries linked list into array usable by interface */
-  struct decoder_event* entry_list = malloc(sizeof(struct decoder_event));
-  struct decoder_event* ev;
+  struct decoder_event *entry_list = malloc(sizeof(struct decoder_event));
+  struct decoder_event *ev;
   int len;
   for (len = 0, ev = entries; ev != NULL; ++len, ev = ev->next) {
     entry_list[len] = *ev;
@@ -581,7 +581,7 @@ START_TEST(check_bulk_decoder_updates) {
 END_TEST
 
 START_TEST(check_cam_nplusone_startup_normal_no_second_trigger) {
-  struct decoder_event* entries = NULL;
+  struct decoder_event *entries = NULL;
   prepare_decoder(TOYOTA_24_1_CAS);
 
   cam_nplusone_normal_startup_to_sync(&entries);
@@ -601,7 +601,7 @@ START_TEST(check_cam_nplusone_startup_normal_no_second_trigger) {
 END_TEST
 
 START_TEST(check_nplusone_decoder_syncloss_expire) {
-  struct decoder_event* entries = NULL;
+  struct decoder_event *entries = NULL;
   prepare_decoder(TOYOTA_24_1_CAS);
 
   cam_nplusone_normal_startup_to_sync(&entries);
@@ -695,8 +695,8 @@ START_TEST(check_update_rpm_window_smaller) {
 }
 END_TEST
 
-TCase* setup_decoder_tests() {
-  TCase* decoder_tests = tcase_create("decoder");
+TCase *setup_decoder_tests() {
+  TCase *decoder_tests = tcase_create("decoder");
   tcase_add_test(decoder_tests, check_tfi_decoder_startup_normal);
   tcase_add_test(decoder_tests, check_tfi_decoder_syncloss_variation);
   tcase_add_test(decoder_tests, check_tfi_decoder_syncloss_expire);

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -190,25 +190,25 @@ void decoder_init(struct decoder *d) {
   d->needs_decoding_t0 = 0;
   d->needs_decoding_t1 = 0;
   switch (d->type) {
-    case FORD_TFI:
-      d->decode = tfi_pip_decoder;
-      d->required_triggers_rpm = 4;
-      d->degrees_per_trigger = 90;
-      d->rpm_window_size = 3;
-      d->num_triggers = 8;
-      d->t0_edge = FALLING_EDGE;
-      break;
-    case TOYOTA_24_1_CAS:
-      d->decode = cam_nplusone_decoder;
-      d->required_triggers_rpm = 8;
-      d->degrees_per_trigger = 30;
-      d->rpm_window_size = 8;
-      d->num_triggers = 24;
-      d->t0_edge = RISING_EDGE;
-      d->t1_edge = RISING_EDGE;
-      break;
-    default:
-      break;
+  case FORD_TFI:
+    d->decode = tfi_pip_decoder;
+    d->required_triggers_rpm = 4;
+    d->degrees_per_trigger = 90;
+    d->rpm_window_size = 3;
+    d->num_triggers = 8;
+    d->t0_edge = FALLING_EDGE;
+    break;
+  case TOYOTA_24_1_CAS:
+    d->decode = cam_nplusone_decoder;
+    d->required_triggers_rpm = 8;
+    d->degrees_per_trigger = 30;
+    d->rpm_window_size = 8;
+    d->num_triggers = 24;
+    d->t0_edge = RISING_EDGE;
+    d->t1_edge = RISING_EDGE;
+    break;
+  default:
+    break;
   }
   d->current_triggers_rpm = 0;
   d->valid = 0;

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -1,16 +1,17 @@
 #include "decoder.h"
-#include "platform.h"
-#include "util.h"
-#include "scheduler.h"
 #include "config.h"
+#include "platform.h"
+#include "scheduler.h"
 #include "stats.h"
+#include "util.h"
 
 #include <assert.h>
 #include <stdlib.h>
 
 static struct timed_callback expire_event;
 
-static void invalidate_decoder() {
+static void
+invalidate_decoder() {
   config.decoder.valid = 0;
   config.decoder.state = DECODER_NOSYNC;
   config.decoder.current_triggers_rpm = 0;
@@ -18,24 +19,28 @@ static void invalidate_decoder() {
   invalidate_scheduled_events(config.events, config.num_events);
 }
 
-static void handle_decoder_expire() {
+static void
+handle_decoder_expire() {
   config.decoder.loss = DECODER_EXPIRED;
   invalidate_decoder();
 }
 
-static void set_expire_event(timeval_t t) {
+static void
+set_expire_event(timeval_t t) {
   schedule_callback(&expire_event, t);
 }
 
-static void push_time(struct decoder *d, timeval_t t) {
+static void
+push_time(struct decoder* d, timeval_t t) {
   for (int i = MAX_TRIGGERS - 1; i > 0; --i) {
     d->times[i] = d->times[i - 1];
   }
   d->times[0] = t;
 }
 
-static unsigned int current_rpm_window_size(unsigned int current_triggers, 
-    unsigned int normal_window_size) {
+static unsigned int
+current_rpm_window_size(unsigned int current_triggers,
+                        unsigned int normal_window_size) {
 
   /* Use the minimum of rpm_window_size and current previous triggers so that
    * rpm is valid in case our window size is larger than required trigger
@@ -48,16 +53,17 @@ static unsigned int current_rpm_window_size(unsigned int current_triggers,
 }
 
 /* Update rpm information and validate */
-static void trigger_update_rpm(struct decoder *d) { 
+static void
+trigger_update_rpm(struct decoder* d) {
   timeval_t diff = d->times[0] - d->times[1];
   unsigned int slicerpm = rpm_from_time_diff(diff, d->degrees_per_trigger);
-  unsigned int rpm_window_size = current_rpm_window_size(d->current_triggers_rpm,
-      d->rpm_window_size);
+  unsigned int rpm_window_size =
+    current_rpm_window_size(d->current_triggers_rpm, d->rpm_window_size);
 
   if (rpm_window_size > 1) {
     /* We have at least two data points to draw an rpm from */
-    d->rpm = rpm_from_time_diff(d->times[0] - d->times[rpm_window_size - 1], 
-      d->degrees_per_trigger * (rpm_window_size - 1));
+    d->rpm = rpm_from_time_diff(d->times[0] - d->times[rpm_window_size - 1],
+                                d->degrees_per_trigger * (rpm_window_size - 1));
     if (d->rpm) {
       d->trigger_cur_rpm_change = abs(d->rpm - slicerpm) / (float)d->rpm;
     }
@@ -67,8 +73,8 @@ static void trigger_update_rpm(struct decoder *d) {
 
   /* Check for excessive per-tooth variation */
   if ((slicerpm <= d->trigger_min_rpm) ||
-       (slicerpm > d->rpm + (d->rpm * d->trigger_max_rpm_change)) ||
-       (slicerpm < d->rpm - (d->rpm * d->trigger_max_rpm_change))) {
+      (slicerpm > d->rpm + (d->rpm * d->trigger_max_rpm_change)) ||
+      (slicerpm < d->rpm - (d->rpm * d->trigger_max_rpm_change))) {
     d->state = DECODER_NOSYNC;
     d->loss = DECODER_VARIATION;
   }
@@ -86,8 +92,8 @@ static void trigger_update_rpm(struct decoder *d) {
   set_expire_event(d->expiration);
 }
 
-
-static void trigger_update(struct decoder *d, timeval_t t) {
+static void
+trigger_update(struct decoder* d, timeval_t t) {
   /* Bookkeeping */
   push_time(d, t);
   d->t0_count++;
@@ -99,9 +105,9 @@ static void trigger_update(struct decoder *d, timeval_t t) {
   }
 
   /* If we get enough triggers, we now have RPM */
-  if ((d->state == DECODER_NOSYNC) && 
+  if ((d->state == DECODER_NOSYNC) &&
       (d->current_triggers_rpm >= d->required_triggers_rpm)) {
-      d->state = DECODER_RPM;
+    d->state = DECODER_RPM;
   }
 
   if (d->state == DECODER_SYNC) {
@@ -114,10 +120,10 @@ static void trigger_update(struct decoder *d, timeval_t t) {
   if (d->state == DECODER_RPM || d->state == DECODER_SYNC) {
     trigger_update_rpm(d);
   }
-
 }
 
-static void sync_update(struct decoder *d) {
+static void
+sync_update(struct decoder* d) {
   d->t1_count++;
   if (d->state == DECODER_RPM) {
     d->state = DECODER_SYNC;
@@ -136,14 +142,15 @@ static void sync_update(struct decoder *d) {
   d->triggers_since_last_sync = 0;
 }
 
-void cam_nplusone_decoder(struct decoder *d) {
+void
+cam_nplusone_decoder(struct decoder* d) {
   timeval_t t0 = d->last_t0;
   decoder_state oldstate = d->state;
 
   if (d->needs_decoding_t0) {
     trigger_update(d, t0);
     d->needs_decoding_t0 = 0;
-  } 
+  }
   if (d->needs_decoding_t1) {
     sync_update(d);
     d->needs_decoding_t1 = 0;
@@ -161,7 +168,8 @@ void cam_nplusone_decoder(struct decoder *d) {
   }
 }
 
-void tfi_pip_decoder(struct decoder *d) {
+void
+tfi_pip_decoder(struct decoder* d) {
   stats_start_timing(STATS_DECODE_TIME);
   timeval_t t0;
   decoder_state oldstate = d->state;
@@ -175,7 +183,8 @@ void tfi_pip_decoder(struct decoder *d) {
     d->loss = DECODER_NO_LOSS;
     d->valid = 1;
     d->last_trigger_time = t0;
-    d->triggers_since_last_sync = 0; /* There is no sync */;
+    d->triggers_since_last_sync = 0; /* There is no sync */
+    ;
   } else {
     if (oldstate == DECODER_SYNC) {
       /* We lost sync */
@@ -185,7 +194,8 @@ void tfi_pip_decoder(struct decoder *d) {
   stats_finish_timing(STATS_DECODE_TIME);
 }
 
-void decoder_init(struct decoder *d) {
+void
+decoder_init(struct decoder* d) {
   d->last_t0 = 0;
   d->last_t1 = 0;
   d->needs_decoding_t0 = 0;
@@ -224,10 +234,11 @@ void decoder_init(struct decoder *d) {
 }
 
 /* When decoder has new information, reschedule everything */
-void decoder_update_scheduling(struct decoder_event *events, unsigned int count) {
+void
+decoder_update_scheduling(struct decoder_event* events, unsigned int count) {
   stats_start_timing(STATS_SCHEDULE_LATENCY);
 
-  for (struct decoder_event *ev = events; count > 0; count--, ev++) {
+  for (struct decoder_event* ev = events; count > 0; count--, ev++) {
     assert(!(ev->t0 && ev->t1));
     if (ev->t0) {
       config.decoder.last_t0 = ev->time;
@@ -257,46 +268,59 @@ void decoder_update_scheduling(struct decoder_event *events, unsigned int count)
 }
 
 #ifdef UNITTEST
-#include "platform.h"
 #include "config.h"
 #include "decoder.h"
+#include "platform.h"
 
 #include <check.h>
 
-static struct decoder_event *find_last_trigger_event(struct decoder_event **entries) {
-  struct decoder_event *entry;
-  for (entry = *entries; entry->next; entry = entry->next);
+static struct decoder_event*
+find_last_trigger_event(struct decoder_event** entries) {
+  struct decoder_event* entry;
+  for (entry = *entries; entry->next; entry = entry->next)
+    ;
   return entry;
 }
 
-static void append_trigger_event(struct decoder_event *last, struct decoder_event new) {
+static void
+append_trigger_event(struct decoder_event* last, struct decoder_event new) {
   last->next = malloc(sizeof(struct decoder_event));
   *(last->next) = new;
 }
 
-static void add_trigger_event(struct decoder_event **entries, timeval_t duration, unsigned int primary, unsigned int secondary) {
+static void
+add_trigger_event(struct decoder_event** entries,
+                  timeval_t duration,
+                  unsigned int primary,
+                  unsigned int secondary) {
 
   if (!*entries) {
     *entries = malloc(sizeof(struct decoder_event));
     **entries = (struct decoder_event){
-      .t0 = primary, .t1 = secondary,
-      .time = duration, .state = DECODER_NOSYNC,
+      .t0 = primary,
+      .t1 = secondary,
+      .time = duration,
+      .state = DECODER_NOSYNC,
     };
     return;
   }
 
-  struct decoder_event *last = find_last_trigger_event(entries);
+  struct decoder_event* last = find_last_trigger_event(entries);
   struct decoder_event new = (struct decoder_event){
-    .t0 = primary, .t1 = secondary,
-      .time = last->time + duration, .state = last->state,
-      .valid = last->valid, .reason = last->reason,
+    .t0 = primary,
+    .t1 = secondary,
+    .time = last->time + duration,
+    .state = last->state,
+    .valid = last->valid,
+    .reason = last->reason,
   };
   append_trigger_event(last, new);
 }
 
-static void free_trigger_list(struct decoder_event *entries) {
-  struct decoder_event *current = entries;
-  struct decoder_event *next;
+static void
+free_trigger_list(struct decoder_event* entries) {
+  struct decoder_event* current = entries;
+  struct decoder_event* next;
   while (current) {
     next = current->next;
     free(current);
@@ -304,44 +328,66 @@ static void free_trigger_list(struct decoder_event *entries) {
   }
 }
 
-static void add_trigger_event_transition_rpm(struct decoder_event **entries, timeval_t duration, unsigned int primary, unsigned int secondary) {
+static void
+add_trigger_event_transition_rpm(struct decoder_event** entries,
+                                 timeval_t duration,
+                                 unsigned int primary,
+                                 unsigned int secondary) {
   ck_assert(*entries);
 
-  struct decoder_event *last = find_last_trigger_event(entries);
+  struct decoder_event* last = find_last_trigger_event(entries);
   struct decoder_event new = (struct decoder_event){
-    .t0 = primary, .t1 = secondary,
-      .time = last->time + duration, .state = DECODER_RPM,
-      .valid = last->valid, .reason = last->reason,
-  };
-  append_trigger_event(last, new);
-
-}
-
-static void add_trigger_event_transition_sync(struct decoder_event **entries, timeval_t duration, unsigned int primary, unsigned int secondary) {
-  ck_assert(*entries);
-
-  struct decoder_event *last = find_last_trigger_event(entries);
-  struct decoder_event new = (struct decoder_event){
-    .t0 = primary, .t1 = secondary,
-      .time = last->time + duration, .state = DECODER_SYNC,
-      .valid = 1, .reason = 0,
+    .t0 = primary,
+    .t1 = secondary,
+    .time = last->time + duration,
+    .state = DECODER_RPM,
+    .valid = last->valid,
+    .reason = last->reason,
   };
   append_trigger_event(last, new);
 }
 
-static void add_trigger_event_transition_loss(struct decoder_event **entries, timeval_t duration, unsigned int primary, unsigned int secondary, decoder_loss_reason reason) {
+static void
+add_trigger_event_transition_sync(struct decoder_event** entries,
+                                  timeval_t duration,
+                                  unsigned int primary,
+                                  unsigned int secondary) {
   ck_assert(*entries);
 
-  struct decoder_event *last = find_last_trigger_event(entries);
+  struct decoder_event* last = find_last_trigger_event(entries);
   struct decoder_event new = (struct decoder_event){
-    .t0 = primary, .t1 = secondary,
-      .time = last->time + duration, .state = DECODER_NOSYNC,
-      .valid = 0, .reason = reason,
+    .t0 = primary,
+    .t1 = secondary,
+    .time = last->time + duration,
+    .state = DECODER_SYNC,
+    .valid = 1,
+    .reason = 0,
   };
   append_trigger_event(last, new);
 }
 
-static void validate_decoder_sequence(struct decoder_event *ev) {
+static void
+add_trigger_event_transition_loss(struct decoder_event** entries,
+                                  timeval_t duration,
+                                  unsigned int primary,
+                                  unsigned int secondary,
+                                  decoder_loss_reason reason) {
+  ck_assert(*entries);
+
+  struct decoder_event* last = find_last_trigger_event(entries);
+  struct decoder_event new = (struct decoder_event){
+    .t0 = primary,
+    .t1 = secondary,
+    .time = last->time + duration,
+    .state = DECODER_NOSYNC,
+    .valid = 0,
+    .reason = reason,
+  };
+  append_trigger_event(last, new);
+}
+
+static void
+validate_decoder_sequence(struct decoder_event* ev) {
   for (; ev; ev = ev->next) {
     if (ev->t0) {
       config.decoder.last_t0 = ev->time;
@@ -354,26 +400,32 @@ static void validate_decoder_sequence(struct decoder_event *ev) {
 
     set_current_time(ev->time);
     decoder_update_scheduling(ev, 1);
-    ck_assert_msg(config.decoder.state == ev->state, 
-        "expected event at %d: (state=%d, valid=%d). Got (state=%d, valid=%d)",
-        ev->time, ev->state, ev->valid, 
-        config.decoder.state, config.decoder.valid);
+    ck_assert_msg(
+      config.decoder.state == ev->state,
+      "expected event at %d: (state=%d, valid=%d). Got (state=%d, valid=%d)",
+      ev->time,
+      ev->state,
+      ev->valid,
+      config.decoder.state,
+      config.decoder.valid);
     if (!ev->valid) {
       ck_assert_msg(config.decoder.loss == ev->reason,
-      "reason mismatch at %d: %d. Got %d",
-      ev->time, ev->reason, config.decoder.loss);
+                    "reason mismatch at %d: %d. Got %d",
+                    ev->time,
+                    ev->reason,
+                    config.decoder.loss);
     }
   }
 }
 
-static void prepare_decoder(trigger_type type) {
+static void
+prepare_decoder(trigger_type type) {
   config.decoder.type = type;
   decoder_init(&config.decoder);
 }
 
-
 START_TEST(check_tfi_decoder_startup_normal) {
-  struct decoder_event *entries = NULL;
+  struct decoder_event* entries = NULL;
   prepare_decoder(FORD_TFI);
 
   /* Triggers to get RPM */
@@ -388,11 +440,11 @@ START_TEST(check_tfi_decoder_startup_normal) {
   ck_assert_int_eq(config.decoder.last_trigger_angle, 90);
 
   free_trigger_list(entries);
-
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_tfi_decoder_syncloss_variation) {
-  struct decoder_event *entries = NULL;
+  struct decoder_event* entries = NULL;
   prepare_decoder(FORD_TFI);
 
   /* Triggers to get RPM */
@@ -409,11 +461,11 @@ START_TEST(check_tfi_decoder_syncloss_variation) {
   ck_assert_int_eq(config.decoder.current_triggers_rpm, 0);
 
   free_trigger_list(entries);
-} END_TEST
-
+}
+END_TEST
 
 START_TEST(check_tfi_decoder_syncloss_expire) {
-  struct decoder_event *entries = NULL;
+  struct decoder_event* entries = NULL;
   prepare_decoder(FORD_TFI);
 
   /* Triggers to get RPM */
@@ -427,8 +479,8 @@ START_TEST(check_tfi_decoder_syncloss_expire) {
 
   /* Currently expiration is not dependent on variation setting, fixed 1.5x
    * trigger time */
-  timeval_t expected_expiration = find_last_trigger_event(&entries)->time + 
-      (1.5 * 25000);
+  timeval_t expected_expiration =
+    find_last_trigger_event(&entries)->time + (1.5 * 25000);
   ck_assert_int_eq(config.decoder.expiration, expected_expiration);
 
   set_current_time(expected_expiration + 500);
@@ -437,10 +489,12 @@ START_TEST(check_tfi_decoder_syncloss_expire) {
   ck_assert_int_eq(0, config.decoder.current_triggers_rpm);
   ck_assert_int_eq(DECODER_EXPIRED, config.decoder.loss);
   free_trigger_list(entries);
-} END_TEST
+}
+END_TEST
 
 /* Gets decoder up to sync, plus an additional trigger */
-static void cam_nplusone_normal_startup_to_sync(struct decoder_event **entries) {
+static void
+cam_nplusone_normal_startup_to_sync(struct decoder_event** entries) {
   /* Triggers to get RPM */
   for (int i = 0; i < config.decoder.required_triggers_rpm - 1; ++i) {
     add_trigger_event(entries, 25000, 1, 0);
@@ -457,49 +511,52 @@ static void cam_nplusone_normal_startup_to_sync(struct decoder_event **entries) 
 }
 
 START_TEST(check_cam_nplusone_startup_normal) {
-  struct decoder_event *entries = NULL;
+  struct decoder_event* entries = NULL;
   prepare_decoder(TOYOTA_24_1_CAS);
 
   cam_nplusone_normal_startup_to_sync(&entries);
-  
+
   /* Two additional triggers, three total after sync pulse */
   add_trigger_event(&entries, 25000, 1, 0);
   add_trigger_event(&entries, 25000, 1, 0);
 
   validate_decoder_sequence(entries);
 
-  ck_assert_int_eq(config.decoder.last_trigger_angle, 
-      3 * config.decoder.degrees_per_trigger);
+  ck_assert_int_eq(config.decoder.last_trigger_angle,
+                   3 * config.decoder.degrees_per_trigger);
 
   free_trigger_list(entries);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_cam_nplusone_startup_normal_then_early_sync) {
-  struct decoder_event *entries = NULL;
+  struct decoder_event* entries = NULL;
   prepare_decoder(TOYOTA_24_1_CAS);
 
   cam_nplusone_normal_startup_to_sync(&entries);
-  
+
   /* Two additional triggers, three total after sync pulse */
   add_trigger_event(&entries, 25000, 1, 0);
   add_trigger_event(&entries, 25000, 1, 0);
 
   /* Spurious early sync */
-  add_trigger_event_transition_loss(&entries, 500, 0, 1, DECODER_TRIGGERCOUNT_LOW);
+  add_trigger_event_transition_loss(
+    &entries, 500, 0, 1, DECODER_TRIGGERCOUNT_LOW);
 
   validate_decoder_sequence(entries);
 
   ck_assert(!config.decoder.valid);
 
   free_trigger_list(entries);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_cam_nplusone_startup_normal_sustained) {
-  struct decoder_event *entries = NULL;
+  struct decoder_event* entries = NULL;
   prepare_decoder(TOYOTA_24_1_CAS);
 
   cam_nplusone_normal_startup_to_sync(&entries);
-  
+
   /* continued wheel of additional triggers */
   for (int i = 0; i < config.decoder.num_triggers - 1; ++i) {
     add_trigger_event(&entries, 25000, 1, 0);
@@ -510,21 +567,22 @@ START_TEST(check_cam_nplusone_startup_normal_sustained) {
 
   validate_decoder_sequence(entries);
 
-  ck_assert_int_eq(config.decoder.last_trigger_angle, 
-      1 * config.decoder.degrees_per_trigger);
+  ck_assert_int_eq(config.decoder.last_trigger_angle,
+                   1 * config.decoder.degrees_per_trigger);
 
   free_trigger_list(entries);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_bulk_decoder_updates) {
-  struct decoder_event *entries = NULL;
+  struct decoder_event* entries = NULL;
   prepare_decoder(TOYOTA_24_1_CAS);
 
   cam_nplusone_normal_startup_to_sync(&entries);
 
   /* Turn entries linked list into array usable by interface */
-  struct decoder_event *entry_list = malloc(sizeof(struct decoder_event));
-  struct decoder_event *ev;
+  struct decoder_event* entry_list = malloc(sizeof(struct decoder_event));
+  struct decoder_event* ev;
   int len;
   for (len = 0, ev = entries; ev != NULL; ++len, ev = ev->next) {
     entry_list[len] = *ev;
@@ -533,36 +591,39 @@ START_TEST(check_bulk_decoder_updates) {
   decoder_update_scheduling(entry_list, len);
 
   ck_assert(config.decoder.valid);
-  ck_assert_int_eq(config.decoder.last_trigger_angle, 
-      1 * config.decoder.degrees_per_trigger);
+  ck_assert_int_eq(config.decoder.last_trigger_angle,
+                   1 * config.decoder.degrees_per_trigger);
   free_trigger_list(entries);
   free(entry_list);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_cam_nplusone_startup_normal_no_second_trigger) {
-  struct decoder_event *entries = NULL;
+  struct decoder_event* entries = NULL;
   prepare_decoder(TOYOTA_24_1_CAS);
 
   cam_nplusone_normal_startup_to_sync(&entries);
-  
+
   /* continued wheel of additional triggers */
   for (int i = 0; i < config.decoder.num_triggers - 1; ++i) {
     add_trigger_event(&entries, 25000, 1, 0);
   }
   /* Another trigger, no sync when there should be one */
-  add_trigger_event_transition_loss(&entries, 25000, 1, 0, DECODER_TRIGGERCOUNT_HIGH);
+  add_trigger_event_transition_loss(
+    &entries, 25000, 1, 0, DECODER_TRIGGERCOUNT_HIGH);
 
   validate_decoder_sequence(entries);
   ck_assert(!config.decoder.valid);
   free_trigger_list(entries);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_nplusone_decoder_syncloss_expire) {
-  struct decoder_event *entries = NULL;
+  struct decoder_event* entries = NULL;
   prepare_decoder(TOYOTA_24_1_CAS);
 
   cam_nplusone_normal_startup_to_sync(&entries);
-  
+
   /* Three extra triggers */
   add_trigger_event(&entries, 25000, 1, 0);
   add_trigger_event(&entries, 25000, 1, 0);
@@ -571,29 +632,30 @@ START_TEST(check_nplusone_decoder_syncloss_expire) {
   validate_decoder_sequence(entries);
   /* Currently expiration is not dependent on variation setting, fixed 1.5x
    * trigger time */
-  timeval_t expected_expiration = find_last_trigger_event(&entries)->time + 
-      (1.5 * 25000);
+  timeval_t expected_expiration =
+    find_last_trigger_event(&entries)->time + (1.5 * 25000);
   ck_assert_int_eq(config.decoder.expiration, expected_expiration);
-    
+
   set_current_time(expected_expiration + 500);
   handle_decoder_expire(&config.decoder);
   ck_assert(!config.decoder.valid);
   ck_assert_int_eq(0, config.decoder.current_triggers_rpm);
   ck_assert_int_eq(DECODER_EXPIRED, config.decoder.loss);
   free_trigger_list(entries);
-
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_current_rpm_window_size) {
   ck_assert_int_eq(current_rpm_window_size(0, 8), 0);
   ck_assert_int_eq(current_rpm_window_size(1, 8), 1);
   ck_assert_int_eq(current_rpm_window_size(8, 8), 8);
   ck_assert_int_eq(current_rpm_window_size(10, 8), 8);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_update_rpm_single_point) {
   struct decoder d = {
-    .times = {100},
+    .times = { 100 },
     .degrees_per_trigger = 30,
     .current_triggers_rpm = 1,
     .rpm_window_size = 4,
@@ -603,11 +665,12 @@ START_TEST(check_update_rpm_single_point) {
   trigger_update_rpm(&d);
   ck_assert_int_eq(d.rpm, 0);
   ck_assert_int_eq(d.state, DECODER_NOSYNC);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_update_rpm_sufficient_points) {
   struct decoder d = {
-    .times = {400, 300, 200, 100},
+    .times = { 400, 300, 200, 100 },
     .degrees_per_trigger = 30,
     .current_triggers_rpm = 4,
     .rpm_window_size = 4,
@@ -617,11 +680,12 @@ START_TEST(check_update_rpm_sufficient_points) {
 
   trigger_update_rpm(&d);
   ck_assert_int_eq(d.rpm, rpm_from_time_diff(100, d.degrees_per_trigger));
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_update_rpm_window_larger) {
   struct decoder d = {
-    .times = {800, 700, 700, 500, 400, 300, 200, 100},
+    .times = { 800, 700, 700, 500, 400, 300, 200, 100 },
     .degrees_per_trigger = 30,
     .current_triggers_rpm = 4,
     .rpm_window_size = 8,
@@ -631,11 +695,12 @@ START_TEST(check_update_rpm_window_larger) {
 
   trigger_update_rpm(&d);
   ck_assert_int_eq(d.rpm, rpm_from_time_diff(100, d.degrees_per_trigger));
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_update_rpm_window_smaller) {
   struct decoder d = {
-    .times = {800, 700, 700, 500, 400, 300, 200, 100},
+    .times = { 800, 700, 700, 500, 400, 300, 200, 100 },
     .degrees_per_trigger = 30,
     .current_triggers_rpm = 8,
     .rpm_window_size = 4,
@@ -645,18 +710,21 @@ START_TEST(check_update_rpm_window_smaller) {
 
   trigger_update_rpm(&d);
   ck_assert_int_eq(d.rpm, rpm_from_time_diff(100, d.degrees_per_trigger));
-} END_TEST
+}
+END_TEST
 
-
-TCase *setup_decoder_tests() {
-  TCase *decoder_tests = tcase_create("decoder");
+TCase*
+setup_decoder_tests() {
+  TCase* decoder_tests = tcase_create("decoder");
   tcase_add_test(decoder_tests, check_tfi_decoder_startup_normal);
   tcase_add_test(decoder_tests, check_tfi_decoder_syncloss_variation);
   tcase_add_test(decoder_tests, check_tfi_decoder_syncloss_expire);
   tcase_add_test(decoder_tests, check_cam_nplusone_startup_normal);
-  tcase_add_test(decoder_tests, check_cam_nplusone_startup_normal_then_early_sync);
+  tcase_add_test(decoder_tests,
+                 check_cam_nplusone_startup_normal_then_early_sync);
   tcase_add_test(decoder_tests, check_cam_nplusone_startup_normal_sustained);
-  tcase_add_test(decoder_tests, check_cam_nplusone_startup_normal_no_second_trigger);
+  tcase_add_test(decoder_tests,
+                 check_cam_nplusone_startup_normal_no_second_trigger);
   tcase_add_test(decoder_tests, check_nplusone_decoder_syncloss_expire);
   tcase_add_test(decoder_tests, check_bulk_decoder_updates);
 
@@ -668,4 +736,3 @@ TCase *setup_decoder_tests() {
   return decoder_tests;
 }
 #endif
-

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -5,7 +5,7 @@
 #define MAX_TRIGGERS 36
 
 struct decoder;
-typedef void (*decoder_func)(struct decoder *);
+typedef void (*decoder_func)(struct decoder*);
 
 typedef enum {
   FORD_TFI,
@@ -80,17 +80,20 @@ struct decoder_event {
   decoder_state state;
   int valid;
   decoder_loss_reason reason;
-  struct decoder_event *next;
+  struct decoder_event* next;
 #endif
-}; 
+};
 
-void decoder_init(struct decoder *);
-void decoder_update_scheduling(struct decoder_event *, unsigned int count);
-void enable_test_trigger(trigger_type t, unsigned int rpm);
+void
+decoder_init(struct decoder*);
+void
+decoder_update_scheduling(struct decoder_event*, unsigned int count);
+void
+enable_test_trigger(trigger_type t, unsigned int rpm);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase *setup_decoder_tests();
+TCase*
+setup_decoder_tests();
 #endif
 #endif
-

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -5,7 +5,7 @@
 #define MAX_TRIGGERS 36
 
 struct decoder;
-typedef void (*decoder_func)(struct decoder*);
+typedef void (*decoder_func)(struct decoder *);
 
 typedef enum {
   FORD_TFI,
@@ -80,16 +80,16 @@ struct decoder_event {
   decoder_state state;
   int valid;
   decoder_loss_reason reason;
-  struct decoder_event* next;
+  struct decoder_event *next;
 #endif
 };
 
-void decoder_init(struct decoder*);
-void decoder_update_scheduling(struct decoder_event*, unsigned int count);
+void decoder_init(struct decoder *);
+void decoder_update_scheduling(struct decoder_event *, unsigned int count);
 void enable_test_trigger(trigger_type t, unsigned int rpm);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase* setup_decoder_tests();
+TCase *setup_decoder_tests();
 #endif
 #endif

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -84,16 +84,12 @@ struct decoder_event {
 #endif
 };
 
-void
-decoder_init(struct decoder*);
-void
-decoder_update_scheduling(struct decoder_event*, unsigned int count);
-void
-enable_test_trigger(trigger_type t, unsigned int rpm);
+void decoder_init(struct decoder*);
+void decoder_update_scheduling(struct decoder_event*, unsigned int count);
+void enable_test_trigger(trigger_type t, unsigned int rpm);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase*
-setup_decoder_tests();
+TCase* setup_decoder_tests();
 #endif
 #endif

--- a/src/platform.h
+++ b/src/platform.h
@@ -1,7 +1,7 @@
 #ifndef _PLATFORM_H
 #define _PLATFORM_H
-#include <stdint.h>
 #include <stddef.h>
+#include <stdint.h>
 
 #ifndef NULL
 #define NULL 0
@@ -16,48 +16,73 @@ typedef uint32_t timeval_t;
 typedef float degrees_t;
 /* timeval_t is gauranteed to be 32 bits */
 
-timeval_t current_time();
-timeval_t cycle_count();
+timeval_t
+current_time();
+timeval_t
+cycle_count();
 
 void set_event_timer(timeval_t);
-timeval_t get_event_timer();
+timeval_t
+get_event_timer();
 /* Clear any pending interrupt */
-void clear_event_timer();
-void disable_event_timer();
+void
+clear_event_timer();
+void
+disable_event_timer();
 
-void platform_init();
+void
+platform_init();
 
-int disable_interrupts();
-void enable_interrupts();
-int interrupts_enabled();
+int
+disable_interrupts();
+void
+enable_interrupts();
+int
+interrupts_enabled();
 
-void set_output(int output, char value);
-int get_output(int output);
-void set_gpio(int output, char value);
-int get_gpio(int output);
-void set_pwm(int output, float value);
-void adc_gather();
+void
+set_output(int output, char value);
+int
+get_output(int output);
+void
+set_gpio(int output, char value);
+int
+get_gpio(int output);
+void
+set_pwm(int output, float value);
+void
+adc_gather();
 
-size_t console_read(void *buf, size_t max);
-size_t console_write(const void *buf, size_t count);
+size_t
+console_read(void* buf, size_t max);
+size_t
+console_write(const void* buf, size_t count);
 
-void platform_load_config();
-void platform_save_config();
+void
+platform_load_config();
+void
+platform_save_config();
 
-timeval_t init_output_thread(uint32_t *buf0, uint32_t *buf1, uint32_t len);
-int current_output_buffer();
-int current_output_slot();
+timeval_t
+init_output_thread(uint32_t* buf0, uint32_t* buf1, uint32_t len);
+int
+current_output_buffer();
+int
+current_output_slot();
 
-void platform_enable_event_logging();
-void platform_disable_event_logging();
-void platform_reset_into_bootloader();
+void
+platform_enable_event_logging();
+void
+platform_disable_event_logging();
+void
+platform_reset_into_bootloader();
 
 #ifdef UNITTEST
 #include <check.h>
 
-void check_platform_reset();
+void
+check_platform_reset();
 void set_current_time(timeval_t);
 #endif
 
 #endif
-

--- a/src/platform.h
+++ b/src/platform.h
@@ -16,72 +16,46 @@ typedef uint32_t timeval_t;
 typedef float degrees_t;
 /* timeval_t is gauranteed to be 32 bits */
 
-timeval_t
-current_time();
-timeval_t
-cycle_count();
+timeval_t current_time();
+timeval_t cycle_count();
 
 void set_event_timer(timeval_t);
-timeval_t
-get_event_timer();
+timeval_t get_event_timer();
 /* Clear any pending interrupt */
-void
-clear_event_timer();
-void
-disable_event_timer();
+void clear_event_timer();
+void disable_event_timer();
 
-void
-platform_init();
+void platform_init();
 
-int
-disable_interrupts();
-void
-enable_interrupts();
-int
-interrupts_enabled();
+int disable_interrupts();
+void enable_interrupts();
+int interrupts_enabled();
 
-void
-set_output(int output, char value);
-int
-get_output(int output);
-void
-set_gpio(int output, char value);
-int
-get_gpio(int output);
-void
-set_pwm(int output, float value);
-void
-adc_gather();
+void set_output(int output, char value);
+int get_output(int output);
+void set_gpio(int output, char value);
+int get_gpio(int output);
+void set_pwm(int output, float value);
+void adc_gather();
 
-size_t
-console_read(void* buf, size_t max);
-size_t
-console_write(const void* buf, size_t count);
+size_t console_read(void* buf, size_t max);
+size_t console_write(const void* buf, size_t count);
 
-void
-platform_load_config();
-void
-platform_save_config();
+void platform_load_config();
+void platform_save_config();
 
-timeval_t
-init_output_thread(uint32_t* buf0, uint32_t* buf1, uint32_t len);
-int
-current_output_buffer();
-int
-current_output_slot();
+timeval_t init_output_thread(uint32_t* buf0, uint32_t* buf1, uint32_t len);
+int current_output_buffer();
+int current_output_slot();
 
-void
-platform_enable_event_logging();
-void
-platform_disable_event_logging();
-void
-platform_reset_into_bootloader();
+void platform_enable_event_logging();
+void platform_disable_event_logging();
+void platform_reset_into_bootloader();
 
 #ifdef UNITTEST
 #include <check.h>
 
-void
-check_platform_reset();
+void check_platform_reset();
 void set_current_time(timeval_t);
 #endif
 

--- a/src/platform.h
+++ b/src/platform.h
@@ -38,13 +38,13 @@ int get_gpio(int output);
 void set_pwm(int output, float value);
 void adc_gather();
 
-size_t console_read(void* buf, size_t max);
-size_t console_write(const void* buf, size_t count);
+size_t console_read(void *buf, size_t max);
+size_t console_write(const void *buf, size_t count);
 
 void platform_load_config();
 void platform_save_config();
 
-timeval_t init_output_thread(uint32_t* buf0, uint32_t* buf1, uint32_t len);
+timeval_t init_output_thread(uint32_t *buf0, uint32_t *buf1, uint32_t len);
 int current_output_buffer();
 int current_output_slot();
 

--- a/src/platforms/hosted.c
+++ b/src/platforms/hosted.c
@@ -48,68 +48,56 @@ size_t cur_slot = 0;
 size_t cur_buffer = 0;
 sigset_t smask;
 
-void
-platform_enable_event_logging() {
+void platform_enable_event_logging() {
   event_logging_enabled = 1;
 }
 
-void
-platform_disable_event_logging() {
+void platform_disable_event_logging() {
   event_logging_enabled = 0;
 }
 
-void
-platform_reset_into_bootloader() {}
+void platform_reset_into_bootloader() {}
 
 uint16_t cur_outputs = 0;
 
-timeval_t
-current_time() {
+timeval_t current_time() {
   return curtime;
 }
 
-timeval_t
-cycle_count() {
+timeval_t cycle_count() {
 
   struct timespec tp;
   clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tp);
   return (timeval_t)(tp.tv_sec * 1000000000 + tp.tv_nsec);
 }
 
-void
-set_event_timer(timeval_t t) {
+void set_event_timer(timeval_t t) {
   eventtimer_time = t;
   eventtimer_enable = 1;
 }
 
-timeval_t
-get_event_timer() {
+timeval_t get_event_timer() {
   return eventtimer_time;
 }
 
-void
-clear_event_timer() {
+void clear_event_timer() {
   eventtimer_enable = 0;
 }
 
-void
-disable_event_timer() {
+void disable_event_timer() {
   eventtimer_enable = 0;
 }
 
 static ucontext_t* sig_context = NULL;
-static void
-signal_handler_entered(struct ucontext_t* context) {
+static void signal_handler_entered(struct ucontext_t* context) {
   sig_context = context;
 }
-static void
-signal_handler_exited() {
+static void signal_handler_exited() {
   sig_context = NULL;
 }
 
 static int interrupts_disabled = 0;
-int
-disable_interrupts() {
+int disable_interrupts() {
   int old = interrupts_disabled;
   if (sig_context) {
     sigaddset(&sig_context->uc_sigmask, SIGVTALRM);
@@ -124,8 +112,7 @@ disable_interrupts() {
   return !old;
 }
 
-void
-enable_interrupts() {
+void enable_interrupts() {
   interrupts_disabled = 0;
   stats_finish_timing(STATS_INT_DISABLE_TIME);
   if (sig_context) {
@@ -138,13 +125,11 @@ enable_interrupts() {
   }
 }
 
-int
-interrupts_enabled() {
+int interrupts_enabled() {
   return !interrupts_disabled;
 }
 
-void
-set_output(int output, char value) {
+void set_output(int output, char value) {
   if (value) {
     cur_outputs |= (1 << output);
   } else {
@@ -152,8 +137,7 @@ set_output(int output, char value) {
   }
 }
 
-void
-set_gpio(int output, char value) {
+void set_gpio(int output, char value) {
   static uint16_t gpios = 0;
   uint16_t old_gpios = gpios;
 
@@ -172,15 +156,12 @@ set_gpio(int output, char value) {
   }
 }
 
-void
-set_pwm(int output, float value) {}
+void set_pwm(int output, float value) {}
 
-void
-adc_gather() {}
+void adc_gather() {}
 
 timeval_t last_tx = 0;
-size_t
-console_write(const void* buf, size_t len) {
+size_t console_write(const void* buf, size_t len) {
   if (curtime - last_tx < 200) {
     return 0;
   }
@@ -196,8 +177,7 @@ console_write(const void* buf, size_t len) {
 
 char rx_buffer[128];
 int rx_amt = 0;
-size_t
-console_read(void* buf, size_t len) {
+size_t console_read(void* buf, size_t len) {
   if (rx_amt == 0) {
     return 0;
   }
@@ -208,37 +188,30 @@ console_read(void* buf, size_t len) {
   return amt;
 }
 
-void
-platform_load_config() {}
+void platform_load_config() {}
 
-void
-platform_save_config() {}
+void platform_save_config() {}
 
-timeval_t
-init_output_thread(uint32_t* buf0, uint32_t* buf1, uint32_t len) {
+timeval_t init_output_thread(uint32_t* buf0, uint32_t* buf1, uint32_t len) {
   output_slots[0] = (struct slot*)buf0;
   output_slots[1] = (struct slot*)buf1;
   max_slots = len;
   return 0;
 }
 
-int
-current_output_buffer() {
+int current_output_buffer() {
   return cur_buffer;
 }
 
-int
-current_output_slot() {
+int current_output_slot() {
   return cur_slot;
 }
 
-void
-enable_test_trigger(trigger_type t, unsigned int rpm) {
+void enable_test_trigger(trigger_type t, unsigned int rpm) {
   test_trigger_rpm = rpm;
 }
 
-static void
-hosted_platform_timer(int sig, siginfo_t* info, void* ucontext) {
+static void hosted_platform_timer(int sig, siginfo_t* info, void* ucontext) {
   /* - Increase "time"
    * - Trigger appropriate interrupts
    *     timer event
@@ -328,8 +301,7 @@ hosted_platform_timer(int sig, siginfo_t* info, void* ucontext) {
   signal_handler_exited();
 }
 
-void
-platform_init() {
+void platform_init() {
 
   /* Set up signal handling */
   sigemptyset(&smask);

--- a/src/platforms/hosted.c
+++ b/src/platforms/hosted.c
@@ -39,8 +39,7 @@ int event_logging_enabled = 1;
 uint32_t test_trigger_rpm = 0;
 timeval_t test_trigger_last = 0;
 
-struct slot
-{
+struct slot {
   uint16_t on_mask;
   uint16_t off_mask;
 } __attribute__((packed)) * output_slots[2];

--- a/src/platforms/hosted.c
+++ b/src/platforms/hosted.c
@@ -3,21 +3,21 @@
 #include <sys/types.h>
 #include <sys/un.h>
 
+#include <fcntl.h>
+#include <poll.h>
+#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
-#include <fcntl.h>
-#include <unistd.h>
-#include <signal.h>
-#include <poll.h>
 #include <time.h>
+#include <unistd.h>
 
-#include "platform.h"
-#include "scheduler.h"
 #include "config.h"
 #include "console.h"
+#include "platform.h"
+#include "scheduler.h"
 #include "stats.h"
 
-/* A platform that runs on a hosted OS, preferably one that supports posix 
+/* A platform that runs on a hosted OS, preferably one that supports posix
  * timers.  Sends console to stdout/stdin
  *
  * Outputs:
@@ -39,68 +39,78 @@ int event_logging_enabled = 1;
 uint32_t test_trigger_rpm = 0;
 timeval_t test_trigger_last = 0;
 
-struct slot {
+struct slot
+{
   uint16_t on_mask;
   uint16_t off_mask;
-} __attribute__((packed)) *output_slots[2];
+} __attribute__((packed)) * output_slots[2];
 size_t max_slots;
 size_t cur_slot = 0;
 size_t cur_buffer = 0;
 sigset_t smask;
 
-void platform_enable_event_logging() {
+void
+platform_enable_event_logging() {
   event_logging_enabled = 1;
 }
 
-void platform_disable_event_logging() {
+void
+platform_disable_event_logging() {
   event_logging_enabled = 0;
 }
 
-void platform_reset_into_bootloader() {
-}
+void
+platform_reset_into_bootloader() {}
 
 uint16_t cur_outputs = 0;
 
-timeval_t current_time() {
+timeval_t
+current_time() {
   return curtime;
 }
 
-timeval_t cycle_count() {
+timeval_t
+cycle_count() {
 
   struct timespec tp;
   clock_gettime(CLOCK_PROCESS_CPUTIME_ID, &tp);
   return (timeval_t)(tp.tv_sec * 1000000000 + tp.tv_nsec);
-
 }
 
-void set_event_timer(timeval_t t) {
+void
+set_event_timer(timeval_t t) {
   eventtimer_time = t;
   eventtimer_enable = 1;
-
 }
 
-timeval_t get_event_timer() {
+timeval_t
+get_event_timer() {
   return eventtimer_time;
 }
 
-void clear_event_timer() {
+void
+clear_event_timer() {
   eventtimer_enable = 0;
 }
 
-void disable_event_timer() {
+void
+disable_event_timer() {
   eventtimer_enable = 0;
-} 
+}
 
-static ucontext_t *sig_context = NULL;
-static void signal_handler_entered(struct ucontext_t *context) {
+static ucontext_t* sig_context = NULL;
+static void
+signal_handler_entered(struct ucontext_t* context) {
   sig_context = context;
 }
-static void signal_handler_exited() {
+static void
+signal_handler_exited() {
   sig_context = NULL;
 }
 
 static int interrupts_disabled = 0;
-int disable_interrupts() {
+int
+disable_interrupts() {
   int old = interrupts_disabled;
   if (sig_context) {
     sigaddset(&sig_context->uc_sigmask, SIGVTALRM);
@@ -115,7 +125,8 @@ int disable_interrupts() {
   return !old;
 }
 
-void enable_interrupts() {
+void
+enable_interrupts() {
   interrupts_disabled = 0;
   stats_finish_timing(STATS_INT_DISABLE_TIME);
   if (sig_context) {
@@ -128,11 +139,13 @@ void enable_interrupts() {
   }
 }
 
-int interrupts_enabled() {
+int
+interrupts_enabled() {
   return !interrupts_disabled;
 }
 
-void set_output(int output, char value) {
+void
+set_output(int output, char value) {
   if (value) {
     cur_outputs |= (1 << output);
   } else {
@@ -140,7 +153,8 @@ void set_output(int output, char value) {
   }
 }
 
-void set_gpio(int output, char value) {
+void
+set_gpio(int output, char value) {
   static uint16_t gpios = 0;
   uint16_t old_gpios = gpios;
 
@@ -152,26 +166,28 @@ void set_gpio(int output, char value) {
 
   if (old_gpios != gpios) {
     console_record_event((struct logged_event){
-        .time = current_time(),
-        .value = gpios,
-        .type = EVENT_GPIO,
-        });
+      .time = current_time(),
+      .value = gpios,
+      .type = EVENT_GPIO,
+    });
   }
 }
 
-void set_pwm(int output, float value) {
-}
+void
+set_pwm(int output, float value) {}
 
-void adc_gather() {
-}
+void
+adc_gather() {}
 
 timeval_t last_tx = 0;
-size_t console_write(const void *buf, size_t len) {
+size_t
+console_write(const void* buf, size_t len) {
   if (curtime - last_tx < 200) {
     return 0;
   }
   ssize_t written = -1;
-  while ((written = write(STDOUT_FILENO, buf, len)) < 0);
+  while ((written = write(STDOUT_FILENO, buf, len)) < 0)
+    ;
   if (written > 0) {
     last_tx = curtime;
     return written;
@@ -181,43 +197,49 @@ size_t console_write(const void *buf, size_t len) {
 
 char rx_buffer[128];
 int rx_amt = 0;
-size_t console_read(void *buf, size_t len) {
+size_t
+console_read(void* buf, size_t len) {
   if (rx_amt == 0) {
     return 0;
   }
 
-  size_t amt = len < rx_amt ? len: rx_amt;
+  size_t amt = len < rx_amt ? len : rx_amt;
   memcpy(buf, rx_buffer, amt);
   rx_amt -= amt;
   return amt;
 }
 
-void platform_load_config() {
-}
+void
+platform_load_config() {}
 
-void platform_save_config() {
-}
+void
+platform_save_config() {}
 
-timeval_t init_output_thread(uint32_t *buf0, uint32_t *buf1, uint32_t len) {
-  output_slots[0] = (struct slot *)buf0;
-  output_slots[1] = (struct slot *)buf1;
+timeval_t
+init_output_thread(uint32_t* buf0, uint32_t* buf1, uint32_t len) {
+  output_slots[0] = (struct slot*)buf0;
+  output_slots[1] = (struct slot*)buf1;
   max_slots = len;
   return 0;
 }
 
-int current_output_buffer() {
+int
+current_output_buffer() {
   return cur_buffer;
 }
 
-int current_output_slot() {
+int
+current_output_slot() {
   return cur_slot;
 }
 
-void enable_test_trigger(trigger_type t, unsigned int rpm) {
+void
+enable_test_trigger(trigger_type t, unsigned int rpm) {
   test_trigger_rpm = rpm;
 }
 
-static void hosted_platform_timer(int sig, siginfo_t *info, void *ucontext) {
+static void
+hosted_platform_timer(int sig, siginfo_t* info, void* ucontext) {
   /* - Increase "time"
    * - Trigger appropriate interrupts
    *     timer event
@@ -239,7 +261,7 @@ static void hosted_platform_timer(int sig, siginfo_t *info, void *ucontext) {
 
   int failing = 0; // (current_time() % 1000000) > 500000;
   if (current_time() % 1000 == 0) {
-    //test_trigger_rpm += 1;
+    // test_trigger_rpm += 1;
     if (test_trigger_rpm > 9000) {
       test_trigger_rpm = 800;
     }
@@ -249,14 +271,14 @@ static void hosted_platform_timer(int sig, siginfo_t *info, void *ucontext) {
     static uint32_t trigger_count = 0;
     if (curtime >= test_trigger_last + time_between) {
       test_trigger_last = curtime;
-      struct decoder_event ev = {.t0 = 1, .time = curtime};
+      struct decoder_event ev = { .t0 = 1, .time = curtime };
       decoder_update_scheduling(&ev, 1);
       trigger_count++;
 
       if ((config.decoder.type == TOYOTA_24_1_CAS) &&
           (trigger_count >= config.decoder.num_triggers)) {
         trigger_count = 0;
-        struct decoder_event ev = {.t1 = 1, .time = curtime};
+        struct decoder_event ev = { .t1 = 1, .time = curtime };
         decoder_update_scheduling(&ev, 1);
       }
     }
@@ -278,16 +300,16 @@ static void hosted_platform_timer(int sig, siginfo_t *info, void *ucontext) {
 
   if (cur_outputs != old_outputs) {
     console_record_event((struct logged_event){
-        .time = curtime,
-        .value = cur_outputs,
-        .type = EVENT_OUTPUT,
-        });
+      .time = curtime,
+      .value = cur_outputs,
+      .type = EVENT_OUTPUT,
+    });
     old_outputs = cur_outputs;
   }
 
   /* poll for command input */
   struct pollfd pfds[] = {
-    {.fd = STDIN_FILENO, .events = POLLIN},
+    { .fd = STDIN_FILENO, .events = POLLIN },
   };
   if (!rx_amt && poll(pfds, 1, 0)) {
     ssize_t r = read(STDIN_FILENO, rx_buffer, 127);
@@ -307,8 +329,8 @@ static void hosted_platform_timer(int sig, siginfo_t *info, void *ucontext) {
   signal_handler_exited();
 }
 
-
-void platform_init() {
+void
+platform_init() {
 
   /* Set up signal handling */
   sigemptyset(&smask);
@@ -342,14 +364,16 @@ void platform_init() {
 #else
   /* Use interval timer */
   struct itimerval t = {
-    .it_interval = (struct timeval) {
-      .tv_sec = 0,
-      .tv_usec = 1,
-    },
-    .it_value = (struct timeval) {
-      .tv_sec = 0,
-      .tv_usec = 1,
-    },
+    .it_interval =
+      (struct timeval){
+        .tv_sec = 0,
+        .tv_usec = 1,
+      },
+    .it_value =
+      (struct timeval){
+        .tv_sec = 0,
+        .tv_usec = 1,
+      },
   };
   setitimer(ITIMER_VIRTUAL, &t, NULL);
 #endif
@@ -357,5 +381,4 @@ void platform_init() {
 
   /* Set stdin nonblock */
   fcntl(STDIN_FILENO, F_SETFL, fcntl(STDIN_FILENO, F_GETFL, 0) | O_NONBLOCK);
-
 }

--- a/src/platforms/hosted.c
+++ b/src/platforms/hosted.c
@@ -88,8 +88,8 @@ void disable_event_timer() {
   eventtimer_enable = 0;
 }
 
-static ucontext_t* sig_context = NULL;
-static void signal_handler_entered(struct ucontext_t* context) {
+static ucontext_t *sig_context = NULL;
+static void signal_handler_entered(struct ucontext_t *context) {
   sig_context = context;
 }
 static void signal_handler_exited() {
@@ -161,7 +161,7 @@ void set_pwm(int output, float value) {}
 void adc_gather() {}
 
 timeval_t last_tx = 0;
-size_t console_write(const void* buf, size_t len) {
+size_t console_write(const void *buf, size_t len) {
   if (curtime - last_tx < 200) {
     return 0;
   }
@@ -177,7 +177,7 @@ size_t console_write(const void* buf, size_t len) {
 
 char rx_buffer[128];
 int rx_amt = 0;
-size_t console_read(void* buf, size_t len) {
+size_t console_read(void *buf, size_t len) {
   if (rx_amt == 0) {
     return 0;
   }
@@ -192,9 +192,9 @@ void platform_load_config() {}
 
 void platform_save_config() {}
 
-timeval_t init_output_thread(uint32_t* buf0, uint32_t* buf1, uint32_t len) {
-  output_slots[0] = (struct slot*)buf0;
-  output_slots[1] = (struct slot*)buf1;
+timeval_t init_output_thread(uint32_t *buf0, uint32_t *buf1, uint32_t len) {
+  output_slots[0] = (struct slot *)buf0;
+  output_slots[1] = (struct slot *)buf1;
   max_slots = len;
   return 0;
 }
@@ -211,7 +211,7 @@ void enable_test_trigger(trigger_type t, unsigned int rpm) {
   test_trigger_rpm = rpm;
 }
 
-static void hosted_platform_timer(int sig, siginfo_t* info, void* ucontext) {
+static void hosted_platform_timer(int sig, siginfo_t *info, void *ucontext) {
   /* - Increase "time"
    * - Trigger appropriate interrupts
    *     timer event

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -135,7 +135,7 @@ void tim1_cc_isr() {
       continue;
     }
     volatile uint32_t timer_flag;
-    volatile uint32_t* timer_ccr;
+    volatile uint32_t *timer_ccr;
     uint32_t pin = config.sensors[i].pin;
     switch (pin) {
       case 1:
@@ -239,8 +239,8 @@ static void platform_init_eventtimer() {
   nvic_set_priority(NVIC_TIM2_IRQ, 32);
 
   /* Set debug unit to stop the timer on halt */
-  *((volatile uint32_t*)0xE0042008) |= 19; /*TIM2, TIM5, and TIM6 */
-  *((volatile uint32_t*)0xE004200C) |= 2;  /* TIM8 stop */
+  *((volatile uint32_t *)0xE0042008) |= 19; /*TIM2, TIM5, and TIM6 */
+  *((volatile uint32_t *)0xE004200C) |= 2;  /* TIM8 stop */
 
   timer_set_mode(TIM8, TIM_CR1_CKD_CK_INT, TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
   timer_set_period(TIM8, 41); /* 0.25 uS */
@@ -264,7 +264,7 @@ static uint32_t output_buffer_len;
  * buffer between buf0 and buf0.
  * Returns the time that buf0 starts at
  */
-timeval_t init_output_thread(uint32_t* buf0, uint32_t* buf1, uint32_t len) {
+timeval_t init_output_thread(uint32_t *buf0, uint32_t *buf1, uint32_t len) {
   timeval_t start;
 
   output_buffer_len = len;
@@ -531,15 +531,15 @@ static void platform_init_spi_adc() {
 }
 
 static uint8_t usbd_control_buffer[128];
-static usbd_device* usbd_dev;
+static usbd_device *usbd_dev;
 
 /* Most of the following is copied from libopencm3-examples */
 static enum usbd_request_return_codes cdcacm_control_request(
-  usbd_device* usbd_dev,
-  struct usb_setup_data* req,
-  uint8_t** buf,
-  uint16_t* len,
-  void (**complete)(usbd_device* usbd_dev, struct usb_setup_data* req)) {
+  usbd_device *usbd_dev,
+  struct usb_setup_data *req,
+  uint8_t **buf,
+  uint16_t *len,
+  void (**complete)(usbd_device *usbd_dev, struct usb_setup_data *req)) {
   (void)complete;
   (void)buf;
   (void)usbd_dev;
@@ -566,13 +566,13 @@ static enum usbd_request_return_codes cdcacm_control_request(
 #define USB_RX_BUF_LEN 1024
 static char usb_rx_buf[USB_RX_BUF_LEN];
 static volatile size_t usb_rx_len = 0;
-static void cdcacm_data_rx_cb(usbd_device* usbd_dev, uint8_t ep) {
+static void cdcacm_data_rx_cb(usbd_device *usbd_dev, uint8_t ep) {
   (void)ep;
   usb_rx_len += usbd_ep_read_packet(
     usbd_dev, 0x01, usb_rx_buf + usb_rx_len, USB_RX_BUF_LEN - usb_rx_len);
 }
 
-static void cdcacm_set_config(usbd_device* usbd_dev, uint16_t wValue) {
+static void cdcacm_set_config(usbd_device *usbd_dev, uint16_t wValue) {
   (void)wValue;
 
   usbd_ep_setup(usbd_dev, 0x01, USB_ENDPOINT_ATTR_BULK, 64, cdcacm_data_rx_cb);
@@ -718,7 +718,7 @@ static const struct usb_config_descriptor usb_config = {
   .interface = ifaces,
 };
 
-static const char* usb_strings[] = {
+static const char *usb_strings[] = {
   "https://github.com/via/viaems/",
   "ViaEMS console",
   "0",
@@ -859,7 +859,7 @@ void platform_reset_into_bootloader() {
   /* 168 Mhz clock */
   rcc_clock_setup_pll(&rcc_hsi_configs[RCC_CLOCK_3V3_168MHZ]);
 
-  __asm__ volatile("msr msp, %0" ::"g"(*(volatile uint32_t*)0x20001000));
+  __asm__ volatile("msr msp, %0" ::"g"(*(volatile uint32_t *)0x20001000));
   (*(void (**)())(0x1fff0004))();
   while (1)
     ;
@@ -1119,7 +1119,7 @@ void platform_save_config() {
 
   /* configrom is sectors 1 through 3, each 16k,
    * compute how many we need to erase */
-  conf_bytes = ((char*)&_econfigdata - (char*)&_sconfigdata);
+  conf_bytes = ((char *)&_econfigdata - (char *)&_sconfigdata);
   n_sectors = (conf_bytes + 16385) / 16386;
 
   for (int sector = 1; sector < 1 + n_sectors; sector++) {
@@ -1133,7 +1133,7 @@ void platform_save_config() {
   flash_lock();
 }
 
-size_t console_read(void* buf, size_t max) {
+size_t console_read(void *buf, size_t max) {
   disable_interrupts();
   stats_start_timing(STATS_CONSOLE_READ_TIME);
   size_t amt = usb_rx_len > max ? max : usb_rx_len;
@@ -1145,7 +1145,7 @@ size_t console_read(void* buf, size_t max) {
   return amt;
 }
 
-size_t console_write(const void* buf, size_t count) {
+size_t console_write(const void *buf, size_t count) {
   size_t rem = count > 64 ? 64 : count;
   /* https://github.com/libopencm3/libopencm3/issues/531
    * We can't let the usb irq be called while writing */
@@ -1156,7 +1156,7 @@ size_t console_write(const void* buf, size_t count) {
 }
 
 /* This should only ever be used in an emergency */
-ssize_t _write(int fd, const void* buf, size_t count) {
+ssize_t _write(int fd, const void *buf, size_t count) {
   (void)fd;
 
   while (count > 0) {

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -138,24 +138,24 @@ void tim1_cc_isr() {
     volatile uint32_t *timer_ccr;
     uint32_t pin = config.sensors[i].pin;
     switch (pin) {
-      case 1:
-        timer_flag = TIM_SR_CC1IF;
-        timer_ccr = &TIM1_CCR1;
-        break;
-      case 2:
-        timer_flag = TIM_SR_CC2IF;
-        timer_ccr = &TIM1_CCR2;
-        break;
-      case 3:
-        timer_flag = TIM_SR_CC3IF;
-        timer_ccr = &TIM1_CCR3;
-        break;
-      case 4:
-        timer_flag = TIM_SR_CC4IF;
-        timer_ccr = &TIM1_CCR4;
-        break;
-      default:
-        continue;
+    case 1:
+      timer_flag = TIM_SR_CC1IF;
+      timer_ccr = &TIM1_CCR1;
+      break;
+    case 2:
+      timer_flag = TIM_SR_CC2IF;
+      timer_ccr = &TIM1_CCR2;
+      break;
+    case 3:
+      timer_flag = TIM_SR_CC3IF;
+      timer_ccr = &TIM1_CCR3;
+      break;
+    case 4:
+      timer_flag = TIM_SR_CC4IF;
+      timer_ccr = &TIM1_CCR4;
+      break;
+    default:
+      continue;
     }
 
     if (timer_get_flag(TIM1, timer_flag)) {
@@ -178,12 +178,12 @@ void tim1_cc_isr() {
 
 static int capture_edge_from_config(trigger_edge e) {
   switch (e) {
-    case RISING_EDGE:
-      return TIM_IC_RISING;
-    case FALLING_EDGE:
-      return TIM_IC_FALLING;
-    case BOTH_EDGES:
-      return TIM_IC_BOTH;
+  case RISING_EDGE:
+    return TIM_IC_RISING;
+  case FALLING_EDGE:
+    return TIM_IC_FALLING;
+  case BOTH_EDGES:
+    return TIM_IC_BOTH;
   }
   return RISING_EDGE;
 }
@@ -369,14 +369,14 @@ static void platform_init_pwm() {
 void set_pwm(int output, float value) {
   int ival = value * 65535;
   switch (output) {
-    case 1:
-      return timer_set_oc_value(TIM3, TIM_OC1, ival);
-    case 2:
-      return timer_set_oc_value(TIM3, TIM_OC2, ival);
-    case 3:
-      return timer_set_oc_value(TIM3, TIM_OC3, ival);
-    case 4:
-      return timer_set_oc_value(TIM3, TIM_OC4, ival);
+  case 1:
+    return timer_set_oc_value(TIM3, TIM_OC1, ival);
+  case 2:
+    return timer_set_oc_value(TIM3, TIM_OC2, ival);
+  case 3:
+    return timer_set_oc_value(TIM3, TIM_OC3, ival);
+  case 4:
+    return timer_set_oc_value(TIM3, TIM_OC4, ival);
   }
 }
 
@@ -545,20 +545,20 @@ static enum usbd_request_return_codes cdcacm_control_request(
   (void)usbd_dev;
 
   switch (req->bRequest) {
-    case USB_CDC_REQ_SET_CONTROL_LINE_STATE: {
-      /*
-       * This Linux cdc_acm driver requires this to be implemented
-       * even though it's optional in the CDC spec, and we don't
-       * advertise it in the ACM functional descriptor.
-       */
-      return USBD_REQ_HANDLED;
+  case USB_CDC_REQ_SET_CONTROL_LINE_STATE: {
+    /*
+     * This Linux cdc_acm driver requires this to be implemented
+     * even though it's optional in the CDC spec, and we don't
+     * advertise it in the ACM functional descriptor.
+     */
+    return USBD_REQ_HANDLED;
+  }
+  case USB_CDC_REQ_SET_LINE_CODING:
+    if (*len < sizeof(struct usb_cdc_line_coding)) {
+      return USBD_REQ_NOTSUPP;
     }
-    case USB_CDC_REQ_SET_LINE_CODING:
-      if (*len < sizeof(struct usb_cdc_line_coding)) {
-        return USBD_REQ_NOTSUPP;
-      }
 
-      return USBD_REQ_HANDLED;
+    return USBD_REQ_HANDLED;
   }
   return USBD_REQ_NOTSUPP;
 }

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -120,8 +120,7 @@ platform_init_freqsensor() {
 
 void
 tim1_cc_isr() {
-  static struct
-  {
+  static struct {
     uint16_t value;
     uint32_t time;
   } prev[4] = { 0 };
@@ -654,8 +653,7 @@ static const struct usb_endpoint_descriptor data_endp[] = {
   }
 };
 
-static const struct
-{
+static const struct {
   struct usb_cdc_header_descriptor header;
   struct usb_cdc_call_management_descriptor call_mgmt;
   struct usb_cdc_acm_descriptor acm;

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -74,8 +74,7 @@
  *
  */
 
-static void
-platform_init_freqsensor() {
+static void platform_init_freqsensor() {
   timer_set_mode(TIM1, TIM_CR1_CKD_CK_INT, TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
   timer_set_period(TIM1, 0xFFFFFFFF);
   timer_disable_preload(TIM1);
@@ -118,8 +117,7 @@ platform_init_freqsensor() {
   nvic_set_priority(NVIC_TIM1_CC_IRQ, 64);
 }
 
-void
-tim1_cc_isr() {
+void tim1_cc_isr() {
   static struct {
     uint16_t value;
     uint32_t time;
@@ -178,8 +176,7 @@ tim1_cc_isr() {
   stats_finish_timing(STATS_INT_TOTAL_TIME);
 }
 
-static int
-capture_edge_from_config(trigger_edge e) {
+static int capture_edge_from_config(trigger_edge e) {
   switch (e) {
     case RISING_EDGE:
       return TIM_IC_RISING;
@@ -191,8 +188,7 @@ capture_edge_from_config(trigger_edge e) {
   return RISING_EDGE;
 }
 
-static void
-platform_init_eventtimer() {
+static void platform_init_eventtimer() {
   /* Set up TIM2 as 32bit clock that is slaved off TIM8*/
 
   timer_set_mode(TIM2, TIM_CR1_CKD_CK_INT, TIM_CR1_CMS_EDGE, TIM_CR1_DIR_UP);
@@ -268,8 +264,7 @@ static uint32_t output_buffer_len;
  * buffer between buf0 and buf0.
  * Returns the time that buf0 starts at
  */
-timeval_t
-init_output_thread(uint32_t* buf0, uint32_t* buf1, uint32_t len) {
+timeval_t init_output_thread(uint32_t* buf0, uint32_t* buf1, uint32_t len) {
   timeval_t start;
 
   output_buffer_len = len;
@@ -302,8 +297,7 @@ init_output_thread(uint32_t* buf0, uint32_t* buf1, uint32_t len) {
 }
 
 /* Returns 0 if buf0 is active */
-int
-current_output_buffer() {
+int current_output_buffer() {
   return dma_get_target(DMA2, DMA_STREAM1);
 }
 
@@ -311,13 +305,11 @@ current_output_buffer() {
  * Note that the slot returned is the one queued to output next, but is already
  * in the FIFO so is considered 'done'
  */
-int
-current_output_slot() {
+int current_output_slot() {
   return output_buffer_len - DMA2_S1NDTR;
 }
 
-static void
-platform_init_pwm() {
+static void platform_init_pwm() {
 
   gpio_mode_setup(GPIOC, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO6);
   gpio_mode_setup(GPIOC, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO7);
@@ -374,8 +366,7 @@ platform_init_pwm() {
   timer_enable_counter(TIM3);
 }
 
-void
-set_pwm(int output, float value) {
+void set_pwm(int output, float value) {
   int ival = value * 65535;
   switch (output) {
     case 1:
@@ -389,8 +380,7 @@ set_pwm(int output, float value) {
   }
 }
 
-static void
-platform_init_scheduled_outputs() {
+static void platform_init_scheduled_outputs() {
   gpio_clear(GPIOD, 0xFFFF);
   unsigned int i;
   for (i = 0; i < config.num_events; ++i) {
@@ -405,8 +395,7 @@ platform_init_scheduled_outputs() {
   gpio_set_output_options(GPIOE, GPIO_OTYPE_PP, GPIO_OSPEED_100MHZ, 0xFF);
 }
 
-void
-platform_enable_event_logging() {
+void platform_enable_event_logging() {
 
   nvic_enable_irq(NVIC_EXTI0_IRQ);
   nvic_enable_irq(NVIC_EXTI1_IRQ);
@@ -421,8 +410,7 @@ platform_enable_event_logging() {
   exti_enable_request(0xFFFF);
 }
 
-void
-platform_disable_event_logging() {
+void platform_disable_event_logging() {
   nvic_disable_irq(NVIC_EXTI0_IRQ);
   nvic_disable_irq(NVIC_EXTI1_IRQ);
   nvic_disable_irq(NVIC_EXTI2_IRQ);
@@ -432,8 +420,7 @@ platform_disable_event_logging() {
   nvic_disable_irq(NVIC_EXTI15_10_IRQ);
 }
 
-static void
-show_scheduled_outputs() {
+static void show_scheduled_outputs() {
   console_record_event((struct logged_event){
     .type = EVENT_OUTPUT,
     .time = current_time(),
@@ -442,28 +429,22 @@ show_scheduled_outputs() {
   exti_reset_request(0xFFFF);
 }
 
-void
-exti0_isr() {
+void exti0_isr() {
   show_scheduled_outputs();
 }
-void
-exti1_isr() {
+void exti1_isr() {
   show_scheduled_outputs();
 }
-void
-exti2_isr() {
+void exti2_isr() {
   show_scheduled_outputs();
 }
-void
-exti3_isr() {
+void exti3_isr() {
   show_scheduled_outputs();
 }
-void
-exti9_5_isr() {
+void exti9_5_isr() {
   show_scheduled_outputs();
 }
-void
-exti15_10_isr() {
+void exti15_10_isr() {
   show_scheduled_outputs();
 }
 
@@ -493,8 +474,7 @@ exti15_10_isr() {
 #endif
 static volatile uint16_t spi_rx_raw_adc[SPI_WRITE_COUNT] = { 0 };
 
-static void
-platform_init_spi_adc() {
+static void platform_init_spi_adc() {
   /* Configure SPI output */
   gpio_mode_setup(
     GPIOB, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO13 | GPIO14 | GPIO15);
@@ -554,13 +534,12 @@ static uint8_t usbd_control_buffer[128];
 static usbd_device* usbd_dev;
 
 /* Most of the following is copied from libopencm3-examples */
-static enum usbd_request_return_codes
-cdcacm_control_request(usbd_device* usbd_dev,
-                       struct usb_setup_data* req,
-                       uint8_t** buf,
-                       uint16_t* len,
-                       void (**complete)(usbd_device* usbd_dev,
-                                         struct usb_setup_data* req)) {
+static enum usbd_request_return_codes cdcacm_control_request(
+  usbd_device* usbd_dev,
+  struct usb_setup_data* req,
+  uint8_t** buf,
+  uint16_t* len,
+  void (**complete)(usbd_device* usbd_dev, struct usb_setup_data* req)) {
   (void)complete;
   (void)buf;
   (void)usbd_dev;
@@ -587,15 +566,13 @@ cdcacm_control_request(usbd_device* usbd_dev,
 #define USB_RX_BUF_LEN 1024
 static char usb_rx_buf[USB_RX_BUF_LEN];
 static volatile size_t usb_rx_len = 0;
-static void
-cdcacm_data_rx_cb(usbd_device* usbd_dev, uint8_t ep) {
+static void cdcacm_data_rx_cb(usbd_device* usbd_dev, uint8_t ep) {
   (void)ep;
   usb_rx_len += usbd_ep_read_packet(
     usbd_dev, 0x01, usb_rx_buf + usb_rx_len, USB_RX_BUF_LEN - usb_rx_len);
 }
 
-static void
-cdcacm_set_config(usbd_device* usbd_dev, uint16_t wValue) {
+static void cdcacm_set_config(usbd_device* usbd_dev, uint16_t wValue) {
   (void)wValue;
 
   usbd_ep_setup(usbd_dev, 0x01, USB_ENDPOINT_ATTR_BULK, 64, cdcacm_data_rx_cb);
@@ -747,8 +724,7 @@ static const char* usb_strings[] = {
   "0",
 };
 
-void
-otg_fs_isr() {
+void otg_fs_isr() {
   stats_increment_counter(STATS_INT_RATE);
   stats_increment_counter(STATS_USB_INTERRUPT_RATE);
   stats_start_timing(STATS_USB_INTERRUPT_TIME);
@@ -758,8 +734,7 @@ otg_fs_isr() {
   stats_finish_timing(STATS_INT_TOTAL_TIME);
 }
 
-void
-platform_init_usb() {
+void platform_init_usb() {
 
   gpio_mode_setup(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO9 | GPIO11 | GPIO12);
   gpio_set_af(GPIOA, GPIO_AF10, GPIO9 | GPIO11 | GPIO12);
@@ -776,8 +751,7 @@ platform_init_usb() {
   nvic_enable_irq(NVIC_OTG_FS_IRQ);
 }
 
-void
-platform_init() {
+void platform_init() {
 
   /* 168 Mhz clock */
   rcc_clock_setup_pll(&rcc_hse_8mhz_3v3[RCC_CLOCK_3V3_168MHZ]);
@@ -831,8 +805,7 @@ platform_init() {
   stats_init(168000000);
 }
 
-void
-platform_reset_into_bootloader() {
+void platform_reset_into_bootloader() {
   handle_emergency_shutdown();
 
   rcc_periph_reset_pulse(RST_OTGFS);
@@ -892,14 +865,12 @@ platform_reset_into_bootloader() {
     ;
 }
 
-uint32_t
-cycle_count() {
+uint32_t cycle_count() {
   return dwt_read_cycle_counter();
 }
 
 static volatile int adc_gather_in_progress = 0;
-void
-adc_gather() {
+void adc_gather() {
 #ifdef SPI_TLC2543
   static uint16_t spi_tx_list[] = {
     0x0C00, 0x1C00, 0x2C00, 0x3C00, 0x4C00, 0x5C00, 0x6C00,
@@ -944,8 +915,7 @@ adc_gather() {
   TIM6_DIER |= TIM_DIER_UDE; /* Enable update dma */
 }
 
-void
-dma1_stream3_isr(void) {
+void dma1_stream3_isr(void) {
   if (!dma_get_interrupt_flag(DMA1, DMA_STREAM3, DMA_TCIF)) {
     return;
   }
@@ -988,8 +958,7 @@ dma1_stream3_isr(void) {
  * graceful overflow (at the expensive of non-critical routines not running,
  * e.g. console).
  */
-void
-tim2_isr() {
+void tim2_isr() {
   stats_increment_counter(STATS_INT_RATE);
   stats_increment_counter(STATS_INT_EVENTTIMER_RATE);
   stats_start_timing(STATS_INT_TOTAL_TIME);
@@ -1029,8 +998,7 @@ tim2_isr() {
   stats_finish_timing(STATS_INT_TOTAL_TIME);
 }
 
-void
-dma2_stream1_isr(void) {
+void dma2_stream1_isr(void) {
   stats_increment_counter(STATS_INT_RATE);
   stats_increment_counter(STATS_INT_BUFFERSWAP_RATE);
   stats_start_timing(STATS_INT_TOTAL_TIME);
@@ -1043,60 +1011,50 @@ dma2_stream1_isr(void) {
   stats_finish_timing(STATS_INT_TOTAL_TIME);
 }
 
-void
-enable_interrupts() {
+void enable_interrupts() {
   stats_finish_timing(STATS_INT_DISABLE_TIME);
   cm_enable_interrupts();
 }
 
 /* Returns current enabled status prior to call */
-int
-disable_interrupts() {
+int disable_interrupts() {
   int ret = interrupts_enabled();
   cm_disable_interrupts();
   stats_start_timing(STATS_INT_DISABLE_TIME);
   return ret;
 }
 
-int
-interrupts_enabled() {
+int interrupts_enabled() {
   return !cm_is_masked_interrupts();
 }
 
-void
-set_event_timer(timeval_t t) {
+void set_event_timer(timeval_t t) {
   timer_set_oc_value(TIM2, TIM_OC1, t);
   timer_enable_irq(TIM2, TIM_DIER_CC1IE);
 }
 
-timeval_t
-get_event_timer() {
+timeval_t get_event_timer() {
   return TIM2_CCR1;
 }
 
-void
-clear_event_timer() {
+void clear_event_timer() {
   timer_clear_flag(TIM2, TIM_SR_CC1IF);
 }
 
-void
-disable_event_timer() {
+void disable_event_timer() {
   timer_disable_irq(TIM2, TIM_DIER_CC1IE);
   timer_clear_flag(TIM2, TIM_SR_CC1IF);
 }
 
-timeval_t
-current_time() {
+timeval_t current_time() {
   return timer_get_counter(TIM2);
 }
 
-int
-get_output(int output) {
+int get_output(int output) {
   return gpio_get(GPIOD, (1 << output)) != 0;
 }
 
-void
-set_output(int output, char value) {
+void set_output(int output, char value) {
   if (value) {
     gpio_set(GPIOD, (1 << output));
   } else {
@@ -1104,13 +1062,11 @@ set_output(int output, char value) {
   }
 }
 
-int
-get_gpio(int output) {
+int get_gpio(int output) {
   return gpio_get(GPIOE, (1 << output)) != 0;
 }
 
-void
-set_gpio(int output, char value) {
+void set_gpio(int output, char value) {
   if (value) {
     gpio_set(GPIOE, (1 << output));
   } else {
@@ -1118,8 +1074,7 @@ set_gpio(int output, char value) {
   }
 }
 
-void
-enable_test_trigger(trigger_type trig, unsigned int rpm) {
+void enable_test_trigger(trigger_type trig, unsigned int rpm) {
   if (trig != FORD_TFI) {
     return;
   }
@@ -1149,8 +1104,7 @@ enable_test_trigger(trigger_type trig, unsigned int rpm) {
 }
 
 extern unsigned _configdata_loadaddr, _sconfigdata, _econfigdata;
-void
-platform_load_config() {
+void platform_load_config() {
   volatile unsigned *src, *dest;
   for (src = &_configdata_loadaddr, dest = &_sconfigdata; dest < &_econfigdata;
        src++, dest++) {
@@ -1158,8 +1112,7 @@ platform_load_config() {
   }
 }
 
-void
-platform_save_config() {
+void platform_save_config() {
   volatile unsigned *src, *dest;
   int n_sectors, conf_bytes;
   flash_unlock();
@@ -1180,8 +1133,7 @@ platform_save_config() {
   flash_lock();
 }
 
-size_t
-console_read(void* buf, size_t max) {
+size_t console_read(void* buf, size_t max) {
   disable_interrupts();
   stats_start_timing(STATS_CONSOLE_READ_TIME);
   size_t amt = usb_rx_len > max ? max : usb_rx_len;
@@ -1193,8 +1145,7 @@ console_read(void* buf, size_t max) {
   return amt;
 }
 
-size_t
-console_write(const void* buf, size_t count) {
+size_t console_write(const void* buf, size_t count) {
   size_t rem = count > 64 ? 64 : count;
   /* https://github.com/libopencm3/libopencm3/issues/531
    * We can't let the usb irq be called while writing */
@@ -1205,8 +1156,7 @@ console_write(const void* buf, size_t count) {
 }
 
 /* This should only ever be used in an emergency */
-ssize_t
-_write(int fd, const void* buf, size_t count) {
+ssize_t _write(int fd, const void* buf, size_t count) {
   (void)fd;
 
   while (count > 0) {
@@ -1220,8 +1170,7 @@ _write(int fd, const void* buf, size_t count) {
   return count;
 }
 
-void
-_exit(int status) {
+void _exit(int status) {
   (void)status;
 
   handle_emergency_shutdown();
@@ -1240,12 +1189,10 @@ __stack_chk_fail(void) {
     ;
 }
 
-void
-platform_freeze_timers() {
+void platform_freeze_timers() {
   timer_disable_counter(TIM8);
 }
 
-void
-platform_unfreeze_timers() {
+void platform_unfreeze_timers() {
   timer_enable_counter(TIM8);
 }

--- a/src/platforms/test.c
+++ b/src/platforms/test.c
@@ -19,49 +19,39 @@ static int output_states[16] = { 0 };
 static int gpio_states[16] = { 0 };
 static int current_buffer = 0;
 
-void
-platform_enable_event_logging() {}
+void platform_enable_event_logging() {}
 
-void
-platform_disable_event_logging() {}
+void platform_disable_event_logging() {}
 
-void
-platform_reset_into_bootloader() {}
+void platform_reset_into_bootloader() {}
 
-void
-set_pwm(int pin, float val) {}
+void set_pwm(int pin, float val) {}
 
-void
-check_platform_reset() {
+void check_platform_reset() {
   curtime = 0;
   current_buffer = 0;
   initialize_scheduler();
 }
 
-int
-disable_interrupts() {
+int disable_interrupts() {
   int old = int_on;
   int_on = 0;
   return old;
 }
 
-void
-enable_interrupts() {
+void enable_interrupts() {
   int_on = 1;
 }
 
-timeval_t
-current_time() {
+timeval_t current_time() {
   return curtime;
 }
 
-timeval_t
-cycle_count() {
+timeval_t cycle_count() {
   return 0;
 }
 
-void
-set_current_time(timeval_t t) {
+void set_current_time(timeval_t t) {
   timeval_t c = curtime;
   curtime = t;
 
@@ -73,85 +63,67 @@ set_current_time(timeval_t t) {
   }
 }
 
-void
-set_event_timer(timeval_t t) {
+void set_event_timer(timeval_t t) {
   cureventtime = t;
 }
 
-timeval_t
-get_event_timer() {
+timeval_t get_event_timer() {
   return cureventtime;
 }
 
-void
-clear_event_timer() {
+void clear_event_timer() {
   cureventtime = 0;
 }
 
-void
-disable_event_timer() {
+void disable_event_timer() {
   cureventtime = 0;
 }
 
-int
-interrupts_enabled() {
+int interrupts_enabled() {
   return int_on;
 }
 
-void
-set_output(int output, char value) {
+void set_output(int output, char value) {
   output_states[output] = value;
 }
 
-int
-get_output(int output) {
+int get_output(int output) {
   return output_states[output];
 }
 
-void
-set_gpio(int output, char value) {
+void set_gpio(int output, char value) {
   gpio_states[output] = value;
 }
 
-int
-get_gpio(int output) {
+int get_gpio(int output) {
   return gpio_states[output];
 }
 
-void
-adc_gather(void* _adc) {}
+void adc_gather(void* _adc) {}
 
-int
-current_output_buffer() {
+int current_output_buffer() {
   return current_buffer;
 }
 
-timeval_t
-init_output_thread(uint32_t* b0, uint32_t* b1, uint32_t len) {
+timeval_t init_output_thread(uint32_t* b0, uint32_t* b1, uint32_t len) {
   return 0;
 }
 
-void
-enable_test_trigger(trigger_type trig, unsigned int rpm) {}
+void enable_test_trigger(trigger_type trig, unsigned int rpm) {}
 
-void
-platform_save_config() {}
+void platform_save_config() {}
 
-void
-platform_load_config() {}
+void platform_load_config() {}
 
-size_t
-console_read(void* ptr, size_t max) {
+size_t console_read(void* ptr, size_t max) {
   return 0;
 }
 
-size_t
-console_write(const void* ptr, size_t max) {
+size_t console_write(const void* ptr, size_t max) {
   return 0;
 }
 
-void
-platform_init() {
+void platform_init() {
   Suite* viaems_suite = suite_create("ViaEMS");
 
   suite_add_tcase(viaems_suite, setup_util_tests());

--- a/src/platforms/test.c
+++ b/src/platforms/test.c
@@ -99,13 +99,13 @@ int get_gpio(int output) {
   return gpio_states[output];
 }
 
-void adc_gather(void* _adc) {}
+void adc_gather(void *_adc) {}
 
 int current_output_buffer() {
   return current_buffer;
 }
 
-timeval_t init_output_thread(uint32_t* b0, uint32_t* b1, uint32_t len) {
+timeval_t init_output_thread(uint32_t *b0, uint32_t *b1, uint32_t len) {
   return 0;
 }
 
@@ -115,16 +115,16 @@ void platform_save_config() {}
 
 void platform_load_config() {}
 
-size_t console_read(void* ptr, size_t max) {
+size_t console_read(void *ptr, size_t max) {
   return 0;
 }
 
-size_t console_write(const void* ptr, size_t max) {
+size_t console_write(const void *ptr, size_t max) {
   return 0;
 }
 
 void platform_init() {
-  Suite* viaems_suite = suite_create("ViaEMS");
+  Suite *viaems_suite = suite_create("ViaEMS");
 
   suite_add_tcase(viaems_suite, setup_util_tests());
   suite_add_tcase(viaems_suite, setup_table_tests());
@@ -134,7 +134,7 @@ void platform_init() {
   suite_add_tcase(viaems_suite, setup_calculations_tests());
   suite_add_tcase(viaems_suite, setup_console_tests());
   suite_add_tcase(viaems_suite, setup_tasks_tests());
-  SRunner* sr = srunner_create(viaems_suite);
+  SRunner *sr = srunner_create(viaems_suite);
   srunner_run_all(sr, CK_VERBOSE);
   exit(srunner_ntests_failed(sr));
 }

--- a/src/platforms/test.c
+++ b/src/platforms/test.c
@@ -1,62 +1,67 @@
-#include <stdlib.h>
 #include <check.h>
+#include <stdlib.h>
 
-#include "scheduler.h"
-#include "platform.h"
+#include "calculations.h"
+#include "config.h"
+#include "console.h"
 #include "decoder.h"
-#include "util.h"
+#include "platform.h"
+#include "scheduler.h"
 #include "sensors.h"
 #include "table.h"
-#include "config.h"
-#include "calculations.h"
-#include "console.h"
 #include "tasks.h"
-
+#include "util.h"
 
 static timeval_t curtime = 0;
 static timeval_t cureventtime = 0;
 static int int_on = 1;
-static int output_states[16] = {0};
-static int gpio_states[16] = {0};
+static int output_states[16] = { 0 };
+static int gpio_states[16] = { 0 };
 static int current_buffer = 0;
 
-void platform_enable_event_logging() {
-}
+void
+platform_enable_event_logging() {}
 
-void platform_disable_event_logging() {
-}
+void
+platform_disable_event_logging() {}
 
-void platform_reset_into_bootloader() {
-}
+void
+platform_reset_into_bootloader() {}
 
-void set_pwm(int pin, float val) {
-}
+void
+set_pwm(int pin, float val) {}
 
-void check_platform_reset() {
+void
+check_platform_reset() {
   curtime = 0;
   current_buffer = 0;
   initialize_scheduler();
 }
 
-int disable_interrupts() {
+int
+disable_interrupts() {
   int old = int_on;
   int_on = 0;
   return old;
 }
 
-void enable_interrupts() {
+void
+enable_interrupts() {
   int_on = 1;
 }
 
-timeval_t current_time() {
+timeval_t
+current_time() {
   return curtime;
 }
 
-timeval_t cycle_count() {
+timeval_t
+cycle_count() {
   return 0;
 }
 
-void set_current_time(timeval_t t) {
+void
+set_current_time(timeval_t t) {
   timeval_t c = curtime;
   curtime = t;
 
@@ -68,75 +73,86 @@ void set_current_time(timeval_t t) {
   }
 }
 
-void set_event_timer(timeval_t t) {
+void
+set_event_timer(timeval_t t) {
   cureventtime = t;
 }
 
-timeval_t get_event_timer() {
+timeval_t
+get_event_timer() {
   return cureventtime;
 }
 
-void clear_event_timer() {
+void
+clear_event_timer() {
   cureventtime = 0;
 }
 
-void disable_event_timer() {
+void
+disable_event_timer() {
   cureventtime = 0;
 }
 
-int interrupts_enabled() {
+int
+interrupts_enabled() {
   return int_on;
 }
 
-void set_output(int output, char value) {
-  output_states[output] = value;  
+void
+set_output(int output, char value) {
+  output_states[output] = value;
 }
 
-int get_output(int output) {
+int
+get_output(int output) {
   return output_states[output];
 }
 
-void set_gpio(int output, char value) {
-  gpio_states[output] = value;  
+void
+set_gpio(int output, char value) {
+  gpio_states[output] = value;
 }
 
-int get_gpio(int output) {
+int
+get_gpio(int output) {
   return gpio_states[output];
 }
 
-void adc_gather(void *_adc) {
-}
+void
+adc_gather(void* _adc) {}
 
-int current_output_buffer() {
+int
+current_output_buffer() {
   return current_buffer;
 }
 
-timeval_t init_output_thread(uint32_t *b0, uint32_t *b1, uint32_t len) {
+timeval_t
+init_output_thread(uint32_t* b0, uint32_t* b1, uint32_t len) {
   return 0;
 }
 
+void
+enable_test_trigger(trigger_type trig, unsigned int rpm) {}
 
-void enable_test_trigger(trigger_type trig, unsigned int rpm) {
-}
+void
+platform_save_config() {}
 
-void platform_save_config() {
+void
+platform_load_config() {}
 
-}
-
-void platform_load_config() {
-
-}
-
-size_t console_read(void *ptr, size_t max) {
+size_t
+console_read(void* ptr, size_t max) {
   return 0;
 }
 
-size_t console_write(const void *ptr, size_t max) {
+size_t
+console_write(const void* ptr, size_t max) {
   return 0;
 }
 
-void platform_init() {
-  Suite *viaems_suite = suite_create("ViaEMS");
+void
+platform_init() {
+  Suite* viaems_suite = suite_create("ViaEMS");
 
   suite_add_tcase(viaems_suite, setup_util_tests());
   suite_add_tcase(viaems_suite, setup_table_tests());
@@ -146,8 +162,7 @@ void platform_init() {
   suite_add_tcase(viaems_suite, setup_calculations_tests());
   suite_add_tcase(viaems_suite, setup_console_tests());
   suite_add_tcase(viaems_suite, setup_tasks_tests());
-  SRunner *sr = srunner_create(viaems_suite);
+  SRunner* sr = srunner_create(viaems_suite);
   srunner_run_all(sr, CK_VERBOSE);
   exit(srunner_ntests_failed(sr));
 }
-

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -10,11 +10,9 @@
 #include <strings.h>
 
 #define OUTPUT_BUFFER_LEN (512)
-static struct output_buffer
-{
+static struct output_buffer {
   timeval_t start;
-  struct output_slot
-  {
+  struct output_slot {
     uint16_t on_mask;  /* On little endian arch, most-significant */
     uint16_t off_mask; /* are last in struct */
   } __attribute__((packed)) slots[OUTPUT_BUFFER_LEN];

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -193,12 +193,12 @@ void invalidate_scheduled_events(struct output_event *evs, int n) {
       continue;
     }
     switch (evs[i].type) {
-      case IGNITION_EVENT:
-      case FUEL_EVENT:
-        deschedule_event(&evs[i]);
-        break;
-      default:
-        break;
+    case IGNITION_EVENT:
+    case FUEL_EVENT:
+      deschedule_event(&evs[i]);
+      break;
+    default:
+      break;
     }
   }
 }
@@ -418,30 +418,30 @@ static int schedule_adc_event(struct output_event *ev, struct decoder *d) {
 
 void schedule_event(struct output_event *ev) {
   switch (ev->type) {
-    case IGNITION_EVENT:
-      if (ignition_cut() || !config.decoder.valid) {
-        invalidate_scheduled_events(config.events, config.num_events);
-        return;
-      }
-      schedule_ignition_event(ev,
-                              &config.decoder,
-                              (degrees_t)calculated_values.timing_advance,
-                              calculated_values.dwell_us);
-      break;
+  case IGNITION_EVENT:
+    if (ignition_cut() || !config.decoder.valid) {
+      invalidate_scheduled_events(config.events, config.num_events);
+      return;
+    }
+    schedule_ignition_event(ev,
+                            &config.decoder,
+                            (degrees_t)calculated_values.timing_advance,
+                            calculated_values.dwell_us);
+    break;
 
-    case FUEL_EVENT:
-      if (fuel_cut() || !config.decoder.valid) {
-        invalidate_scheduled_events(config.events, config.num_events);
-        return;
-      }
-      schedule_fuel_event(ev, &config.decoder, calculated_values.fueling_us);
-      break;
+  case FUEL_EVENT:
+    if (fuel_cut() || !config.decoder.valid) {
+      invalidate_scheduled_events(config.events, config.num_events);
+      return;
+    }
+    schedule_fuel_event(ev, &config.decoder, calculated_values.fueling_us);
+    break;
 
-    case ADC_EVENT:
-      schedule_adc_event(ev, &config.decoder);
-      break;
-    default:
-      break;
+  case ADC_EVENT:
+    schedule_adc_event(ev, &config.decoder);
+    break;
+  default:
+    break;
   }
 }
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -22,8 +22,7 @@ static struct output_buffer {
 struct timed_callback* callbacks[MAX_CALLBACKS] = { 0 };
 static int n_callbacks = 0;
 
-static int
-sched_entry_has_fired(struct sched_entry* en) {
+static int sched_entry_has_fired(struct sched_entry* en) {
   int ret = 0;
   int ints_on = disable_interrupts();
   if (en && en->buffer) {
@@ -40,20 +39,17 @@ sched_entry_has_fired(struct sched_entry* en) {
   return ret;
 }
 
-int
-event_is_active(struct output_event* ev) {
+int event_is_active(struct output_event* ev) {
   return (sched_entry_has_fired(&ev->start) &&
           !sched_entry_has_fired(&ev->stop));
 }
 
-int
-event_has_fired(struct output_event* ev) {
+int event_has_fired(struct output_event* ev) {
   return (sched_entry_has_fired(&ev->start) &&
           sched_entry_has_fired(&ev->stop));
 }
 
-static struct output_buffer*
-buffer_for_time(timeval_t time) {
+static struct output_buffer* buffer_for_time(timeval_t time) {
   struct output_buffer* buf = NULL;
   if (time_in_range(time,
                     output_buffers[0].start,
@@ -67,8 +63,7 @@ buffer_for_time(timeval_t time) {
   return buf;
 }
 
-static int
-fired_if_failed(struct sched_entry* en, int success) {
+static int fired_if_failed(struct sched_entry* en, int success) {
   en->fired = !success;
   return success;
 }
@@ -80,8 +75,7 @@ fired_if_failed(struct sched_entry* en, int success) {
  * time.
  *
  * Does no bookkeeping but can set fired flag */
-static int
-sched_entry_disable(const struct sched_entry* en, timeval_t time) {
+static int sched_entry_disable(const struct sched_entry* en, timeval_t time) {
 
   assert(!interrupts_enabled());
   /* before either buffer starts */
@@ -124,8 +118,7 @@ sched_entry_disable(const struct sched_entry* en, timeval_t time) {
  * Return of 0 means the event did not fire.
  *
  * Does no bookkeeping of sched_entry */
-static int
-sched_entry_enable(const struct sched_entry* en, timeval_t time) {
+static int sched_entry_enable(const struct sched_entry* en, timeval_t time) {
 
   assert(!interrupts_enabled());
   /* before either buffer starts */
@@ -162,21 +155,18 @@ sched_entry_enable(const struct sched_entry* en, timeval_t time) {
   return 1;
 }
 
-static void
-sched_entry_update(struct sched_entry* en, timeval_t time) {
+static void sched_entry_update(struct sched_entry* en, timeval_t time) {
   en->buffer = buffer_for_time(time);
   en->scheduled = 1;
   en->time = time;
 }
 
-static void
-sched_entry_off(struct sched_entry* en) {
+static void sched_entry_off(struct sched_entry* en) {
   en->scheduled = 0;
   en->buffer = NULL;
 }
 
-void
-deschedule_event(struct output_event* ev) {
+void deschedule_event(struct output_event* ev) {
   int ints_en = disable_interrupts();
 
   if (ev->start.fired) {
@@ -197,8 +187,7 @@ deschedule_event(struct output_event* ev) {
   }
 }
 
-void
-invalidate_scheduled_events(struct output_event* evs, int n) {
+void invalidate_scheduled_events(struct output_event* evs, int n) {
   for (int i = 0; i < n; ++i) {
     if (!evs[i].start.scheduled) {
       continue;
@@ -214,8 +203,9 @@ invalidate_scheduled_events(struct output_event* evs, int n) {
   }
 }
 
-static void
-reschedule_end(struct sched_entry* s, timeval_t old, timeval_t new) {
+static void reschedule_end(struct sched_entry* s,
+                           timeval_t old,
+                           timeval_t new) {
   if (new == old)
     return;
 
@@ -235,11 +225,10 @@ reschedule_end(struct sched_entry* s, timeval_t old, timeval_t new) {
 /* Schedules an output event in a hazard-free manner, assuming
  * that the start and stop times occur at least after curtime
  */
-void
-schedule_output_event_safely(struct output_event* ev,
-                             timeval_t newstart,
-                             timeval_t newstop,
-                             int preserve_duration) {
+void schedule_output_event_safely(struct output_event* ev,
+                                  timeval_t newstart,
+                                  timeval_t newstop,
+                                  int preserve_duration) {
 
   stats_start_timing(STATS_SCHED_SINGLE_TIME);
   int success;
@@ -310,11 +299,10 @@ schedule_output_event_safely(struct output_event* ev,
   stats_finish_timing(STATS_SCHED_SINGLE_TIME);
 }
 
-static int
-schedule_ignition_event(struct output_event* ev,
-                        struct decoder* d,
-                        degrees_t advance,
-                        unsigned int usecs_dwell) {
+static int schedule_ignition_event(struct output_event* ev,
+                                   struct decoder* d,
+                                   degrees_t advance,
+                                   unsigned int usecs_dwell) {
 
   timeval_t stop_time;
   timeval_t start_time;
@@ -363,10 +351,9 @@ schedule_ignition_event(struct output_event* ev,
   return 1;
 }
 
-static int
-schedule_fuel_event(struct output_event* ev,
-                    struct decoder* d,
-                    unsigned int usecs_pw) {
+static int schedule_fuel_event(struct output_event* ev,
+                               struct decoder* d,
+                               unsigned int usecs_pw) {
 
   timeval_t stop_time;
   timeval_t start_time;
@@ -408,8 +395,7 @@ schedule_fuel_event(struct output_event* ev,
   return 1;
 }
 
-static int
-schedule_adc_event(struct output_event* ev, struct decoder* d) {
+static int schedule_adc_event(struct output_event* ev, struct decoder* d) {
   int firing_angle;
   timeval_t collect_time;
 
@@ -430,8 +416,7 @@ schedule_adc_event(struct output_event* ev, struct decoder* d) {
   return 1;
 }
 
-void
-schedule_event(struct output_event* ev) {
+void schedule_event(struct output_event* ev) {
   switch (ev->type) {
     case IGNITION_EVENT:
       if (ignition_cut() || !config.decoder.valid) {
@@ -460,8 +445,7 @@ schedule_event(struct output_event* ev) {
   }
 }
 
-static void
-callback_remove(struct timed_callback* tcb) {
+static void callback_remove(struct timed_callback* tcb) {
   int i;
   int tcb_pos;
   for (i = 0; i < n_callbacks; ++i) {
@@ -481,8 +465,7 @@ callback_remove(struct timed_callback* tcb) {
   tcb->scheduled = 0;
 }
 
-static void
-callback_insert(struct timed_callback* tcb) {
+static void callback_insert(struct timed_callback* tcb) {
 
   int i;
   int tcb_pos;
@@ -502,8 +485,7 @@ callback_insert(struct timed_callback* tcb) {
   tcb->scheduled = 1;
 }
 
-int
-schedule_callback(struct timed_callback* tcb, timeval_t time) {
+int schedule_callback(struct timed_callback* tcb, timeval_t time) {
 
   int ints_on = disable_interrupts();
   if (tcb->scheduled) {
@@ -528,8 +510,7 @@ schedule_callback(struct timed_callback* tcb, timeval_t time) {
   return 0;
 }
 
-void
-scheduler_callback_timer_execute() {
+void scheduler_callback_timer_execute() {
   while (n_callbacks && time_before(callbacks[0]->time, current_time())) {
     clear_event_timer();
     struct timed_callback* cb = callbacks[0];
@@ -545,8 +526,7 @@ scheduler_callback_timer_execute() {
   }
 }
 
-void
-scheduler_buffer_swap() {
+void scheduler_buffer_swap() {
   int newbuf = (current_output_buffer() + 1) % 2;
   struct output_buffer* obuf = &output_buffers[newbuf];
 
@@ -588,8 +568,7 @@ scheduler_buffer_swap() {
   enable_interrupts();
 }
 
-void
-initialize_scheduler() {
+void initialize_scheduler() {
   memset(&output_buffers, 0, sizeof(output_buffers));
 
   output_buffers[0].start =
@@ -607,8 +586,7 @@ initialize_scheduler() {
 
 static struct output_event* oev = &config.events[0];
 
-static void
-check_scheduler_setup() {
+static void check_scheduler_setup() {
   decoder_init(&config.decoder);
   check_platform_reset();
   config.decoder.last_trigger_angle = 0;
@@ -1132,8 +1110,7 @@ START_TEST(check_callback_execute) {
 }
 END_TEST
 
-TCase*
-setup_scheduler_tests() {
+TCase* setup_scheduler_tests() {
   TCase* tc = tcase_create("scheduler");
   tcase_add_checked_fixture(tc, check_scheduler_setup, NULL);
   tcase_add_test(tc, check_schedule_ignition);

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -4,7 +4,6 @@
 #include "platform.h"
 //#include "queue.h"
 
-
 typedef enum {
   DISABLED_EVENT,
   FUEL_EVENT,
@@ -22,7 +21,7 @@ struct sched_entry {
 
   volatile unsigned char fired;
   volatile unsigned char scheduled; /* current time is valid */
-  struct output_buffer *buffer;
+  struct output_buffer* buffer;
 };
 
 /* Meaning of scheduled/fired:
@@ -34,8 +33,8 @@ struct sched_entry {
  */
 
 struct timed_callback {
-  void (*callback)(void *);
-  void *data;
+  void (*callback)(void*);
+  void* data;
   timeval_t time;
   int scheduled;
 };
@@ -51,25 +50,34 @@ struct output_event {
   struct timed_callback callback;
 };
 
+void
+schedule_event(struct output_event* ev);
+void
+deschedule_event(struct output_event*);
 
-void schedule_event(struct output_event *ev);
-void deschedule_event(struct output_event *);
+int
+schedule_callback(struct timed_callback* tcb, timeval_t time);
 
-int schedule_callback(struct timed_callback *tcb, timeval_t time);
+void
+scheduler_callback_timer_execute();
+void
+initialize_scheduler();
+void
+scheduler_buffer_swap();
 
-void scheduler_callback_timer_execute();
-void initialize_scheduler();
-void scheduler_buffer_swap();
-
-int event_is_active(struct output_event *);
-int event_has_fired(struct output_event *);
-void invalidate_scheduled_events(struct output_event *, int);
+int
+event_is_active(struct output_event*);
+int
+event_has_fired(struct output_event*);
+void
+invalidate_scheduled_events(struct output_event*, int);
 
 #ifdef UNITTEST
 #include <check.h>
-void check_add_buffer_tests(TCase *);
-TCase *setup_scheduler_tests();
+void
+check_add_buffer_tests(TCase*);
+TCase*
+setup_scheduler_tests();
 #endif
 
-#endif 
-
+#endif

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -21,7 +21,7 @@ struct sched_entry {
 
   volatile unsigned char fired;
   volatile unsigned char scheduled; /* current time is valid */
-  struct output_buffer* buffer;
+  struct output_buffer *buffer;
 };
 
 /* Meaning of scheduled/fired:
@@ -33,8 +33,8 @@ struct sched_entry {
  */
 
 struct timed_callback {
-  void (*callback)(void*);
-  void* data;
+  void (*callback)(void *);
+  void *data;
   timeval_t time;
   int scheduled;
 };
@@ -50,23 +50,23 @@ struct output_event {
   struct timed_callback callback;
 };
 
-void schedule_event(struct output_event* ev);
-void deschedule_event(struct output_event*);
+void schedule_event(struct output_event *ev);
+void deschedule_event(struct output_event *);
 
-int schedule_callback(struct timed_callback* tcb, timeval_t time);
+int schedule_callback(struct timed_callback *tcb, timeval_t time);
 
 void scheduler_callback_timer_execute();
 void initialize_scheduler();
 void scheduler_buffer_swap();
 
-int event_is_active(struct output_event*);
-int event_has_fired(struct output_event*);
-void invalidate_scheduled_events(struct output_event*, int);
+int event_is_active(struct output_event *);
+int event_has_fired(struct output_event *);
+void invalidate_scheduled_events(struct output_event *, int);
 
 #ifdef UNITTEST
 #include <check.h>
-void check_add_buffer_tests(TCase*);
-TCase* setup_scheduler_tests();
+void check_add_buffer_tests(TCase *);
+TCase *setup_scheduler_tests();
 #endif
 
 #endif

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -50,34 +50,23 @@ struct output_event {
   struct timed_callback callback;
 };
 
-void
-schedule_event(struct output_event* ev);
-void
-deschedule_event(struct output_event*);
+void schedule_event(struct output_event* ev);
+void deschedule_event(struct output_event*);
 
-int
-schedule_callback(struct timed_callback* tcb, timeval_t time);
+int schedule_callback(struct timed_callback* tcb, timeval_t time);
 
-void
-scheduler_callback_timer_execute();
-void
-initialize_scheduler();
-void
-scheduler_buffer_swap();
+void scheduler_callback_timer_execute();
+void initialize_scheduler();
+void scheduler_buffer_swap();
 
-int
-event_is_active(struct output_event*);
-int
-event_has_fired(struct output_event*);
-void
-invalidate_scheduled_events(struct output_event*, int);
+int event_is_active(struct output_event*);
+int event_has_fired(struct output_event*);
+void invalidate_scheduled_events(struct output_event*, int);
 
 #ifdef UNITTEST
 #include <check.h>
-void
-check_add_buffer_tests(TCase*);
-TCase*
-setup_scheduler_tests();
+void check_add_buffer_tests(TCase*);
+TCase* setup_scheduler_tests();
 #endif
 
 #endif

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -5,7 +5,7 @@
 #include "sensors.h"
 #include "stats.h"
 
-static float sensor_convert_linear(struct sensor_input* in, float raw) {
+static float sensor_convert_linear(struct sensor_input *in, float raw) {
   float partial = raw / 4096.0f;
   return in->params.range.min +
          partial * (in->params.range.max - in->params.range.min);
@@ -20,7 +20,7 @@ static float sensor_convert_freq(float raw) {
   return 40.96f * 1.0 / ((raw * SENSOR_FREQ_DIVIDER) / tickrate);
 }
 
-float sensor_convert_thermistor(struct thermistor_config* tc, float raw) {
+float sensor_convert_thermistor(struct thermistor_config *tc, float raw) {
   stats_start_timing(STATS_SENSOR_THERM_TIME);
   float r = tc->bias / ((4096.0f / raw) - 1);
   float t = 1 / (tc->a + tc->b * logf(r) + tc->c * powf(logf(r), 3));
@@ -29,7 +29,7 @@ float sensor_convert_thermistor(struct thermistor_config* tc, float raw) {
   return t - 273.15f;
 }
 
-static void sensor_convert(struct sensor_input* in) {
+static void sensor_convert(struct sensor_input *in) {
   /* Handle conn and range fault conditions */
   if ((in->fault == FAULT_NONE) && (in->fault_config.max != 0)) {
     if ((in->fault_config.min > in->raw_value) ||
@@ -147,8 +147,8 @@ START_TEST(check_sensor_convert_therm) {
 }
 END_TEST
 
-TCase* setup_sensor_tests() {
-  TCase* sensor_tests = tcase_create("sensors");
+TCase *setup_sensor_tests() {
+  TCase *sensor_tests = tcase_create("sensors");
   tcase_add_test(sensor_tests, check_sensor_convert_linear);
   tcase_add_test(sensor_tests, check_sensor_convert_freq);
   tcase_add_test(sensor_tests, check_sensor_convert_therm);

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -44,31 +44,31 @@ static void sensor_convert(struct sensor_input *in) {
 
   float raw;
   switch (in->source) {
-    case SENSOR_ADC:
-      raw = in->raw_value;
-      break;
-    case SENSOR_FREQ:
-      raw = sensor_convert_freq(in->raw_value);
-      break;
-    case SENSOR_CONST:
-      in->processed_value = in->params.fixed_value;
-      return;
-    default:
-      raw = 0.0;
-      break;
+  case SENSOR_ADC:
+    raw = in->raw_value;
+    break;
+  case SENSOR_FREQ:
+    raw = sensor_convert_freq(in->raw_value);
+    break;
+  case SENSOR_CONST:
+    in->processed_value = in->params.fixed_value;
+    return;
+  default:
+    raw = 0.0;
+    break;
   }
 
   float old_value = in->processed_value;
   switch (in->method) {
-    case METHOD_LINEAR:
-      in->processed_value = sensor_convert_linear(in, raw);
-      break;
-    case METHOD_TABLE:
-      in->processed_value = interpolate_table_oneaxis(in->params.table, raw);
-      break;
-    case METHOD_THERM:
-      in->processed_value = sensor_convert_thermistor(&in->params.therm, raw);
-      break;
+  case METHOD_LINEAR:
+    in->processed_value = sensor_convert_linear(in, raw);
+    break;
+  case METHOD_TABLE:
+    in->processed_value = interpolate_table_oneaxis(in->params.table, raw);
+    break;
+  case METHOD_THERM:
+    in->processed_value = sensor_convert_thermistor(&in->params.therm, raw);
+    break;
   }
 
   /* Do lag filtering */

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -5,16 +5,14 @@
 #include "sensors.h"
 #include "stats.h"
 
-static float
-sensor_convert_linear(struct sensor_input* in, float raw) {
+static float sensor_convert_linear(struct sensor_input* in, float raw) {
   float partial = raw / 4096.0f;
   return in->params.range.min +
          partial * (in->params.range.max - in->params.range.min);
 }
 
 /* Returns 0 - 4095 for 0 Hz - 2 kHz */
-static float
-sensor_convert_freq(float raw) {
+static float sensor_convert_freq(float raw) {
   float tickrate = TICKRATE;
   if (!raw) {
     return 0.0; /* Prevent div by zero */
@@ -22,8 +20,7 @@ sensor_convert_freq(float raw) {
   return 40.96f * 1.0 / ((raw * SENSOR_FREQ_DIVIDER) / tickrate);
 }
 
-float
-sensor_convert_thermistor(struct thermistor_config* tc, float raw) {
+float sensor_convert_thermistor(struct thermistor_config* tc, float raw) {
   stats_start_timing(STATS_SENSOR_THERM_TIME);
   float r = tc->bias / ((4096.0f / raw) - 1);
   float t = 1 / (tc->a + tc->b * logf(r) + tc->c * powf(logf(r), 3));
@@ -32,8 +29,7 @@ sensor_convert_thermistor(struct thermistor_config* tc, float raw) {
   return t - 273.15f;
 }
 
-static void
-sensor_convert(struct sensor_input* in) {
+static void sensor_convert(struct sensor_input* in) {
   /* Handle conn and range fault conditions */
   if ((in->fault == FAULT_NONE) && (in->fault_config.max != 0)) {
     if ((in->fault_config.min > in->raw_value) ||
@@ -88,8 +84,7 @@ sensor_convert(struct sensor_input* in) {
   in->process_time = process_time;
 }
 
-void
-sensors_process(sensor_source source) {
+void sensors_process(sensor_source source) {
   for (int i = 0; i < NUM_SENSORS; ++i) {
     if (config.sensors[i].source != source) {
       continue;
@@ -97,8 +92,7 @@ sensors_process(sensor_source source) {
     sensor_convert(&config.sensors[i]);
   }
 }
-uint32_t
-sensor_fault_status() {
+uint32_t sensor_fault_status() {
   uint32_t faults = 0;
   for (int i = 0; i < NUM_SENSORS; ++i) {
     if (config.sensors[i].fault != FAULT_NONE) {
@@ -153,8 +147,7 @@ START_TEST(check_sensor_convert_therm) {
 }
 END_TEST
 
-TCase*
-setup_sensor_tests() {
+TCase* setup_sensor_tests() {
   TCase* sensor_tests = tcase_create("sensors");
   tcase_add_test(sensor_tests, check_sensor_convert_linear);
   tcase_add_test(sensor_tests, check_sensor_convert_freq);

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -52,7 +52,7 @@ struct sensor_input {
       float min;
       float max;
     } range;
-    struct table* table;
+    struct table *table;
     float fixed_value;
     struct thermistor_config therm;
   } params;
@@ -75,7 +75,7 @@ uint32_t sensor_fault_status();
 
 #ifdef UNITTEST
 #include <check.h>
-TCase* setup_sensor_tests();
+TCase *setup_sensor_tests();
 #endif
 
 #endif

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -52,7 +52,7 @@ struct sensor_input {
       float min;
       float max;
     } range;
-    struct table *table;
+    struct table* table;
     float fixed_value;
     struct thermistor_config therm;
   } params;
@@ -70,13 +70,15 @@ struct sensor_input {
   sensor_fault fault;
 };
 
-void sensors_process(sensor_source source);
-uint32_t sensor_fault_status();
+void
+sensors_process(sensor_source source);
+uint32_t
+sensor_fault_status();
 
 #ifdef UNITTEST
 #include <check.h>
-TCase *setup_sensor_tests();
+TCase*
+setup_sensor_tests();
 #endif
 
 #endif
-

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -70,15 +70,12 @@ struct sensor_input {
   sensor_fault fault;
 };
 
-void
-sensors_process(sensor_source source);
-uint32_t
-sensor_fault_status();
+void sensors_process(sensor_source source);
+uint32_t sensor_fault_status();
 
 #ifdef UNITTEST
 #include <check.h>
-TCase*
-setup_sensor_tests();
+TCase* setup_sensor_tests();
 #endif
 
 #endif

--- a/src/stats.c
+++ b/src/stats.c
@@ -1,5 +1,5 @@
-#include <stdio.h>
 #include <assert.h>
+#include <stdio.h>
 
 #include "platform.h"
 #include "stats.h"
@@ -71,7 +71,8 @@ struct stats_entry stats_entries[] = {
 
 static timeval_t ticks_per_sec = 1000000;
 
-void stats_init(timeval_t ticks) {
+void
+stats_init(timeval_t ticks) {
   ticks_per_sec = ticks;
 
   for (int i = 0; i < STATS_LAST; ++i) {
@@ -87,7 +88,8 @@ void stats_init(timeval_t ticks) {
   }
 }
 
-static void stats_update(stats_field_t type, timeval_t val) {
+static void
+stats_update(stats_field_t type, timeval_t val) {
 
   if (val < stats_entries[type].min) {
     stats_entries[type].min = val;
@@ -102,16 +104,19 @@ static void stats_update(stats_field_t type, timeval_t val) {
   stats_entries[type]._prev[1] = stats_entries[type]._prev[0];
   stats_entries[type]._prev[0] = val;
 
-  timeval_t total = stats_entries[type]._prev[3] + stats_entries[type]._prev[2] +
-    stats_entries[type]._prev[1] + stats_entries[type]._prev[0];
+  timeval_t total = stats_entries[type]._prev[3] +
+                    stats_entries[type]._prev[2] +
+                    stats_entries[type]._prev[1] + stats_entries[type]._prev[0];
   stats_entries[type].avg = total / 4;
 }
 
-void stats_start_timing(stats_field_t type) {
+void
+stats_start_timing(stats_field_t type) {
   stats_entries[type]._window = cycle_count();
 }
 
-void stats_finish_timing(stats_field_t type) {
+void
+stats_finish_timing(stats_field_t type) {
 
   timeval_t time;
   time = cycle_count();
@@ -120,7 +125,8 @@ void stats_finish_timing(stats_field_t type) {
   stats_update(type, time / (ticks_per_sec / 1000000));
 }
 
-void stats_increment_counter(stats_field_t type) {
+void
+stats_increment_counter(stats_field_t type) {
 
   if (cycle_count() - stats_entries[type]._window > ticks_per_sec) {
     /* We've reached the window edge, calculate and reset */

--- a/src/stats.c
+++ b/src/stats.c
@@ -71,8 +71,7 @@ struct stats_entry stats_entries[] = {
 
 static timeval_t ticks_per_sec = 1000000;
 
-void
-stats_init(timeval_t ticks) {
+void stats_init(timeval_t ticks) {
   ticks_per_sec = ticks;
 
   for (int i = 0; i < STATS_LAST; ++i) {
@@ -88,8 +87,7 @@ stats_init(timeval_t ticks) {
   }
 }
 
-static void
-stats_update(stats_field_t type, timeval_t val) {
+static void stats_update(stats_field_t type, timeval_t val) {
 
   if (val < stats_entries[type].min) {
     stats_entries[type].min = val;
@@ -110,13 +108,11 @@ stats_update(stats_field_t type, timeval_t val) {
   stats_entries[type].avg = total / 4;
 }
 
-void
-stats_start_timing(stats_field_t type) {
+void stats_start_timing(stats_field_t type) {
   stats_entries[type]._window = cycle_count();
 }
 
-void
-stats_finish_timing(stats_field_t type) {
+void stats_finish_timing(stats_field_t type) {
 
   timeval_t time;
   time = cycle_count();
@@ -125,8 +121,7 @@ stats_finish_timing(stats_field_t type) {
   stats_update(type, time / (ticks_per_sec / 1000000));
 }
 
-void
-stats_increment_counter(stats_field_t type) {
+void stats_increment_counter(stats_field_t type) {
 
   if (cycle_count() - stats_entries[type]._window > ticks_per_sec) {
     /* We've reached the window edge, calculate and reset */

--- a/src/stats.h
+++ b/src/stats.h
@@ -39,15 +39,11 @@ typedef enum {
   STATS_LAST,
 } stats_field_t;
 
-void
-stats_init(timeval_t ticks_per_us);
+void stats_init(timeval_t ticks_per_us);
 
-void
-stats_increment_counter(stats_field_t type);
-void
-stats_start_timing(stats_field_t type);
-void
-stats_finish_timing(stats_field_t type);
+void stats_increment_counter(stats_field_t type);
+void stats_start_timing(stats_field_t type);
+void stats_finish_timing(stats_field_t type);
 
 extern struct stats_entry stats_entries[];
 

--- a/src/stats.h
+++ b/src/stats.h
@@ -2,7 +2,7 @@
 #define STATS_H
 
 struct stats_entry {
-  const char* name;
+  const char *name;
   timeval_t min;
   timeval_t avg;
   timeval_t max;

--- a/src/stats.h
+++ b/src/stats.h
@@ -2,7 +2,7 @@
 #define STATS_H
 
 struct stats_entry {
-  const char *name;
+  const char* name;
   timeval_t min;
   timeval_t avg;
   timeval_t max;
@@ -39,14 +39,16 @@ typedef enum {
   STATS_LAST,
 } stats_field_t;
 
+void
+stats_init(timeval_t ticks_per_us);
 
-void stats_init(timeval_t ticks_per_us);
-
-void stats_increment_counter(stats_field_t type);
-void stats_start_timing(stats_field_t type);
-void stats_finish_timing(stats_field_t type);
+void
+stats_increment_counter(stats_field_t type);
+void
+stats_start_timing(stats_field_t type);
+void
+stats_finish_timing(stats_field_t type);
 
 extern struct stats_entry stats_entries[];
 
 #endif
-

--- a/src/table.c
+++ b/src/table.c
@@ -1,6 +1,6 @@
 #include "table.h"
 
-float interpolate_table_oneaxis(struct table* t, float val) {
+float interpolate_table_oneaxis(struct table *t, float val) {
   if (t->num_axis != 1) {
     while (1)
       ;
@@ -26,7 +26,7 @@ float interpolate_table_oneaxis(struct table* t, float val) {
   return 0;
 }
 
-float interpolate_table_twoaxis(struct table* t, float x, float y) {
+float interpolate_table_twoaxis(struct table *t, float x, float y) {
   float x1 = 0, x2 = 0, y1 = 0, y2 = 0;
   int x1_ind = 0, y1_ind = 0;
   float xy1, xy2, xy;
@@ -72,7 +72,7 @@ float interpolate_table_twoaxis(struct table* t, float x, float y) {
   return xy;
 }
 
-static int table_valid_axis(struct table_axis* a) {
+static int table_valid_axis(struct table_axis *a) {
   if (a->num > MAX_AXIS_SIZE) {
     return 0;
   }
@@ -84,7 +84,7 @@ static int table_valid_axis(struct table_axis* a) {
   return 1;
 }
 
-int table_valid(struct table* t) {
+int table_valid(struct table *t) {
 
   if ((t->num_axis != 1) && (t->num_axis != 2)) {
     return 0;
@@ -161,8 +161,8 @@ START_TEST(check_table_twoaxis_clamp) {
 }
 END_TEST
 
-TCase* setup_table_tests() {
-  TCase* table_tests = tcase_create("tables");
+TCase *setup_table_tests() {
+  TCase *table_tests = tcase_create("tables");
   tcase_add_test(table_tests, check_table_oneaxis_interpolate);
   tcase_add_test(table_tests, check_table_oneaxis_clamp);
   tcase_add_test(table_tests, check_table_twoaxis_interpolate);

--- a/src/table.c
+++ b/src/table.c
@@ -1,9 +1,10 @@
 #include "table.h"
 
 float
-interpolate_table_oneaxis(struct table *t, float val) {
+interpolate_table_oneaxis(struct table* t, float val) {
   if (t->num_axis != 1) {
-    while(1);
+    while (1)
+      ;
   }
   /* Clamp to bottom */
   if (val < t->axis[0].values[0]) {
@@ -16,8 +17,7 @@ interpolate_table_oneaxis(struct table *t, float val) {
   for (int x = 0; x < t->axis[0].num - 1; ++x) {
     float first_axis = t->axis[0].values[x];
     float second_axis = t->axis[0].values[x + 1];
-    if ((val >= first_axis) &&
-        (val <= second_axis)) {
+    if ((val >= first_axis) && (val <= second_axis)) {
       float partial = (val - first_axis) / (second_axis - first_axis);
       float first_val = t->data.one[x];
       float second_val = t->data.one[x + 1];
@@ -28,12 +28,13 @@ interpolate_table_oneaxis(struct table *t, float val) {
 }
 
 float
-interpolate_table_twoaxis(struct table *t, float x, float y) {
+interpolate_table_twoaxis(struct table* t, float x, float y) {
   float x1 = 0, x2 = 0, y1 = 0, y2 = 0;
   int x1_ind = 0, y1_ind = 0;
   float xy1, xy2, xy;
   if (t->num_axis != 2) {
-    while(1);
+    while (1)
+      ;
   }
   /* Clamp X to bottom */
   if (x < t->axis[0].values[0]) {
@@ -65,16 +66,16 @@ interpolate_table_twoaxis(struct table *t, float x, float y) {
       break;
     }
   }
-  xy1 = (x2 - x) / (x2 - x1) * t->data.two[y1_ind][x1_ind] + 
+  xy1 = (x2 - x) / (x2 - x1) * t->data.two[y1_ind][x1_ind] +
         (x - x1) / (x2 - x1) * t->data.two[y1_ind][x1_ind + 1];
-  xy2 = (x2 - x) / (x2 - x1) * t->data.two[y1_ind + 1][x1_ind] + 
+  xy2 = (x2 - x) / (x2 - x1) * t->data.two[y1_ind + 1][x1_ind] +
         (x - x1) / (x2 - x1) * t->data.two[y1_ind + 1][x1_ind + 1];
-  xy = (y2 - y) / (y2 - y1) * xy1 +
-       (y - y1) / (y2 - y1) * xy2;
+  xy = (y2 - y) / (y2 - y1) * xy1 + (y - y1) / (y2 - y1) * xy2;
   return xy;
 }
 
-static int table_valid_axis(struct table_axis *a) {
+static int
+table_valid_axis(struct table_axis* a) {
   if (a->num > MAX_AXIS_SIZE) {
     return 0;
   }
@@ -86,8 +87,9 @@ static int table_valid_axis(struct table_axis *a) {
   return 1;
 }
 
-int table_valid(struct table *t) {
-  
+int
+table_valid(struct table* t) {
+
   if ((t->num_axis != 1) && (t->num_axis != 2)) {
     return 0;
   }
@@ -103,19 +105,16 @@ int table_valid(struct table *t) {
   return 1;
 }
 
-
 #ifdef UNITTEST
 #include <check.h>
 
 static struct table t1 = {
   .num_axis = 1,
-  .axis = { { 
+  .axis = { {
     .num = 4,
-    .values = {5, 10, 15, 20},
-   } },
-   .data = {
-     .one = {50, 100, 150, 200}
-   },
+    .values = { 5, 10, 15, 20 },
+  } },
+  .data = { .one = { 50, 100, 150, 200 } },
 };
 
 static struct table t2 = {
@@ -140,19 +139,22 @@ START_TEST(check_table_oneaxis_interpolate) {
   ck_assert(interpolate_table_oneaxis(&t1, 5) == 50);
   ck_assert(interpolate_table_oneaxis(&t1, 10) == 100);
   ck_assert(interpolate_table_oneaxis(&t1, 20) == 200);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_table_oneaxis_clamp) {
   ck_assert(interpolate_table_oneaxis(&t1, 0) == 50);
   ck_assert(interpolate_table_oneaxis(&t1, 30) == 200);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_table_twoaxis_interpolate) {
   ck_assert(interpolate_table_twoaxis(&t2, 5, -50) == 50);
   ck_assert(interpolate_table_twoaxis(&t2, 7.5, -50) == 75);
   ck_assert(interpolate_table_twoaxis(&t2, 5, -45) == 55);
   ck_assert(interpolate_table_twoaxis(&t2, 7.5, -45) == 80);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_table_twoaxis_clamp) {
   ck_assert(interpolate_table_twoaxis(&t2, 10, -60) == 100);
@@ -160,10 +162,12 @@ START_TEST(check_table_twoaxis_clamp) {
   ck_assert(interpolate_table_twoaxis(&t2, 0, -40) == 60);
   ck_assert(interpolate_table_twoaxis(&t2, 30, -40) == 210);
   ck_assert(interpolate_table_twoaxis(&t2, 30, -45) == 205);
-} END_TEST
+}
+END_TEST
 
-TCase *setup_table_tests() {
-  TCase *table_tests = tcase_create("tables");
+TCase*
+setup_table_tests() {
+  TCase* table_tests = tcase_create("tables");
   tcase_add_test(table_tests, check_table_oneaxis_interpolate);
   tcase_add_test(table_tests, check_table_oneaxis_clamp);
   tcase_add_test(table_tests, check_table_twoaxis_interpolate);
@@ -172,4 +176,3 @@ TCase *setup_table_tests() {
 }
 
 #endif
-

--- a/src/table.c
+++ b/src/table.c
@@ -1,7 +1,6 @@
 #include "table.h"
 
-float
-interpolate_table_oneaxis(struct table* t, float val) {
+float interpolate_table_oneaxis(struct table* t, float val) {
   if (t->num_axis != 1) {
     while (1)
       ;
@@ -27,8 +26,7 @@ interpolate_table_oneaxis(struct table* t, float val) {
   return 0;
 }
 
-float
-interpolate_table_twoaxis(struct table* t, float x, float y) {
+float interpolate_table_twoaxis(struct table* t, float x, float y) {
   float x1 = 0, x2 = 0, y1 = 0, y2 = 0;
   int x1_ind = 0, y1_ind = 0;
   float xy1, xy2, xy;
@@ -74,8 +72,7 @@ interpolate_table_twoaxis(struct table* t, float x, float y) {
   return xy;
 }
 
-static int
-table_valid_axis(struct table_axis* a) {
+static int table_valid_axis(struct table_axis* a) {
   if (a->num > MAX_AXIS_SIZE) {
     return 0;
   }
@@ -87,8 +84,7 @@ table_valid_axis(struct table_axis* a) {
   return 1;
 }
 
-int
-table_valid(struct table* t) {
+int table_valid(struct table* t) {
 
   if ((t->num_axis != 1) && (t->num_axis != 2)) {
     return 0;
@@ -165,8 +161,7 @@ START_TEST(check_table_twoaxis_clamp) {
 }
 END_TEST
 
-TCase*
-setup_table_tests() {
+TCase* setup_table_tests() {
   TCase* table_tests = tcase_create("tables");
   tcase_add_test(table_tests, check_table_oneaxis_interpolate);
   tcase_add_test(table_tests, check_table_oneaxis_clamp);

--- a/src/table.h
+++ b/src/table.h
@@ -8,27 +8,29 @@ struct table_axis {
   unsigned char num; /* Max of 24 */
   float values[MAX_AXIS_SIZE];
 };
-  
 
 struct table {
   char title[32];
   unsigned int num_axis;
   struct table_axis axis[2];
   union {
-    float one [MAX_AXIS_SIZE];
-    float two [MAX_AXIS_SIZE][MAX_AXIS_SIZE];
+    float one[MAX_AXIS_SIZE];
+    float two[MAX_AXIS_SIZE][MAX_AXIS_SIZE];
   } data;
 };
 
-float interpolate_table_oneaxis(struct table *, float a);
-float interpolate_table_twoaxis(struct table *, float a1, float a2);
+float
+interpolate_table_oneaxis(struct table*, float a);
+float
+interpolate_table_twoaxis(struct table*, float a1, float a2);
 
-int table_valid(struct table *);
+int
+table_valid(struct table*);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase *setup_table_tests();
+TCase*
+setup_table_tests();
 #endif
 
 #endif
-

--- a/src/table.h
+++ b/src/table.h
@@ -19,18 +19,14 @@ struct table {
   } data;
 };
 
-float
-interpolate_table_oneaxis(struct table*, float a);
-float
-interpolate_table_twoaxis(struct table*, float a1, float a2);
+float interpolate_table_oneaxis(struct table*, float a);
+float interpolate_table_twoaxis(struct table*, float a1, float a2);
 
-int
-table_valid(struct table*);
+int table_valid(struct table*);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase*
-setup_table_tests();
+TCase* setup_table_tests();
 #endif
 
 #endif

--- a/src/table.h
+++ b/src/table.h
@@ -19,14 +19,14 @@ struct table {
   } data;
 };
 
-float interpolate_table_oneaxis(struct table*, float a);
-float interpolate_table_twoaxis(struct table*, float a1, float a2);
+float interpolate_table_oneaxis(struct table *, float a);
+float interpolate_table_twoaxis(struct table *, float a1, float a2);
 
-int table_valid(struct table*);
+int table_valid(struct table *);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase* setup_table_tests();
+TCase *setup_table_tests();
 #endif
 
 #endif

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -111,8 +111,8 @@ START_TEST(check_tasks_handle_fuel_pump) {
 }
 END_TEST
 
-TCase* setup_tasks_tests() {
-  TCase* tasks_tests = tcase_create("tasks");
+TCase *setup_tasks_tests() {
+  TCase *tasks_tests = tcase_create("tasks");
   tcase_add_test(tasks_tests, check_tasks_handle_fuel_pump);
   return tasks_tests;
 }

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -1,10 +1,11 @@
-#include "platform.h"
+#include "tasks.h"
 #include "config.h"
 #include "decoder.h"
+#include "platform.h"
 #include "util.h"
-#include "tasks.h"
 
-void handle_fuel_pump() {
+void
+handle_fuel_pump() {
   static timeval_t last_valid = 0;
 
   /* If engine is turning, keep pump on */
@@ -25,24 +26,28 @@ void handle_fuel_pump() {
   }
 }
 
-void handle_boost_control() {
+void
+handle_boost_control() {
   float duty;
-  if ((config.sensors[SENSOR_MAP].processed_value < config.boost_control.threshhold_kpa)) {
+  if ((config.sensors[SENSOR_MAP].processed_value <
+       config.boost_control.threshhold_kpa)) {
     if (config.sensors[SENSOR_TPS].processed_value > 90.0) {
       duty = 100.0;
     } else {
       duty = 0.0;
     }
   } else {
-    duty = interpolate_table_oneaxis(config.boost_control.pwm_duty_vs_rpm, config.decoder.rpm);
+    duty = interpolate_table_oneaxis(config.boost_control.pwm_duty_vs_rpm,
+                                     config.decoder.rpm);
   }
   set_pwm(config.boost_control.pin, duty);
 }
 
-void handle_idle_control() {
-}
+void
+handle_idle_control() {}
 
-void handle_emergency_shutdown() {
+void
+handle_emergency_shutdown() {
 
   /* Fuel pump off */
   set_gpio(config.fueling.fuel_pump_pin, 0);
@@ -69,52 +74,52 @@ START_TEST(check_tasks_handle_fuel_pump) {
   ck_assert_int_eq(get_gpio(1), 0);
 
   set_current_time(time_from_us(500));
-  handle_fuel_pump();  
+  handle_fuel_pump();
   ck_assert_int_eq(get_gpio(1), 1);
 
   /* Wait 4 seconds, should turn off */
   set_current_time(time_from_us(4000000));
-  handle_fuel_pump();  
+  handle_fuel_pump();
   ck_assert_int_eq(get_gpio(1), 0);
 
   /* Wait 4 more seconds, should still be off */
   set_current_time(time_from_us(8000000));
-  handle_fuel_pump();  
+  handle_fuel_pump();
   ck_assert_int_eq(get_gpio(1), 0);
 
   /* Get RPM sync */
   config.decoder.state = DECODER_RPM;
-  handle_fuel_pump();  
+  handle_fuel_pump();
   ck_assert_int_eq(get_gpio(1), 1);
 
   /* Wait 10 more seconds, should still be on */
   set_current_time(time_from_us(18000000));
-  handle_fuel_pump();  
+  handle_fuel_pump();
   ck_assert_int_eq(get_gpio(1), 1);
 
   /* Lose RPM sync */
   config.decoder.state = DECODER_NOSYNC;
   set_current_time(time_from_us(19000000));
-  handle_fuel_pump();  
+  handle_fuel_pump();
   ck_assert_int_eq(get_gpio(1), 1);
 
   /* Keep waiting, should shut off */
   set_current_time(time_from_us(25000000));
-  handle_fuel_pump();  
+  handle_fuel_pump();
   ck_assert_int_eq(get_gpio(1), 0);
 
   /* Keep waiting, should stay shut off */
   set_current_time(time_from_us(40000000));
-  handle_fuel_pump();  
+  handle_fuel_pump();
   ck_assert_int_eq(get_gpio(1), 0);
+}
+END_TEST
 
-} END_TEST
-
-TCase *setup_tasks_tests() {
-  TCase *tasks_tests = tcase_create("tasks");
+TCase*
+setup_tasks_tests() {
+  TCase* tasks_tests = tcase_create("tasks");
   tcase_add_test(tasks_tests, check_tasks_handle_fuel_pump);
   return tasks_tests;
 }
 
 #endif
-

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -4,8 +4,7 @@
 #include "platform.h"
 #include "util.h"
 
-void
-handle_fuel_pump() {
+void handle_fuel_pump() {
   static timeval_t last_valid = 0;
 
   /* If engine is turning, keep pump on */
@@ -26,8 +25,7 @@ handle_fuel_pump() {
   }
 }
 
-void
-handle_boost_control() {
+void handle_boost_control() {
   float duty;
   if ((config.sensors[SENSOR_MAP].processed_value <
        config.boost_control.threshhold_kpa)) {
@@ -43,11 +41,9 @@ handle_boost_control() {
   set_pwm(config.boost_control.pin, duty);
 }
 
-void
-handle_idle_control() {}
+void handle_idle_control() {}
 
-void
-handle_emergency_shutdown() {
+void handle_emergency_shutdown() {
 
   /* Fuel pump off */
   set_gpio(config.fueling.fuel_pump_pin, 0);
@@ -115,8 +111,7 @@ START_TEST(check_tasks_handle_fuel_pump) {
 }
 END_TEST
 
-TCase*
-setup_tasks_tests() {
+TCase* setup_tasks_tests() {
   TCase* tasks_tests = tcase_create("tasks");
   tcase_add_test(tasks_tests, check_tasks_handle_fuel_pump);
   return tasks_tests;

--- a/src/tasks.h
+++ b/src/tasks.h
@@ -1,23 +1,26 @@
 #ifndef TASKS_H
 #define TASKS_H
 
-
 struct boost_control_config {
-  struct table *pwm_duty_vs_rpm;
+  struct table* pwm_duty_vs_rpm;
   float threshhold_kpa;
   int pin;
   float overboost;
 };
 
-void handle_fuel_pump();
-void handle_boost_control();
-void handle_idle_control();
-void handle_emergency_shutdown();
+void
+handle_fuel_pump();
+void
+handle_boost_control();
+void
+handle_idle_control();
+void
+handle_emergency_shutdown();
 
 #ifdef UNITTEST
 #include <check.h>
-TCase *setup_tasks_tests();
+TCase*
+setup_tasks_tests();
 #endif
 
 #endif
-

--- a/src/tasks.h
+++ b/src/tasks.h
@@ -8,19 +8,14 @@ struct boost_control_config {
   float overboost;
 };
 
-void
-handle_fuel_pump();
-void
-handle_boost_control();
-void
-handle_idle_control();
-void
-handle_emergency_shutdown();
+void handle_fuel_pump();
+void handle_boost_control();
+void handle_idle_control();
+void handle_emergency_shutdown();
 
 #ifdef UNITTEST
 #include <check.h>
-TCase*
-setup_tasks_tests();
+TCase* setup_tasks_tests();
 #endif
 
 #endif

--- a/src/tasks.h
+++ b/src/tasks.h
@@ -2,7 +2,7 @@
 #define TASKS_H
 
 struct boost_control_config {
-  struct table* pwm_duty_vs_rpm;
+  struct table *pwm_duty_vs_rpm;
   float threshhold_kpa;
   int pin;
   float overboost;
@@ -15,7 +15,7 @@ void handle_emergency_shutdown();
 
 #ifdef UNITTEST
 #include <check.h>
-TCase* setup_tasks_tests();
+TCase *setup_tasks_tests();
 #endif
 
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -2,34 +2,29 @@
 #include "limits.h"
 #include "platform.h"
 
-unsigned int
-rpm_from_time_diff(timeval_t t1, degrees_t deg) {
+unsigned int rpm_from_time_diff(timeval_t t1, degrees_t deg) {
   float ticks_per_degree = t1 / deg;
   unsigned int rpm = (TICKRATE / 6) / ticks_per_degree;
   return rpm;
 }
 
-timeval_t
-time_from_rpm_diff(unsigned int rpm, degrees_t deg) {
+timeval_t time_from_rpm_diff(unsigned int rpm, degrees_t deg) {
   float ticks_per_degree = (TICKRATE / 6.0) / (float)rpm;
   return ticks_per_degree * deg;
 }
 
-timeval_t
-time_from_us(unsigned int us) {
+timeval_t time_from_us(unsigned int us) {
   timeval_t ticks = us * (TICKRATE / 1000000.0);
   return ticks;
 }
 
 /* True if n is before x */
-int
-time_before(timeval_t n, timeval_t x) {
+int time_before(timeval_t n, timeval_t x) {
   signed int res = n - x;
   return (res < 0);
 }
 
-int
-time_in_range(timeval_t val, timeval_t t1, timeval_t t2) {
+int time_in_range(timeval_t val, timeval_t t1, timeval_t t2) {
   if (t2 >= t1) {
     /* No timer wrap */
     if ((val >= t1) && (val <= t2)) {
@@ -42,13 +37,11 @@ time_in_range(timeval_t val, timeval_t t1, timeval_t t2) {
   }
   return 0;
 }
-timeval_t
-time_diff(timeval_t later, timeval_t earlier) {
+timeval_t time_diff(timeval_t later, timeval_t earlier) {
   return later - earlier;
 }
 
-degrees_t
-clamp_angle(degrees_t ang, degrees_t max) {
+degrees_t clamp_angle(degrees_t ang, degrees_t max) {
   while (ang < 0) {
     ang += max;
   }
@@ -146,8 +139,7 @@ START_TEST(check_clamp_angle) {
 }
 END_TEST
 
-TCase*
-setup_util_tests() {
+TCase* setup_util_tests() {
   TCase* util_tests = tcase_create("util");
   tcase_add_test(util_tests, check_rpm_from_time_diff);
   tcase_add_test(util_tests, check_time_from_rpm_diff);

--- a/src/util.c
+++ b/src/util.c
@@ -139,8 +139,8 @@ START_TEST(check_clamp_angle) {
 }
 END_TEST
 
-TCase* setup_util_tests() {
-  TCase* util_tests = tcase_create("util");
+TCase *setup_util_tests() {
+  TCase *util_tests = tcase_create("util");
   tcase_add_test(util_tests, check_rpm_from_time_diff);
   tcase_add_test(util_tests, check_time_from_rpm_diff);
   tcase_add_test(util_tests, check_time_in_range);

--- a/src/util.c
+++ b/src/util.c
@@ -1,30 +1,35 @@
 #include "util.h"
-#include "platform.h"
 #include "limits.h"
+#include "platform.h"
 
-unsigned int rpm_from_time_diff(timeval_t t1, degrees_t deg) {
+unsigned int
+rpm_from_time_diff(timeval_t t1, degrees_t deg) {
   float ticks_per_degree = t1 / deg;
-  unsigned int rpm  = (TICKRATE / 6) / ticks_per_degree;
+  unsigned int rpm = (TICKRATE / 6) / ticks_per_degree;
   return rpm;
 }
 
-timeval_t time_from_rpm_diff(unsigned int rpm, degrees_t deg) {
+timeval_t
+time_from_rpm_diff(unsigned int rpm, degrees_t deg) {
   float ticks_per_degree = (TICKRATE / 6.0) / (float)rpm;
   return ticks_per_degree * deg;
 }
 
-timeval_t time_from_us(unsigned int us) {
+timeval_t
+time_from_us(unsigned int us) {
   timeval_t ticks = us * (TICKRATE / 1000000.0);
   return ticks;
 }
 
 /* True if n is before x */
-int time_before(timeval_t n, timeval_t x) {
+int
+time_before(timeval_t n, timeval_t x) {
   signed int res = n - x;
   return (res < 0);
 }
 
-int time_in_range(timeval_t val, timeval_t t1, timeval_t t2) {
+int
+time_in_range(timeval_t val, timeval_t t1, timeval_t t2) {
   if (t2 >= t1) {
     /* No timer wrap */
     if ((val >= t1) && (val <= t2)) {
@@ -37,11 +42,13 @@ int time_in_range(timeval_t val, timeval_t t1, timeval_t t2) {
   }
   return 0;
 }
-timeval_t time_diff(timeval_t later, timeval_t earlier) {
+timeval_t
+time_diff(timeval_t later, timeval_t earlier) {
   return later - earlier;
 }
 
-degrees_t clamp_angle(degrees_t ang, degrees_t max) {
+degrees_t
+clamp_angle(degrees_t ang, degrees_t max) {
   while (ang < 0) {
     ang += max;
   }
@@ -60,7 +67,8 @@ START_TEST(check_rpm_from_time_diff) {
 
   /* 90 degrees for 0.00125 s is 6000 rpm */
   ck_assert_float_eq_tol(rpm_from_time_diff(5000, 45), 6000, 50);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_time_from_rpm_diff) {
   /* 6000 RPMS, 180 degrees = 0.005 s */
@@ -68,12 +76,14 @@ START_TEST(check_time_from_rpm_diff) {
 
   /* 6000 RPMS, 90 is 0.00125 s */
   ck_assert_float_eq_tol(time_from_rpm_diff(6000, 45), 5000, 50);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_time_from_us) {
   ck_assert_int_eq(time_from_us(0), 0);
   ck_assert_int_eq(time_from_us(1000), 1000 * (TICKRATE / 1000000));
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_time_in_range) {
   timeval_t t1, t2, val;
@@ -107,7 +117,8 @@ START_TEST(check_time_in_range) {
   val = 0x1000;
   t2 = 0x1000;
   ck_assert_int_eq(time_in_range(val, t1, t2), 1);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_time_diff) {
   timeval_t t1, t2;
@@ -123,7 +134,8 @@ START_TEST(check_time_diff) {
   t1 = 0xFFFFFF00;
   t2 = 0xFFFFFF00;
   ck_assert_int_eq(time_diff(t2, t1), 0);
-} END_TEST
+}
+END_TEST
 
 START_TEST(check_clamp_angle) {
   ck_assert_int_eq(clamp_angle(0, 720), 0);
@@ -131,11 +143,12 @@ START_TEST(check_clamp_angle) {
   ck_assert_int_eq(clamp_angle(-1080, 720), 360);
   ck_assert_int_eq(clamp_angle(720, 720), 0);
   ck_assert_int_eq(clamp_angle(1080, 720), 360);
-} END_TEST
+}
+END_TEST
 
-
-TCase *setup_util_tests() {
-  TCase *util_tests = tcase_create("util");
+TCase*
+setup_util_tests() {
+  TCase* util_tests = tcase_create("util");
   tcase_add_test(util_tests, check_rpm_from_time_diff);
   tcase_add_test(util_tests, check_time_from_rpm_diff);
   tcase_add_test(util_tests, check_time_in_range);
@@ -146,4 +159,3 @@ TCase *setup_util_tests() {
 }
 
 #endif
-

--- a/src/util.h
+++ b/src/util.h
@@ -13,7 +13,7 @@ degrees_t clamp_angle(degrees_t, degrees_t);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase* setup_util_tests();
+TCase *setup_util_tests();
 #endif
 
 #endif

--- a/src/util.h
+++ b/src/util.h
@@ -3,18 +3,24 @@
 
 #include "platform.h"
 
-timeval_t time_diff(timeval_t t1, timeval_t t2);
-int time_before(timeval_t n, timeval_t x);
-timeval_t time_from_us(unsigned int us);
-unsigned int rpm_from_time_diff(timeval_t t1, degrees_t degrees);
-timeval_t time_from_rpm_diff(unsigned int rpm, degrees_t degrees);
-int time_in_range(timeval_t val, timeval_t t1, timeval_t t2);
+timeval_t
+time_diff(timeval_t t1, timeval_t t2);
+int
+time_before(timeval_t n, timeval_t x);
+timeval_t
+time_from_us(unsigned int us);
+unsigned int
+rpm_from_time_diff(timeval_t t1, degrees_t degrees);
+timeval_t
+time_from_rpm_diff(unsigned int rpm, degrees_t degrees);
+int
+time_in_range(timeval_t val, timeval_t t1, timeval_t t2);
 degrees_t clamp_angle(degrees_t, degrees_t);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase *setup_util_tests();
+TCase*
+setup_util_tests();
 #endif
 
 #endif
-

--- a/src/util.h
+++ b/src/util.h
@@ -3,24 +3,17 @@
 
 #include "platform.h"
 
-timeval_t
-time_diff(timeval_t t1, timeval_t t2);
-int
-time_before(timeval_t n, timeval_t x);
-timeval_t
-time_from_us(unsigned int us);
-unsigned int
-rpm_from_time_diff(timeval_t t1, degrees_t degrees);
-timeval_t
-time_from_rpm_diff(unsigned int rpm, degrees_t degrees);
-int
-time_in_range(timeval_t val, timeval_t t1, timeval_t t2);
+timeval_t time_diff(timeval_t t1, timeval_t t2);
+int time_before(timeval_t n, timeval_t x);
+timeval_t time_from_us(unsigned int us);
+unsigned int rpm_from_time_diff(timeval_t t1, degrees_t degrees);
+timeval_t time_from_rpm_diff(unsigned int rpm, degrees_t degrees);
+int time_in_range(timeval_t val, timeval_t t1, timeval_t t2);
 degrees_t clamp_angle(degrees_t, degrees_t);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase*
-setup_util_tests();
+TCase* setup_util_tests();
 #endif
 
 #endif

--- a/src/viaems.c
+++ b/src/viaems.c
@@ -11,8 +11,7 @@
 #include <assert.h>
 #include <stdio.h>
 
-int
-main() {
+int main() {
   platform_load_config();
   decoder_init(&config.decoder);
   console_init();

--- a/src/viaems.c
+++ b/src/viaems.c
@@ -1,18 +1,18 @@
-#include <stdio.h>
-#include <assert.h>
-#include "platform.h"
-#include "util.h"
-#include "decoder.h"
-#include "scheduler.h"
-#include "config.h"
-#include "table.h"
-#include "sensors.h"
 #include "calculations.h"
+#include "config.h"
+#include "decoder.h"
+#include "platform.h"
+#include "scheduler.h"
+#include "sensors.h"
 #include "stats.h"
+#include "table.h"
 #include "tasks.h"
+#include "util.h"
+#include <assert.h>
+#include <stdio.h>
 
-
-int main() {
+int
+main() {
   platform_load_config();
   decoder_init(&config.decoder);
   console_init();
@@ -24,7 +24,7 @@ int main() {
   enable_test_trigger(FORD_TFI, 2000);
 
   sensors_process(SENSOR_CONST);
-  while (1) {                   
+  while (1) {
     stats_increment_counter(STATS_MAINLOOP_RATE);
 
     console_process();
@@ -37,4 +37,3 @@ int main() {
 
   return 0;
 }
-


### PR DESCRIPTION
Mozilla mode, with a few modifications:
 - toplevel function return values on same lines
 - K&R braces on same lines as structs, enums, functions, etc
 - Best pointer alignment
 - Case labels unindented
 