### PR TITLE
Allow dwell control VS voltage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ port A.
 - Implement check engine light
 - Implement cold start cranking enrich
 - Record frequency and trigger edges with DMA, allowing higher rpm operation
+- Implement dwell controlled by battery voltage
 
 ### 1.1.0 (2019 Dec 14)
 Introduces a breaking change with the console format for tables, as well as

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Member | Meaning
 `fueling.cylinder_cc` | Individual cylinder volume
 `fueling.injections_per_cycle` | Number of times an injector is fired per cycle.  1 for sequential, 2 for batched pairs, etc
 `fueling.fuel_pump_pin` | GPIO port number that controls the fuel pump
-`ignition.dwell_us` | Fixed (currently) time in uS to dwell ignition
+`ignition.dwell_us` | Fixed (when in fixed dwell mode) time in uS to dwell ignition
 
 ### Frequency and Trigger inputs
 Certain inputs are used as frequency inputs which may also act as the decoder

--- a/TODO
+++ b/TODO
@@ -1,13 +1,8 @@
 - Detect overlapping output schedules on same pin
-- New frequency sensors that use DMA (TBD)
 
-+ Trigger input DMA to circular buffer
-+ Dwell time vs BRV
 + Basic tasks
-    + Boost control
     + Fan control
     + Idle Control
-    + Priming
 
 - Determine better ADC strategy, the graphs look awful for every-tooth (for now
   just gather adc async)

--- a/src/calculations.c
+++ b/src/calculations.c
@@ -50,7 +50,7 @@ void calculate_ignition() {
     calculated_values.dwell_us = config.ignition.dwell_us;
     break;
   case DWELL_BRV:
-    calculated_values.dwell_us = interpolate_table_oneaxis(config.dwell, config.sensors[SENSOR_BRV].processed_value);
+    calculated_values.dwell_us = 1000 * interpolate_table_oneaxis(config.dwell, config.sensors[SENSOR_BRV].processed_value);
     break;
   }
 }

--- a/src/calculations.c
+++ b/src/calculations.c
@@ -49,6 +49,9 @@ void calculate_ignition() {
   case DWELL_FIXED_TIME:
     calculated_values.dwell_us = config.ignition.dwell_us;
     break;
+  case DWELL_BRV:
+    calculated_values.dwell_us = interpolate_table_oneaxis(config.dwell, config.sensors[SENSOR_BRV].processed_value);
+    break;
   }
 }
 

--- a/src/calculations.h
+++ b/src/calculations.h
@@ -22,6 +22,7 @@ struct fueling_config {
 typedef enum {
   DWELL_FIXED_DUTY,
   DWELL_FIXED_TIME,
+  DWELL_BRV,
 } dwell_type;
 
 struct ignition_config {

--- a/src/config.c
+++ b/src/config.c
@@ -277,8 +277,7 @@ struct config config __attribute__((section(".configdata"))) = {
     },
   },
   .ignition = {
-    .dwell = DWELL_FIXED_TIME,
-    .dwell_us = 2800,
+    .dwell = DWELL_BRV,
     .min_fire_time_us = 500,
   },
   .boost_control = {

--- a/src/config.c
+++ b/src/config.c
@@ -55,6 +55,18 @@ struct table tipin_duration_vs_rpm __attribute__((section(".configdata"))) = {
   },
 };
 
+struct table dwell_ms_vs_brv __attribute__((section(".configdata"))) = {
+  .title = "dwell", .num_axis = 1,
+  .axis = { { 
+      .name = "BRV", .num = 4,
+      .values = {5, 10, 14, 18},
+    },
+  },
+  .data = {
+    .one = {6.0, 4.0, 2.5, 1.8}
+  },
+};
+
 struct table ve_vs_rpm_and_map __attribute__((section(".configdata"))) = {
   .title = "ve", .num_axis = 2,
   .axis = { { 
@@ -247,6 +259,7 @@ struct config config __attribute__((section(".configdata"))) = {
   .engine_temp_enrich = &enrich_vs_temp_and_map,
   .tipin_enrich_amount = &tipin_vs_tpsrate_and_tps,
   .tipin_enrich_duration = &tipin_duration_vs_rpm,
+  .dwell = &dwell_ms_vs_brv,
   .rpm_stop = 6700,
   .rpm_start = 6200,
   .fueling = {

--- a/src/config.h
+++ b/src/config.h
@@ -35,6 +35,7 @@ struct config {
   struct table *commanded_lambda;
   struct table *injector_pw_compensation;
   struct table *engine_temp_enrich;
+  struct table *dwell;
   struct table *tipin_enrich_amount;
   struct table *tipin_enrich_duration;
 
@@ -60,6 +61,7 @@ extern struct table enrich_vs_temp_and_map;
 extern struct table tipin_vs_tpsrate_and_tps;
 extern struct table tipin_duration_vs_rpm;
 extern struct table boost_control_pwm;
+extern struct table dwell_ms_vs_brv;
 
 int config_valid();
 

--- a/src/console.c
+++ b/src/console.c
@@ -562,6 +562,9 @@ static void console_get_dwell_type(const struct console_config_node *self,
   case DWELL_FIXED_TIME:
     result = "fixed-time";
     break;
+  case DWELL_BRV:
+    result = "brv";
+    break;
   }
   strcat(dest, result);
 }
@@ -576,6 +579,8 @@ static void console_set_dwell_type(const struct console_config_node *self,
     *t = DWELL_FIXED_DUTY;
   } else if (!strcmp("fixed-time", remaining)) {
     *t = DWELL_FIXED_TIME;
+  } else if (!strcmp("brv", remaining)) {
+    *t = DWELL_BRV;
   }
 }
 

--- a/src/console.c
+++ b/src/console.c
@@ -901,6 +901,10 @@ static struct console_config_node console_config_nodes[] = {
     .val = &boost_control_pwm,
     .get = console_get_table,
     .set = console_set_table },
+  { .name = "config.tables.dwell",
+    .val = &dwell_ms_vs_brv,
+    .get = console_get_table,
+    .set = console_set_table },
 
   /* Decoding */
   { .name = "config.decoder" },


### PR DESCRIPTION
Fixed dwell is not ideal, since we need larger dwell during cranking, and especially low voltage cranking.

This implements a lookup table of dwell with respect to battery voltage.