### PR TITLE
Fix concurrent slot dma transfer safety check

### DIFF
--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -422,9 +422,6 @@ void platform_disable_event_logging() {
 
 static void show_scheduled_outputs() {
   uint32_t flag_changes = exti_get_flag_status(0xFF);
-  if (flag_changes == 0) {
-    while(1);
-  }
   console_record_event((struct logged_event){
     .type = EVENT_OUTPUT,
     .time = current_time(),
@@ -445,6 +442,9 @@ void exti2_isr() {
   show_scheduled_outputs();
 }
 void exti3_isr() {
+  show_scheduled_outputs();
+}
+void exti4_isr() {
   show_scheduled_outputs();
 }
 void exti9_5_isr() {

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -144,7 +144,7 @@ static int sched_entry_enable(const struct sched_entry *en, timeval_t time) {
   *addr = value;
   timeval_t after_time = current_time();
 
-  if (time_in_range(time - 1, before_time, after_time + 1)) {
+  if (time_in_range(time, before_time, after_time + 1)) {
     set_output(en->pin, en->val);
   }
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -101,7 +101,7 @@ static int sched_entry_disable(const struct sched_entry *en, timeval_t time) {
   *addr = value;
   timeval_t after_time = current_time();
 
-  if (time_in_range(time - 1, before_time, after_time)) {
+  if (time_in_range(time, before_time, after_time + 1)) {
     set_output(en->pin, en->val);
     return 0;
   }
@@ -144,7 +144,7 @@ static int sched_entry_enable(const struct sched_entry *en, timeval_t time) {
   *addr = value;
   timeval_t after_time = current_time();
 
-  if (time_in_range(time - 1, before_time, after_time)) {
+  if (time_in_range(time - 1, before_time, after_time + 1)) {
     set_output(en->pin, en->val);
   }
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -101,7 +101,7 @@ static int sched_entry_disable(const struct sched_entry *en, timeval_t time) {
   *addr = value;
   timeval_t after_time = current_time();
 
-  if (time_in_range(time, before_time, after_time)) {
+  if (time_in_range(time - 1, before_time, after_time)) {
     set_output(en->pin, en->val);
     return 0;
   }
@@ -144,7 +144,7 @@ static int sched_entry_enable(const struct sched_entry *en, timeval_t time) {
   *addr = value;
   timeval_t after_time = current_time();
 
-  if (time_in_range(time, before_time, after_time)) {
+  if (time_in_range(time - 1, before_time, after_time)) {
     set_output(en->pin, en->val);
   }
 


### PR DESCRIPTION
The DMA is in mem-to-peripheral mode, which even in direct mode loads
the current transfer on the previous trigger, storing it in a single
transfer fifo.  This means that for the purpose of this safety check,
the transfer window that matters for the DMA is one time cycle before
its actual time value.

I don't love introducing a platform-specific weirdness here, but this is
the quick fix. We can look at making this more platform agnostic in the
future.