### PR TITLE
Disable LTO

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -10,12 +10,12 @@ AR=arm-none-eabi-ar
 OBJS=libssp.a libssp_nonshared.a
 OBJCOPY=arm-none-eabi-objcopy
 OPENCM3_DIR=../libopencm3
-CFLAGS=  -I. -std=c99 -Wall -O3 -Wextra -g -flto
+CFLAGS=  -I. -std=c99 -Wall -O3 -Wextra -g
 CFLAGS+= -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -mcpu=cortex-m4
 CFLAGS+= -D TICKRATE=4000000
 CFLAGS+=  -L${OPENCM3_DIR}/lib -I${OPENCM3_DIR}/include -DSTM32F4
 CFLAGS+= -fstack-protector-strong -fno-strict-aliasing
-LDFLAGS+= -lopencm3_stm32f4 -lc -lm -lnosys -flto -L .
+LDFLAGS+= -lopencm3_stm32f4 -lc -lm -lnosys -L .
 LDFLAGS+= -T platforms/stm32f4-discovery.ld -nostartfiles
 
 .elif ${PLATFORM} == "hosted"


### PR DESCRIPTION
LTO gives a fairly impressive performance increase for some of the time critical code pieces.  For some interrupt handlers it reduces total time spent by half.  However, performance is not currently an issue without LTO enabled, and it occured to me the build instructions are wrong unless libopencm3 is also built with LTO.

Rather than providing the options to build libopencm3 with LTO, lets just disable LTO until we really need it down the road: It may introduce some issues and its very hard to debug problems with it.