### PR TITLE
Simplify scheduler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+### master (unreleased)
+
+ - Implement simpler and easier-to-understand scheduler
+
 ### 1.4.0 (2022 Feb 16)
 This introduces a breaking change with interface software.
 

--- a/integration/interface-tests.py
+++ b/integration/interface-tests.py
@@ -111,7 +111,7 @@ class ViaemsInterfaceTests(unittest.TestCase):
         assert(_leaves_have_types(result['response']))
 
         outputs = result['response']['outputs']
-        assert(len(outputs) == 24)
+        assert(len(outputs) == 16)
         assert(outputs[0]['_type'] == 'output')
 
         sensors = result['response']['sensors']

--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -27,10 +27,8 @@ static void do_fuel_calculation_bench() {
 static void do_schedule_ignition_event_bench() {
   platform_load_config();
 
-  config.events[0].start.scheduled = 0;
-  config.events[0].start.fired = 0;
-  config.events[0].stop.scheduled = 0;
-  config.events[0].stop.fired = 0;
+  config.events[0].start.state = SCHED_UNSCHEDULED;
+  config.events[0].stop.state = SCHED_UNSCHEDULED;
   config.events[0].angle = 180;
 
   config.decoder.valid = 1;
@@ -40,7 +38,7 @@ static void do_schedule_ignition_event_bench() {
   uint64_t start = cycle_count();
   schedule_event(&config.events[0]);
   uint64_t end = cycle_count();
-  assert(config.events[0].start.scheduled);
+  assert(config.events[0].start.state == SCHED_SCHEDULED);
 
   printf("fresh ignition schedule_event: %llu ns\r\n",
          (unsigned long long)cycles_to_ns(end - start));
@@ -104,43 +102,7 @@ static void do_sensor_single_therm() {
          (unsigned long long)cycles_to_ns(end - start));
 }
 
-void do_buffer_swap_bench_best_case() {
-  platform_load_config();
-
-  uint64_t start = cycle_count();
-  scheduler_buffer_swap();
-  uint64_t end = cycle_count();
-
-  printf("best case buffer_swap: %llu ns\r\n",
-         (unsigned long long)cycles_to_ns(end - start));
-}
-
-void do_buffer_swap_bench_all_fired() {
-  platform_load_config();
-
-  bench_set_all_events_fired();
-  uint64_t start = cycle_count();
-  scheduler_buffer_swap();
-  uint64_t end = cycle_count();
-
-  printf("worst case 'fired' buffer_swap: %llu ns\r\n",
-         (unsigned long long)cycles_to_ns(end - start));
-}
-
-void do_buffer_swap_bench_all_ready() {
-  platform_load_config();
-
-  bench_set_all_events_ready_to_schedule();
-  uint64_t start = cycle_count();
-  scheduler_buffer_swap();
-  uint64_t end = cycle_count();
-
-  printf("worst case 'ready' buffer_swap: %llu ns\r\n",
-         (unsigned long long)cycles_to_ns(end - start));
-}
-
 int main() {
-  platform_benchmark_init();
   initialize_scheduler();
 
   /* Preparations for all benchmarks */
@@ -155,9 +117,6 @@ int main() {
     do_schedule_ignition_event_bench();
     do_sensor_adc_calcs();
     do_sensor_single_therm();
-    do_buffer_swap_bench_best_case();
-    do_buffer_swap_bench_all_fired();
-    do_buffer_swap_bench_all_ready();
   } while (1);
   return 0;
 }

--- a/src/calculations.h
+++ b/src/calculations.h
@@ -54,10 +54,10 @@ struct calculated_values {
 
 extern struct calculated_values calculated_values;
 
-void calculate_ignition();
-void calculate_fueling();
-bool ignition_cut();
-bool fuel_cut();
+void calculate_ignition(void);
+void calculate_fueling(void);
+bool ignition_cut(void);
+bool fuel_cut(void);
 
 #ifdef UNITTEST
 #include <check.h>

--- a/src/config.h
+++ b/src/config.h
@@ -11,7 +11,7 @@
 #include "tasks.h"
 #include "util.h"
 
-#define MAX_EVENTS 24
+#define MAX_EVENTS 16
 
 struct config {
   /* Event list */

--- a/src/config.h
+++ b/src/config.h
@@ -49,6 +49,6 @@ struct config {
 
 extern struct config config;
 
-int config_valid();
+int config_valid(void);
 
 #endif

--- a/src/console.h
+++ b/src/console.h
@@ -117,13 +117,13 @@ struct console_feed_node {
 void render_description_field(CborEncoder *, const char *desc);
 void render_type_field(CborEncoder *, const char *type);
 
-void console_process();
+void console_process(void);
 
 void console_record_event(struct logged_event);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase *setup_console_tests();
+TCase *setup_console_tests(void);
 #endif
 
 #endif

--- a/src/decoder.h
+++ b/src/decoder.h
@@ -89,10 +89,10 @@ struct decoder_event {
 void decoder_init(struct decoder *);
 void decoder_update_scheduling(struct decoder_event *, unsigned int count);
 void decoder_desync(decoder_loss_reason);
-degrees_t current_angle();
+degrees_t current_angle(void);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase *setup_decoder_tests();
+TCase *setup_decoder_tests(void);
 #endif
 #endif

--- a/src/platform.h
+++ b/src/platform.h
@@ -16,23 +16,23 @@ typedef uint32_t timeval_t;
 typedef float degrees_t;
 /* timeval_t is gauranteed to be 32 bits */
 
-timeval_t current_time();
-uint64_t cycle_count();
+timeval_t current_time(void);
+uint64_t cycle_count(void);
 uint64_t cycles_to_ns(uint64_t cycles);
 
 void set_event_timer(timeval_t);
-timeval_t get_event_timer();
+timeval_t get_event_timer(void);
 /* Clear any pending interrupt */
-void clear_event_timer();
-void disable_event_timer();
+void clear_event_timer(void);
+void disable_event_timer(void);
 
 void platform_init();
 /* Benchmark init is minimum necessary to use platform for benchmark */
-void platform_benchmark_init();
+void platform_benchmark_init(void);
 
-void disable_interrupts();
-void enable_interrupts();
-int interrupts_enabled();
+void disable_interrupts(void);
+void enable_interrupts(void);
+int interrupts_enabled(void);
 
 void set_output(int output, char value);
 int get_output(int output);
@@ -43,24 +43,25 @@ void set_pwm(int output, float percent);
 size_t console_read(void *buf, size_t max);
 size_t console_write(const void *buf, size_t count);
 
-void platform_load_config();
-void platform_save_config();
+void platform_load_config(void);
+void platform_save_config(void);
 
-timeval_t init_output_thread(uint32_t *buf0, uint32_t *buf1, uint32_t len);
-int current_output_buffer();
-int current_output_slot();
-
-void platform_enable_event_logging();
-void platform_disable_event_logging();
-void platform_reset_into_bootloader();
+void platform_enable_event_logging(void);
+void platform_disable_event_logging(void);
+void platform_reset_into_bootloader(void);
 
 void set_test_trigger_rpm(uint32_t rpm);
-uint32_t get_test_trigger_rpm();
+uint32_t get_test_trigger_rpm(void);
+
+/* Returns the earliest time that may still be scheduled.  This can only change
+ * when buffers are swapped, so it is safe to use this value to schedule events
+ * if interrupts are disabled */
+timeval_t platform_output_earliest_schedulable_time(void);
 
 #ifdef UNITTEST
 #include <check.h>
 
-void check_platform_reset();
+void check_platform_reset(void);
 void set_current_time(timeval_t);
 #endif
 

--- a/src/platforms/hosted.c
+++ b/src/platforms/hosted.c
@@ -21,16 +21,8 @@ static _Atomic timeval_t curtime;
 static _Atomic timeval_t eventtimer_time;
 static _Atomic uint32_t eventtimer_enable = 0;
 static int event_logging_enabled = 1;
-static uint32_t test_trigger_rpm = 0;
-static _Atomic uint16_t cur_outputs = 0;
-
-struct slot {
-  uint16_t on_mask;
-  uint16_t off_mask;
-} __attribute__((packed)) * output_slots[2] = { 0 };
-static size_t max_slots;
-static _Atomic size_t cur_slot = 0;
-static _Atomic size_t cur_buffer = 0;
+static uint32_t test_trigger_rpm = 100;
+static uint16_t cur_outputs = 0;
 
 void platform_enable_event_logging() {
   event_logging_enabled = 1;
@@ -166,21 +158,6 @@ void platform_load_config() {}
 
 void platform_save_config() {}
 
-timeval_t init_output_thread(uint32_t *buf0, uint32_t *buf1, uint32_t len) {
-  output_slots[0] = (struct slot *)buf0;
-  output_slots[1] = (struct slot *)buf1;
-  max_slots = len;
-  return curtime / len * curtime;
-}
-
-int current_output_buffer() {
-  return cur_buffer;
-}
-
-int current_output_slot() {
-  return cur_slot;
-}
-
 void set_test_trigger_rpm(uint32_t rpm) {
   test_trigger_rpm = rpm;
 }
@@ -302,32 +279,88 @@ void *platform_interrupt_thread(void *_interrupt_fd) {
   } while (1);
 }
 
+#define MAX_SLOTS 128
+static struct sched_entry output_events[64];
+static size_t num_output_events = 0;
+static size_t next_output_event = 0;
+
+static void clear_output_events() {
+  num_output_events = 0;
+  next_output_event = 0;
+}
+
+static void add_output_event(struct sched_entry *se) {
+  output_events[num_output_events] = *se;
+  num_output_events++;
+}
+
+static int output_event_compare(const void *_a, const void *_b) {
+  const struct sched_entry *a = _a;
+  const struct sched_entry *b = _b;
+
+  if (a->time == b->time) {
+    return 0;
+  }
+  return time_before(a->time, b->time) ? -1 : 1;
+}
+
+static void platform_buffer_swap() {
+
+  disable_interrupts();
+  clear_output_events();
+  for (int i = 0; i < MAX_EVENTS; i++) {
+    struct output_event *oev = &config.events[i];
+    if (sched_entry_get_state(&oev->start) == SCHED_SUBMITTED) {
+      sched_entry_set_state(&oev->start, SCHED_FIRED);
+    }
+    if (sched_entry_get_state(&oev->stop) == SCHED_SUBMITTED) {
+      sched_entry_set_state(&oev->stop, SCHED_FIRED);
+    }
+    if (sched_entry_get_state(&oev->start) == SCHED_SCHEDULED &&
+        time_in_range(
+          oev->start.time, current_time(), current_time() + MAX_SLOTS - 1)) {
+      add_output_event(&oev->start);
+      sched_entry_set_state(&oev->start, SCHED_SUBMITTED);
+    }
+    if (sched_entry_get_state(&oev->stop) == SCHED_SCHEDULED &&
+        time_in_range(
+          oev->stop.time, current_time(), current_time() + MAX_SLOTS - 1)) {
+      add_output_event(&oev->stop);
+      sched_entry_set_state(&oev->stop, SCHED_SUBMITTED);
+    }
+  }
+  enable_interrupts();
+  /* Sort the outputs by ascending time */
+  qsort(output_events,
+        num_output_events,
+        sizeof(struct sched_entry),
+        output_event_compare);
+}
+
+timeval_t platform_output_earliest_schedulable_time() {
+  /* Round down to nearest MAX_SLOTS and then go to next window */
+  return current_time() / MAX_SLOTS * MAX_SLOTS + MAX_SLOTS;
+}
+
 static void do_output_slots() {
-  static uint16_t old_outputs = 0;
-  static uint16_t old_fifo_on_mask = 0;
-  static uint16_t old_fifo_off_mask = 0;
-
-  if (!output_slots[0]) {
-    return;
+  /* Only take action on first slot time */
+  if (curtime % MAX_SLOTS == 0) {
+    platform_buffer_swap();
   }
 
-  cur_slot++;
-  if (cur_slot == max_slots) {
-    cur_buffer = (cur_buffer + 1) % 2;
-    cur_slot = 0;
-    scheduler_buffer_swap();
+  uint16_t old_outputs = cur_outputs;
+
+  while ((next_output_event < num_output_events) &&
+         (output_events[next_output_event].time == current_time())) {
+    struct sched_entry s = output_events[next_output_event];
+    next_output_event++;
+    if (s.val) {
+      cur_outputs |= (1 << s.pin);
+    } else {
+      cur_outputs &= ~(1 << s.pin);
+    }
   }
-
-  int read_slot = (cur_slot + 1) % max_slots;
-  int read_buffer = (read_slot == 0) ? !cur_buffer : cur_buffer;
-
-  cur_outputs |= old_fifo_on_mask;
-  cur_outputs &= ~old_fifo_off_mask;
-
-  old_fifo_on_mask = output_slots[read_buffer][read_slot].on_mask;
-  old_fifo_off_mask = output_slots[read_buffer][read_slot].off_mask;
-
-  if (cur_outputs != old_outputs) {
+  if (old_outputs != cur_outputs) {
     char output[64];
     sprintf(output, "# OUTPUTS %lu %2x\n", (long unsigned)curtime, cur_outputs);
     write(STDERR_FILENO, output, strlen(output));
@@ -336,9 +369,9 @@ static void do_output_slots() {
       .value = cur_outputs,
       .type = EVENT_OUTPUT,
     });
-    old_outputs = cur_outputs;
   }
 }
+
 /* Thread that busywaits to increment the primary timebase.  This loop is also
  * responsible for triggering event timer, buffer swap, and trigger events
  */
@@ -359,12 +392,7 @@ void *platform_timebase_thread(void *_interrupt_fd) {
     clock_nanosleep_busywait(next_tick);
     current_time = next_tick;
 
-    if (!output_slots[0]) {
-      continue;
-    }
-
     curtime += 1;
-
     do_output_slots();
 
     if ((curtime % 10000) == 0) {

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -1,4 +1,3 @@
-
 #include <libopencm3/cm3/cortex.h>
 #include <libopencm3/cm3/dwt.h>
 #include <libopencm3/cm3/nvic.h>
@@ -27,6 +26,7 @@
 #include "tasks.h"
 #include "util.h"
 
+#include <stdatomic.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -70,14 +70,12 @@
  *   - 0-15 Maps to Port E
  *
  *  nvic priorities:
- *    tim2 (triggers) 32
- *    dma2s1 (buffer swap) 16
- *    dma1s3 (adc) 64
  *    tim6 (test trigger) 0
- *
- *    unset:
- *    otg (usb) 0
- *
+ *    dma2s1 (buffer swap) 16
+ *    tim2 (triggers, callbacks, scheduling, fueling calcs) 32
+ *    dma1s3 (adc) 64
+ *    otg (usb) 128
+ *    systick 128
  */
 
 static int capture_edge_from_config(trigger_edge e) {
@@ -173,56 +171,6 @@ static void platform_init_eventtimer() {
   platform_setup_tim8();
 }
 
-static uint32_t output_buffer_len;
-/* Give two buffers of len size, dma will start reading from buf0 and double
- * buffer between buf0 and buf0.
- * Returns the time that buf0 starts at
- */
-timeval_t init_output_thread(uint32_t *buf0, uint32_t *buf1, uint32_t len) {
-  timeval_t start;
-
-  output_buffer_len = len;
-  /* dma2 stream 1, channel 7*/
-  dma_stream_reset(DMA2, DMA_STREAM1);
-  dma_set_priority(DMA2, DMA_STREAM1, DMA_SxCR_PL_HIGH);
-  dma_enable_double_buffer_mode(DMA2, DMA_STREAM1);
-  dma_set_memory_size(DMA2, DMA_STREAM1, DMA_SxCR_MSIZE_32BIT);
-  dma_set_peripheral_size(DMA2, DMA_STREAM1, DMA_SxCR_PSIZE_32BIT);
-  dma_enable_memory_increment_mode(DMA2, DMA_STREAM1);
-  dma_set_transfer_mode(DMA2, DMA_STREAM1, DMA_SxCR_DIR_MEM_TO_PERIPHERAL);
-  dma_enable_circular_mode(DMA2, DMA_STREAM1);
-  dma_set_peripheral_address(DMA2, DMA_STREAM1, (uint32_t)&GPIOD_BSRR);
-  dma_set_memory_address(DMA2, DMA_STREAM1, (uint32_t)buf0);
-  dma_set_memory_address_1(DMA2, DMA_STREAM1, (uint32_t)buf1);
-  dma_set_number_of_data(DMA2, DMA_STREAM1, len);
-  dma_channel_select(DMA2, DMA_STREAM1, DMA_SxCR_CHSEL_7);
-  dma_enable_direct_mode(DMA2, DMA_STREAM1);
-  dma_enable_transfer_complete_interrupt(DMA2, DMA_STREAM1);
-
-  timer_disable_counter(TIM8);
-  dma_enable_stream(DMA2, DMA_STREAM1);
-  start = timer_get_counter(TIM2);
-  timer_enable_counter(TIM8);
-
-  nvic_enable_irq(NVIC_DMA2_STREAM1_IRQ);
-  nvic_set_priority(NVIC_DMA2_STREAM1_IRQ, 16);
-
-  return start;
-}
-
-/* Returns 0 if buf0 is active */
-int current_output_buffer() {
-  return dma_get_target(DMA2, DMA_STREAM1);
-}
-
-/* Returns the current slot that DMA is pointing at.
- * Note that the slot returned is the one queued to output next, but is already
- * in the FIFO so is considered 'done'
- */
-int current_output_slot() {
-  return output_buffer_len - DMA2_S1NDTR;
-}
-
 static void platform_init_pwm() {
 
   gpio_mode_setup(GPIOC, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO6);
@@ -299,6 +247,51 @@ void set_pwm(int output, float percent) {
   }
 }
 
+#define NUM_SLOTS 128
+/* GPIO BSRR is 16 bits of "on" mask and 16 bits of "off" mask */
+struct output_slot {
+  uint16_t on;
+  uint16_t off;
+} __attribute__((packed)) __attribute((aligned(4)));
+
+struct output_buffer {
+  timeval_t first_time; /* First time represented by the range */
+  struct output_slot slots[NUM_SLOTS];
+};
+
+static struct output_buffer output_buffers[2] = { 0 };
+static int current_buffer = 0;
+
+static void platform_output_slot_unset(struct output_slot *slots,
+                                       uint32_t index,
+                                       uint32_t pin,
+                                       bool value) {
+  if (value) {
+    slots[index].on &= ~(1 << pin);
+  } else {
+    slots[index].off &= ~(1 << pin);
+  }
+}
+
+static void platform_output_slot_set(struct output_slot *slots,
+                                     uint32_t index,
+                                     uint32_t pin,
+                                     bool value) {
+  if (value) {
+    slots[index].on |= (1 << pin);
+  } else {
+    slots[index].off |= (1 << pin);
+  }
+}
+
+/* Return the first time that is gauranteed to be changable.  We use a circular
+ * pair of buffers: We can't change the current buffer, and its likely the next
+ * buffer's time range is already submitted, so use the time after that.
+ */
+timeval_t platform_output_earliest_schedulable_time() {
+  return output_buffers[current_buffer].first_time + NUM_SLOTS * 2;
+}
+
 static void platform_init_scheduled_outputs() {
   gpio_clear(GPIOD, 0xFFFF);
   unsigned int i;
@@ -312,6 +305,31 @@ static void platform_init_scheduled_outputs() {
     GPIOD, GPIO_OTYPE_PP, GPIO_OSPEED_100MHZ, 0xFFFF & ~GPIO5);
   gpio_mode_setup(GPIOE, GPIO_MODE_OUTPUT, GPIO_PUPD_NONE, 0xFF);
   gpio_set_output_options(GPIOE, GPIO_OTYPE_PP, GPIO_OSPEED_100MHZ, 0xFF);
+
+  /* dma2 stream 1, channel 7*/
+  dma_stream_reset(DMA2, DMA_STREAM1);
+  dma_set_priority(DMA2, DMA_STREAM1, DMA_SxCR_PL_HIGH);
+  dma_enable_double_buffer_mode(DMA2, DMA_STREAM1);
+  dma_set_memory_size(DMA2, DMA_STREAM1, DMA_SxCR_MSIZE_32BIT);
+  dma_set_peripheral_size(DMA2, DMA_STREAM1, DMA_SxCR_PSIZE_32BIT);
+  dma_enable_memory_increment_mode(DMA2, DMA_STREAM1);
+  dma_set_transfer_mode(DMA2, DMA_STREAM1, DMA_SxCR_DIR_MEM_TO_PERIPHERAL);
+  dma_enable_circular_mode(DMA2, DMA_STREAM1);
+  dma_set_peripheral_address(DMA2, DMA_STREAM1, (uint32_t)&GPIOD_BSRR);
+  dma_set_memory_address(DMA2, DMA_STREAM1, (uint32_t)output_buffers[0].slots);
+  dma_set_memory_address_1(
+    DMA2, DMA_STREAM1, (uint32_t)output_buffers[1].slots);
+  dma_set_number_of_data(DMA2, DMA_STREAM1, NUM_SLOTS);
+  dma_channel_select(DMA2, DMA_STREAM1, DMA_SxCR_CHSEL_7);
+  dma_enable_direct_mode(DMA2, DMA_STREAM1);
+  dma_enable_transfer_complete_interrupt(DMA2, DMA_STREAM1);
+
+  timer_disable_counter(TIM8);
+  dma_enable_stream(DMA2, DMA_STREAM1);
+  timer_enable_counter(TIM8);
+
+  nvic_enable_irq(NVIC_DMA2_STREAM1_IRQ);
+  nvic_set_priority(NVIC_DMA2_STREAM1_IRQ, 16);
 }
 
 void platform_enable_event_logging() {
@@ -716,6 +734,7 @@ void platform_init_usb() {
 
   usbd_register_set_config_callback(usbd_dev, cdcacm_set_config);
   nvic_enable_irq(NVIC_OTG_FS_IRQ);
+  nvic_set_priority(NVIC_OTG_FS_IRQ, 128);
 }
 
 void platform_init_test_trigger() {
@@ -1075,17 +1094,81 @@ void tim2_isr() {
   stats_finish_timing(STATS_INT_TOTAL_TIME);
 }
 
+/* Retire all stop/stop events that are in the time range of our "completed"
+ * buffer and were previously submitted by setting them to "fired" and clearing
+ * out the dma bits */
+static void retire_output_buffer(struct output_buffer *buf) {
+  timeval_t offset_from_start;
+  for (int i = 0; i < MAX_EVENTS; i++) {
+    struct output_event *oev = &config.events[i];
+
+    offset_from_start = oev->start.time - buf->first_time;
+    if (sched_entry_get_state(&oev->start) == SCHED_SUBMITTED &&
+        offset_from_start < NUM_SLOTS) {
+      platform_output_slot_unset(
+        buf->slots, offset_from_start, oev->start.pin, oev->start.val);
+      sched_entry_set_state(&oev->start, SCHED_FIRED);
+    }
+
+    offset_from_start = oev->stop.time - buf->first_time;
+    if (sched_entry_get_state(&oev->stop) == SCHED_SUBMITTED &&
+        offset_from_start < NUM_SLOTS) {
+      platform_output_slot_unset(
+        buf->slots, offset_from_start, oev->stop.pin, oev->stop.val);
+      sched_entry_set_state(&oev->stop, SCHED_FIRED);
+    }
+  }
+}
+
+/* Any scheduled start/stop event in the time range for the new buffer can be
+ * "submitted" and the dma bits set */
+static void populate_output_buffer(struct output_buffer *buf) {
+  timeval_t offset_from_start;
+  for (int i = 0; i < MAX_EVENTS; i++) {
+    struct output_event *oev = &config.events[i];
+    offset_from_start = oev->start.time - buf->first_time;
+    if (sched_entry_get_state(&oev->start) == SCHED_SCHEDULED &&
+        offset_from_start < NUM_SLOTS) {
+      platform_output_slot_set(
+        buf->slots, offset_from_start, oev->start.pin, oev->start.val);
+      sched_entry_set_state(&oev->start, SCHED_SUBMITTED);
+    }
+    offset_from_start = oev->stop.time - buf->first_time;
+    if (sched_entry_get_state(&oev->stop) == SCHED_SCHEDULED &&
+        offset_from_start < NUM_SLOTS) {
+      platform_output_slot_set(
+        buf->slots, offset_from_start, oev->stop.pin, oev->stop.val);
+      sched_entry_set_state(&oev->stop, SCHED_SUBMITTED);
+    }
+  }
+}
+
+static timeval_t round_time_to_buffer_start(timeval_t time) {
+  timeval_t time_since_buffer_start = time % NUM_SLOTS;
+  return time - time_since_buffer_start;
+}
+
+static void platform_buffer_swap() {
+  struct output_buffer *buf = &output_buffers[current_buffer];
+  current_buffer = (current_buffer + 1) % 2;
+
+  retire_output_buffer(buf);
+
+  buf->first_time = round_time_to_buffer_start(current_time()) + NUM_SLOTS;
+
+  populate_output_buffer(buf);
+}
+
 void dma2_stream1_isr(void) {
-  stats_increment_counter(STATS_INT_RATE);
-  stats_increment_counter(STATS_INT_BUFFERSWAP_RATE);
-  stats_start_timing(STATS_INT_TOTAL_TIME);
   if (dma_get_interrupt_flag(DMA2, DMA_STREAM1, DMA_TCIF)) {
     dma_clear_interrupt_flags(DMA2, DMA_STREAM1, DMA_TCIF);
-    stats_start_timing(STATS_INT_BUFFERSWAP_TIME);
-    scheduler_buffer_swap();
-    stats_finish_timing(STATS_INT_BUFFERSWAP_TIME);
+    platform_buffer_swap();
+
+    if (current_buffer != dma_get_target(DMA2, DMA_STREAM1)) {
+      /* We have overflowed or gone out of sync, abort immediately */
+      abort();
+    }
   }
-  stats_finish_timing(STATS_INT_TOTAL_TIME);
 }
 
 volatile int interrupt_disables = 0;
@@ -1228,7 +1311,7 @@ _write(int fd, const char *buf, size_t count) {
   return count;
 }
 
-void _exit(int status) {
+void __attribute__((externally_visible)) _exit(int status) {
   (void)status;
 
   handle_emergency_shutdown();

--- a/src/platforms/stm32f4-discovery.c
+++ b/src/platforms/stm32f4-discovery.c
@@ -1250,6 +1250,7 @@ void platform_save_config() {
   int n_sectors, conf_bytes;
 
   handle_emergency_shutdown();
+  platform_disable_periphs();
   /* Flash erase takes longer than our watchdog */
   iwdg_set_period_ms(5000);
 
@@ -1269,7 +1270,6 @@ void platform_save_config() {
   }
 
   flash_lock();
-  platform_disable_periphs();
   reset_handler();
 }
 

--- a/src/platforms/test.c
+++ b/src/platforms/test.c
@@ -17,7 +17,6 @@ static timeval_t cureventtime = 0;
 static int int_disables = 0;
 static int output_states[16] = { 0 };
 static int gpio_states[16] = { 0 };
-static int current_buffer = 0;
 
 void platform_enable_event_logging() {}
 
@@ -32,7 +31,6 @@ void set_pwm(int pin, float val) {
 
 void check_platform_reset() {
   curtime = 0;
-  current_buffer = 0;
   memset(config.events, 0, sizeof(config.events));
   initialize_scheduler();
 }
@@ -54,16 +52,25 @@ uint64_t cycle_count() {
   return 0;
 }
 
-void set_current_time(timeval_t t) {
-  timeval_t c = curtime;
-  curtime = t;
+timeval_t platform_output_earliest_schedulable_time() {
+  /* Round/floor to nearest 128-time buffer start, then use next one */
+  return curtime + 1;
+}
 
-  /* Swap buffers until we're at time t */
-  while (c < ((t / 512) * 512)) {
-    current_buffer = (current_buffer + 1) % 2;
-    scheduler_buffer_swap();
-    c += 512;
+void set_current_time(timeval_t t) {
+  /* All events between old time and new time that are scheduled get fired */
+  for (int i = 0; i < MAX_EVENTS; i++) {
+    struct output_event *oev = &config.events[i];
+    if (sched_entry_get_state(&oev->start) == SCHED_SCHEDULED &&
+        time_in_range(oev->start.time, current_time(), t)) {
+      sched_entry_set_state(&oev->start, SCHED_FIRED);
+    }
+    if (sched_entry_get_state(&oev->stop) == SCHED_SCHEDULED &&
+        time_in_range(oev->stop.time, current_time(), t)) {
+      sched_entry_set_state(&oev->stop, SCHED_FIRED);
+    }
   }
+  curtime = t;
 }
 
 void set_event_timer(timeval_t t) {
@@ -104,17 +111,6 @@ int get_gpio(int output) {
 
 void adc_gather(void *_adc) {
   (void)_adc;
-}
-
-int current_output_buffer() {
-  return current_buffer;
-}
-
-timeval_t init_output_thread(uint32_t *b0, uint32_t *b1, uint32_t len) {
-  (void)b0;
-  (void)b1;
-  (void)len;
-  return 0;
 }
 
 void set_test_trigger_rpm(uint32_t rpm) {

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -9,195 +9,80 @@
 #include <string.h>
 #include <strings.h>
 
-#define OUTPUT_BUFFER_LEN (512)
-static struct output_buffer {
-  timeval_t start;
-  struct output_slot {
-    uint16_t on_mask;  /* On little endian arch, most-significant */
-    uint16_t off_mask; /* are last in struct */
-  } __attribute__((packed)) __attribute__((aligned(4)))
-  slots[OUTPUT_BUFFER_LEN];
-} output_buffers[2];
-
 #define MAX_CALLBACKS 32
 struct timed_callback *callbacks[MAX_CALLBACKS] = { 0 };
 static int n_callbacks = 0;
 
-/*
- * For this check to be valid, output buffer swaps *must* have executed in time
- */
-static int sched_entry_has_fired(struct sched_entry *en) {
-  assert(en);
-
-  int ret = 0;
-  disable_interrupts();
-
-  if (en->buffer && time_before(en->buffer->start, current_time()) &&
-      time_in_range(en->time, en->buffer->start, current_time())) {
-    ret = 1;
-  }
-  if (en->fired) {
-    ret = 1;
-  }
-  enable_interrupts();
-  return ret;
+/* Returns true if both the start and stop entry have been confirmed to fire */
+static bool event_has_fired(struct output_event *ev) {
+  return (ev->start.state == SCHED_FIRED) && (ev->stop.state == SCHED_FIRED);
 }
 
-int event_is_active(struct output_event *ev) {
-  return (sched_entry_has_fired(&ev->start) &&
-          !sched_entry_has_fired(&ev->stop));
+/* Returns true if both the start and stop entry are unscheduled */
+static bool event_is_unscheduled(struct output_event *ev) {
+  return (ev->start.state == SCHED_UNSCHEDULED) &&
+         (ev->stop.state == SCHED_UNSCHEDULED);
 }
 
-int event_has_fired(struct output_event *ev) {
-  return (sched_entry_has_fired(&ev->start) &&
-          sched_entry_has_fired(&ev->stop));
-}
-
-static struct output_buffer *buffer_for_time(timeval_t time) {
-  struct output_buffer *buf = NULL;
-  if (time_in_range(time,
-                    output_buffers[0].start,
-                    output_buffers[0].start + OUTPUT_BUFFER_LEN - 1)) {
-    buf = &output_buffers[0];
-  } else if (time_in_range(time,
-                           output_buffers[1].start,
-                           output_buffers[1].start + OUTPUT_BUFFER_LEN - 1)) {
-    buf = &output_buffers[1];
-  }
-  return buf;
-}
-
-/* Sets the fired flag based on a sched_entry enable/disable status result.
- * This is used when we're modifying sched entries in a way that they might
- * fire, but not be accounted for automatically in the buffer swap (because the
- * output buffer contents does not match) */
-static int fired_if_failed(struct sched_entry *en, int success) {
-  en->fired = !success;
-  return success;
-}
-
-/* Modifies the output buffer to not have the event, returns 0 if event is in
- * the past.
- *
- * Return of 1 means event has not fired. 0 means it couldn't be removed in
- * time.
- *
- * Does no bookkeeping but can set fired flag */
-static int sched_entry_disable(const struct sched_entry *en, timeval_t time) {
+/* Disables a scheduled entry if it is possible.
+ * Returns true for success if it was an entry that was still changable, and
+ * false if the entry has already been submitted or fired */
+static bool sched_entry_disable(struct sched_entry *en) {
 
   assert(!interrupts_enabled());
-  /* before either buffer starts */
-  if (time_before(time, output_buffers[0].start) &&
-      time_before(time, output_buffers[1].start)) {
-    return 0;
+  assert(en->state != SCHED_UNSCHEDULED);
+  if (en->state != SCHED_SCHEDULED) {
+    return false;
   }
 
-  struct output_buffer *buf = buffer_for_time(time);
-
-  /* In the future, bail out successfully */
-  if (!buf) {
-    return 1;
-  }
-
-  int slot = time - buf->start;
-  assert((slot >= 0) && (slot < 512));
-
-  uint16_t *addr =
-    en->val ? &buf->slots[slot].on_mask : &buf->slots[slot].off_mask;
-  uint16_t value = *addr & ~(1 << en->pin);
-
-  timeval_t before_time = current_time();
-  *addr = value;
-  timeval_t after_time = current_time();
-
-  if (time_in_range(time - 1, before_time, after_time)) {
-    set_output(en->pin, en->val);
-    return 0;
-  }
-  if (time_before(time - 1, before_time) || en->fired) {
-    return 0;
-  }
-
-  return 1;
+  en->state = SCHED_UNSCHEDULED;
+  return true;
 }
 
-/* Modifies the output buffer to have the event, returns 0 if event is in the
- * past.
- *
- * Return of 0 means the event did not fire.
- *
- * Does no bookkeeping of sched_entry */
-static int sched_entry_enable(const struct sched_entry *en, timeval_t time) {
+/* Set an entry to fire at a specific time.  If the entry is an
+ * already-scheduled entry that has been submitted or fired, it can no longer be
+ * changed and must be reset before scheduling again.
+ * Returns true if the entry is settable and if the specified time is feasible
+ * to schedule */
+static bool sched_entry_enable(struct sched_entry *en, timeval_t time) {
 
   assert(!interrupts_enabled());
-  /* before either buffer starts */
-  if (time_before(time, output_buffers[0].start) &&
-      time_before(time, output_buffers[1].start)) {
-    return 0;
+  if ((en->state == SCHED_SUBMITTED) || (en->state == SCHED_FIRED)) {
+    return false;
   }
 
-  struct output_buffer *buf = buffer_for_time(time);
-
-  /* In the future, bail out successfully */
-  if (!buf) {
-    return 1;
+  if (time_before(time, platform_output_earliest_schedulable_time())) {
+    return false;
   }
 
-  int slot = time - buf->start;
-  assert((slot >= 0) && (slot < 512));
-
-  uint16_t *addr =
-    en->val ? &buf->slots[slot].on_mask : &buf->slots[slot].off_mask;
-  uint16_t value = *addr | (1 << en->pin);
-
-  timeval_t before_time = current_time();
-  *addr = value;
-  timeval_t after_time = current_time();
-
-  if (time_in_range(time - 1, before_time, after_time)) {
-    set_output(en->pin, en->val);
-  }
-
-  if (time_before(time - 1, before_time)) {
-    return 0;
-  }
-
-  return 1;
-}
-
-static void sched_entry_update(struct sched_entry *en, timeval_t time) {
-  en->buffer = buffer_for_time(time);
-  en->scheduled = 1;
   en->time = time;
+  en->state = SCHED_SCHEDULED;
+  return true;
 }
 
-static void sched_entry_off(struct sched_entry *en) {
-  en->scheduled = 0;
-  en->buffer = NULL;
+/* Set a fired entry to be unscheduled */
+static void reset_fired_event(struct output_event *ev) {
+  assert(ev->start.state == SCHED_FIRED);
+  assert(ev->stop.state == SCHED_FIRED);
+  ev->start.state = SCHED_UNSCHEDULED;
+  ev->stop.state = SCHED_UNSCHEDULED;
 }
 
+/* Attempt to deschedule an output event. If the start event can't be disabled,
+ * do nothing. */
 void deschedule_event(struct output_event *ev) {
   disable_interrupts();
 
-  if (ev->start.fired) {
-    enable_interrupts();
-    return;
-  }
-
-  int success;
-  success = fired_if_failed(&ev->start,
-                            sched_entry_disable(&ev->start, ev->start.time));
+  int success = sched_entry_disable(&ev->start);
   if (success) {
-    fired_if_failed(&ev->stop, sched_entry_disable(&ev->stop, ev->stop.time));
-    sched_entry_off(&ev->start);
-    sched_entry_off(&ev->stop);
+    sched_entry_disable(&ev->stop);
   }
   enable_interrupts();
 }
 
 void invalidate_scheduled_events(struct output_event *evs, int n) {
   for (int i = 0; i < n; ++i) {
-    if (!evs[i].start.scheduled) {
+    if (evs[i].start.state == SCHED_UNSCHEDULED) {
       continue;
     }
     switch (evs[i].type) {
@@ -210,116 +95,6 @@ void invalidate_scheduled_events(struct output_event *evs, int n) {
     }
   }
 }
-
-/* Reschedule the end of an event */
-static void reschedule_end(struct sched_entry *s,
-                           timeval_t old,
-                           timeval_t new) {
-  if (new == old)
-    return;
-
-  int success;
-  success = sched_entry_enable(s, new);
-  if (success) {
-    success = fired_if_failed(s, sched_entry_disable(s, old));
-    if (!success) {
-      /* if we failed to disable the old time, remove the stale enable of the
-       * new time */
-      sched_entry_disable(s, new);
-      sched_entry_update(s, old);
-    } else {
-      /* Otherwise, update book-keeping to point to the new end */
-      sched_entry_update(s, new);
-    }
-  }
-  /* If we failed to schedule the new end time, there is nothing we can do.
-   * Either the new end time was after the old end time, so the event is over
-   * anyway, or its before, and we must live with a longer-than-desired event */
-}
-
-static void schedule_output_safely_backwards(struct output_event *ev,
-                                             timeval_t newstart,
-                                             timeval_t newstop) {
-  timeval_t oldstart = ev->start.time;
-  timeval_t oldstop = ev->stop.time;
-  int success;
-
-  /* Moving an event backwards carries three possible scenarios:
-   * 1) New end time is before old start time (no overlap, totally backwards)
-   * 2) New end time is between old start and stop (partial overlap)
-   * 3) New end time is after old end time (new even is longer and totally
-   *    overlaps)
-   */
-
-  /* Opportunistically we try to enable the new start. This is safe because if
-   * we fail, the old start will still happen later */
-  success = sched_entry_enable(&ev->start, newstart);
-
-  /* For fueling, preserve the duration of the event if we failed */
-  if (!success && (ev->type == FUEL_EVENT)) {
-    newstop += oldstart - newstart;
-  }
-
-  if (success) {
-    /* If we succeeded, for (2) and (3) the old start is a no-op so it is safe
-     * to disable and ignore. For (1), we have not scheduled the new end yet, so
-     * worst case is an extra-long event */
-    sched_entry_disable(&ev->start, oldstart);
-    sched_entry_update(&ev->start, newstart);
-  } else {
-    /* If we failed, we deschedule our new start time, */
-    sched_entry_disable(&ev->start, newstart);
-  }
-
-  /* If the eventual start time we used is before our new stop time, reschedule
-   * the stop.  This would be true unless we failed to reschedule the start, and
-   * it was a nonoverlapping (1) case */
-  if (time_before(ev->start.time, newstop)) {
-    reschedule_end(&ev->stop, oldstop, newstop);
-  }
-}
-
-static void schedule_output_safely_forwards(struct output_event *ev,
-                                            timeval_t newstart,
-                                            timeval_t newstop) {
-  timeval_t oldstart = ev->start.time;
-  timeval_t oldstop = ev->stop.time;
-  int success;
-
-  /*  Moving an event forwards has three possible scenarios:
-   *  1) New event starts after old ends, no overlap
-   *  2) New event ends before old event ends, partial overlap
-   *  3) New event ends before old event ends, full overlap
-   */
-  if (time_in_range(newstart, oldstart, oldstop)) {
-    /* Case (2) or (3), it is safe to schedule the new start, since failing
-     * would be a no-op */
-    sched_entry_enable(&ev->start, newstart);
-  }
-  /* Disable the old start. If we failed, the event has definitely already
-   * started, mark as such */
-  success =
-    fired_if_failed(&ev->start, sched_entry_disable(&ev->start, oldstart));
-
-  /* For fueling, preserve the duration of the event if we failed */
-  if (!success && (ev->type == FUEL_EVENT)) {
-    newstop += oldstart - newstart;
-  }
-  reschedule_end(&ev->stop, oldstop, newstop);
-
-  if (success) {
-    /* Special handling of case (1) */
-    sched_entry_enable(&ev->start, newstart);
-    sched_entry_update(&ev->start, newstart);
-  } else {
-    /* If we failed, and we handled (2) and (3) first, don't leave a stray
-     * enable */
-    if (time_in_range(newstart, oldstart, oldstop)) {
-      sched_entry_disable(&ev->start, newstart);
-    }
-  }
-}
-
 /* Schedules an output event in a hazard-free manner, assuming
  * that the start and stop times occur at least after curtime
  */
@@ -327,42 +102,34 @@ static void schedule_output_event_safely(struct output_event *ev,
                                          timeval_t newstart,
                                          timeval_t newstop) {
 
-  stats_start_timing(STATS_SCHED_SINGLE_TIME);
-
   ev->start.pin = ev->pin;
   ev->start.val = ev->inverted ? 0 : 1;
   ev->stop.pin = ev->pin;
   ev->stop.val = ev->inverted ? 1 : 0;
 
-  if (!ev->start.scheduled && !ev->stop.scheduled) {
-    disable_interrupts();
-    if (sched_entry_enable(&ev->stop, newstop)) {
-      sched_entry_update(&ev->stop, newstop);
-      if (sched_entry_enable(&ev->start, newstart)) {
-        sched_entry_update(&ev->start, newstart);
-      } else {
-        sched_entry_disable(&ev->start, newstart);
-        sched_entry_off(&ev->start);
-        sched_entry_disable(&ev->stop, newstop);
-        sched_entry_off(&ev->stop);
-      }
-    }
-    enable_interrupts();
-    stats_finish_timing(STATS_SCHED_SINGLE_TIME);
-    return;
-  }
-
   disable_interrupts();
-  if (ev->start.time == newstart) {
-    reschedule_end(&ev->stop, ev->stop.time, newstop);
-  } else if (time_before(newstart, ev->start.time)) {
-    schedule_output_safely_backwards(ev, newstart, newstop);
+
+  if (event_is_unscheduled(ev)) {
+    /* Schedule start first, if it succeeds we're gauranteed to be able to
+     * schedule the stop and be done, if we failed, leave the event unscheduled
+     * */
+    if (sched_entry_enable(&ev->start, newstart)) {
+      sched_entry_enable(&ev->stop, newstop);
+    }
   } else {
-    schedule_output_safely_forwards(ev, newstart, newstop);
+
+    timeval_t oldstart = ev->start.time;
+
+    int success = sched_entry_enable(&ev->start, newstart);
+    /* If we failed to move the start time, adjust the stop time to preserve
+     * fuel pulse time */
+    if (!success && (ev->type == FUEL_EVENT)) {
+      newstop += oldstart - newstart;
+    }
+    sched_entry_enable(&ev->stop, newstop);
   }
 
   enable_interrupts();
-  stats_finish_timing(STATS_SCHED_SINGLE_TIME);
 }
 
 static int schedule_ignition_event(struct output_event *ev,
@@ -392,16 +159,13 @@ static int schedule_ignition_event(struct output_event *ev,
          time_from_rpm_diff(d->rpm, 90))) {
       return 0;
     }
-
-    ev->start.fired = 0;
-    ev->stop.fired = 0;
-    ev->start.scheduled = 0;
-    ev->stop.scheduled = 0;
+    reset_fired_event(ev);
   }
 
   /* Don't let the stop time move more than 180*
    * forward once it is scheduled */
-  if (ev->stop.scheduled && time_before(ev->stop.time, stop_time) &&
+  if (ev->stop.state == SCHED_SCHEDULED &&
+      time_before(ev->stop.time, stop_time) &&
       ((time_diff(stop_time, ev->stop.time) >
         time_from_rpm_diff(d->rpm, 180)))) {
     return 0;
@@ -445,17 +209,15 @@ static int schedule_fuel_event(struct output_event *ev,
       return 0;
     }
 
-    ev->start.fired = 0;
-    ev->stop.fired = 0;
-    ev->start.scheduled = 0;
-    ev->stop.scheduled = 0;
+    reset_fired_event(ev);
   }
 
   /* Don't let the stop time move more than 180*
    * forward once it is scheduled
    * TODO evaluate if this is necessary for fueling */
 
-  if (ev->stop.scheduled && time_before(ev->stop.time, stop_time) &&
+  if (ev->stop.state == SCHED_SCHEDULED &&
+      time_before(ev->stop.time, stop_time) &&
       ((time_diff(stop_time, ev->stop.time) >
         time_from_rpm_diff(d->rpm, 180)))) {
     return 0;
@@ -463,8 +225,11 @@ static int schedule_fuel_event(struct output_event *ev,
 
   schedule_output_event_safely(ev, start_time, stop_time);
 
-  /* Schedule a callback to reschedule this immediately after it fires */
-  if (ev->stop.scheduled) {
+  /* If the stop event is scheduled, we know we just successfully set a new stop
+   * time for the event, lets also schedule a callback to reschedule it when it
+   * fires immediately.  This allows fuel events to use close to 100% duty cycle
+   * without having to wait until the next trigger for rescheduling */
+  if (ev->stop.state == SCHED_SCHEDULED) {
     ev->callback.callback = (void (*)(void *))schedule_event;
     ev->callback.data = ev;
     schedule_callback(&ev->callback, ev->stop.time);
@@ -578,97 +343,8 @@ void scheduler_callback_timer_execute() {
   }
 }
 
-void scheduler_buffer_swap() {
-  disable_interrupts();
-
-  int newbuf = (current_output_buffer() + 1) % 2;
-  struct output_buffer *obuf = &output_buffers[newbuf];
-
-  struct output_event *oev;
-  int i;
-  for (i = 0; i < MAX_EVENTS; ++i) {
-    oev = &config.events[i];
-
-    /* OEVs that were in the old buffer are no longer */
-    if (oev->start.buffer == obuf) {
-      oev->start.buffer = NULL;
-      oev->start.fired = 1;
-    }
-    if (oev->stop.buffer == obuf) {
-      oev->stop.buffer = NULL;
-      oev->stop.fired = 1;
-    }
-  }
-
-  memset(obuf->slots, 0, sizeof(struct output_slot) * OUTPUT_BUFFER_LEN);
-  obuf->start += 2 * OUTPUT_BUFFER_LEN;
-  timeval_t end = obuf->start + OUTPUT_BUFFER_LEN - 1;
-
-  for (i = 0; i < MAX_EVENTS; ++i) {
-    oev = &config.events[i];
-    /* Is this an event that is scheduled for this time window? */
-    if (oev->start.scheduled &&
-        time_in_range(oev->start.time, obuf->start, end)) {
-      sched_entry_enable(&oev->start, oev->start.time);
-      sched_entry_update(&oev->start, oev->start.time);
-    }
-    if (oev->stop.scheduled &&
-        time_in_range(oev->stop.time, obuf->start, end)) {
-      sched_entry_enable(&oev->stop, oev->stop.time);
-      sched_entry_update(&oev->stop, oev->stop.time);
-    }
-  }
-  enable_interrupts();
-}
 void initialize_scheduler() {
-  memset(&output_buffers, 0, sizeof(output_buffers));
-
-  output_buffers[0].start =
-    init_output_thread((uint32_t *)output_buffers[0].slots,
-                       (uint32_t *)output_buffers[1].slots,
-                       OUTPUT_BUFFER_LEN);
-  output_buffers[1].start = output_buffers[0].start + OUTPUT_BUFFER_LEN;
-
   n_callbacks = 0;
-}
-
-/* Used for benchmarking, prepare all events such that they will be retired on
- * the next scheduler swap */
-void bench_set_all_events_fired() {
-  struct output_buffer *obuf =
-    &output_buffers[(current_output_buffer() + 1) % 2];
-
-  for (int i = 0; i < MAX_EVENTS; i++) {
-    struct output_event *oev = &config.events[i];
-    oev->start = (struct sched_entry){
-      .buffer = obuf,
-
-    };
-    oev->stop = (struct sched_entry){
-      .buffer = obuf,
-    };
-  }
-}
-
-/* Used for benchmarking, prepare all events such that they will be scheduled
- * into a buffer on the next scheduler swap */
-void bench_set_all_events_ready_to_schedule() {
-  struct output_buffer *obuf =
-    &output_buffers[(current_output_buffer() + 1) % 2];
-
-  for (int i = 0; i < MAX_EVENTS; i++) {
-    struct output_event *oev = &config.events[i];
-    oev->start = (struct sched_entry){
-      .buffer = NULL,
-      .scheduled = 1,
-      .time = obuf->start + 10 + OUTPUT_BUFFER_LEN * 2,
-    };
-    oev->stop = (struct sched_entry){
-      .buffer = NULL,
-      .scheduled = 1,
-      .time = obuf->start + 10 + OUTPUT_BUFFER_LEN * 2,
-    };
-  }
 }
 
 #ifdef UNITTEST
@@ -696,36 +372,29 @@ static void check_scheduler_setup() {
 
 START_TEST(check_schedule_ignition) {
 
-  /* Set our current position at 270* for an event at 360* */
-  set_current_time(time_from_rpm_diff(6000, 270));
   schedule_ignition_event(oev, &config.decoder, 10, 1000);
-  ck_assert(oev->start.scheduled);
-  ck_assert(oev->stop.scheduled);
-  ck_assert(!oev->start.fired);
-  ck_assert(!oev->stop.fired);
+  ck_assert(oev->start.state == SCHED_SCHEDULED);
+  ck_assert(oev->stop.state == SCHED_SCHEDULED);
 
   ck_assert_int_eq(oev->stop.time - oev->start.time,
                    1000 * (TICKRATE / 1000000));
   ck_assert_int_eq(oev->stop.time,
                    time_from_rpm_diff(config.decoder.rpm,
                                       oev->angle + config.decoder.offset - 10));
+
+  set_current_time(oev->stop.time + 512);
 }
 END_TEST
 
 START_TEST(check_schedule_ignition_reschedule_completely_later) {
 
-  set_current_time(time_from_rpm_diff(6000, 270));
   schedule_ignition_event(oev, &config.decoder, 10, 1000);
-
-  set_current_time(oev->start.time - 100);
 
   /* Reschedule 10 degrees later */
   schedule_ignition_event(oev, &config.decoder, 0, 1000);
 
-  ck_assert(oev->start.scheduled);
-  ck_assert(oev->stop.scheduled);
-  ck_assert(!oev->start.fired);
-  ck_assert(!oev->stop.fired);
+  ck_assert(oev->start.state == SCHED_SCHEDULED);
+  ck_assert(oev->stop.state == SCHED_SCHEDULED);
 
   ck_assert_int_eq(oev->stop.time - oev->start.time,
                    1000 * (TICKRATE / 1000000));
@@ -737,21 +406,17 @@ END_TEST
 
 START_TEST(check_schedule_ignition_reschedule_completely_earlier_still_future) {
 
-  set_current_time(time_from_rpm_diff(6000, 180));
   schedule_ignition_event(oev, &config.decoder, 10, 1000);
   /* Reschedule 10 earlier later */
-  schedule_ignition_event(oev, &config.decoder, 50, 1000);
-
-  ck_assert(oev->start.scheduled);
-  ck_assert(oev->stop.scheduled);
-  ck_assert(!oev->start.fired);
-  ck_assert(!oev->stop.fired);
+  schedule_ignition_event(oev, &config.decoder, 20, 1000);
+  ck_assert(oev->start.state == SCHED_SCHEDULED);
+  ck_assert(oev->stop.state == SCHED_SCHEDULED);
 
   ck_assert_int_eq(oev->stop.time - oev->start.time,
                    1000 * (TICKRATE / 1000000));
   ck_assert_int_eq(oev->stop.time,
                    time_from_rpm_diff(config.decoder.rpm,
-                                      oev->angle + config.decoder.offset - 50));
+                                      oev->angle + config.decoder.offset - 20));
 }
 END_TEST
 
@@ -760,29 +425,64 @@ START_TEST(check_schedule_ignition_reschedule_onto_now) {
   set_current_time(time_from_rpm_diff(6000, 340));
   schedule_ignition_event(oev, &config.decoder, 15, 1000);
 
-  /* Start would fail, stop should schedule */
-  ck_assert(!oev->start.scheduled);
-  ck_assert(!oev->stop.scheduled);
-  ck_assert(!oev->start.fired);
-  ck_assert(!oev->stop.fired);
+  ck_assert(oev->start.state == SCHED_UNSCHEDULED);
+  ck_assert(oev->stop.state == SCHED_UNSCHEDULED);
 }
 END_TEST
 
 START_TEST(check_schedule_ignition_reschedule_active_later) {
 
-  set_current_time(time_from_rpm_diff(6000, 270));
   schedule_ignition_event(oev, &config.decoder, 10, 1000);
+  timeval_t start_time = oev->start.time;
 
-  /* Emulate firing of the event */
+  /* Move to a time we're sure the event can no longer reschedule */
   set_current_time(oev->start.time + 1);
+  ck_assert(oev->start.state == SCHED_SUBMITTED ||
+            oev->start.state == SCHED_FIRED);
+
+  /* metatest: make sure we chose numbers that allow us to still change the stop
+   * */
+  ck_assert(
+    !time_before(oev->stop.time, platform_output_earliest_schedulable_time()));
 
   /* Reschedule 10* later */
   schedule_ignition_event(oev, &config.decoder, 0, 1000);
 
-  ck_assert(oev->stop.scheduled);
+  ck_assert(oev->stop.state == SCHED_SCHEDULED);
+  /* We shouldn't have changed the start */
+  ck_assert_int_eq(oev->start.time, start_time);
   ck_assert_int_eq(
     oev->stop.time,
     time_from_rpm_diff(config.decoder.rpm, oev->angle + config.decoder.offset));
+}
+END_TEST
+
+START_TEST(check_schedule_fuel_reschedule_active_later) {
+
+  oev->angle = 360;
+  oev->type = FUEL_EVENT;
+  schedule_fuel_event(oev, &config.decoder, 1000);
+  timeval_t start_time = oev->start.time;
+
+  /* Move to a time we're sure the event can no longer reschedule */
+  set_current_time(oev->start.time + 1);
+  ck_assert(oev->start.state == SCHED_SUBMITTED ||
+            oev->start.state == SCHED_FIRED);
+
+  /* metatest: make sure we chose numbers that allow us to still change the stop
+   * */
+  ck_assert(
+    !time_before(oev->stop.time, platform_output_earliest_schedulable_time()));
+
+  /* Reschedule 10* later, but one tick longer */
+  oev->angle = 370;
+  schedule_fuel_event(oev, &config.decoder, 1001);
+
+  ck_assert(oev->stop.state == SCHED_SCHEDULED);
+  /* We shouldn't have changed the start */
+  ck_assert_int_eq(oev->start.time, start_time);
+  /* and total time should be the new 1001 time */
+  ck_assert_int_eq(oev->stop.time, start_time + time_from_us(1001));
 }
 END_TEST
 
@@ -790,16 +490,23 @@ END_TEST
  * reinterpretted as future */
 START_TEST(check_schedule_ignition_reschedule_active_too_early) {
   oev->angle = 60;
-  set_current_time(time_from_rpm_diff(6000, 0));
   schedule_ignition_event(oev, &config.decoder, 0, 1000);
+  ck_assert(oev->start.state == SCHED_SCHEDULED);
+  ck_assert(oev->stop.state == SCHED_SCHEDULED);
+
   /* Emulate firing of the event */
   set_current_time(oev->start.time + 5);
+
+  /* metatest: make sure we chose numbers that allow us to still change the stop
+   * */
+  ck_assert(
+    !time_before(oev->stop.time, platform_output_earliest_schedulable_time()));
 
   timeval_t old_stop = oev->stop.time;
   /* Reschedule 45* earlier, now in past*/
   schedule_ignition_event(oev, &config.decoder, 45, 1000);
 
-  ck_assert(oev->stop.scheduled);
+  ck_assert(oev->stop.state == SCHED_SCHEDULED);
   ck_assert_int_eq(oev->stop.time, old_stop);
 }
 END_TEST
@@ -808,318 +515,57 @@ START_TEST(check_schedule_fuel_immediately_after_finish) {
   oev->angle = 60;
   config.decoder.rpm = 6000;
   schedule_fuel_event(oev, &config.decoder, 1000);
+  ck_assert(oev->start.state == SCHED_SCHEDULED);
+  ck_assert(oev->stop.state == SCHED_SCHEDULED);
 
   /* Emulate firing of the event */
   set_current_time(oev->stop.time + 5);
 
   /* Reschedule same event */
-  ck_assert(!schedule_fuel_event(oev, &config.decoder, 1000));
+  schedule_fuel_event(oev, &config.decoder, 1000);
+  ck_assert(oev->start.state != SCHED_SCHEDULED);
+  ck_assert(oev->stop.state != SCHED_SCHEDULED);
 }
-END_TEST
-
-START_TEST(check_event_is_active) {
-  ck_assert(!event_is_active(oev));
-
-  oev->start.fired = 1;
-  ck_assert(event_is_active(oev));
-
-  oev->stop.fired = 1;
-  ck_assert(!event_is_active(oev));
-
-  oev->start.fired = 0;
-  ck_assert(!event_is_active(oev));
-}
-END_TEST
-
-START_TEST(check_event_has_fired) {}
 END_TEST
 
 START_TEST(check_invalidate_events_when_active) {
   /* Schedule an event, get in the middle of it */
-  set_current_time(time_from_rpm_diff(6000, 270));
   schedule_ignition_event(oev, &config.decoder, 10, 1000);
-  set_current_time(oev->start.time + 500);
+  set_current_time(oev->start.time + 5);
 
   invalidate_scheduled_events(oev, 1);
 
-  ck_assert(oev->stop.scheduled);
+  ck_assert(oev->stop.state != SCHED_UNSCHEDULED);
 }
 END_TEST
 
-START_TEST(check_deschedule_event) {}
-END_TEST
+START_TEST(check_deschedule_event) {
+  /* Test descheduling scheduled event in the future */
+  oev->start = (struct sched_entry){ .time = current_time() + 10,
+                                     .state = SCHED_SCHEDULED };
+  oev->stop = (struct sched_entry){ .time = current_time() + 20,
+                                    .state = SCHED_SCHEDULED };
+  deschedule_event(oev);
+  ck_assert(oev->start.state == SCHED_UNSCHEDULED);
+  ck_assert(oev->stop.state == SCHED_UNSCHEDULED);
 
-START_TEST(check_buffer_insert_totally_after) {
-  struct output_event oev = { 0 };
-  oev.type = IGNITION_EVENT;
+  /* Test descheduling scheduled event with already-submitted start */
+  oev->start = (struct sched_entry){ .time = current_time() + 10,
+                                     .state = SCHED_SUBMITTED };
+  oev->stop = (struct sched_entry){ .time = current_time() + 20,
+                                    .state = SCHED_SCHEDULED };
+  deschedule_event(oev);
+  ck_assert(oev->start.state != SCHED_UNSCHEDULED);
+  ck_assert(oev->stop.state != SCHED_UNSCHEDULED);
 
-  schedule_output_event_safely(&oev, 20, 40);
-
-  schedule_output_event_safely(&oev, 80, 100);
-  ck_assert_int_eq(output_buffers[0].slots[20].on_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[40].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[80].on_mask, 1);
-  ck_assert_int_eq(output_buffers[0].slots[100].off_mask, 1);
-  ck_assert_int_eq(oev.start.scheduled, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-
-  oev.type = FUEL_EVENT;
-  schedule_output_event_safely(&oev, 100, 150);
-  ck_assert_int_eq(output_buffers[0].slots[80].on_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[100].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[100].on_mask, 1);
-  ck_assert_int_eq(output_buffers[0].slots[150].off_mask, 1);
-  ck_assert_int_eq(oev.start.scheduled, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-}
-END_TEST
-
-START_TEST(check_buffer_insert_totally_before) {
-  struct output_event oev = { 0 };
-
-  oev.type = IGNITION_EVENT;
-  schedule_output_event_safely(&oev, 80, 100);
-
-  schedule_output_event_safely(&oev, 20, 40);
-  ck_assert_int_eq(output_buffers[0].slots[80].on_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[100].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[20].on_mask, 1);
-  ck_assert_int_eq(output_buffers[0].slots[40].off_mask, 1);
-  ck_assert_int_eq(oev.start.scheduled, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-
-  oev.type = FUEL_EVENT;
-  schedule_output_event_safely(&oev, 10, 15);
-  ck_assert_int_eq(output_buffers[0].slots[20].on_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[40].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[10].on_mask, 1);
-  ck_assert_int_eq(output_buffers[0].slots[15].off_mask, 1);
-  ck_assert_int_eq(oev.start.scheduled, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-}
-END_TEST
-
-START_TEST(check_buffer_insert_totally_inside) {
-  struct output_event oev = { 0 };
-  oev.type = IGNITION_EVENT;
-
-  schedule_output_event_safely(&oev, 20, 100);
-
-  schedule_output_event_safely(&oev, 30, 90);
-  ck_assert_int_eq(output_buffers[0].slots[20].on_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[100].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 1);
-  ck_assert_int_eq(output_buffers[0].slots[90].off_mask, 1);
-  ck_assert_int_eq(oev.start.scheduled, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-
-  schedule_output_event_safely(&oev, 30, 80);
-  ck_assert_int_eq(output_buffers[0].slots[90].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 1);
-  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 1);
-  ck_assert_int_eq(oev.start.scheduled, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-
-  schedule_output_event_safely(&oev, 40, 80);
-  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[40].on_mask, 1);
-  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 1);
-  ck_assert_int_eq(oev.start.scheduled, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-}
-END_TEST
-
-START_TEST(check_buffer_insert_totally_outside) {
-  struct output_event oev = { 0 };
-  oev.type = IGNITION_EVENT;
-
-  schedule_output_event_safely(&oev, 40, 80);
-
-  schedule_output_event_safely(&oev, 30, 90);
-  ck_assert_int_eq(output_buffers[0].slots[40].on_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 1);
-  ck_assert_int_eq(output_buffers[0].slots[90].off_mask, 1);
-  ck_assert_int_eq(oev.start.scheduled, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-
-  schedule_output_event_safely(&oev, 30, 100);
-  ck_assert_int_eq(output_buffers[0].slots[90].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 1);
-  ck_assert_int_eq(output_buffers[0].slots[100].off_mask, 1);
-  ck_assert_int_eq(oev.start.scheduled, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-
-  schedule_output_event_safely(&oev, 20, 100);
-  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[20].on_mask, 1);
-  ck_assert_int_eq(output_buffers[0].slots[100].off_mask, 1);
-  ck_assert_int_eq(oev.start.scheduled, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-}
-END_TEST
-
-START_TEST(check_buffer_insert_partially_later) {
-  struct output_event oev = { 0 };
-  oev.type = IGNITION_EVENT;
-
-  schedule_output_event_safely(&oev, 40, 80);
-
-  schedule_output_event_safely(&oev, 50, 90);
-  ck_assert_int_eq(output_buffers[0].slots[40].on_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[50].on_mask, 1);
-  ck_assert_int_eq(output_buffers[0].slots[90].off_mask, 1);
-  ck_assert_int_eq(oev.start.scheduled, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-}
-END_TEST
-
-START_TEST(check_buffer_insert_partially_earlier) {
-  struct output_event oev = { 0 };
-  oev.type = IGNITION_EVENT;
-
-  schedule_output_event_safely(&oev, 40, 80);
-
-  schedule_output_event_safely(&oev, 30, 70);
-  ck_assert_int_eq(output_buffers[0].slots[40].on_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[30].on_mask, 1);
-  ck_assert_int_eq(output_buffers[0].slots[70].off_mask, 1);
-  ck_assert_int_eq(oev.start.scheduled, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-}
-END_TEST
-
-START_TEST(check_buffer_insert_active_later) {
-  struct output_event oev = { 0 };
-  oev.type = IGNITION_EVENT;
-
-  schedule_output_event_safely(&oev, 40, 80);
-
-  set_current_time(50);
-  /* If we don't preserve duration, it'll stay fired through */
-  schedule_output_event_safely(&oev, 100, 120);
-  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[120].off_mask, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-}
-END_TEST
-
-START_TEST(check_buffer_insert_active_later_preserve_duration) {
-  struct output_event oev = { 0 };
-  oev.type = FUEL_EVENT;
-
-  schedule_output_event_safely(&oev, 40, 80);
-
-  set_current_time(50);
-  /* We want to preserve the pulse width at the expense
-   * of end time */
-  schedule_output_event_safely(&oev, 100, 120);
-  ck_assert_int_eq(output_buffers[0].slots[60].off_mask, 1);
-  ck_assert_int_eq(output_buffers[0].slots[100].on_mask, 0);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-}
-END_TEST
-
-START_TEST(check_buffer_insert_active_earlier) {
-  struct output_event oev = { 0 };
-  oev.type = IGNITION_EVENT;
-
-  schedule_output_event_safely(&oev, 40, 80);
-
-  set_current_time(50);
-  /* Currently in this situation we give up, leave it the same.
-   * The naive fix to this causes errors in other situations */
-  schedule_output_event_safely(&oev, 30, 70);
-  ck_assert_int_eq(output_buffers[0].slots[40].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[70].off_mask, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-}
-END_TEST
-
-START_TEST(check_buffer_insert_active_earlier_repeated) {
-  struct output_event oev = { 0 };
-  oev.type = IGNITION_EVENT;
-
-  schedule_output_event_safely(&oev, 40, 80);
-
-  set_current_time(50);
-  schedule_output_event_safely(&oev, 30, 70);
-  ck_assert_int_eq(output_buffers[0].slots[40].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[70].off_mask, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-
-  set_current_time(55);
-  schedule_output_event_safely(&oev, 30, 60);
-  ck_assert_int_eq(output_buffers[0].slots[70].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[60].off_mask, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-
-  set_current_time(58);
-  schedule_output_event_safely(&oev, 30, 55);
-  ck_assert_int_eq(output_buffers[0].slots[60].off_mask, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-}
-END_TEST
-
-START_TEST(check_buffer_insert_active_earlier_longer) {
-  struct output_event oev = { 0 };
-  oev.type = IGNITION_EVENT;
-
-  schedule_output_event_safely(&oev, 40, 80);
-
-  set_current_time(50);
-  schedule_output_event_safely(&oev, 30, 90);
-  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[90].off_mask, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-}
-END_TEST
-
-START_TEST(check_buffer_insert_active_too_earlier) {
-  struct output_event oev = { 0 };
-  oev.type = IGNITION_EVENT;
-
-  schedule_output_event_safely(&oev, 40, 80);
-
-  set_current_time(50);
-  schedule_output_event_safely(&oev, 30, 45);
-  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-}
-END_TEST
-
-START_TEST(check_buffer_insert_active_earlier_not_yet_started) {
-  struct output_event oev = { 0 };
-  oev.type = IGNITION_EVENT;
-
-  schedule_output_event_safely(&oev, 40, 80);
-
-  set_current_time(50);
-  schedule_output_event_safely(&oev, 60, 70);
-  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[70].off_mask, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
-}
-END_TEST
-
-START_TEST(check_buffer_insert_active_earlier_preserve_duration) {
-  struct output_event oev = { 0 };
-  oev.type = FUEL_EVENT;
-
-  schedule_output_event_safely(&oev, 40, 80);
-
-  set_current_time(50);
-  /* We want to preserve the pulse width at the expense
-   * of end time */
-  schedule_output_event_safely(&oev, 30, 60);
-  ck_assert_int_eq(output_buffers[0].slots[80].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[60].off_mask, 0);
-  ck_assert_int_eq(output_buffers[0].slots[70].off_mask, 1);
-  ck_assert_int_eq(oev.stop.scheduled, 1);
+  /* Test descheduling scheduled event with already-fired start */
+  oev->start =
+    (struct sched_entry){ .time = current_time() - 10, .state = SCHED_FIRED };
+  oev->stop = (struct sched_entry){ .time = current_time() + 20,
+                                    .state = SCHED_SCHEDULED };
+  deschedule_event(oev);
+  ck_assert(oev->start.state != SCHED_UNSCHEDULED);
+  ck_assert(oev->stop.state != SCHED_UNSCHEDULED);
 }
 END_TEST
 
@@ -1226,28 +672,11 @@ TCase *setup_scheduler_tests() {
     tc, check_schedule_ignition_reschedule_completely_earlier_still_future);
   tcase_add_test(tc, check_schedule_ignition_reschedule_onto_now);
   tcase_add_test(tc, check_schedule_ignition_reschedule_active_later);
+  tcase_add_test(tc, check_schedule_fuel_reschedule_active_later);
   tcase_add_test(tc, check_schedule_ignition_reschedule_active_too_early);
   tcase_add_test(tc, check_schedule_fuel_immediately_after_finish);
-  tcase_add_test(tc, check_event_is_active);
-  tcase_add_test(tc, check_event_has_fired);
   tcase_add_test(tc, check_invalidate_events_when_active);
   tcase_add_test(tc, check_deschedule_event);
-  tcase_add_test(tc, check_buffer_insert_totally_after);
-  tcase_add_test(tc, check_buffer_insert_totally_before);
-  tcase_add_test(tc, check_buffer_insert_totally_inside);
-  tcase_add_test(tc, check_buffer_insert_totally_outside);
-  tcase_add_test(tc, check_buffer_insert_partially_later);
-  tcase_add_test(tc, check_buffer_insert_partially_earlier);
-
-  tcase_add_test(tc, check_buffer_insert_active_later);
-  tcase_add_test(tc, check_buffer_insert_active_later_preserve_duration);
-  tcase_add_test(tc, check_buffer_insert_active_earlier);
-  tcase_add_test(tc, check_buffer_insert_active_earlier_repeated);
-  tcase_add_test(tc, check_buffer_insert_active_earlier_longer);
-  tcase_add_test(tc, check_buffer_insert_active_too_earlier);
-  tcase_add_test(tc, check_buffer_insert_active_earlier_not_yet_started);
-  tcase_add_test(tc, check_buffer_insert_active_earlier_preserve_duration);
-
   tcase_add_test(tc, check_callback_insert);
   tcase_add_test(tc, check_callback_remove);
   tcase_add_test(tc, check_callback_execute);

--- a/src/table.h
+++ b/src/table.h
@@ -28,7 +28,7 @@ int table_valid(struct table *);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase *setup_table_tests();
+TCase *setup_table_tests(void);
 #endif
 
 #endif

--- a/src/tasks.h
+++ b/src/tasks.h
@@ -17,12 +17,12 @@ struct cel_config {
   float lean_boost_ego;
 };
 
-void handle_emergency_shutdown();
-void run_tasks();
+void handle_emergency_shutdown(void);
+void run_tasks(void);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase *setup_tasks_tests();
+TCase *setup_tasks_tests(void);
 #endif
 
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -26,24 +26,15 @@ timeval_t time_from_us(unsigned int us) {
 }
 
 /* True if n is before x */
-int time_before(timeval_t n, timeval_t x) {
+bool time_before(timeval_t n, timeval_t x) {
   signed int res = n - x;
   return (res < 0);
 }
 
-int time_in_range(timeval_t val, timeval_t t1, timeval_t t2) {
-  if (t2 >= t1) {
-    /* No timer wrap */
-    if ((val >= t1) && (val <= t2)) {
-      return 1;
-    }
-  } else {
-    if ((val >= t1) || (val < t2)) {
-      return 1;
-    }
-  }
-  return 0;
+bool time_in_range(timeval_t val, timeval_t t1, timeval_t t2) {
+  return (val - t1) <= (t2 - t1);
 }
+
 timeval_t time_diff(timeval_t later, timeval_t earlier) {
   return later - earlier;
 }

--- a/src/util.h
+++ b/src/util.h
@@ -1,16 +1,17 @@
 #ifndef UTIL_H
 #define UTIL_H
 
+#include <stdbool.h>
 #include "platform.h"
 #include <stdbool.h>
 
 timeval_t time_diff(timeval_t t1, timeval_t t2);
-int time_before(timeval_t n, timeval_t x);
+bool time_before(timeval_t n, timeval_t x);
 timeval_t time_from_us(unsigned int us);
 unsigned int rpm_from_time_diff(timeval_t t1, degrees_t degrees);
 timeval_t time_from_rpm_diff(unsigned int rpm, degrees_t degrees);
 degrees_t degrees_from_time_diff(timeval_t, unsigned int);
-int time_in_range(timeval_t val, timeval_t t1, timeval_t t2);
+bool time_in_range(timeval_t val, timeval_t t1, timeval_t t2);
 degrees_t clamp_angle(degrees_t, degrees_t);
 
 #ifdef UNITTEST

--- a/src/util.h
+++ b/src/util.h
@@ -2,6 +2,7 @@
 #define UTIL_H
 
 #include "platform.h"
+#include <stdbool.h>
 
 timeval_t time_diff(timeval_t t1, timeval_t t2);
 int time_before(timeval_t n, timeval_t x);
@@ -14,7 +15,7 @@ degrees_t clamp_angle(degrees_t, degrees_t);
 
 #ifdef UNITTEST
 #include <check.h>
-TCase *setup_util_tests();
+TCase *setup_util_tests(void);
 #endif
 
 #endif

--- a/targets/hosted.mk
+++ b/targets/hosted.mk
@@ -1,6 +1,6 @@
 OBJS+= hosted.o
 
-CFLAGS+= -O0 -ggdb -DSUPPORTS_POSIX_TIMERS
+CFLAGS+= -Og -ggdb -DSUPPORTS_POSIX_TIMERS -Wno-error=unused-result
 CFLAGS+= -D TICKRATE=4000000 -D_POSIX_C_SOURCE=199309L -D_GNU_SOURCE
 CFLAGS+= -fsanitize=undefined -fsanitize=address -pthread
 

--- a/targets/test.mk
+++ b/targets/test.mk
@@ -1,7 +1,7 @@
 OBJS+= test.o
 
 CFLAGS+= $(shell pkg-config --cflags check)
-CFLAGS+= -O0 -ggdb
+CFLAGS+= -Og -ggdb
 CFLAGS+= -D TICKRATE=4000000 -DUNITTEST
 CFLAGS+= -fsanitize=undefined -fsanitize=address
 


### PR DESCRIPTION
The scheduler uses DMA double buffering to drive the GPIO, and does so with a pair of 128 uS buffers representing the current 128 uS and the next 128 uS.  Substantial logic is used to allow these buffers to be changed while they are the actively-read buffer. For example, since it is impossible to pause the dma, we collect the time before and after the store into the buffer and explicitly set the gpio if we believed we may have failed to set the bit, since it is actually impossible to tell if we succeeded.  This logic is error prone and very difficult to validate. Many bugs have been found in the past around this logic: even in direct mode, a single value is buffered by the DMA, and more recently, being unable to rely on the stm32's DMA updating NDTR before triggering an interrupt.  Furthermore, all of this logic is fairly specific to the limitations/abilities of the stm32f4, probably wouldn't work on a chip supporting data caches such as the F7, and leaks into the scheduler code abstraction.

The benefit of this setup is that we can change upcoming events immediately, even if they are <1 uS from occuring. However, if we reduce the buffer size, I would accept losing this feature if it meant simplifying the code and testability.

This change reduces the buffer size such that each buffer represents 32 uS, and disallows changes to any buffers the DMA is using:
 - `fired` and `scheduled` are replaced with a single state enum
 -  Entries that are unscheduled or scheduled are owned by the scheduler. Changes to it are with interrupts disabled to prevent the platform buffer swap
 - On an interval (stm32: driven by the dma buffer swap interrupt), the scheduler changed scheduled events that are in the time range of a buffer to submitted, and events that we fired as fired
 - Once an event is submitted, it cannot be changed and is going to happen (and may or may not already have).  Eventually it'll reach fired state, and when both a start/stop are fired, we can re-schedule the event
 - The platform code entirely owns the process of submitting/marking-fired events, and hardware specifics such as the dma citcular buffers are entirely contained in the platform
