### PR TITLE
Move sensor config params from union to toplevel

### DIFF
--- a/src/config.c
+++ b/src/config.c
@@ -217,40 +217,40 @@ struct config config __attribute__((section(".configdata"))) = {
   },
   .sensors = {
     [SENSOR_BRV] = {.pin=0, .source=SENSOR_ADC, .method=METHOD_LINEAR,
-      .params={.range={.min=0, .max=24.5}}, .lag=80,
+      .range={.min=0, .max=24.5}, .lag=80,
       .fault_config={.min = 100, .max = 4000, .fault_value = 13.8}},
     [SENSOR_IAT] = {.pin=1, .source=SENSOR_ADC, .method=METHOD_THERM,
       .fault_config={.min = 2, .max = 4095, .fault_value = 10.0},
-      .params={.therm={
+      .therm={
         .bias=2490,
         .a=0.00146167419060305,
         .b=0.00022887572003919,
         .c=1.64484831669638E-07,
-      }}},
+      }},
     [SENSOR_CLT] = {.pin=2, .source=SENSOR_ADC, .method=METHOD_THERM,
       .fault_config={.min = 2, .max = 4095, .fault_value = 50.0},
-      .params={.therm={
+      .therm={
         .bias=2490,
         .a=0.00131586818223649,
         .b=0.00025618700140100302,
         .c=0.00000018474199456928,
-      }}},
+      }},
     [SENSOR_EGO] = {.pin=3, .source=SENSOR_ADC, .method=METHOD_LINEAR,
-      .params={.range={.min=0.499, .max=1.309}}},
+      .range={.min=0.499, .max=1.309}},
     [SENSOR_MAP] = {.pin=4, .source=SENSOR_ADC, .method=METHOD_LINEAR_WINDOWED,
-      .params={.range={.min=12, .max=420}}, /* AEM 3.5 bar MAP sensor*/
+      .range={.min=12, .max=420}, /* AEM 3.5 bar MAP sensor*/
       .fault_config={.min = 10, .max = 4050, .fault_value = 50.0},
       .window={.total_width=120, .capture_width = 120}},
     [SENSOR_AAP] = {.pin=5, .source=SENSOR_ADC, .method=METHOD_LINEAR,
-      .params={.range={.min=10.5, .max=121.6}}, /* AEM 3.5 bar MAP sensor*/
+      .range={.min=10.5, .max=121.6}, /* AEM 3.5 bar MAP sensor*/
       .fault_config={.min = 10, .max = 4050, .fault_value = 50.0}},
     [SENSOR_TPS] = {.pin=6, .source=SENSOR_ADC, .method=METHOD_LINEAR,
-      .params={.range={.min=-15.74, .max=145.47}},
+      .range={.min=-15.74, .max=145.47},
       .fault_config={.min = 200, .max = 3200, .fault_value = 25.0},
       .lag = 10.0},
-    [SENSOR_FRT] = {.source=SENSOR_CONST, .params={.fixed_value = 15.0}},
+    [SENSOR_FRT] = {.source=SENSOR_CONST, .fixed_value = 15.0},
     [SENSOR_FRP] = {.pin=7, .source=SENSOR_ADC, .method=METHOD_LINEAR,
-      .params={.range={.min=-86, .max=862}}, /* AEM 3.5 bar MAP sensor*/
+      .range={.min=-86, .max=862}, /* AEM 3.5 bar MAP sensor*/
     }
   },
   .timing = &timing_vs_rpm_and_map,

--- a/src/console.c
+++ b/src/console.c
@@ -1011,16 +1011,11 @@ static void render_sensor_object(struct console_request_context *ctx,
     ctx, "range-min", "min for linear mapping", &input->range.min);
   render_float_map_field(
     ctx, "range-max", "max for linear mapping", &input->range.max);
-  render_float_map_field(ctx,
-                         "fixed-value",
-                         "value to hold for const input",
-                         &input->fixed_value);
   render_float_map_field(
-    ctx, "therm-a", "thermistor A", &input->therm.a);
-  render_float_map_field(
-    ctx, "therm-b", "thermistor B", &input->therm.b);
-  render_float_map_field(
-    ctx, "therm-c", "thermistor C", &input->therm.c);
+    ctx, "fixed-value", "value to hold for const input", &input->fixed_value);
+  render_float_map_field(ctx, "therm-a", "thermistor A", &input->therm.a);
+  render_float_map_field(ctx, "therm-b", "thermistor B", &input->therm.b);
+  render_float_map_field(ctx, "therm-c", "thermistor C", &input->therm.c);
   render_float_map_field(ctx,
                          "therm-bias",
                          "thermistor resistor bias value (ohms)",

--- a/src/console.c
+++ b/src/console.c
@@ -1008,23 +1008,23 @@ static void render_sensor_object(struct console_request_context *ctx,
   input->method = method;
 
   render_float_map_field(
-    ctx, "range-min", "min for linear mapping", &input->params.range.min);
+    ctx, "range-min", "min for linear mapping", &input->range.min);
   render_float_map_field(
-    ctx, "range-max", "max for linear mapping", &input->params.range.max);
+    ctx, "range-max", "max for linear mapping", &input->range.max);
   render_float_map_field(ctx,
                          "fixed-value",
                          "value to hold for const input",
-                         &input->params.fixed_value);
+                         &input->fixed_value);
   render_float_map_field(
-    ctx, "therm-a", "thermistor A", &input->params.therm.a);
+    ctx, "therm-a", "thermistor A", &input->therm.a);
   render_float_map_field(
-    ctx, "therm-b", "thermistor B", &input->params.therm.b);
+    ctx, "therm-b", "thermistor B", &input->therm.b);
   render_float_map_field(
-    ctx, "therm-c", "thermistor C", &input->params.therm.c);
+    ctx, "therm-c", "thermistor C", &input->therm.c);
   render_float_map_field(ctx,
                          "therm-bias",
                          "thermistor resistor bias value (ohms)",
-                         &input->params.therm.bias);
+                         &input->therm.bias);
   render_uint32_map_field(ctx,
                           "fault-min",
                           "Lower bound for raw sensor input",

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -8,8 +8,8 @@
 
 static float sensor_convert_linear(struct sensor_input *in, float raw) {
   float partial = raw / 4096.0f;
-  return in->params.range.min +
-         partial * (in->params.range.max - in->params.range.min);
+  return in->range.min +
+         partial * (in->range.max - in->range.min);
 }
 
 static int current_angle_in_window(struct sensor_input *in, degrees_t angle) {
@@ -100,7 +100,7 @@ static void sensor_convert(struct sensor_input *in) {
     raw = sensor_convert_freq(in->raw_value);
     break;
   case SENSOR_CONST:
-    in->processed_value = in->params.fixed_value;
+    in->processed_value = in->fixed_value;
     return;
   default:
     raw = 0.0;
@@ -116,10 +116,10 @@ static void sensor_convert(struct sensor_input *in) {
       sensor_convert_linear_windowed(in, current_angle(), raw);
     break;
   case METHOD_TABLE:
-    in->processed_value = interpolate_table_oneaxis(in->params.table, raw);
+    in->processed_value = interpolate_table_oneaxis(in->table, raw);
     break;
   case METHOD_THERM:
-    in->processed_value = sensor_convert_thermistor(&in->params.therm, raw);
+    in->processed_value = sensor_convert_thermistor(&in->therm, raw);
     break;
   }
 
@@ -164,9 +164,7 @@ uint32_t sensor_fault_status() {
 
 START_TEST(check_sensor_convert_linear) {
   struct sensor_input si = {
-    .params = {
-      .range = { .min=-10.0, .max=10.0},
-    },
+    .range = { .min=-10.0, .max=10.0},
   };
 
   si.raw_value = 0;
@@ -183,9 +181,7 @@ END_TEST
 START_TEST(check_sensor_convert_linear_windowed) {
   struct sensor_input si = {
     .processed_value = 12.0,
-    .params = {
-      .range = { .min=0, .max=4096.0},
-    },
+    .range = { .min=0, .max=4096.0},
     .window = {
       .total_width = 90,
       .capture_width = 45,
@@ -215,9 +211,7 @@ END_TEST
 START_TEST(check_sensor_convert_linear_windowed_skipped) {
   struct sensor_input si = {
     .processed_value = 12.0,
-    .params = {
-      .range = { .min=0, .max=4096.0},
-    },
+    .range = { .min=0, .max=4096.0},
     .window = {
       .total_width = 90,
       .capture_width = 45,
@@ -252,9 +246,7 @@ END_TEST
 START_TEST(check_sensor_convert_linear_windowed_wide) {
   struct sensor_input si = {
     .processed_value = 12.0,
-    .params = {
-      .range = { .min=0, .max=4096.0},
-    },
+    .range = { .min=0, .max=4096.0},
     .window = {
       .total_width = 90,
       .capture_width = 90,
@@ -293,9 +285,7 @@ END_TEST
 START_TEST(check_sensor_convert_linear_windowed_offset) {
   struct sensor_input si = {
     .processed_value = 12.0,
-    .params = {
-      .range = { .min=0, .max=4096.0},
-    },
+    .range = { .min=0, .max=4096.0},
     .window = {
       .total_width = 90,
       .capture_width = 45,

--- a/src/sensors.c
+++ b/src/sensors.c
@@ -8,8 +8,7 @@
 
 static float sensor_convert_linear(struct sensor_input *in, float raw) {
   float partial = raw / 4096.0f;
-  return in->range.min +
-         partial * (in->range.max - in->range.min);
+  return in->range.min + partial * (in->range.max - in->range.min);
 }
 
 static int current_angle_in_window(struct sensor_input *in, degrees_t angle) {
@@ -164,7 +163,7 @@ uint32_t sensor_fault_status() {
 
 START_TEST(check_sensor_convert_linear) {
   struct sensor_input si = {
-    .range = { .min=-10.0, .max=10.0},
+    .range = { .min = -10.0, .max = 10.0 },
   };
 
   si.raw_value = 0;

--- a/src/sensors.h
+++ b/src/sensors.h
@@ -48,24 +48,15 @@ struct sensor_input {
   sensor_source source;
   sensor_method method;
 
-  union {
-    struct {
-      float min;
-      float max;
-    } range;
-    struct table *table;
-    float fixed_value;
-    struct thermistor_config therm;
-  } params;
-
-  uint32_t raw_value;
-  float processed_value;
-  float lag;
   struct {
-    timeval_t last_sample_time;
-    float last_sample_value;
-    float value;
-  } derivative;
+    float min;
+    float max;
+  } range;
+  struct table *table;
+  float fixed_value;
+  struct thermistor_config therm;
+
+  float lag;
   struct {
     uint32_t min;
     uint32_t max;
@@ -81,6 +72,14 @@ struct sensor_input {
     uint8_t collecting;
     degrees_t collection_start_angle;
   } window;
+
+  uint32_t raw_value;
+  float processed_value;
+  struct {
+    timeval_t last_sample_time;
+    float last_sample_value;
+    float value;
+  } derivative;
   sensor_fault fault;
 };
 


### PR DESCRIPTION
Using a union with no checking on the EMS means that client interfaces need to only set the params relevent to the sensor type or else they'll clobber the params.  Removing this allows a naive always-set/get-everything approach, and makes the code a little easier to read.