### PR TITLE
Implement check engine light conditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Features:
 - PWM outputs
 - Fuelpump safety cutoff
 - Mostly runtime-configurable over USB interface
+- Check Engine / Malfunction Indicator control
 
 1. [Decoding](#decoding)
     1. [EEC-IV TFI](#eec-iv-tfi)
@@ -30,6 +31,7 @@ Features:
     1. [Events](#events-1)
     2. [Sensors](#sensors-1)
     3. [Tables](#tables-1)
+    4. [Tasks](#tasks)
 4. [Compiling](#compiling)
 5. [Programming](#programming)
 6. [Simulation](#simulation)
@@ -91,7 +93,7 @@ Member | Meaning
 `fueling.cylinder_cc` | Individual cylinder volume
 `fueling.injections_per_cycle` | Number of times an injector is fired per cycle.  1 for sequential, 2 for batched pairs, etc
 `fueling.fuel_pump_pin` | GPIO port number that controls the fuel pump
-`ignition.dwell_ud` | Fixed (currently) time in uS to dwell ignition
+`ignition.dwell_us` | Fixed (currently) time in uS to dwell ignition
 
 ### Events
 Event configuration is done with an array of schedulable events.  This entire
@@ -256,6 +258,19 @@ get config.sensors.iat
 * source=adc method=therm pin=2 therm-bias=2400.00 therm-a=1.461674e-03 therm-b=2.288757e-04 therm-c=1.644848e-07 fault-min=2 fault-max=4095 fault-val=10.00 lag=0.000000
 ```
 
+### Tasks
+Tasks are low priority tasks that execute during idle cycles.  These are useful
+for management of non-timing-critical outputs, such as boost control and fuel
+  pumps.
+
+Node | Meaning
+--- | ---
+`config.tasks.boost_control.overboost` | Fuel and ignition cuts are activated at this manifold pressure
+`config.tasks.boost_control.pin` | PWM output for boost control solenoid
+`config.tasks.boost_control.threshold` | Boost control will not activate until this pressure is reached, though the solenoid will be fully activated below level if at WOT
+`config.tasks.cel.pin` | GPIO output for Check-Engine light
+`config.tasks.cel.lean_boost_kpa` | CEL will trigger in a boosted lean condition if lean above this pressure
+`config.tasks.cel.lean_boost_ego` | CEL will trigger in a boosted lean condition if leaner than this EGO value
 
 # Compiling
 Requires:

--- a/src/config.c
+++ b/src/config.c
@@ -268,6 +268,11 @@ struct config config __attribute__((section(".configdata"))) = {
     .pin = 1,
     .overboost = 200.0,
   },
+  .cel = {
+    .pin = 2,
+    .lean_boost_kpa = 140.0,
+    .lean_boost_ego = .91,
+  },
 };
 
 int config_valid() {

--- a/src/config.h
+++ b/src/config.h
@@ -39,6 +39,7 @@ struct config {
   struct fueling_config fueling;
   struct ignition_config ignition;
   struct boost_control_config boost_control;
+  struct cel_config cel;
 
   /* Cutoffs */
   unsigned int rpm_stop;

--- a/src/console.c
+++ b/src/console.c
@@ -940,6 +940,18 @@ static struct console_config_node console_config_nodes[] = {
     .val = &config.boost_control.threshhold_kpa,
     .get = console_get_float,
     .set = console_set_float },
+  { .name = "config.tasks.cel.pin",
+    .val = &config.cel.pin,
+    .get = console_get_uint,
+    .set = console_set_uint },
+  { .name = "config.tasks.cel.lean_boost_kpa",
+    .val = &config.cel.lean_boost_kpa,
+    .get = console_get_float,
+    .set = console_set_float },
+  { .name = "config.tasks.cel.lean_boost_ego",
+    .val = &config.cel.lean_boost_ego,
+    .get = console_get_float,
+    .set = console_set_float },
 
   /* Hardware config */
   { .name = "config.hardware" },

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -51,17 +51,19 @@ void handle_idle_control() {}
  * Lean in boost - 3s of 1/5s blink
  */
 
-void handle_check_engine_light() {
-  static enum {
-    CEL_NONE,
-    CEL_CONSTANT,
-    CEL_SLOWBLINK,
-    CEL_FASTBLINK,
-  } cel_state = CEL_NONE, next_cel_state = CEL_NONE;
+typedef enum {
+  CEL_NONE,
+  CEL_CONSTANT,
+  CEL_SLOWBLINK,
+  CEL_FASTBLINK,
+} cel_state_t;
 
-  static timeval_t last_cel = 0;
+static cel_state_t cel_state = CEL_NONE;
+static timeval_t last_cel = 0;
 
-  /* Determine CEL conditions */
+static cel_state_t determine_next_cel_state() {
+  static cel_state_t next_cel_state;
+
   int sensor_in_fault = (sensor_fault_status() > 0);
   int decode_loss = !config.decoder.valid && (config.decoder.rpm > 0);
   int lean_in_boost =
@@ -78,6 +80,27 @@ void handle_check_engine_light() {
   } else {
     next_cel_state = CEL_NONE;
   }
+  return next_cel_state;
+}
+
+static int determine_cel_pin_state(cel_state_t state, timeval_t cur_time, timeval_t cel_start_time) {
+  switch (state) {
+    case CEL_NONE:
+      return 0;
+    case CEL_CONSTANT:
+      return 1;
+    case CEL_SLOWBLINK:
+      return (cur_time - cel_start_time) / time_from_us(500000) % 2;
+    case CEL_FASTBLINK:
+      return (cur_time - cel_start_time) / time_from_us(200000) % 2;
+    default:
+      return 1;
+  }
+}
+
+void handle_check_engine_light() {
+
+  cel_state_t next_cel_state = determine_next_cel_state();
 
   /* Handle 3s reset of CEL state */
   if (time_diff(current_time(), last_cel) > time_from_us(3000000)) {
@@ -90,25 +113,7 @@ void handle_check_engine_light() {
     last_cel = current_time();
   }
 
-  int pin_state;
-  switch (cel_state) {
-    case CEL_NONE:
-      pin_state = 0;
-      break;
-    case CEL_CONSTANT:
-      pin_state = 1;
-      break;
-    case CEL_SLOWBLINK:
-      pin_state = (current_time() - last_cel) / time_from_us(500000) % 2;
-      break;
-    case CEL_FASTBLINK:
-      pin_state = (current_time() - last_cel) / time_from_us(200000) % 2;
-      break;
-    default:
-      pin_state = 1;
-  }
-  set_gpio(config.cel.pin, pin_state);
-
+  set_gpio(config.cel.pin, determine_cel_pin_state(cel_state, current_time(), last_cel));
 }
 
 void handle_emergency_shutdown() {
@@ -179,9 +184,61 @@ START_TEST(check_tasks_handle_fuel_pump) {
 }
 END_TEST
 
+START_TEST(check_tasks_next_cel_state) {
+  /* no fault */
+  config.decoder.valid = 1;
+  ck_assert_int_eq(determine_next_cel_state(), CEL_NONE);
+
+  /* Sensor fault */
+  config.sensors[SENSOR_MAP].fault = FAULT_RANGE;
+  ck_assert_int_eq(determine_next_cel_state(), CEL_CONSTANT);
+
+  /* Decoder loss */
+  config.decoder.valid = 0;
+  config.decoder.rpm = 1000;
+  config.sensors[SENSOR_MAP].fault = FAULT_NONE;
+  ck_assert_int_eq(determine_next_cel_state(), CEL_SLOWBLINK);
+
+  /* Still decoder loss, add sensor fault */
+  config.sensors[SENSOR_MAP].fault = FAULT_RANGE;
+  ck_assert_int_eq(determine_next_cel_state(), CEL_SLOWBLINK);
+
+  /* Lean in boost */
+  config.sensors[SENSOR_MAP].fault = FAULT_NONE;
+  config.decoder.valid = 1;
+  config.sensors[SENSOR_MAP].processed_value = 180;
+  config.sensors[SENSOR_EGO].processed_value = 1.1;
+  ck_assert_int_eq(determine_next_cel_state(), CEL_FASTBLINK);
+
+} END_TEST
+
+START_TEST(check_tasks_cel_pin_state) {
+
+  /* with no cel, time is irrelevent */
+  ck_assert_int_eq(determine_cel_pin_state(CEL_NONE, 0, 0), 0);
+
+  /* With constant, time still irrelevent */
+  ck_assert_int_eq(determine_cel_pin_state(CEL_CONSTANT, 0, 0), 1);
+
+  /* Slowblink should be on at .75 s, off at 1.25 s */
+  ck_assert_int_eq(determine_cel_pin_state(CEL_SLOWBLINK, 
+        time_from_us(10750000), time_from_us(10000000)), 1);
+  ck_assert_int_eq(determine_cel_pin_state(CEL_SLOWBLINK, 
+        time_from_us(11250000), time_from_us(10000000)), 0);
+
+  /* Fastblink should be on at 1.1 s, off at 1.3 s */
+  ck_assert_int_eq(determine_cel_pin_state(CEL_FASTBLINK, 
+        time_from_us(11100000), time_from_us(10000000)), 1);
+  ck_assert_int_eq(determine_cel_pin_state(CEL_FASTBLINK, 
+        time_from_us(11300000), time_from_us(10000000)), 0);
+
+} END_TEST
+
 TCase *setup_tasks_tests() {
   TCase *tasks_tests = tcase_create("tasks");
   tcase_add_test(tasks_tests, check_tasks_handle_fuel_pump);
+  tcase_add_test(tasks_tests, check_tasks_next_cel_state);
+  tcase_add_test(tasks_tests, check_tasks_cel_pin_state);
   return tasks_tests;
 }
 

--- a/src/tasks.h
+++ b/src/tasks.h
@@ -8,8 +8,16 @@ struct boost_control_config {
   float overboost;
 };
 
+struct cel_config {
+  int pin;
+
+  float lean_boost_kpa;
+  float lean_boost_ego;
+};
+
 void handle_fuel_pump();
 void handle_boost_control();
+void handle_check_engine_light();
 void handle_idle_control();
 void handle_emergency_shutdown();
 

--- a/src/viaems.c
+++ b/src/viaems.c
@@ -30,6 +30,7 @@ int main() {
     handle_fuel_pump();
     handle_boost_control();
     handle_idle_control();
+    handle_check_engine_light();
 
     adc_gather();
   }


### PR DESCRIPTION
After the near miss with dying alternator, lets give the driver an
indication that something is wrong. In order of increasing severity:
 - If a sensor is in fault mode, keep CEL constant on
 - If we lose sync, blink for 3s at 2 Hz
 - If we go lean in boost (configurable thresholds), blink for 3s at 5 Hz

If a fault condition of higher severity happens during a lower severity
condition, it takes precedence.

TODO:

- [x] Add unit tests
- [x] Update README