### PR TITLE
Add support for booleans in cbor console configuration

### DIFF
--- a/INTERFACE.md
+++ b/INTERFACE.md
@@ -256,7 +256,7 @@ response (trimmed for display):
                 "description": "angle past TDC to trigger event"
             },
             "inverted": {
-                "_type": "uint32",
+                "_type": "bool",
                 "description": "inverted"
             },
             "pin": {
@@ -280,6 +280,7 @@ response (trimmed for display):
 #### Types
 - `uint32` fields represent an unsigned integer
 - `float` fields represent a single precision floating point value
+- `bool` fields represent a boolean value
 - `string` fields represent a text string, but frequently also represent an
   enumeration value. These fields will also contain a `choices` field that lists
   acceptable string values.

--- a/src/console.h
+++ b/src/console.h
@@ -47,6 +47,11 @@ void render_uint32_map_field(struct console_request_context *ctx,
                              const char *description,
                              uint32_t *ptr);
 
+void render_bool_map_field(struct console_request_context *ctx,
+                             const char *id,
+                             const char *description,
+                             bool *ptr);
+
 void render_float_map_field(struct console_request_context *ctx,
                             const char *id,
                             const char *description,
@@ -85,6 +90,9 @@ void render_uint32_object(struct console_request_context *ctx,
 void render_float_object(struct console_request_context *ctx,
                          const char *description,
                          float *ptr);
+void render_bool_object(struct console_request_context *ctx,
+                          const char *description,
+                          bool *ptr);
 
 void render_map_object(struct console_request_context *ctx,
                        console_renderer map_renderer,

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -365,7 +365,7 @@ static void check_scheduler_setup() {
     .type = IGNITION_EVENT,
     .angle = 360,
     .pin = 0,
-    .inverted = 0,
+    .inverted = false,
   };
 }
 

--- a/src/scheduler.h
+++ b/src/scheduler.h
@@ -47,7 +47,7 @@ struct output_event {
   event_type_t type;
   degrees_t angle;
   uint32_t pin;
-  uint32_t inverted;
+  bool inverted;
 
   struct sched_entry start;
   struct sched_entry stop;


### PR DESCRIPTION
Additionally, change some low hanging fruits to booleans: output "inverted" flags, and event logging enable/disable.

[ ] - Add support to flviaems for booleans