### PR TITLE
Don't allow reschedule of ignition event to move stop time more than 90 degrees

### DIFF
--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -332,11 +332,11 @@ static int schedule_ignition_event(struct output_event *ev,
     ev->stop.scheduled = 0;
   }
 
-  /* Don't let the stop time move more than 90*
+  /* Don't let the stop time move more than 180*
    * forward once it is scheduled */
   if (ev->stop.scheduled && time_before(ev->stop.time, stop_time) &&
       ((time_diff(stop_time, ev->stop.time) >
-        time_from_rpm_diff(d->rpm, 90)))) {
+        time_from_rpm_diff(d->rpm, 180)))) {
     return 0;
   }
 
@@ -383,13 +383,13 @@ static int schedule_fuel_event(struct output_event *ev,
     ev->stop.scheduled = 0;
   }
 
-  /* Don't let the stop time move more than 90*
+  /* Don't let the stop time move more than 180*
    * forward once it is scheduled
    * TODO evaluate if this is necessary for fueling */
 
   if (ev->stop.scheduled && time_before(ev->stop.time, stop_time) &&
       ((time_diff(stop_time, ev->stop.time) >
-        time_from_rpm_diff(d->rpm, 90)))) {
+        time_from_rpm_diff(d->rpm, 180)))) {
     return 0;
   }
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -336,7 +336,7 @@ static int schedule_ignition_event(struct output_event *ev,
    * forward once it is scheduled */
   if (ev->stop.scheduled && time_before(ev->stop.time, stop_time) &&
       ((time_diff(stop_time, ev->stop.time) >
-        time_from_rpm_diff(d->rpm, 360)))) {
+        time_from_rpm_diff(d->rpm, 90)))) {
     return 0;
   }
 
@@ -381,6 +381,16 @@ static int schedule_fuel_event(struct output_event *ev,
     ev->stop.fired = 0;
     ev->start.scheduled = 0;
     ev->stop.scheduled = 0;
+  }
+
+  /* Don't let the stop time move more than 90*
+   * forward once it is scheduled
+   * TODO evaluate if this is necessary for fueling */
+
+  if (ev->stop.scheduled && time_before(ev->stop.time, stop_time) &&
+      ((time_diff(stop_time, ev->stop.time) >
+        time_from_rpm_diff(d->rpm, 90)))) {
+    return 0;
   }
 
   schedule_output_event_safely(ev, start_time, stop_time, 1);


### PR DESCRIPTION
This was originally 90 degrees for ignition, and the comment even says
90 degrees, but a few years ago this inexplicably was changed to 360
degrees. Aside from the fact that this seems wrong, the issue this was
originally intended to fix is cropping up:

Ignition pulses starting at the right time, but not releasing until a
full cycle later.  This results in misfires, and overdwelling, though
never a too-advance spark at least.

I'm not 100% sure this same problem couldn't happen to fueling pulses,
so for now, also adding the logic to fueling until more investigation
and tests are written.