### PR TITLE
Move console buffers out of configdata space

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -44,9 +44,6 @@ struct config {
   /* Cutoffs */
   unsigned int rpm_stop;
   unsigned int rpm_start;
-
-  /* Console config */
-  struct console console;
 };
 
 extern struct config config;

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -724,7 +724,7 @@ static const struct usb_config_descriptor usb_config = {
   .interface = ifaces,
 };
 
-static const char *usb_strings[] = {
+static const char *const usb_strings[] = {
   "https://github.com/via/viaems/",
   "ViaEMS console",
   "0",
@@ -989,14 +989,14 @@ uint32_t cycle_count() {
 static volatile int adc_gather_in_progress = 0;
 void adc_gather() {
 #ifdef SPI_TLC2543
-  static uint16_t spi_tx_list[] = {
+  static const uint16_t spi_tx_list[] = {
     0x0C00, 0x1C00, 0x2C00, 0x3C00, 0x4C00, 0x5C00, 0x6C00,
     0x7C00, 0x8C00, 0x9C00, 0xAC00, 0xBC00, /* Check value (Vref+ + Vref-) / 2
                                              */
     0xBC00, /* Duplicated to actually get previous read */
   };
 #else
-  static uint16_t spi_tx_list[] = {
+  static const uint16_t spi_tx_list[] = {
     0x0400, 0x0C00, 0x1400, 0x1C00, 0x2400, 0x2C00, 0x3400, 0x3C00, 0x3C00,
   };
 #endif


### PR DESCRIPTION
The rx/tx console buffers do not need to be in the special configdata space.

While we're at it, move various strings from ram to flash.