### PR TITLE
scheduler: fix case where event does not get scheduled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ port A.
 - Better ADC strategy:
   - Faster and more deterministic sampling
   - Implement customizable averaging windows based on crank angles
+- Fix occasional miss due to incorrectly descheduling events
 
 ### 1.1.0 (2019 Dec 14)
 Introduces a breaking change with the console format for tables, as well as

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -105,11 +105,11 @@ static int sched_entry_disable(const struct sched_entry *en, timeval_t time) {
   *addr = value;
   timeval_t after_time = current_time();
 
-  if (time_in_range(time, before_time, after_time + 1)) {
+  if (time_in_range(time - 1, before_time, after_time)) {
     set_output(en->pin, en->val);
     return 0;
   }
-  if (time_before(time, before_time) || en->fired) {
+  if (time_before(time - 1, before_time) || en->fired) {
     return 0;
   }
 
@@ -149,11 +149,11 @@ static int sched_entry_enable(const struct sched_entry *en, timeval_t time) {
   *addr = value;
   timeval_t after_time = current_time();
 
-  if (time_in_range(time, before_time, after_time + 1)) {
+  if (time_in_range(time - 1, before_time, after_time)) {
     set_output(en->pin, en->val);
   }
 
-  if (time_before(time, before_time)) {
+  if (time_before(time - 1, before_time)) {
     return 0;
   }
 

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -28,10 +28,10 @@ static int sched_entry_has_fired(struct sched_entry *en) {
   int ret = 0;
   int ints_on = disable_interrupts();
 
-  if (en->buffer) {
-    if (time_in_range(en->time, en->buffer->start, current_time())) {
-      ret = 1;
-    }
+  if (en->buffer && 
+      time_before(en->buffer->start, current_time()) &&
+      time_in_range(en->time, en->buffer->start, current_time())) {
+    ret = 1;
   }
   if (en->fired) {
     ret = 1;
@@ -82,7 +82,8 @@ static int sched_entry_disable(const struct sched_entry *en, timeval_t time) {
 
   assert(!interrupts_enabled());
   /* before either buffer starts */
-  if (time_before(time, output_buffers[current_output_buffer()].start)) {
+  if (time_before(time, output_buffers[0].start) &&
+      time_before(time, output_buffers[1].start)) {
     return 0;
   }
 
@@ -125,7 +126,8 @@ static int sched_entry_enable(const struct sched_entry *en, timeval_t time) {
 
   assert(!interrupts_enabled());
   /* before either buffer starts */
-  if (time_before(time, output_buffers[current_output_buffer()].start)) {
+  if (time_before(time, output_buffers[0].start) &&
+      time_before(time, output_buffers[1].start)) {
     return 0;
   }
 


### PR DESCRIPTION
Rescheduling forward moving events could be completely descheduled if the new start time passed between the old time's deschedule and scheduling the new time.

The scheduler has been very much so "write once" code, and its hard to try to fix the logic because its so opaque. This change splits it up a little bit, and tries to explain the flow.

There was also a logic error in determining if an event had definitely passed for `sched_entry_enable`/`sched_entry_disable`.