### PR TITLE
Revert DMA for triggers and frequency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 This introduces a breaking change with interface software.
 
 - New console and logging interface, as defined in INTERFACE.md. 
+- Revert trigger inputs to old non-dma interrupts
+- Fix linear window sensor glitch caused by race in current_angle()
 
 ### 1.3.0 (2020 Nov 20)
 - Switch build system to a GNU makefile at the toplevel

--- a/src/console.c
+++ b/src/console.c
@@ -4,11 +4,10 @@
 #endif
 
 #include <assert.h>
-#include <stdio.h>
+#include <math.h>
 #include <stdlib.h>
 #include <string.h>
 #include <strings.h>
-#include <math.h>
 
 #include "calculations.h"
 #include "config.h"
@@ -17,6 +16,10 @@
 #include "platform.h"
 #include "sensors.h"
 #include "stats.h"
+
+static uint32_t render_loss_reason() {
+  return (uint32_t)config.decoder.loss;
+};
 
 const struct console_feed_node console_feed_nodes[] = {
   { .id = "cputime", .uint32_fptr = current_time },
@@ -57,6 +60,7 @@ const struct console_feed_node console_feed_nodes[] = {
   /* Decoder */
   { .id = "rpm", .uint32_ptr = &config.decoder.rpm },
   { .id = "sync", .uint32_ptr = &config.decoder.valid },
+  { .id = "loss", .uint32_fptr = render_loss_reason },
   { .id = "rpm_variance", .float_ptr = &config.decoder.trigger_cur_rpm_change },
   { .id = "last_trigger_angle",
     .float_ptr = &config.decoder.last_trigger_angle },

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -267,11 +267,15 @@ degrees_t current_angle() {
   if (!config.decoder.rpm) {
     return config.decoder.last_trigger_angle;
   }
-  degrees_t angle_since_last_tooth = degrees_from_time_diff(
-    current_time() - config.decoder.last_trigger_time, config.decoder.rpm);
+  disable_interrupts();
+  timeval_t last_time = config.decoder.last_trigger_time;
+  degrees_t last_angle = config.decoder.last_trigger_angle;
+  enable_interrupts();
 
-  return clamp_angle(config.decoder.last_trigger_angle + angle_since_last_tooth,
-                     720);
+  degrees_t angle_since_last_tooth =
+    degrees_from_time_diff(current_time() - last_time, config.decoder.rpm);
+
+  return clamp_angle(last_angle + angle_since_last_tooth, 720);
 }
 
 #ifdef UNITTEST

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -28,6 +28,11 @@ static void set_expire_event(timeval_t t) {
   schedule_callback(&expire_event, t);
 }
 
+void decoder_desync(decoder_loss_reason reason) {
+  config.decoder.loss = reason;
+  invalidate_decoder();
+}
+
 static void push_time(struct decoder *d, timeval_t t) {
   for (int i = MAX_TRIGGERS - 1; i > 0; --i) {
     d->times[i] = d->times[i - 1];

--- a/src/decoder.c
+++ b/src/decoder.c
@@ -468,7 +468,7 @@ START_TEST(check_tfi_decoder_syncloss_expire) {
   ck_assert_int_eq(config.decoder.expiration, expected_expiration);
 
   set_current_time(expected_expiration + 500);
-  handle_decoder_expire(&config.decoder);
+  handle_decoder_expire();
   ck_assert(!config.decoder.valid);
   ck_assert_int_eq(0, config.decoder.current_triggers_rpm);
   ck_assert_int_eq(DECODER_EXPIRED, config.decoder.loss);
@@ -620,7 +620,7 @@ START_TEST(check_nplusone_decoder_syncloss_expire) {
   ck_assert_int_eq(config.decoder.expiration, expected_expiration);
 
   set_current_time(expected_expiration + 500);
-  handle_decoder_expire(&config.decoder);
+  handle_decoder_expire();
   ck_assert(!config.decoder.valid);
   ck_assert_int_eq(0, config.decoder.current_triggers_rpm);
   ck_assert_int_eq(DECODER_EXPIRED, config.decoder.loss);

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -24,6 +24,7 @@ typedef enum {
   DECODER_TRIGGERCOUNT_HIGH,
   DECODER_TRIGGERCOUNT_LOW,
   DECODER_EXPIRED,
+  DECODER_OVERFLOW,
 } decoder_loss_reason;
 
 struct decoder {
@@ -77,7 +78,7 @@ struct decoder_event {
 
 void decoder_init(struct decoder *);
 void decoder_update_scheduling(struct decoder_event *, unsigned int count);
-
+void decoder_desync(decoder_loss_reason);
 degrees_t current_angle();
 
 #ifdef UNITTEST

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -1001,6 +1001,17 @@ void tim2_isr() {
     timer_clear_flag(TIM2, TIM_SR_CC2IF);
   }
 
+  /* Did we miss a capture event? */
+  if (timer_get_flag(TIM2, TIM_SR_CC1OF) || 
+      timer_get_flag(TIM2, TIM_SR_CC2OF)) {
+    timer_clear_flag(TIM2, TIM_SR_CC1OF);
+    timer_clear_flag(TIM2, TIM_SR_CC2OF);
+    decoder_desync(DECODER_OVERFLOW);
+    stats_finish_timing(STATS_INT_TOTAL_TIME);
+    return;
+  }
+
+
   if (cc1_fired && cc2_fired) {
     if (time_before(cc2, cc1)) {
       evs[0] = (struct decoder_event){ .trigger = 1, .time = cc2 };

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -1002,7 +1002,7 @@ void tim2_isr() {
   }
 
   /* Did we miss a capture event? */
-  if (timer_get_flag(TIM2, TIM_SR_CC1OF) || 
+  if (timer_get_flag(TIM2, TIM_SR_CC1OF) ||
       timer_get_flag(TIM2, TIM_SR_CC2OF)) {
     timer_clear_flag(TIM2, TIM_SR_CC1OF);
     timer_clear_flag(TIM2, TIM_SR_CC2OF);
@@ -1010,7 +1010,6 @@ void tim2_isr() {
     stats_finish_timing(STATS_INT_TOTAL_TIME);
     return;
   }
-
 
   if (cc1_fired && cc2_fired) {
     if (time_before(cc2, cc1)) {

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -1132,14 +1132,14 @@ START_TEST(check_callback_remove) {
 }
 END_TEST
 
+static void _increase_count(void *_c) {
+  int *c = (int *)_c;
+  (*c)++;
+}
+
 START_TEST(check_callback_execute) {
 
   int count = 0;
-
-  void _increase_count(void *_c) {
-    int *c = (int *)_c;
-    (*c)++;
-  }
 
   struct timed_callback tc1 = {
     .time = 95,

--- a/targets/test.mk
+++ b/targets/test.mk
@@ -8,4 +8,4 @@ CFLAGS+= -fsanitize=undefined -fsanitize=address
 LDFLAGS+= $(shell pkg-config --libs check)
 
 check: ${OBJDIR}/viaems
-	${OBJDIR}/viaems
+	CK_DEFAULT_TIMEOUT=10 ${OBJDIR}/viaems


### PR DESCRIPTION
The DMA used for triggers and frequency inputs relies on the NDTR register of the DMA to know if what values it may use from the circular buffer. According to the reference manual, this register is guaranteed to be incremented (in the circular dma mode) after the DMA has written to memory.  However, this does not appear to always happen.  This isn't documented as an official errata, but various sources on the internet confirm this is a bug, either in hardware or in the documentation.

Unfortunately all of the DMA wheels work very much so depends on this working.  We'll need another solution, and in the meantime we need to revert this.