### PR TITLE
Eliminate various accidental double promotions

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -14,6 +14,7 @@ OBJCOPY=arm-none-eabi-objcopy
 OPENCM3_DIR=../libopencm3
 CFLAGS=  -I. -std=c99 -Wall -O3 -Wextra -g -DGIT_DESCRIBE=\"${GITDESC}\"
 CFLAGS+= -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -mcpu=cortex-m4
+CFLAGS+= -Wdouble-promotion
 CFLAGS+= -D TICKRATE=4000000
 CFLAGS+=  -L${OPENCM3_DIR}/lib -I${OPENCM3_DIR}/include -DSTM32F4
 CFLAGS+= -fstack-protector-strong -fno-strict-aliasing

--- a/src/Makefile
+++ b/src/Makefile
@@ -14,12 +14,14 @@ OBJCOPY=arm-none-eabi-objcopy
 OPENCM3_DIR=../libopencm3
 CFLAGS=  -I. -std=c99 -Wall -O3 -Wextra -g -DGIT_DESCRIBE=\"${GITDESC}\"
 CFLAGS+= -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -mcpu=cortex-m4
-CFLAGS+= -Wdouble-promotion
 CFLAGS+= -D TICKRATE=4000000
 CFLAGS+=  -L${OPENCM3_DIR}/lib -I${OPENCM3_DIR}/include -DSTM32F4
 CFLAGS+= -fstack-protector-strong -fno-strict-aliasing
 LDFLAGS+= -lopencm3_stm32f4 -lc -lm -lnosys -L .
 LDFLAGS+= -T platforms/stm32f4-discovery.ld -nostartfiles
+
+# TODO: can we exclude console.c, or stop using double promotions there?
+#CFLAGS+= -Wdouble-promotion
 
 .elif ${PLATFORM} == "hosted"
 CC=gcc

--- a/src/calculations.c
+++ b/src/calculations.c
@@ -63,15 +63,15 @@ static float air_density(float iat_celsius, float atmos_kpa) {
 
 static float fuel_density(float fuel_celsius) {
   const float beta = 950.0; /* Gasoline 10^-6/K */
-  float delta_temp = fuel_celsius - 15.0;
-  return config.fueling.density_of_fuel - (delta_temp * beta / 1000000.0);
+  float delta_temp = fuel_celsius - 15.0f;
+  return config.fueling.density_of_fuel - (delta_temp * beta / 1000000.0f);
 }
 
 /* Returns mass of air injested into a cylinder */
 static float calculate_airmass(float ve, float map, float aap, float iat) {
 
   float injested_air_volume_per_cycle =
-    (ve / 100.0) * (map / aap) * config.fueling.cylinder_cc;
+    (ve / 100.0f) * (map / aap) * config.fueling.cylinder_cc;
 
   float injested_air_mass_per_cycle =
     injested_air_volume_per_cycle * air_density(iat, aap);
@@ -142,7 +142,7 @@ void calculate_fueling() {
   float tpsrate = config.sensors[SENSOR_TPS].derivative;
 
   if (config.ve) {
-    float load = map / aap * 100.0;
+    float load = map / aap * 100.0f;
     ve = interpolate_table_twoaxis(config.ve, config.decoder.rpm, load);
   } else {
     ve = 100.0;

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -71,7 +71,7 @@ static void sensor_convert(struct sensor_input *in) {
 
   /* Do lag filtering */
   in->processed_value =
-    ((old_value * in->lag) + (in->processed_value * (100.0 - in->lag))) / 100.0;
+    ((old_value * in->lag) + (in->processed_value * (100.0f - in->lag))) / 100.0f;
 
   /* Process derivative */
   timeval_t process_time = current_time();

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -21,7 +21,8 @@ static float sensor_convert_freq(float raw) {
 float sensor_convert_thermistor(struct thermistor_config *tc, float raw) {
   stats_start_timing(STATS_SENSOR_THERM_TIME);
   float r = tc->bias / ((4096.0f / raw) - 1);
-  float t = 1 / (tc->a + tc->b * logf(r) + tc->c * powf(logf(r), 3));
+  float logf_r = logf(r);
+  float t = 1 / (tc->a + tc->b * logf_r + tc->c * logf_r * logf_r * logf_r);
   stats_finish_timing(STATS_SENSOR_THERM_TIME);
 
   return t - 273.15f;

--- a/src/tasks.c
+++ b/src/tasks.c
@@ -29,7 +29,7 @@ void handle_boost_control() {
   float duty;
   if ((config.sensors[SENSOR_MAP].processed_value <
        config.boost_control.threshhold_kpa)) {
-    if (config.sensors[SENSOR_TPS].processed_value > 90.0) {
+    if (config.sensors[SENSOR_TPS].processed_value > 90.0f) {
       duty = 100.0;
     } else {
       duty = 0.0;

--- a/src/util.c
+++ b/src/util.c
@@ -2,19 +2,21 @@
 #include "limits.h"
 #include "platform.h"
 
+const float tick_degree_rpm_ratio = (TICKRATE / 6.0f);
+
 unsigned int rpm_from_time_diff(timeval_t t1, degrees_t deg) {
   float ticks_per_degree = t1 / deg;
-  unsigned int rpm = (TICKRATE / 6) / ticks_per_degree;
+  unsigned int rpm = tick_degree_rpm_ratio / ticks_per_degree;
   return rpm;
 }
 
 timeval_t time_from_rpm_diff(unsigned int rpm, degrees_t deg) {
-  float ticks_per_degree = (TICKRATE / 6.0) / (float)rpm;
+  float ticks_per_degree = tick_degree_rpm_ratio / (float)rpm;
   return ticks_per_degree * deg;
 }
 
 timeval_t time_from_us(unsigned int us) {
-  timeval_t ticks = us * (TICKRATE / 1000000.0);
+  timeval_t ticks = us * (TICKRATE / 1000000.0f);
   return ticks;
 }
 


### PR DESCRIPTION
Profiling found a bunch of unfortunate cases of double promotion, causing slowdowns in some critical sections.

Use single precision constants where appropriate.  The -Wdouble-promotion is super useful, except there's no good way to prevent it for the printf family.