### PR TITLE
Add support for GD32F470

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "tinycbor"]
 	path = contrib/tinycbor
 	url = https://github.com/intel/tinycbor
+[submodule "CMSIS"]
+	path = contrib/CMSIS_5
+	url = https://github.com/ARM-software/CMSIS_5.git
+	shallow = true

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libopencm3"]
-	path = libopencm3
+	path = contrib/libopencm3
 	url = https://github.com/libopencm3/libopencm3
 [submodule "tinycbor"]
-	path = tinycbor
+	path = contrib/tinycbor
 	url = https://github.com/intel/tinycbor

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
  - Implement simpler and easier-to-understand scheduler
  - Relicense to GPLv3
+ - Add new platform: gd32f470
 
 ### 1.4.0 (2022 Feb 16)
 This introduces a breaking change with interface software.

--- a/Makefile
+++ b/Makefile
@@ -25,13 +25,13 @@ DEPS = $(wildcard ${OBJDIR}/*.d)
 
 
 GITDESC=$(shell git describe --tags --dirty)
-CFLAGS+=-I src/ -Wall -Wextra -Werror -g -std=c11 -DGIT_DESCRIBE=\"${GITDESC}\"
-CFLAGS+=-I ${TINYCBOR_DIR}/src
+CFLAGS+=-Isrc/ -Isrc/platforms/common -Wall -Wextra -g -std=c11 -DGIT_DESCRIBE=\"${GITDESC}\"
+CFLAGS+=-I${TINYCBOR_DIR}/src
 LDFLAGS+= -lm -L${OBJDIR} -l:${TINYCBOR_LIB}
 
 OPENCM3_DIR=$(PWD)/contrib/libopencm3
 
-VPATH=src src/platforms
+VPATH+=src src/platforms src/platforms/common
 DESTOBJS = $(addprefix ${OBJDIR}/, ${OBJS})
 
 $(OBJDIR):

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 PLATFORM?=stm32f4
 OBJDIR=obj/${PLATFORM}
 
-TINYCBOR_DIR=$(PWD)/tinycbor
+TINYCBOR_DIR=$(PWD)/contrib/tinycbor
 TINYCBOR_LIB=libtinycbor.a
 
 
@@ -29,7 +29,7 @@ CFLAGS+=-I src/ -Wall -Wextra -Werror -g -std=c11 -DGIT_DESCRIBE=\"${GITDESC}\"
 CFLAGS+=-I ${TINYCBOR_DIR}/src
 LDFLAGS+= -lm -L${OBJDIR} -l:${TINYCBOR_LIB}
 
-OPENCM3_DIR=$(PWD)/libopencm3
+OPENCM3_DIR=$(PWD)/contrib/libopencm3
 
 VPATH=src src/platforms
 DESTOBJS = $(addprefix ${OBJDIR}/, ${OBJS})

--- a/Makefile
+++ b/Makefile
@@ -52,7 +52,7 @@ ${OBJDIR}/${TINYCBOR_LIB}:
 	cp ${TINYCBOR_DIR}/lib/${TINYCBOR_LIB} ${OBJDIR}
 
 format:
-	clang-format -i src/*.c src/*.h src/platforms/*.c
+	clang-format -i src/*.[ch] src/platforms/*.[ch] src/platforms/*/*.[ch] src/platforms/common/*.[ch]
 
 lint:
 	clang-tidy src/*.c -- ${CFLAGS}

--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Features:
 6. [Simulation](#simulation)
 7. [Hardware](#hardware)
     1. [STM32F4](#stm32f4)
+    2. [GD32F470](src/platforms/gd32f470/README.md).
 
 ## Decoding
 Currently the only two decoders styles implemented are even-tooth and
@@ -251,7 +252,7 @@ otherwise constrain it to a single cpu.
 # Hardware
 The current primary hardware platform is an ST Micro STM32F407VGT
 microcontroller.  There are a few non-production-ready hardware designs
-available under https://github.com/via/tfi-board, though I would recommend
+available under https://github.com/via/viaems-boards, though I would recommend
 anyone attempting to use those designs contact me.  The STM32F4-DISCOVERY board
 *can* be used with this firmware, with appropriate extra hardware for vehicle
 interfacing.
@@ -274,4 +275,3 @@ ADC | `PB12`, `PB13`, `PB14`, and `PB15`
 OUT | `PD0`-`PD15`
 GPIO | `PE0`-`PE15`
 PWM | `PC6`, `PC7`, `PC8`, and `PC9` (currently all fixed at same frequenty)
-

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Include/gd32f4xx.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Include/gd32f4xx.h
@@ -1,0 +1,368 @@
+/*!
+    \file    gd32f4xx.h
+    \brief   general definitions for GD32F4xx
+    
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2020, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_H
+#define GD32F4XX_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif 
+
+/* define GD32F4xx */
+#if !defined (GD32F450)  && !defined (GD32F405) && !defined (GD32F407) && !defined (GD32F470)  && !defined (GD32F425) && !defined (GD32F427)
+  /* #define GD32F450 */
+  /* #define GD32F405 */
+  /* #define GD32F407 */
+  /* #define GD32F470 */
+  /* #define GD32F425 */
+  /* #define GD32F427 */
+#endif /* define GD32F4xx */
+   
+#if !defined (GD32F450)  && !defined (GD32F405) && !defined (GD32F407) && !defined (GD32F470)  && !defined (GD32F425) && !defined (GD32F427)
+ #error "Please select the target GD32F4xx device in gd32f4xx.h file"
+#endif /* undefine GD32F4xx tip */
+
+/* define value of high speed crystal oscillator (HXTAL) in Hz */
+#if !defined  (HXTAL_VALUE)
+#define HXTAL_VALUE    ((uint32_t)25000000)
+#endif /* high speed crystal oscillator value */
+
+/* define startup timeout value of high speed crystal oscillator (HXTAL) */
+#if !defined  (HXTAL_STARTUP_TIMEOUT)
+#define HXTAL_STARTUP_TIMEOUT   ((uint16_t)0xFFFF)
+#endif /* high speed crystal oscillator startup timeout */
+
+/* define value of internal 16MHz RC oscillator (IRC16M) in Hz */
+#if !defined  (IRC16M_VALUE) 
+#define IRC16M_VALUE  ((uint32_t)16000000)
+#endif /* internal 16MHz RC oscillator value */
+
+/* define startup timeout value of internal 16MHz RC oscillator (IRC16M) */
+#if !defined  (IRC16M_STARTUP_TIMEOUT)
+#define IRC16M_STARTUP_TIMEOUT   ((uint16_t)0x0500)
+#endif /* internal 16MHz RC oscillator startup timeout */
+
+/* define value of internal 32KHz RC oscillator(IRC32K) in Hz */
+#if !defined  (IRC32K_VALUE) 
+#define IRC32K_VALUE  ((uint32_t)32000)
+#endif /* internal 32KHz RC oscillator value */
+
+/* define value of low speed crystal oscillator (LXTAL)in Hz */
+#if !defined  (LXTAL_VALUE) 
+#define LXTAL_VALUE  ((uint32_t)32768)
+#endif /* low speed crystal oscillator value */
+
+/* I2S external clock in selection */
+//#define I2S_EXTERNAL_CLOCK_IN          (uint32_t)12288000U
+
+/* GD32F4xx firmware library version number V1.0 */
+#define __GD32F4xx_STDPERIPH_VERSION_MAIN   (0x03) /*!< [31:24] main version     */
+#define __GD32F4xx_STDPERIPH_VERSION_SUB1   (0x00) /*!< [23:16] sub1 version     */
+#define __GD32F4xx_STDPERIPH_VERSION_SUB2   (0x00) /*!< [15:8]  sub2 version     */
+#define __GD32F4xx_STDPERIPH_VERSION_RC     (0x00) /*!< [7:0]  release candidate */ 
+#define __GD32F4xx_STDPERIPH_VERSION        ((__GD32F4xx_STDPERIPH_VERSION_MAIN << 24)\
+                                            |(__GD32F4xx_STDPERIPH_VERSION_SUB1 << 16)\
+                                            |(__GD32F4xx_STDPERIPH_VERSION_SUB2 << 8)\
+                                            |(__GD32F4xx_STDPERIPH_VERSION_RC))
+
+/* configuration of the cortex-M4 processor and core peripherals */
+#define __CM4_REV                 0x0001   /*!< core revision r0p1                                       */
+#define __MPU_PRESENT             1        /*!< GD32F4xx provide MPU                                     */
+#define __NVIC_PRIO_BITS          4        /*!< GD32F4xx uses 4 bits for the priority levels             */
+#define __Vendor_SysTickConfig    0        /*!< set to 1 if different sysTick config is used             */
+#define __FPU_PRESENT             1        /*!< FPU present                                              */
+/* define interrupt number */
+typedef enum IRQn
+{
+    /* cortex-M4 processor exceptions numbers */
+    NonMaskableInt_IRQn          = -14,    /*!< 2 non maskable interrupt                                 */
+    MemoryManagement_IRQn        = -12,    /*!< 4 cortex-M4 memory management interrupt                  */
+    BusFault_IRQn                = -11,    /*!< 5 cortex-M4 bus fault interrupt                          */
+    UsageFault_IRQn              = -10,    /*!< 6 cortex-M4 usage fault interrupt                        */
+    SVCall_IRQn                  = -5,     /*!< 11 cortex-M4 SV call interrupt                           */
+    DebugMonitor_IRQn            = -4,     /*!< 12 cortex-M4 debug monitor interrupt                     */
+    PendSV_IRQn                  = -2,     /*!< 14 cortex-M4 pend SV interrupt                           */
+    SysTick_IRQn                 = -1,     /*!< 15 cortex-M4 system tick interrupt                       */
+    /* interruput numbers */
+    WWDGT_IRQn                   = 0,      /*!< window watchdog timer interrupt                          */
+    LVD_IRQn                     = 1,      /*!< LVD through EXTI line detect interrupt                   */
+    TAMPER_STAMP_IRQn            = 2,      /*!< tamper and timestamp through EXTI line detect            */
+    RTC_WKUP_IRQn                = 3,      /*!< RTC wakeup through EXTI line interrupt                   */
+    FMC_IRQn                     = 4,      /*!< FMC interrupt                                            */
+    RCU_CTC_IRQn                 = 5,      /*!< RCU and CTC interrupt                                    */
+    EXTI0_IRQn                   = 6,      /*!< EXTI line 0 interrupts                                   */
+    EXTI1_IRQn                   = 7,      /*!< EXTI line 1 interrupts                                   */
+    EXTI2_IRQn                   = 8,      /*!< EXTI line 2 interrupts                                   */
+    EXTI3_IRQn                   = 9,      /*!< EXTI line 3 interrupts                                   */
+    EXTI4_IRQn                   = 10,     /*!< EXTI line 4 interrupts                                   */
+    DMA0_Channel0_IRQn           = 11,     /*!< DMA0 channel0 Interrupt                                  */
+    DMA0_Channel1_IRQn           = 12,     /*!< DMA0 channel1 Interrupt                                  */
+    DMA0_Channel2_IRQn           = 13,     /*!< DMA0 channel2 interrupt                                  */
+    DMA0_Channel3_IRQn           = 14,     /*!< DMA0 channel3 interrupt                                  */
+    DMA0_Channel4_IRQn           = 15,     /*!< DMA0 channel4 interrupt                                  */
+    DMA0_Channel5_IRQn           = 16,     /*!< DMA0 channel5 interrupt                                  */
+    DMA0_Channel6_IRQn           = 17,     /*!< DMA0 channel6 interrupt                                  */
+    ADC_IRQn                     = 18,     /*!< ADC interrupt                                            */
+    CAN0_TX_IRQn                 = 19,     /*!< CAN0 TX interrupt                                        */
+    CAN0_RX0_IRQn                = 20,     /*!< CAN0 RX0 interrupt                                       */
+    CAN0_RX1_IRQn                = 21,     /*!< CAN0 RX1 interrupt                                       */
+    CAN0_EWMC_IRQn               = 22,     /*!< CAN0 EWMC interrupt                                      */
+    EXTI5_9_IRQn                 = 23,     /*!< EXTI[9:5] interrupts                                     */
+    TIMER0_BRK_TIMER8_IRQn       = 24,     /*!< TIMER0 break and TIMER8 interrupts                       */
+    TIMER0_UP_TIMER9_IRQn        = 25,     /*!< TIMER0 update and TIMER9 interrupts                      */
+    TIMER0_TRG_CMT_TIMER10_IRQn  = 26,     /*!< TIMER0 trigger and commutation  and TIMER10 interrupts   */
+    TIMER0_Channel_IRQn          = 27,     /*!< TIMER0 channel capture compare interrupt                 */
+    TIMER1_IRQn                  = 28,     /*!< TIMER1 interrupt                                         */
+    TIMER2_IRQn                  = 29,     /*!< TIMER2 interrupt                                         */
+    TIMER3_IRQn                  = 30,     /*!< TIMER3 interrupts                                        */
+    I2C0_EV_IRQn                 = 31,     /*!< I2C0 event interrupt                                     */
+    I2C0_ER_IRQn                 = 32,     /*!< I2C0 error interrupt                                     */
+    I2C1_EV_IRQn                 = 33,     /*!< I2C1 event interrupt                                     */
+    I2C1_ER_IRQn                 = 34,     /*!< I2C1 error interrupt                                     */
+    SPI0_IRQn                    = 35,     /*!< SPI0 interrupt                                           */
+    SPI1_IRQn                    = 36,     /*!< SPI1 interrupt                                           */
+    USART0_IRQn                  = 37,     /*!< USART0 interrupt                                         */
+    USART1_IRQn                  = 38,     /*!< USART1 interrupt                                         */
+    USART2_IRQn                  = 39,     /*!< USART2 interrupt                                         */
+    EXTI10_15_IRQn               = 40,     /*!< EXTI[15:10] interrupts                                   */
+    RTC_Alarm_IRQn               = 41,     /*!< RTC alarm interrupt                                      */
+    USBFS_WKUP_IRQn              = 42,     /*!< USBFS wakeup interrupt                                   */
+    TIMER7_BRK_TIMER11_IRQn      = 43,     /*!< TIMER7 break and TIMER11 interrupts                      */
+    TIMER7_UP_TIMER12_IRQn       = 44,     /*!< TIMER7 update and TIMER12 interrupts                     */
+    TIMER7_TRG_CMT_TIMER13_IRQn  = 45,     /*!< TIMER7 trigger and commutation and TIMER13 interrupts    */
+    TIMER7_Channel_IRQn          = 46,     /*!< TIMER7 channel capture compare interrupt                 */
+    DMA0_Channel7_IRQn           = 47,     /*!< DMA0 channel7 interrupt                                  */
+    
+#if defined (GD32F450) || defined (GD32F470)
+    EXMC_IRQn                    = 48,     /*!< EXMC interrupt                                           */
+    SDIO_IRQn                    = 49,     /*!< SDIO interrupt                                           */
+    TIMER4_IRQn                  = 50,     /*!< TIMER4 interrupt                                         */
+    SPI2_IRQn                    = 51,     /*!< SPI2 interrupt                                           */
+    UART3_IRQn                   = 52,     /*!< UART3 interrupt                                          */
+    UART4_IRQn                   = 53,     /*!< UART4 interrupt                                          */
+    TIMER5_DAC_IRQn              = 54,     /*!< TIMER5 and DAC0 DAC1 underrun error interrupts           */
+    TIMER6_IRQn                  = 55,     /*!< TIMER6 interrupt                                         */
+    DMA1_Channel0_IRQn           = 56,     /*!< DMA1 channel0 interrupt                                  */
+    DMA1_Channel1_IRQn           = 57,     /*!< DMA1 channel1 interrupt                                  */
+    DMA1_Channel2_IRQn           = 58,     /*!< DMA1 channel2 interrupt                                  */
+    DMA1_Channel3_IRQn           = 59,     /*!< DMA1 channel3 interrupt                                  */
+    DMA1_Channel4_IRQn           = 60,     /*!< DMA1 channel4 interrupt                                  */
+    ENET_IRQn                    = 61,     /*!< ENET interrupt                                           */
+    ENET_WKUP_IRQn               = 62,     /*!< ENET wakeup through EXTI line interrupt                  */
+    CAN1_TX_IRQn                 = 63,     /*!< CAN1 TX interrupt                                        */
+    CAN1_RX0_IRQn                = 64,     /*!< CAN1 RX0 interrupt                                       */
+    CAN1_RX1_IRQn                = 65,     /*!< CAN1 RX1 interrupt                                       */
+    CAN1_EWMC_IRQn               = 66,     /*!< CAN1 EWMC interrupt                                      */
+    USBFS_IRQn                   = 67,     /*!< USBFS interrupt                                          */
+    DMA1_Channel5_IRQn           = 68,     /*!< DMA1 channel5 interrupt                                  */
+    DMA1_Channel6_IRQn           = 69,     /*!< DMA1 channel6 interrupt                                  */
+    DMA1_Channel7_IRQn           = 70,     /*!< DMA1 channel7 interrupt                                  */
+    USART5_IRQn                  = 71,     /*!< USART5 interrupt                                         */
+    I2C2_EV_IRQn                 = 72,     /*!< I2C2 event interrupt                                     */
+    I2C2_ER_IRQn                 = 73,     /*!< I2C2 error interrupt                                     */
+    USBHS_EP1_Out_IRQn           = 74,     /*!< USBHS endpoint 1 out interrupt                           */
+    USBHS_EP1_In_IRQn            = 75,     /*!< USBHS endpoint 1 in interrupt                            */
+    USBHS_WKUP_IRQn              = 76,     /*!< USBHS wakeup through EXTI line interrupt                 */
+    USBHS_IRQn                   = 77,     /*!< USBHS interrupt                                          */
+    DCI_IRQn                     = 78,     /*!< DCI interrupt                                            */
+    TRNG_IRQn                    = 80,     /*!< TRNG interrupt                                           */
+    FPU_IRQn                     = 81,     /*!< FPU interrupt                                            */
+    UART6_IRQn                   = 82,     /*!< UART6 interrupt                                          */
+    UART7_IRQn                   = 83,     /*!< UART7 interrupt                                          */
+    SPI3_IRQn                    = 84,     /*!< SPI3 interrupt                                           */
+    SPI4_IRQn                    = 85,     /*!< SPI4 interrupt                                           */
+    SPI5_IRQn                    = 86,     /*!< SPI5 interrupt                                           */
+    TLI_IRQn                     = 88,     /*!< TLI interrupt                                            */
+    TLI_ER_IRQn                  = 89,     /*!< TLI error interrupt                                      */
+    IPA_IRQn                     = 90,     /*!< IPA interrupt                                            */
+#endif /* GD32F450 and GD32F470 */
+
+#if defined (GD32F405) || defined (GD32F425)
+    SDIO_IRQn                    = 49,     /*!< SDIO interrupt                                           */
+    TIMER4_IRQn                  = 50,     /*!< TIMER4 interrupt                                         */
+    SPI2_IRQn                    = 51,     /*!< SPI2 interrupt                                           */
+    UART3_IRQn                   = 52,     /*!< UART3 interrupt                                          */
+    UART4_IRQn                   = 53,     /*!< UART4 interrupt                                          */
+    TIMER5_DAC_IRQn              = 54,     /*!< TIMER5 and DAC0 DAC1 underrun error interrupts           */
+    TIMER6_IRQn                  = 55,     /*!< TIMER6 interrupt                                         */
+    DMA1_Channel0_IRQn           = 56,     /*!< DMA1 channel0 interrupt                                  */
+    DMA1_Channel1_IRQn           = 57,     /*!< DMA1 channel1 interrupt                                  */
+    DMA1_Channel2_IRQn           = 58,     /*!< DMA1 channel2 interrupt                                  */
+    DMA1_Channel3_IRQn           = 59,     /*!< DMA1 channel3 interrupt                                  */
+    DMA1_Channel4_IRQn           = 60,     /*!< DMA1 channel4 interrupt                                  */
+    CAN1_TX_IRQn                 = 63,     /*!< CAN1 TX interrupt                                        */
+    CAN1_RX0_IRQn                = 64,     /*!< CAN1 RX0 interrupt                                       */
+    CAN1_RX1_IRQn                = 65,     /*!< CAN1 RX1 interrupt                                       */
+    CAN1_EWMC_IRQn               = 66,     /*!< CAN1 EWMC interrupt                                      */
+    USBFS_IRQn                   = 67,     /*!< USBFS interrupt                                          */
+    DMA1_Channel5_IRQn           = 68,     /*!< DMA1 channel5 interrupt                                  */
+    DMA1_Channel6_IRQn           = 69,     /*!< DMA1 channel6 interrupt                                  */
+    DMA1_Channel7_IRQn           = 70,     /*!< DMA1 channel7 interrupt                                  */
+    USART5_IRQn                  = 71,     /*!< USART5 interrupt                                         */
+    I2C2_EV_IRQn                 = 72,     /*!< I2C2 event interrupt                                     */
+    I2C2_ER_IRQn                 = 73,     /*!< I2C2 error interrupt                                     */
+    USBHS_EP1_Out_IRQn           = 74,     /*!< USBHS endpoint 1 Out interrupt                           */
+    USBHS_EP1_In_IRQn            = 75,     /*!< USBHS endpoint 1 in interrupt                            */
+    USBHS_WKUP_IRQn              = 76,     /*!< USBHS wakeup through EXTI line interrupt                 */
+    USBHS_IRQn                   = 77,     /*!< USBHS interrupt                                          */
+    DCI_IRQn                     = 78,     /*!< DCI interrupt                                            */
+    TRNG_IRQn                    = 80,     /*!< TRNG interrupt                                           */
+    FPU_IRQn                     = 81,     /*!< FPU interrupt                                            */
+#endif /* GD32F405 and GD32F425 */
+
+#if defined (GD32F407) || defined (GD32F427)
+    EXMC_IRQn                    = 48,     /*!< EXMC interrupt                                           */
+    SDIO_IRQn                    = 49,     /*!< SDIO interrupt                                           */
+    TIMER4_IRQn                  = 50,     /*!< TIMER4 interrupt                                         */
+    SPI2_IRQn                    = 51,     /*!< SPI2 interrupt                                           */
+    UART3_IRQn                   = 52,     /*!< UART3 interrupt                                          */
+    UART4_IRQn                   = 53,     /*!< UART4 interrupt                                          */
+    TIMER5_DAC_IRQn              = 54,     /*!< TIMER5 and DAC0 DAC1 underrun error interrupts           */
+    TIMER6_IRQn                  = 55,     /*!< TIMER6 interrupt                                         */
+    DMA1_Channel0_IRQn           = 56,     /*!< DMA1 channel0 interrupt                                  */
+    DMA1_Channel1_IRQn           = 57,     /*!< DMA1 channel1 interrupt                                  */
+    DMA1_Channel2_IRQn           = 58,     /*!< DMA1 channel2 interrupt                                  */
+    DMA1_Channel3_IRQn           = 59,     /*!< DMA1 channel3 interrupt                                  */
+    DMA1_Channel4_IRQn           = 60,     /*!< DMA1 channel4 interrupt                                  */
+    ENET_IRQn                    = 61,     /*!< ENET interrupt                                           */
+    ENET_WKUP_IRQn               = 62,     /*!< ENET wakeup through EXTI line interrupt                  */
+    CAN1_TX_IRQn                 = 63,     /*!< CAN1 TX interrupt                                        */
+    CAN1_RX0_IRQn                = 64,     /*!< CAN1 RX0 interrupt                                       */
+    CAN1_RX1_IRQn                = 65,     /*!< CAN1 RX1 interrupt                                       */
+    CAN1_EWMC_IRQn               = 66,     /*!< CAN1 EWMC interrupt                                      */
+    USBFS_IRQn                   = 67,     /*!< USBFS interrupt                                          */
+    DMA1_Channel5_IRQn           = 68,     /*!< DMA1 channel5 interrupt                                  */
+    DMA1_Channel6_IRQn           = 69,     /*!< DMA1 channel6 interrupt                                  */
+    DMA1_Channel7_IRQn           = 70,     /*!< DMA1 channel7 interrupt                                  */
+    USART5_IRQn                  = 71,     /*!< USART5 interrupt                                         */
+    I2C2_EV_IRQn                 = 72,     /*!< I2C2 event interrupt                                     */
+    I2C2_ER_IRQn                 = 73,     /*!< I2C2 error interrupt                                     */
+    USBHS_EP1_Out_IRQn           = 74,     /*!< USBHS endpoint 1 out interrupt                           */
+    USBHS_EP1_In_IRQn            = 75,     /*!< USBHS endpoint 1 in interrupt                            */
+    USBHS_WKUP_IRQn              = 76,     /*!< USBHS wakeup through EXTI line interrupt                 */
+    USBHS_IRQn                   = 77,     /*!< USBHS interrupt                                          */
+    DCI_IRQn                     = 78,     /*!< DCI interrupt                                            */
+    TRNG_IRQn                    = 80,     /*!< TRNG interrupt                                           */
+    FPU_IRQn                     = 81,     /*!< FPU interrupt                                            */
+#endif /* GD32F407 and GD32F427 */
+
+} IRQn_Type;
+
+/* includes */
+#include "core_cm4.h"
+#include "system_gd32f4xx.h"
+#include <stdint.h>
+
+/* enum definitions */
+typedef enum {DISABLE = 0, ENABLE = !DISABLE} EventStatus, ControlStatus;
+typedef enum {RESET = 0, SET = !RESET} FlagStatus;
+typedef enum {ERROR = 0, SUCCESS = !ERROR} ErrStatus;
+
+/* bit operations */
+#define REG32(addr)                  (*(volatile uint32_t *)(uint32_t)(addr))
+#define REG16(addr)                  (*(volatile uint16_t *)(uint32_t)(addr))
+#define REG8(addr)                   (*(volatile uint8_t *)(uint32_t)(addr))
+#define BIT(x)                       ((uint32_t)((uint32_t)0x01U<<(x)))
+#define BITS(start, end)             ((0xFFFFFFFFUL << (start)) & (0xFFFFFFFFUL >> (31U - (uint32_t)(end)))) 
+#define GET_BITS(regval, start, end) (((regval) & BITS((start),(end))) >> (start))
+
+/* main flash and SRAM memory map */
+#define FLASH_BASE            ((uint32_t)0x08000000U)        /*!< main FLASH base address          */
+#define TCMSRAM_BASE          ((uint32_t)0x10000000U)        /*!< TCMSRAM(64KB) base address       */
+#define OPTION_BASE           ((uint32_t)0x1FFEC000U)        /*!< Option bytes base address        */
+#define SRAM_BASE             ((uint32_t)0x20000000U)        /*!< SRAM0 base address               */
+
+/* peripheral memory map */
+#define APB1_BUS_BASE         ((uint32_t)0x40000000U)        /*!< apb1 base address                */
+#define APB2_BUS_BASE         ((uint32_t)0x40010000U)        /*!< apb2 base address                */
+#define AHB1_BUS_BASE         ((uint32_t)0x40020000U)        /*!< ahb1 base address                */
+#define AHB2_BUS_BASE         ((uint32_t)0x50000000U)        /*!< ahb2 base address                */
+
+/* EXMC memory map */
+#define EXMC_BASE             ((uint32_t)0xA0000000U)        /*!< EXMC register base address       */
+
+/* advanced peripheral bus 1 memory map */
+#define TIMER_BASE            (APB1_BUS_BASE + 0x00000000U)  /*!< TIMER base address               */
+#define RTC_BASE              (APB1_BUS_BASE + 0x00002800U)  /*!< RTC base address                 */
+#define WWDGT_BASE            (APB1_BUS_BASE + 0x00002C00U)  /*!< WWDGT base address               */
+#define FWDGT_BASE            (APB1_BUS_BASE + 0x00003000U)  /*!< FWDGT base address               */
+#define I2S_ADD_BASE          (APB1_BUS_BASE + 0x00003400U)  /*!< I2S1_add base address            */
+#define SPI_BASE              (APB1_BUS_BASE + 0x00003800U)  /*!< SPI base address                 */
+#define USART_BASE            (APB1_BUS_BASE + 0x00004400U)  /*!< USART base address               */
+#define I2C_BASE              (APB1_BUS_BASE + 0x00005400U)  /*!< I2C base address                 */
+#define CAN_BASE              (APB1_BUS_BASE + 0x00006400U)  /*!< CAN base address                 */
+#define CTC_BASE              (APB1_BUS_BASE + 0x00006C00U)  /*!< CTC base address                 */
+#define PMU_BASE              (APB1_BUS_BASE + 0x00007000U)  /*!< PMU base address                 */
+#define DAC_BASE              (APB1_BUS_BASE + 0x00007400U)  /*!< DAC base address                 */
+#define IREF_BASE             (APB1_BUS_BASE + 0x0000C400U)  /*!< IREF base address                */
+
+/* advanced peripheral bus 2 memory map */
+#define TLI_BASE              (APB2_BUS_BASE + 0x00006800U)  /*!< TLI base address                 */
+#define SYSCFG_BASE           (APB2_BUS_BASE + 0x00003800U)  /*!< SYSCFG base address              */
+#define EXTI_BASE             (APB2_BUS_BASE + 0x00003C00U)  /*!< EXTI base address                */
+#define SDIO_BASE             (APB2_BUS_BASE + 0x00002C00U)  /*!< SDIO base address                */
+#define ADC_BASE              (APB2_BUS_BASE + 0x00002000U)  /*!< ADC base address                 */
+/* advanced high performance bus 1 memory map */
+#define GPIO_BASE             (AHB1_BUS_BASE + 0x00000000U)  /*!< GPIO base address                */
+#define CRC_BASE              (AHB1_BUS_BASE + 0x00003000U)  /*!< CRC base address                 */
+#define RCU_BASE              (AHB1_BUS_BASE + 0x00003800U)  /*!< RCU base address                 */
+#define FMC_BASE              (AHB1_BUS_BASE + 0x00003C00U)  /*!< FMC base address                 */
+#define BKPSRAM_BASE          (AHB1_BUS_BASE + 0x00004000U)  /*!< BKPSRAM base address             */
+#define DMA_BASE              (AHB1_BUS_BASE + 0x00006000U)  /*!< DMA base address                 */
+#define ENET_BASE             (AHB1_BUS_BASE + 0x00008000U)  /*!< ENET base address                */
+#define IPA_BASE              (AHB1_BUS_BASE + 0x0000B000U)  /*!< IPA base address                 */
+#define USBHS_BASE            (AHB1_BUS_BASE + 0x00020000U)  /*!< USBHS base address               */
+
+/* advanced high performance bus 2 memory map */
+#define USBFS_BASE            (AHB2_BUS_BASE + 0x00000000U)  /*!< USBFS base address               */
+#define DCI_BASE              (AHB2_BUS_BASE + 0x00050000U)  /*!< DCI base address                 */
+#define TRNG_BASE             (AHB2_BUS_BASE + 0x00060800U)  /*!< TRNG base address                */
+/* option byte and debug memory map */
+#define OB_BASE               ((uint32_t)0x1FFEC000U)        /*!< OB base address                  */
+#define DBG_BASE              ((uint32_t)0xE0042000U)        /*!< DBG base address                 */
+
+/* define marco USE_STDPERIPH_DRIVER */
+#if !defined  USE_STDPERIPH_DRIVER
+#define USE_STDPERIPH_DRIVER
+#endif 
+#ifdef USE_STDPERIPH_DRIVER
+#include "gd32f4xx_libopt.h"
+#endif /* USE_STDPERIPH_DRIVER */
+
+#ifdef __cplusplus
+}
+#endif
+#endif 

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Include/system_gd32f4xx.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Include/system_gd32f4xx.h
@@ -1,0 +1,58 @@
+/*!
+    \file  system_gd32f4xx.h
+    \brief CMSIS Cortex-M4 Device Peripheral Access Layer Header File for
+           GD32F4xx Device Series
+*/
+
+/* Copyright (c) 2012 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+/* This file refers the CMSIS standard, some adjustments are made according to GigaDevice chips */
+
+#ifndef SYSTEM_GD32F4XX_H
+#define SYSTEM_GD32F4XX_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/* system clock frequency (core clock) */
+extern uint32_t SystemCoreClock;
+
+/* function declarations */
+/* initialize the system and update the SystemCoreClock variable */
+extern void SystemInit (void);
+/* update the SystemCoreClock with current core clock retrieved from cpu registers */
+extern void SystemCoreClockUpdate (void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SYSTEM_GD32F4XX_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/ARM/startup_gd32f405_425.s
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/ARM/startup_gd32f405_425.s
@@ -1,0 +1,423 @@
+;/*!
+;    \file    startup_gd32f405_425.s
+;    \brief   start up file
+;
+;    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+;    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+;    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+;    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+;*/
+;
+;/*
+;    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+;
+;    Redistribution and use in source and binary forms, with or without modification, 
+;are permitted provided that the following conditions are met:
+;
+;    1. Redistributions of source code must retain the above copyright notice, this 
+;       list of conditions and the following disclaimer.
+;    2. Redistributions in binary form must reproduce the above copyright notice, 
+;       this list of conditions and the following disclaimer in the documentation 
+;       and/or other materials provided with the distribution.
+;    3. Neither the name of the copyright holder nor the names of its contributors 
+;       may be used to endorse or promote products derived from this software without 
+;       specific prior written permission.
+;
+;    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+;AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+;WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+;IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+;INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+;NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+;PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+;WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+;ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+;OF SUCH DAMAGE.
+;*/
+
+; <h> Stack Configuration
+;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Stack_Size      EQU     0x00000400
+
+                AREA    STACK, NOINIT, READWRITE, ALIGN=3
+Stack_Mem       SPACE   Stack_Size
+__initial_sp
+
+
+; <h> Heap Configuration
+;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Heap_Size       EQU     0x00000400
+
+                AREA    HEAP, NOINIT, READWRITE, ALIGN=3
+__heap_base
+Heap_Mem        SPACE   Heap_Size
+__heap_limit
+
+                PRESERVE8
+                THUMB
+
+;               /* reset Vector Mapped to at Address 0 */
+                AREA    RESET, DATA, READONLY
+                EXPORT  __Vectors
+                EXPORT  __Vectors_End
+                EXPORT  __Vectors_Size
+
+__Vectors       DCD     __initial_sp                      ; Top of Stack
+                DCD     Reset_Handler                     ; Reset Handler
+                DCD     NMI_Handler                       ; NMI Handler
+                DCD     HardFault_Handler                 ; Hard Fault Handler
+                DCD     MemManage_Handler                 ; MPU Fault Handler
+                DCD     BusFault_Handler                  ; Bus Fault Handler
+                DCD     UsageFault_Handler                ; Usage Fault Handler
+                DCD     0                                 ; Reserved
+                DCD     0                                 ; Reserved
+                DCD     0                                 ; Reserved
+                DCD     0                                 ; Reserved
+                DCD     SVC_Handler                       ; SVCall Handler
+                DCD     DebugMon_Handler                  ; Debug Monitor Handler
+                DCD     0                                 ; Reserved
+                DCD     PendSV_Handler                    ; PendSV Handler
+                DCD     SysTick_Handler                   ; SysTick Handler
+
+;               /* external interrupts handler */
+                DCD     WWDGT_IRQHandler                  ; 16:Window Watchdog Timer
+                DCD     LVD_IRQHandler                    ; 17:LVD through EXTI Line detect
+                DCD     TAMPER_STAMP_IRQHandler           ; 18:Tamper and TimeStamp through EXTI Line detect
+                DCD     RTC_WKUP_IRQHandler               ; 19:RTC Wakeup through EXTI Line
+                DCD     FMC_IRQHandler                    ; 20:FMC
+                DCD     RCU_CTC_IRQHandler                ; 21:RCU and CTC
+                DCD     EXTI0_IRQHandler                  ; 22:EXTI Line 0
+                DCD     EXTI1_IRQHandler                  ; 23:EXTI Line 1
+                DCD     EXTI2_IRQHandler                  ; 24:EXTI Line 2
+                DCD     EXTI3_IRQHandler                  ; 25:EXTI Line 3
+                DCD     EXTI4_IRQHandler                  ; 26:EXTI Line 4
+                DCD     DMA0_Channel0_IRQHandler          ; 27:DMA0 Channel0
+                DCD     DMA0_Channel1_IRQHandler          ; 28:DMA0 Channel1
+                DCD     DMA0_Channel2_IRQHandler          ; 29:DMA0 Channel2
+                DCD     DMA0_Channel3_IRQHandler          ; 30:DMA0 Channel3
+                DCD     DMA0_Channel4_IRQHandler          ; 31:DMA0 Channel4
+                DCD     DMA0_Channel5_IRQHandler          ; 32:DMA0 Channel5
+                DCD     DMA0_Channel6_IRQHandler          ; 33:DMA0 Channel6
+                DCD     ADC_IRQHandler                    ; 34:ADC
+                DCD     CAN0_TX_IRQHandler                ; 35:CAN0 TX
+                DCD     CAN0_RX0_IRQHandler               ; 36:CAN0 RX0
+                DCD     CAN0_RX1_IRQHandler               ; 37:CAN0 RX1
+                DCD     CAN0_EWMC_IRQHandler              ; 38:CAN0 EWMC
+                DCD     EXTI5_9_IRQHandler                ; 39:EXTI5 to EXTI9
+                DCD     TIMER0_BRK_TIMER8_IRQHandler      ; 40:TIMER0 Break and TIMER8
+                DCD     TIMER0_UP_TIMER9_IRQHandler       ; 41:TIMER0 Update and TIMER9
+                DCD     TIMER0_TRG_CMT_TIMER10_IRQHandler ; 42:TIMER0 Trigger and Commutation and TIMER10
+                DCD     TIMER0_Channel_IRQHandler         ; 43:TIMER0 Channel Capture Compare
+                DCD     TIMER1_IRQHandler                 ; 44:TIMER1
+                DCD     TIMER2_IRQHandler                 ; 45:TIMER2
+                DCD     TIMER3_IRQHandler                 ; 46:TIMER3
+                DCD     I2C0_EV_IRQHandler                ; 47:I2C0 Event
+                DCD     I2C0_ER_IRQHandler                ; 48:I2C0 Error
+                DCD     I2C1_EV_IRQHandler                ; 49:I2C1 Event
+                DCD     I2C1_ER_IRQHandler                ; 50:I2C1 Error
+                DCD     SPI0_IRQHandler                   ; 51:SPI0
+                DCD     SPI1_IRQHandler                   ; 52:SPI1
+                DCD     USART0_IRQHandler                 ; 53:USART0
+                DCD     USART1_IRQHandler                 ; 54:USART1
+                DCD     USART2_IRQHandler                 ; 55:USART2
+                DCD     EXTI10_15_IRQHandler              ; 56:EXTI10 to EXTI15
+                DCD     RTC_Alarm_IRQHandler              ; 57:RTC Alarm
+                DCD     USBFS_WKUP_IRQHandler             ; 58:USBFS Wakeup
+                DCD     TIMER7_BRK_TIMER11_IRQHandler     ; 59:TIMER7 Break and TIMER11
+                DCD     TIMER7_UP_TIMER12_IRQHandler      ; 60:TIMER7 Update and TIMER12
+                DCD     TIMER7_TRG_CMT_TIMER13_IRQHandler ; 61:TIMER7 Trigger and Commutation and TIMER13
+                DCD     TIMER7_Channel_IRQHandler         ; 62:TIMER7 Channel Capture Compare
+                DCD     DMA0_Channel7_IRQHandler          ; 63:DMA0 Channel7
+                DCD     0                                 ; 64:Reserved
+                DCD     SDIO_IRQHandler                   ; 65:SDIO
+                DCD     TIMER4_IRQHandler                 ; 66:TIMER4
+                DCD     SPI2_IRQHandler                   ; 67:SPI2
+                DCD     UART3_IRQHandler                  ; 68:UART3
+                DCD     UART4_IRQHandler                  ; 69:UART4
+                DCD     TIMER5_DAC_IRQHandler             ; 70:TIMER5 and DAC0 DAC1 Underrun error
+                DCD     TIMER6_IRQHandler                 ; 71:TIMER6
+                DCD     DMA1_Channel0_IRQHandler          ; 72:DMA1 Channel0
+                DCD     DMA1_Channel1_IRQHandler          ; 73:DMA1 Channel1
+                DCD     DMA1_Channel2_IRQHandler          ; 74:DMA1 Channel2
+                DCD     DMA1_Channel3_IRQHandler          ; 75:DMA1 Channel3
+                DCD     DMA1_Channel4_IRQHandler          ; 76:DMA1 Channel4
+                DCD     0                                 ; 77:Reserved
+                DCD     0                                 ; 78:Reserved
+                DCD     CAN1_TX_IRQHandler                ; 79:CAN1 TX
+                DCD     CAN1_RX0_IRQHandler               ; 80:CAN1 RX0
+                DCD     CAN1_RX1_IRQHandler               ; 81:CAN1 RX1
+                DCD     CAN1_EWMC_IRQHandler              ; 82:CAN1 EWMC
+                DCD     USBFS_IRQHandler                  ; 83:USBFS
+                DCD     DMA1_Channel5_IRQHandler          ; 84:DMA1 Channel5
+                DCD     DMA1_Channel6_IRQHandler          ; 85:DMA1 Channel6
+                DCD     DMA1_Channel7_IRQHandler          ; 86:DMA1 Channel7
+                DCD     USART5_IRQHandler                 ; 87:USART5
+                DCD     I2C2_EV_IRQHandler                ; 88:I2C2 Event
+                DCD     I2C2_ER_IRQHandler                ; 89:I2C2 Error
+                DCD     USBHS_EP1_Out_IRQHandler          ; 90:USBHS Endpoint 1 Out 
+                DCD     USBHS_EP1_In_IRQHandler           ; 91:USBHS Endpoint 1 in
+                DCD     USBHS_WKUP_IRQHandler             ; 92:USBHS Wakeup through EXTI Line
+                DCD     USBHS_IRQHandler                  ; 93:USBHS
+                DCD     DCI_IRQHandler                    ; 94:DCI
+                DCD     0                                 ; 95:Reserved
+                DCD     TRNG_IRQHandler                   ; 96:TRNG
+                DCD     FPU_IRQHandler                    ; 97:FPU
+
+__Vectors_End
+
+__Vectors_Size  EQU     __Vectors_End - __Vectors
+
+                AREA    |.text|, CODE, READONLY
+
+;/* reset Handler */
+Reset_Handler   PROC
+                EXPORT  Reset_Handler                     [WEAK]
+                IMPORT  SystemInit
+                IMPORT  __main
+                LDR     R0, =SystemInit
+                BLX     R0
+                LDR     R0, =__main
+                BX      R0
+                ENDP
+
+;/* dummy Exception Handlers */
+NMI_Handler     PROC
+                EXPORT  NMI_Handler                       [WEAK]
+                B       .
+                ENDP
+HardFault_Handler\
+                PROC
+                EXPORT  HardFault_Handler                 [WEAK]
+                B       .
+                ENDP
+MemManage_Handler\
+                PROC
+                EXPORT  MemManage_Handler                 [WEAK]
+                B       .
+                ENDP
+BusFault_Handler\
+                PROC
+                EXPORT  BusFault_Handler                  [WEAK]
+                B       .
+                ENDP
+UsageFault_Handler\
+                PROC
+                EXPORT  UsageFault_Handler                [WEAK]
+                B       .
+                ENDP
+SVC_Handler     PROC
+                EXPORT  SVC_Handler                       [WEAK]
+                B       .
+                ENDP
+DebugMon_Handler\
+                PROC
+                EXPORT  DebugMon_Handler                  [WEAK]
+                B       .
+                ENDP
+PendSV_Handler\
+                PROC
+                EXPORT  PendSV_Handler                    [WEAK]
+                B       .
+                ENDP
+SysTick_Handler\
+                PROC
+                EXPORT  SysTick_Handler                   [WEAK]
+                B       .
+                ENDP
+
+Default_Handler PROC
+;               /* external interrupts handler */
+                EXPORT  WWDGT_IRQHandler                  [WEAK]
+                EXPORT  LVD_IRQHandler                    [WEAK]                  
+                EXPORT  TAMPER_STAMP_IRQHandler           [WEAK]           
+                EXPORT  RTC_WKUP_IRQHandler               [WEAK]               
+                EXPORT  FMC_IRQHandler                    [WEAK]                
+                EXPORT  RCU_CTC_IRQHandler                [WEAK]                 
+                EXPORT  EXTI0_IRQHandler                  [WEAK]                  
+                EXPORT  EXTI1_IRQHandler                  [WEAK]                 
+                EXPORT  EXTI2_IRQHandler                  [WEAK]               
+                EXPORT  EXTI3_IRQHandler                  [WEAK]                
+                EXPORT  EXTI4_IRQHandler                  [WEAK]                 
+                EXPORT  DMA0_Channel0_IRQHandler          [WEAK]         
+                EXPORT  DMA0_Channel1_IRQHandler          [WEAK]          
+                EXPORT  DMA0_Channel2_IRQHandler          [WEAK]        
+                EXPORT  DMA0_Channel3_IRQHandler          [WEAK]         
+                EXPORT  DMA0_Channel4_IRQHandler          [WEAK]          
+                EXPORT  DMA0_Channel5_IRQHandler          [WEAK]          
+                EXPORT  DMA0_Channel6_IRQHandler          [WEAK]          
+                EXPORT  ADC_IRQHandler                    [WEAK]         
+                EXPORT  CAN0_TX_IRQHandler                [WEAK]          
+                EXPORT  CAN0_RX0_IRQHandler               [WEAK]          
+                EXPORT  CAN0_RX1_IRQHandler               [WEAK]           
+                EXPORT  CAN0_EWMC_IRQHandler              [WEAK]           
+                EXPORT  EXTI5_9_IRQHandler                [WEAK]           
+                EXPORT  TIMER0_BRK_TIMER8_IRQHandler      [WEAK]  
+                EXPORT  TIMER0_UP_TIMER9_IRQHandler       [WEAK]  
+                EXPORT  TIMER0_TRG_CMT_TIMER10_IRQHandler [WEAK]
+                EXPORT  TIMER0_Channel_IRQHandler         [WEAK]        
+                EXPORT  TIMER1_IRQHandler                 [WEAK]       
+                EXPORT  TIMER2_IRQHandler                 [WEAK]           
+                EXPORT  TIMER3_IRQHandler                 [WEAK]           
+                EXPORT  I2C0_EV_IRQHandler                [WEAK]          
+                EXPORT  I2C0_ER_IRQHandler                [WEAK]         
+                EXPORT  I2C1_EV_IRQHandler                [WEAK]         
+                EXPORT  I2C1_ER_IRQHandler                [WEAK]         
+                EXPORT  SPI0_IRQHandler                   [WEAK]        
+                EXPORT  SPI1_IRQHandler                   [WEAK]          
+                EXPORT  USART0_IRQHandler                 [WEAK]         
+                EXPORT  USART1_IRQHandler                 [WEAK]         
+                EXPORT  USART2_IRQHandler                 [WEAK]        
+                EXPORT  EXTI10_15_IRQHandler              [WEAK]        
+                EXPORT  RTC_Alarm_IRQHandler              [WEAK]        
+                EXPORT  USBFS_WKUP_IRQHandler             [WEAK]        
+                EXPORT  TIMER7_BRK_TIMER11_IRQHandler     [WEAK] 
+                EXPORT  TIMER7_UP_TIMER12_IRQHandler      [WEAK] 
+                EXPORT  TIMER7_TRG_CMT_TIMER13_IRQHandler [WEAK]
+                EXPORT  TIMER7_Channel_IRQHandler         [WEAK]        
+                EXPORT  DMA0_Channel7_IRQHandler          [WEAK]       
+                EXPORT  SDIO_IRQHandler                   [WEAK]           
+                EXPORT  TIMER4_IRQHandler                 [WEAK]           
+                EXPORT  SPI2_IRQHandler                   [WEAK]          
+                EXPORT  UART3_IRQHandler                  [WEAK]          
+                EXPORT  UART4_IRQHandler                  [WEAK]          
+                EXPORT  TIMER5_DAC_IRQHandler             [WEAK]         
+                EXPORT  TIMER6_IRQHandler                 [WEAK]        
+                EXPORT  DMA1_Channel0_IRQHandler          [WEAK]          
+                EXPORT  DMA1_Channel1_IRQHandler          [WEAK]          
+                EXPORT  DMA1_Channel2_IRQHandler          [WEAK]         
+                EXPORT  DMA1_Channel3_IRQHandler          [WEAK]         
+                EXPORT  DMA1_Channel4_IRQHandler          [WEAK]          
+                EXPORT  CAN1_TX_IRQHandler                [WEAK]          
+                EXPORT  CAN1_RX0_IRQHandler               [WEAK]         
+                EXPORT  CAN1_RX1_IRQHandler               [WEAK]          
+                EXPORT  CAN1_EWMC_IRQHandler              [WEAK]          
+                EXPORT  USBFS_IRQHandler                  [WEAK]          
+                EXPORT  DMA1_Channel5_IRQHandler          [WEAK]          
+                EXPORT  DMA1_Channel6_IRQHandler          [WEAK]          
+                EXPORT  DMA1_Channel7_IRQHandler          [WEAK]          
+                EXPORT  USART5_IRQHandler                 [WEAK]          
+                EXPORT  I2C2_EV_IRQHandler                [WEAK]         
+                EXPORT  I2C2_ER_IRQHandler                [WEAK]          
+                EXPORT  USBHS_EP1_Out_IRQHandler          [WEAK]    
+                EXPORT  USBHS_EP1_In_IRQHandler           [WEAK]    
+                EXPORT  USBHS_WKUP_IRQHandler             [WEAK]             
+                EXPORT  USBHS_IRQHandler                  [WEAK]            
+                EXPORT  DCI_IRQHandler                    [WEAK]                      
+                EXPORT  TRNG_IRQHandler                   [WEAK]          
+                EXPORT  FPU_IRQHandler                    [WEAK]          
+
+;/* external interrupts handler */
+WWDGT_IRQHandler                  
+LVD_IRQHandler                    
+TAMPER_STAMP_IRQHandler           
+RTC_WKUP_IRQHandler               
+FMC_IRQHandler                   
+RCU_CTC_IRQHandler                   
+EXTI0_IRQHandler                  
+EXTI1_IRQHandler                 
+EXTI2_IRQHandler                
+EXTI3_IRQHandler                 
+EXTI4_IRQHandler                  
+DMA0_Channel0_IRQHandler         
+DMA0_Channel1_IRQHandler          
+DMA0_Channel2_IRQHandler        
+DMA0_Channel3_IRQHandler         
+DMA0_Channel4_IRQHandler          
+DMA0_Channel5_IRQHandler          
+DMA0_Channel6_IRQHandler          
+ADC_IRQHandler                   
+CAN0_TX_IRQHandler                
+CAN0_RX0_IRQHandler               
+CAN0_RX1_IRQHandler               
+CAN0_EWMC_IRQHandler               
+EXTI5_9_IRQHandler                
+TIMER0_BRK_TIMER8_IRQHandler    
+TIMER0_UP_TIMER9_IRQHandler   
+TIMER0_TRG_CMT_TIMER10_IRQHandler 
+TIMER0_Channel_IRQHandler        
+TIMER1_IRQHandler             
+TIMER2_IRQHandler                 
+TIMER3_IRQHandler                 
+I2C0_EV_IRQHandler                
+I2C0_ER_IRQHandler               
+I2C1_EV_IRQHandler               
+I2C1_ER_IRQHandler               
+SPI0_IRQHandler                  
+SPI1_IRQHandler                   
+USART0_IRQHandler                 
+USART1_IRQHandler                 
+USART2_IRQHandler                
+EXTI10_15_IRQHandler              
+RTC_Alarm_IRQHandler             
+USBFS_WKUP_IRQHandler             
+TIMER7_BRK_TIMER11_IRQHandler   
+TIMER7_UP_TIMER12_IRQHandler  
+TIMER7_TRG_CMT_TIMER13_IRQHandler 
+TIMER7_Channel_IRQHandler         
+DMA0_Channel7_IRQHandler         
+SDIO_IRQHandler                   
+TIMER4_IRQHandler                 
+SPI2_IRQHandler                  
+UART3_IRQHandler                  
+UART4_IRQHandler                  
+TIMER5_DAC_IRQHandler             
+TIMER6_IRQHandler                
+DMA1_Channel0_IRQHandler          
+DMA1_Channel1_IRQHandler         
+DMA1_Channel2_IRQHandler         
+DMA1_Channel3_IRQHandler         
+DMA1_Channel4_IRQHandler          
+CAN1_TX_IRQHandler                
+CAN1_RX0_IRQHandler              
+CAN1_RX1_IRQHandler               
+CAN1_EWMC_IRQHandler               
+USBFS_IRQHandler                  
+DMA1_Channel5_IRQHandler          
+DMA1_Channel6_IRQHandler          
+DMA1_Channel7_IRQHandler          
+USART5_IRQHandler                 
+I2C2_EV_IRQHandler               
+I2C2_ER_IRQHandler                
+USBHS_EP1_Out_IRQHandler    
+USBHS_EP1_In_IRQHandler     
+USBHS_WKUP_IRQHandler             
+USBHS_IRQHandler                  
+DCI_IRQHandler                                    
+TRNG_IRQHandler                  
+FPU_IRQHandler                    
+
+                B       .
+                ENDP
+
+                ALIGN
+
+; user Initial Stack & Heap
+
+                IF      :DEF:__MICROLIB
+
+                EXPORT  __initial_sp
+                EXPORT  __heap_base
+                EXPORT  __heap_limit
+
+                ELSE
+
+                IMPORT  __use_two_region_memory
+                EXPORT  __user_initial_stackheap
+
+__user_initial_stackheap PROC
+                LDR     R0, =  Heap_Mem
+                LDR     R1, =(Stack_Mem + Stack_Size)
+                LDR     R2, = (Heap_Mem +  Heap_Size)
+                LDR     R3, = Stack_Mem
+                BX      LR
+                ENDP
+
+                ALIGN
+
+                ENDIF
+
+                END

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/ARM/startup_gd32f407_427.s
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/ARM/startup_gd32f407_427.s
@@ -1,0 +1,429 @@
+;/*!
+;    \file    startup_gd32f407_427.s
+;    \brief   start up file
+;
+;    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+;    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+;    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+;    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+;*/
+;
+;/*
+;    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+;
+;    Redistribution and use in source and binary forms, with or without modification, 
+;are permitted provided that the following conditions are met:
+;
+;    1. Redistributions of source code must retain the above copyright notice, this 
+;       list of conditions and the following disclaimer.
+;    2. Redistributions in binary form must reproduce the above copyright notice, 
+;       this list of conditions and the following disclaimer in the documentation 
+;       and/or other materials provided with the distribution.
+;    3. Neither the name of the copyright holder nor the names of its contributors 
+;       may be used to endorse or promote products derived from this software without 
+;       specific prior written permission.
+;
+;    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+;AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+;WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+;IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+;INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+;NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+;PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+;WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+;ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+;OF SUCH DAMAGE.
+;*/
+
+; <h> Stack Configuration
+;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Stack_Size      EQU     0x00000400
+
+                AREA    STACK, NOINIT, READWRITE, ALIGN=3
+Stack_Mem       SPACE   Stack_Size
+__initial_sp
+
+
+; <h> Heap Configuration
+;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Heap_Size       EQU     0x00000400
+
+                AREA    HEAP, NOINIT, READWRITE, ALIGN=3
+__heap_base
+Heap_Mem        SPACE   Heap_Size
+__heap_limit
+
+                PRESERVE8
+                THUMB
+
+;               /* reset Vector Mapped to at Address 0 */
+                AREA    RESET, DATA, READONLY
+                EXPORT  __Vectors
+                EXPORT  __Vectors_End
+                EXPORT  __Vectors_Size
+
+__Vectors       DCD     __initial_sp                      ; Top of Stack
+                DCD     Reset_Handler                     ; Reset Handler
+                DCD     NMI_Handler                       ; NMI Handler
+                DCD     HardFault_Handler                 ; Hard Fault Handler
+                DCD     MemManage_Handler                 ; MPU Fault Handler
+                DCD     BusFault_Handler                  ; Bus Fault Handler
+                DCD     UsageFault_Handler                ; Usage Fault Handler
+                DCD     0                                 ; Reserved
+                DCD     0                                 ; Reserved
+                DCD     0                                 ; Reserved
+                DCD     0                                 ; Reserved
+                DCD     SVC_Handler                       ; SVCall Handler
+                DCD     DebugMon_Handler                  ; Debug Monitor Handler
+                DCD     0                                 ; Reserved
+                DCD     PendSV_Handler                    ; PendSV Handler
+                DCD     SysTick_Handler                   ; SysTick Handler
+
+;               /* external interrupts handler */
+                DCD     WWDGT_IRQHandler                  ; 16:Window Watchdog Timer
+                DCD     LVD_IRQHandler                    ; 17:LVD through EXTI Line detect
+                DCD     TAMPER_STAMP_IRQHandler           ; 18:Tamper and TimeStamp through EXTI Line detect
+                DCD     RTC_WKUP_IRQHandler               ; 19:RTC Wakeup through EXTI Line
+                DCD     FMC_IRQHandler                    ; 20:FMC
+                DCD     RCU_CTC_IRQHandler                ; 21:RCU and CTC
+                DCD     EXTI0_IRQHandler                  ; 22:EXTI Line 0
+                DCD     EXTI1_IRQHandler                  ; 23:EXTI Line 1
+                DCD     EXTI2_IRQHandler                  ; 24:EXTI Line 2
+                DCD     EXTI3_IRQHandler                  ; 25:EXTI Line 3
+                DCD     EXTI4_IRQHandler                  ; 26:EXTI Line 4
+                DCD     DMA0_Channel0_IRQHandler          ; 27:DMA0 Channel0
+                DCD     DMA0_Channel1_IRQHandler          ; 28:DMA0 Channel1
+                DCD     DMA0_Channel2_IRQHandler          ; 29:DMA0 Channel2
+                DCD     DMA0_Channel3_IRQHandler          ; 30:DMA0 Channel3
+                DCD     DMA0_Channel4_IRQHandler          ; 31:DMA0 Channel4
+                DCD     DMA0_Channel5_IRQHandler          ; 32:DMA0 Channel5
+                DCD     DMA0_Channel6_IRQHandler          ; 33:DMA0 Channel6
+                DCD     ADC_IRQHandler                    ; 34:ADC
+                DCD     CAN0_TX_IRQHandler                ; 35:CAN0 TX
+                DCD     CAN0_RX0_IRQHandler               ; 36:CAN0 RX0
+                DCD     CAN0_RX1_IRQHandler               ; 37:CAN0 RX1
+                DCD     CAN0_EWMC_IRQHandler              ; 38:CAN0 EWMC
+                DCD     EXTI5_9_IRQHandler                ; 39:EXTI5 to EXTI9
+                DCD     TIMER0_BRK_TIMER8_IRQHandler      ; 40:TIMER0 Break and TIMER8
+                DCD     TIMER0_UP_TIMER9_IRQHandler       ; 41:TIMER0 Update and TIMER9
+                DCD     TIMER0_TRG_CMT_TIMER10_IRQHandler ; 42:TIMER0 Trigger and Commutation and TIMER10
+                DCD     TIMER0_Channel_IRQHandler         ; 43:TIMER0 Channel Capture Compare
+                DCD     TIMER1_IRQHandler                 ; 44:TIMER1
+                DCD     TIMER2_IRQHandler                 ; 45:TIMER2
+                DCD     TIMER3_IRQHandler                 ; 46:TIMER3
+                DCD     I2C0_EV_IRQHandler                ; 47:I2C0 Event
+                DCD     I2C0_ER_IRQHandler                ; 48:I2C0 Error
+                DCD     I2C1_EV_IRQHandler                ; 49:I2C1 Event
+                DCD     I2C1_ER_IRQHandler                ; 50:I2C1 Error
+                DCD     SPI0_IRQHandler                   ; 51:SPI0
+                DCD     SPI1_IRQHandler                   ; 52:SPI1
+                DCD     USART0_IRQHandler                 ; 53:USART0
+                DCD     USART1_IRQHandler                 ; 54:USART1
+                DCD     USART2_IRQHandler                 ; 55:USART2
+                DCD     EXTI10_15_IRQHandler              ; 56:EXTI10 to EXTI15
+                DCD     RTC_Alarm_IRQHandler              ; 57:RTC Alarm
+                DCD     USBFS_WKUP_IRQHandler             ; 58:USBFS Wakeup
+                DCD     TIMER7_BRK_TIMER11_IRQHandler     ; 59:TIMER7 Break and TIMER11
+                DCD     TIMER7_UP_TIMER12_IRQHandler      ; 60:TIMER7 Update and TIMER12
+                DCD     TIMER7_TRG_CMT_TIMER13_IRQHandler ; 61:TIMER7 Trigger and Commutation and TIMER13
+                DCD     TIMER7_Channel_IRQHandler         ; 62:TIMER7 Capture Compare
+                DCD     DMA0_Channel7_IRQHandler          ; 63:DMA0 Channel7
+                DCD     EXMC_IRQHandler                   ; 64:EXMC
+                DCD     SDIO_IRQHandler                   ; 65:SDIO
+                DCD     TIMER4_IRQHandler                 ; 66:TIMER4
+                DCD     SPI2_IRQHandler                   ; 67:SPI2
+                DCD     UART3_IRQHandler                  ; 68:UART3
+                DCD     UART4_IRQHandler                  ; 69:UART4
+                DCD     TIMER5_DAC_IRQHandler             ; 70:TIMER5 and DAC0 DAC1 Underrun error
+                DCD     TIMER6_IRQHandler                 ; 71:TIMER6
+                DCD     DMA1_Channel0_IRQHandler          ; 72:DMA1 Channel0
+                DCD     DMA1_Channel1_IRQHandler          ; 73:DMA1 Channel1
+                DCD     DMA1_Channel2_IRQHandler          ; 74:DMA1 Channel2
+                DCD     DMA1_Channel3_IRQHandler          ; 75:DMA1 Channel3
+                DCD     DMA1_Channel4_IRQHandler          ; 76:DMA1 Channel4
+                DCD     ENET_IRQHandler                   ; 77:Ethernet
+                DCD     ENET_WKUP_IRQHandler              ; 78:Ethernet Wakeup through EXTI Line
+                DCD     CAN1_TX_IRQHandler                ; 79:CAN1 TX
+                DCD     CAN1_RX0_IRQHandler               ; 80:CAN1 RX0
+                DCD     CAN1_RX1_IRQHandler               ; 81:CAN1 RX1
+                DCD     CAN1_EWMC_IRQHandler              ; 82:CAN1 EWMC
+                DCD     USBFS_IRQHandler                  ; 83:USBFS
+                DCD     DMA1_Channel5_IRQHandler          ; 84:DMA1 Channel5
+                DCD     DMA1_Channel6_IRQHandler          ; 85:DMA1 Channel6
+                DCD     DMA1_Channel7_IRQHandler          ; 86:DMA1 Channel7
+                DCD     USART5_IRQHandler                 ; 87:USART5
+                DCD     I2C2_EV_IRQHandler                ; 88:I2C2 Event
+                DCD     I2C2_ER_IRQHandler                ; 89:I2C2 Error
+                DCD     USBHS_EP1_Out_IRQHandler          ; 90:USBHS Endpoint 1 Out 
+                DCD     USBHS_EP1_In_IRQHandler           ; 91:USBHS Endpoint 1 in
+                DCD     USBHS_WKUP_IRQHandler             ; 92:USBHS Wakeup through EXTI Line
+                DCD     USBHS_IRQHandler                  ; 93:USBHS
+                DCD     DCI_IRQHandler                    ; 94:DCI
+                DCD     0                                 ; 95:Reserved
+                DCD     TRNG_IRQHandler                   ; 96:TRNG
+                DCD     FPU_IRQHandler                    ; 97:FPU
+
+__Vectors_End
+
+__Vectors_Size  EQU     __Vectors_End - __Vectors
+
+                AREA    |.text|, CODE, READONLY
+
+;/* reset Handler */
+Reset_Handler   PROC
+                EXPORT  Reset_Handler                     [WEAK]
+                IMPORT  SystemInit
+                IMPORT  __main
+                LDR     R0, =SystemInit
+                BLX     R0
+                LDR     R0, =__main
+                BX      R0
+                ENDP
+
+;/* dummy Exception Handlers */
+NMI_Handler     PROC
+                EXPORT  NMI_Handler                       [WEAK]
+                B       .
+                ENDP
+HardFault_Handler\
+                PROC
+                EXPORT  HardFault_Handler                 [WEAK]
+                B       .
+                ENDP
+MemManage_Handler\
+                PROC
+                EXPORT  MemManage_Handler                 [WEAK]
+                B       .
+                ENDP
+BusFault_Handler\
+                PROC
+                EXPORT  BusFault_Handler                  [WEAK]
+                B       .
+                ENDP
+UsageFault_Handler\
+                PROC
+                EXPORT  UsageFault_Handler                [WEAK]
+                B       .
+                ENDP
+SVC_Handler     PROC
+                EXPORT  SVC_Handler                       [WEAK]
+                B       .
+                ENDP
+DebugMon_Handler\
+                PROC
+                EXPORT  DebugMon_Handler                  [WEAK]
+                B       .
+                ENDP
+PendSV_Handler\
+                PROC
+                EXPORT  PendSV_Handler                    [WEAK]
+                B       .
+                ENDP
+SysTick_Handler\
+                PROC
+                EXPORT  SysTick_Handler                   [WEAK]
+                B       .
+                ENDP
+
+Default_Handler PROC
+;               /* external interrupts handler */
+                EXPORT  WWDGT_IRQHandler                  [WEAK]
+                EXPORT  LVD_IRQHandler                    [WEAK]                  
+                EXPORT  TAMPER_STAMP_IRQHandler           [WEAK]           
+                EXPORT  RTC_WKUP_IRQHandler               [WEAK]               
+                EXPORT  FMC_IRQHandler                    [WEAK]                
+                EXPORT  RCU_CTC_IRQHandler                [WEAK]                 
+                EXPORT  EXTI0_IRQHandler                  [WEAK]                  
+                EXPORT  EXTI1_IRQHandler                  [WEAK]                 
+                EXPORT  EXTI2_IRQHandler                  [WEAK]               
+                EXPORT  EXTI3_IRQHandler                  [WEAK]                
+                EXPORT  EXTI4_IRQHandler                  [WEAK]                 
+                EXPORT  DMA0_Channel0_IRQHandler          [WEAK]         
+                EXPORT  DMA0_Channel1_IRQHandler          [WEAK]          
+                EXPORT  DMA0_Channel2_IRQHandler          [WEAK]        
+                EXPORT  DMA0_Channel3_IRQHandler          [WEAK]         
+                EXPORT  DMA0_Channel4_IRQHandler          [WEAK]          
+                EXPORT  DMA0_Channel5_IRQHandler          [WEAK]          
+                EXPORT  DMA0_Channel6_IRQHandler          [WEAK]          
+                EXPORT  ADC_IRQHandler                    [WEAK]         
+                EXPORT  CAN0_TX_IRQHandler                [WEAK]          
+                EXPORT  CAN0_RX0_IRQHandler               [WEAK]          
+                EXPORT  CAN0_RX1_IRQHandler               [WEAK]           
+                EXPORT  CAN0_EWMC_IRQHandler              [WEAK]           
+                EXPORT  EXTI5_9_IRQHandler                [WEAK]           
+                EXPORT  TIMER0_BRK_TIMER8_IRQHandler      [WEAK]  
+                EXPORT  TIMER0_UP_TIMER9_IRQHandler       [WEAK]  
+                EXPORT  TIMER0_TRG_CMT_TIMER10_IRQHandler [WEAK]
+                EXPORT  TIMER0_Channel_IRQHandler         [WEAK]        
+                EXPORT  TIMER1_IRQHandler                 [WEAK]       
+                EXPORT  TIMER2_IRQHandler                 [WEAK]           
+                EXPORT  TIMER3_IRQHandler                 [WEAK]           
+                EXPORT  I2C0_EV_IRQHandler                [WEAK]          
+                EXPORT  I2C0_ER_IRQHandler                [WEAK]         
+                EXPORT  I2C1_EV_IRQHandler                [WEAK]         
+                EXPORT  I2C1_ER_IRQHandler                [WEAK]         
+                EXPORT  SPI0_IRQHandler                   [WEAK]        
+                EXPORT  SPI1_IRQHandler                   [WEAK]          
+                EXPORT  USART0_IRQHandler                 [WEAK]         
+                EXPORT  USART1_IRQHandler                 [WEAK]         
+                EXPORT  USART2_IRQHandler                 [WEAK]        
+                EXPORT  EXTI10_15_IRQHandler              [WEAK]        
+                EXPORT  RTC_Alarm_IRQHandler              [WEAK]        
+                EXPORT  USBFS_WKUP_IRQHandler             [WEAK]        
+                EXPORT  TIMER7_BRK_TIMER11_IRQHandler     [WEAK] 
+                EXPORT  TIMER7_UP_TIMER12_IRQHandler      [WEAK] 
+                EXPORT  TIMER7_TRG_CMT_TIMER13_IRQHandler [WEAK]
+                EXPORT  TIMER7_Channel_IRQHandler         [WEAK]        
+                EXPORT  DMA0_Channel7_IRQHandler          [WEAK]       
+                EXPORT  EXMC_IRQHandler                   [WEAK]         
+                EXPORT  SDIO_IRQHandler                   [WEAK]           
+                EXPORT  TIMER4_IRQHandler                 [WEAK]           
+                EXPORT  SPI2_IRQHandler                   [WEAK]          
+                EXPORT  UART3_IRQHandler                  [WEAK]          
+                EXPORT  UART4_IRQHandler                  [WEAK]          
+                EXPORT  TIMER5_DAC_IRQHandler             [WEAK]         
+                EXPORT  TIMER6_IRQHandler                 [WEAK]        
+                EXPORT  DMA1_Channel0_IRQHandler          [WEAK]          
+                EXPORT  DMA1_Channel1_IRQHandler          [WEAK]          
+                EXPORT  DMA1_Channel2_IRQHandler          [WEAK]         
+                EXPORT  DMA1_Channel3_IRQHandler          [WEAK]         
+                EXPORT  DMA1_Channel4_IRQHandler          [WEAK]          
+                EXPORT  ENET_IRQHandler                   [WEAK]         
+                EXPORT  ENET_WKUP_IRQHandler              [WEAK]         
+                EXPORT  CAN1_TX_IRQHandler                [WEAK]          
+                EXPORT  CAN1_RX0_IRQHandler               [WEAK]         
+                EXPORT  CAN1_RX1_IRQHandler               [WEAK]          
+                EXPORT  CAN1_EWMC_IRQHandler              [WEAK]          
+                EXPORT  USBFS_IRQHandler                  [WEAK]          
+                EXPORT  DMA1_Channel5_IRQHandler          [WEAK]          
+                EXPORT  DMA1_Channel6_IRQHandler          [WEAK]          
+                EXPORT  DMA1_Channel7_IRQHandler          [WEAK]          
+                EXPORT  USART5_IRQHandler                 [WEAK]          
+                EXPORT  I2C2_EV_IRQHandler                [WEAK]         
+                EXPORT  I2C2_ER_IRQHandler                [WEAK]          
+                EXPORT  USBHS_EP1_Out_IRQHandler          [WEAK]    
+                EXPORT  USBHS_EP1_In_IRQHandler           [WEAK]    
+                EXPORT  USBHS_WKUP_IRQHandler             [WEAK]             
+                EXPORT  USBHS_IRQHandler                  [WEAK]            
+                EXPORT  DCI_IRQHandler                    [WEAK]                      
+                EXPORT  TRNG_IRQHandler                   [WEAK]          
+                EXPORT  FPU_IRQHandler                    [WEAK]          
+
+;/* external interrupts handler */
+WWDGT_IRQHandler                  
+LVD_IRQHandler                    
+TAMPER_STAMP_IRQHandler           
+RTC_WKUP_IRQHandler               
+FMC_IRQHandler                   
+RCU_CTC_IRQHandler                   
+EXTI0_IRQHandler                  
+EXTI1_IRQHandler                 
+EXTI2_IRQHandler                
+EXTI3_IRQHandler                 
+EXTI4_IRQHandler                  
+DMA0_Channel0_IRQHandler         
+DMA0_Channel1_IRQHandler          
+DMA0_Channel2_IRQHandler        
+DMA0_Channel3_IRQHandler         
+DMA0_Channel4_IRQHandler          
+DMA0_Channel5_IRQHandler          
+DMA0_Channel6_IRQHandler          
+ADC_IRQHandler                   
+CAN0_TX_IRQHandler                
+CAN0_RX0_IRQHandler               
+CAN0_RX1_IRQHandler               
+CAN0_EWMC_IRQHandler               
+EXTI5_9_IRQHandler                
+TIMER0_BRK_TIMER8_IRQHandler    
+TIMER0_UP_TIMER9_IRQHandler   
+TIMER0_TRG_CMT_TIMER10_IRQHandler 
+TIMER0_Channel_IRQHandler        
+TIMER1_IRQHandler             
+TIMER2_IRQHandler                 
+TIMER3_IRQHandler                 
+I2C0_EV_IRQHandler                
+I2C0_ER_IRQHandler               
+I2C1_EV_IRQHandler               
+I2C1_ER_IRQHandler               
+SPI0_IRQHandler                  
+SPI1_IRQHandler                   
+USART0_IRQHandler                 
+USART1_IRQHandler                 
+USART2_IRQHandler                
+EXTI10_15_IRQHandler              
+RTC_Alarm_IRQHandler             
+USBFS_WKUP_IRQHandler             
+TIMER7_BRK_TIMER11_IRQHandler   
+TIMER7_UP_TIMER12_IRQHandler  
+TIMER7_TRG_CMT_TIMER13_IRQHandler 
+TIMER7_Channel_IRQHandler         
+DMA0_Channel7_IRQHandler         
+EXMC_IRQHandler                   
+SDIO_IRQHandler                   
+TIMER4_IRQHandler                 
+SPI2_IRQHandler                  
+UART3_IRQHandler                  
+UART4_IRQHandler                  
+TIMER5_DAC_IRQHandler             
+TIMER6_IRQHandler                
+DMA1_Channel0_IRQHandler          
+DMA1_Channel1_IRQHandler         
+DMA1_Channel2_IRQHandler         
+DMA1_Channel3_IRQHandler         
+DMA1_Channel4_IRQHandler          
+ENET_IRQHandler                  
+ENET_WKUP_IRQHandler             
+CAN1_TX_IRQHandler                
+CAN1_RX0_IRQHandler              
+CAN1_RX1_IRQHandler               
+CAN1_EWMC_IRQHandler               
+USBFS_IRQHandler                  
+DMA1_Channel5_IRQHandler          
+DMA1_Channel6_IRQHandler          
+DMA1_Channel7_IRQHandler          
+USART5_IRQHandler                 
+I2C2_EV_IRQHandler               
+I2C2_ER_IRQHandler                
+USBHS_EP1_Out_IRQHandler    
+USBHS_EP1_In_IRQHandler     
+USBHS_WKUP_IRQHandler             
+USBHS_IRQHandler                  
+DCI_IRQHandler                                    
+TRNG_IRQHandler                  
+FPU_IRQHandler                    
+
+                B       .
+                ENDP
+
+                ALIGN
+
+; user Initial Stack & Heap
+
+                IF      :DEF:__MICROLIB
+
+                EXPORT  __initial_sp
+                EXPORT  __heap_base
+                EXPORT  __heap_limit
+
+                ELSE
+
+                IMPORT  __use_two_region_memory
+                EXPORT  __user_initial_stackheap
+
+__user_initial_stackheap PROC
+                LDR     R0, =  Heap_Mem
+                LDR     R1, =(Stack_Mem + Stack_Size)
+                LDR     R2, = (Heap_Mem +  Heap_Size)
+                LDR     R3, = Stack_Mem
+                BX      LR
+                ENDP
+
+                ALIGN
+
+                ENDIF
+
+                END

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/ARM/startup_gd32f450_470.s
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/ARM/startup_gd32f450_470.s
@@ -1,0 +1,454 @@
+;/*!
+;    \file    startup_gd32f450_470.s
+;    \brief   start up file
+;
+;    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+;    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+;    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+;    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+;*/
+;
+;/*
+;    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+;
+;    Redistribution and use in source and binary forms, with or without modification, 
+;are permitted provided that the following conditions are met:
+;
+;    1. Redistributions of source code must retain the above copyright notice, this 
+;       list of conditions and the following disclaimer.
+;    2. Redistributions in binary form must reproduce the above copyright notice, 
+;       this list of conditions and the following disclaimer in the documentation 
+;       and/or other materials provided with the distribution.
+;    3. Neither the name of the copyright holder nor the names of its contributors 
+;       may be used to endorse or promote products derived from this software without 
+;       specific prior written permission.
+;
+;    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+;AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+;WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+;IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+;INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+;NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+;PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+;WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+;ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+;OF SUCH DAMAGE.
+;*/
+
+; <h> Stack Configuration
+;   <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Stack_Size      EQU     0x00000400
+
+                AREA    STACK, NOINIT, READWRITE, ALIGN=3
+Stack_Mem       SPACE   Stack_Size
+__initial_sp
+
+
+; <h> Heap Configuration
+;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+; </h>
+
+Heap_Size       EQU     0x00000400
+
+                AREA    HEAP, NOINIT, READWRITE, ALIGN=3
+__heap_base
+Heap_Mem        SPACE   Heap_Size
+__heap_limit
+
+                PRESERVE8
+                THUMB
+
+;               /* reset Vector Mapped to at Address 0 */
+                AREA    RESET, DATA, READONLY
+                EXPORT  __Vectors
+                EXPORT  __Vectors_End
+                EXPORT  __Vectors_Size
+
+__Vectors       DCD     __initial_sp                      ; Top of Stack
+                DCD     Reset_Handler                     ; Reset Handler
+                DCD     NMI_Handler                       ; NMI Handler
+                DCD     HardFault_Handler                 ; Hard Fault Handler
+                DCD     MemManage_Handler                 ; MPU Fault Handler
+                DCD     BusFault_Handler                  ; Bus Fault Handler
+                DCD     UsageFault_Handler                ; Usage Fault Handler
+                DCD     0                                 ; Reserved
+                DCD     0                                 ; Reserved
+                DCD     0                                 ; Reserved
+                DCD     0                                 ; Reserved
+                DCD     SVC_Handler                       ; SVCall Handler
+                DCD     DebugMon_Handler                  ; Debug Monitor Handler
+                DCD     0                                 ; Reserved
+                DCD     PendSV_Handler                    ; PendSV Handler
+                DCD     SysTick_Handler                   ; SysTick Handler
+
+;               /* external interrupts handler */
+                DCD     WWDGT_IRQHandler                  ; 16:Window Watchdog Timer
+                DCD     LVD_IRQHandler                    ; 17:LVD through EXTI Line detect
+                DCD     TAMPER_STAMP_IRQHandler           ; 18:Tamper and TimeStamp through EXTI Line detect
+                DCD     RTC_WKUP_IRQHandler               ; 19:RTC Wakeup through EXTI Line
+                DCD     FMC_IRQHandler                    ; 20:FMC
+                DCD     RCU_CTC_IRQHandler                ; 21:RCU and CTC
+                DCD     EXTI0_IRQHandler                  ; 22:EXTI Line 0
+                DCD     EXTI1_IRQHandler                  ; 23:EXTI Line 1
+                DCD     EXTI2_IRQHandler                  ; 24:EXTI Line 2
+                DCD     EXTI3_IRQHandler                  ; 25:EXTI Line 3
+                DCD     EXTI4_IRQHandler                  ; 26:EXTI Line 4
+                DCD     DMA0_Channel0_IRQHandler          ; 27:DMA0 Channel0
+                DCD     DMA0_Channel1_IRQHandler          ; 28:DMA0 Channel1
+                DCD     DMA0_Channel2_IRQHandler          ; 29:DMA0 Channel2
+                DCD     DMA0_Channel3_IRQHandler          ; 30:DMA0 Channel3
+                DCD     DMA0_Channel4_IRQHandler          ; 31:DMA0 Channel4
+                DCD     DMA0_Channel5_IRQHandler          ; 32:DMA0 Channel5
+                DCD     DMA0_Channel6_IRQHandler          ; 33:DMA0 Channel6
+                DCD     ADC_IRQHandler                    ; 34:ADC
+                DCD     CAN0_TX_IRQHandler                ; 35:CAN0 TX
+                DCD     CAN0_RX0_IRQHandler               ; 36:CAN0 RX0
+                DCD     CAN0_RX1_IRQHandler               ; 37:CAN0 RX1
+                DCD     CAN0_EWMC_IRQHandler              ; 38:CAN0 EWMC
+                DCD     EXTI5_9_IRQHandler                ; 39:EXTI5 to EXTI9
+                DCD     TIMER0_BRK_TIMER8_IRQHandler      ; 40:TIMER0 Break and TIMER8
+                DCD     TIMER0_UP_TIMER9_IRQHandler       ; 41:TIMER0 Update and TIMER9
+                DCD     TIMER0_TRG_CMT_TIMER10_IRQHandler ; 42:TIMER0 Trigger and Commutation and TIMER10
+                DCD     TIMER0_Channel_IRQHandler         ; 43:TIMER0 Capture Compare
+                DCD     TIMER1_IRQHandler                 ; 44:TIMER1
+                DCD     TIMER2_IRQHandler                 ; 45:TIMER2
+                DCD     TIMER3_IRQHandler                 ; 46:TIMER3
+                DCD     I2C0_EV_IRQHandler                ; 47:I2C0 Event
+                DCD     I2C0_ER_IRQHandler                ; 48:I2C0 Error
+                DCD     I2C1_EV_IRQHandler                ; 49:I2C1 Event
+                DCD     I2C1_ER_IRQHandler                ; 50:I2C1 Error
+                DCD     SPI0_IRQHandler                   ; 51:SPI0
+                DCD     SPI1_IRQHandler                   ; 52:SPI1
+                DCD     USART0_IRQHandler                 ; 53:USART0
+                DCD     USART1_IRQHandler                 ; 54:USART1
+                DCD     USART2_IRQHandler                 ; 55:USART2
+                DCD     EXTI10_15_IRQHandler              ; 56:EXTI10 to EXTI15
+                DCD     RTC_Alarm_IRQHandler              ; 57:RTC Alarm
+                DCD     USBFS_WKUP_IRQHandler             ; 58:USBFS Wakeup
+                DCD     TIMER7_BRK_TIMER11_IRQHandler     ; 59:TIMER7 Break and TIMER11
+                DCD     TIMER7_UP_TIMER12_IRQHandler      ; 60:TIMER7 Update and TIMER12
+                DCD     TIMER7_TRG_CMT_TIMER13_IRQHandler ; 61:TIMER7 Trigger and Commutation and TIMER13
+                DCD     TIMER7_Channel_IRQHandler         ; 62:TIMER7 Channel Capture Compare
+                DCD     DMA0_Channel7_IRQHandler          ; 63:DMA0 Channel7
+                DCD     EXMC_IRQHandler                   ; 64:EXMC
+                DCD     SDIO_IRQHandler                   ; 65:SDIO
+                DCD     TIMER4_IRQHandler                 ; 66:TIMER4
+                DCD     SPI2_IRQHandler                   ; 67:SPI2
+                DCD     UART3_IRQHandler                  ; 68:UART3
+                DCD     UART4_IRQHandler                  ; 69:UART4
+                DCD     TIMER5_DAC_IRQHandler             ; 70:TIMER5 and DAC0 DAC1 Underrun error
+                DCD     TIMER6_IRQHandler                 ; 71:TIMER6
+                DCD     DMA1_Channel0_IRQHandler          ; 72:DMA1 Channel0
+                DCD     DMA1_Channel1_IRQHandler          ; 73:DMA1 Channel1
+                DCD     DMA1_Channel2_IRQHandler          ; 74:DMA1 Channel2
+                DCD     DMA1_Channel3_IRQHandler          ; 75:DMA1 Channel3
+                DCD     DMA1_Channel4_IRQHandler          ; 76:DMA1 Channel4
+                DCD     ENET_IRQHandler                   ; 77:Ethernet
+                DCD     ENET_WKUP_IRQHandler              ; 78:Ethernet Wakeup through EXTI Line
+                DCD     CAN1_TX_IRQHandler                ; 79:CAN1 TX
+                DCD     CAN1_RX0_IRQHandler               ; 80:CAN1 RX0
+                DCD     CAN1_RX1_IRQHandler               ; 81:CAN1 RX1
+                DCD     CAN1_EWMC_IRQHandler              ; 82:CAN1 EWMC
+                DCD     USBFS_IRQHandler                  ; 83:USBFS
+                DCD     DMA1_Channel5_IRQHandler          ; 84:DMA1 Channel5
+                DCD     DMA1_Channel6_IRQHandler          ; 85:DMA1 Channel6
+                DCD     DMA1_Channel7_IRQHandler          ; 86:DMA1 Channel7
+                DCD     USART5_IRQHandler                 ; 87:USART5
+                DCD     I2C2_EV_IRQHandler                ; 88:I2C2 Event
+                DCD     I2C2_ER_IRQHandler                ; 89:I2C2 Error
+                DCD     USBHS_EP1_Out_IRQHandler          ; 90:USBHS Endpoint 1 Out 
+                DCD     USBHS_EP1_In_IRQHandler           ; 91:USBHS Endpoint 1 in
+                DCD     USBHS_WKUP_IRQHandler             ; 92:USBHS Wakeup through EXTI Line
+                DCD     USBHS_IRQHandler                  ; 93:USBHS
+                DCD     DCI_IRQHandler                    ; 94:DCI
+                DCD     0                                 ; 95:Reserved
+                DCD     TRNG_IRQHandler                   ; 96:TRNG
+                DCD     FPU_IRQHandler                    ; 97:FPU
+                DCD     UART6_IRQHandler                  ; 98:UART6
+                DCD     UART7_IRQHandler                  ; 99:UART7
+                DCD     SPI3_IRQHandler                   ; 100:SPI3
+                DCD     SPI4_IRQHandler                   ; 101:SPI4
+                DCD     SPI5_IRQHandler                   ; 102:SPI5
+                DCD     0                                 ; 103:Reserved
+                DCD     TLI_IRQHandler                    ; 104:TLI
+                DCD     TLI_ER_IRQHandler                 ; 105:TLI Error
+                DCD     IPA_IRQHandler                    ; 106:IPA
+
+__Vectors_End
+
+__Vectors_Size  EQU     __Vectors_End - __Vectors
+
+                AREA    |.text|, CODE, READONLY
+
+;/* reset Handler */
+Reset_Handler   PROC
+                EXPORT  Reset_Handler                     [WEAK]
+                IMPORT  SystemInit
+                IMPORT  __main
+                LDR     R0, =SystemInit
+                BLX     R0
+                LDR     R0, =__main
+                BX      R0
+                ENDP
+
+;/* dummy Exception Handlers */
+NMI_Handler     PROC
+                EXPORT  NMI_Handler                       [WEAK]
+                B       .
+                ENDP
+HardFault_Handler\
+                PROC
+                EXPORT  HardFault_Handler                 [WEAK]
+                B       .
+                ENDP
+MemManage_Handler\
+                PROC
+                EXPORT  MemManage_Handler                 [WEAK]
+                B       .
+                ENDP
+BusFault_Handler\
+                PROC
+                EXPORT  BusFault_Handler                  [WEAK]
+                B       .
+                ENDP
+UsageFault_Handler\
+                PROC
+                EXPORT  UsageFault_Handler                [WEAK]
+                B       .
+                ENDP
+SVC_Handler     PROC
+                EXPORT  SVC_Handler                       [WEAK]
+                B       .
+                ENDP
+DebugMon_Handler\
+                PROC
+                EXPORT  DebugMon_Handler                  [WEAK]
+                B       .
+                ENDP
+PendSV_Handler\
+                PROC
+                EXPORT  PendSV_Handler                    [WEAK]
+                B       .
+                ENDP
+SysTick_Handler\
+                PROC
+                EXPORT  SysTick_Handler                   [WEAK]
+                B       .
+                ENDP
+
+Default_Handler PROC
+;               /* external interrupts handler */
+                EXPORT  WWDGT_IRQHandler                  [WEAK]
+                EXPORT  LVD_IRQHandler                    [WEAK]                  
+                EXPORT  TAMPER_STAMP_IRQHandler           [WEAK]           
+                EXPORT  RTC_WKUP_IRQHandler               [WEAK]               
+                EXPORT  FMC_IRQHandler                    [WEAK]                
+                EXPORT  RCU_CTC_IRQHandler                [WEAK]                 
+                EXPORT  EXTI0_IRQHandler                  [WEAK]                  
+                EXPORT  EXTI1_IRQHandler                  [WEAK]                 
+                EXPORT  EXTI2_IRQHandler                  [WEAK]               
+                EXPORT  EXTI3_IRQHandler                  [WEAK]                
+                EXPORT  EXTI4_IRQHandler                  [WEAK]                 
+                EXPORT  DMA0_Channel0_IRQHandler          [WEAK]         
+                EXPORT  DMA0_Channel1_IRQHandler          [WEAK]          
+                EXPORT  DMA0_Channel2_IRQHandler          [WEAK]        
+                EXPORT  DMA0_Channel3_IRQHandler          [WEAK]         
+                EXPORT  DMA0_Channel4_IRQHandler          [WEAK]          
+                EXPORT  DMA0_Channel5_IRQHandler          [WEAK]          
+                EXPORT  DMA0_Channel6_IRQHandler          [WEAK]          
+                EXPORT  ADC_IRQHandler                    [WEAK]         
+                EXPORT  CAN0_TX_IRQHandler                [WEAK]          
+                EXPORT  CAN0_RX0_IRQHandler               [WEAK]          
+                EXPORT  CAN0_RX1_IRQHandler               [WEAK]           
+                EXPORT  CAN0_EWMC_IRQHandler              [WEAK]           
+                EXPORT  EXTI5_9_IRQHandler                [WEAK]           
+                EXPORT  TIMER0_BRK_TIMER8_IRQHandler      [WEAK]  
+                EXPORT  TIMER0_UP_TIMER9_IRQHandler       [WEAK]  
+                EXPORT  TIMER0_TRG_CMT_TIMER10_IRQHandler [WEAK]
+                EXPORT  TIMER0_Channel_IRQHandler         [WEAK]        
+                EXPORT  TIMER1_IRQHandler                 [WEAK]       
+                EXPORT  TIMER2_IRQHandler                 [WEAK]           
+                EXPORT  TIMER3_IRQHandler                 [WEAK]           
+                EXPORT  I2C0_EV_IRQHandler                [WEAK]          
+                EXPORT  I2C0_ER_IRQHandler                [WEAK]         
+                EXPORT  I2C1_EV_IRQHandler                [WEAK]         
+                EXPORT  I2C1_ER_IRQHandler                [WEAK]         
+                EXPORT  SPI0_IRQHandler                   [WEAK]        
+                EXPORT  SPI1_IRQHandler                   [WEAK]          
+                EXPORT  USART0_IRQHandler                 [WEAK]         
+                EXPORT  USART1_IRQHandler                 [WEAK]         
+                EXPORT  USART2_IRQHandler                 [WEAK]        
+                EXPORT  EXTI10_15_IRQHandler              [WEAK]        
+                EXPORT  RTC_Alarm_IRQHandler              [WEAK]        
+                EXPORT  USBFS_WKUP_IRQHandler             [WEAK]        
+                EXPORT  TIMER7_BRK_TIMER11_IRQHandler     [WEAK] 
+                EXPORT  TIMER7_UP_TIMER12_IRQHandler      [WEAK] 
+                EXPORT  TIMER7_TRG_CMT_TIMER13_IRQHandler [WEAK]
+                EXPORT  TIMER7_Channel_IRQHandler         [WEAK]        
+                EXPORT  DMA0_Channel7_IRQHandler          [WEAK]       
+                EXPORT  EXMC_IRQHandler                   [WEAK]         
+                EXPORT  SDIO_IRQHandler                   [WEAK]           
+                EXPORT  TIMER4_IRQHandler                 [WEAK]           
+                EXPORT  SPI2_IRQHandler                   [WEAK]          
+                EXPORT  UART3_IRQHandler                  [WEAK]          
+                EXPORT  UART4_IRQHandler                  [WEAK]          
+                EXPORT  TIMER5_DAC_IRQHandler             [WEAK]         
+                EXPORT  TIMER6_IRQHandler                 [WEAK]        
+                EXPORT  DMA1_Channel0_IRQHandler          [WEAK]          
+                EXPORT  DMA1_Channel1_IRQHandler          [WEAK]          
+                EXPORT  DMA1_Channel2_IRQHandler          [WEAK]         
+                EXPORT  DMA1_Channel3_IRQHandler          [WEAK]         
+                EXPORT  DMA1_Channel4_IRQHandler          [WEAK]          
+                EXPORT  ENET_IRQHandler                   [WEAK]         
+                EXPORT  ENET_WKUP_IRQHandler              [WEAK]         
+                EXPORT  CAN1_TX_IRQHandler                [WEAK]          
+                EXPORT  CAN1_RX0_IRQHandler               [WEAK]         
+                EXPORT  CAN1_RX1_IRQHandler               [WEAK]          
+                EXPORT  CAN1_EWMC_IRQHandler              [WEAK]          
+                EXPORT  USBFS_IRQHandler                  [WEAK]          
+                EXPORT  DMA1_Channel5_IRQHandler          [WEAK]          
+                EXPORT  DMA1_Channel6_IRQHandler          [WEAK]          
+                EXPORT  DMA1_Channel7_IRQHandler          [WEAK]          
+                EXPORT  USART5_IRQHandler                 [WEAK]          
+                EXPORT  I2C2_EV_IRQHandler                [WEAK]         
+                EXPORT  I2C2_ER_IRQHandler                [WEAK]          
+                EXPORT  USBHS_EP1_Out_IRQHandler          [WEAK]    
+                EXPORT  USBHS_EP1_In_IRQHandler           [WEAK]    
+                EXPORT  USBHS_WKUP_IRQHandler             [WEAK]             
+                EXPORT  USBHS_IRQHandler                  [WEAK]            
+                EXPORT  DCI_IRQHandler                    [WEAK]                      
+                EXPORT  TRNG_IRQHandler                   [WEAK]          
+                EXPORT  FPU_IRQHandler                    [WEAK]          
+                EXPORT  UART6_IRQHandler                  [WEAK]          
+                EXPORT  UART7_IRQHandler                  [WEAK]          
+                EXPORT  SPI3_IRQHandler                   [WEAK]          
+                EXPORT  SPI4_IRQHandler                   [WEAK]          
+                EXPORT  SPI5_IRQHandler                   [WEAK]                 
+                EXPORT  TLI_IRQHandler                    [WEAK]         
+                EXPORT  TLI_ER_IRQHandler                 [WEAK]         
+                EXPORT  IPA_IRQHandler                    [WEAK]          
+  
+;/* external interrupts handler */
+WWDGT_IRQHandler                  
+LVD_IRQHandler                    
+TAMPER_STAMP_IRQHandler           
+RTC_WKUP_IRQHandler               
+FMC_IRQHandler                   
+RCU_CTC_IRQHandler                   
+EXTI0_IRQHandler                  
+EXTI1_IRQHandler                 
+EXTI2_IRQHandler                
+EXTI3_IRQHandler                 
+EXTI4_IRQHandler                  
+DMA0_Channel0_IRQHandler         
+DMA0_Channel1_IRQHandler          
+DMA0_Channel2_IRQHandler        
+DMA0_Channel3_IRQHandler         
+DMA0_Channel4_IRQHandler          
+DMA0_Channel5_IRQHandler          
+DMA0_Channel6_IRQHandler          
+ADC_IRQHandler                   
+CAN0_TX_IRQHandler                
+CAN0_RX0_IRQHandler               
+CAN0_RX1_IRQHandler               
+CAN0_EWMC_IRQHandler               
+EXTI5_9_IRQHandler                
+TIMER0_BRK_TIMER8_IRQHandler    
+TIMER0_UP_TIMER9_IRQHandler   
+TIMER0_TRG_CMT_TIMER10_IRQHandler 
+TIMER0_Channel_IRQHandler        
+TIMER1_IRQHandler             
+TIMER2_IRQHandler                 
+TIMER3_IRQHandler                 
+I2C0_EV_IRQHandler                
+I2C0_ER_IRQHandler               
+I2C1_EV_IRQHandler               
+I2C1_ER_IRQHandler               
+SPI0_IRQHandler                  
+SPI1_IRQHandler                   
+USART0_IRQHandler                 
+USART1_IRQHandler                 
+USART2_IRQHandler                
+EXTI10_15_IRQHandler              
+RTC_Alarm_IRQHandler             
+USBFS_WKUP_IRQHandler             
+TIMER7_BRK_TIMER11_IRQHandler   
+TIMER7_UP_TIMER12_IRQHandler  
+TIMER7_TRG_CMT_TIMER13_IRQHandler 
+TIMER7_Channel_IRQHandler         
+DMA0_Channel7_IRQHandler         
+EXMC_IRQHandler                   
+SDIO_IRQHandler                   
+TIMER4_IRQHandler                 
+SPI2_IRQHandler                  
+UART3_IRQHandler                  
+UART4_IRQHandler                  
+TIMER5_DAC_IRQHandler             
+TIMER6_IRQHandler                
+DMA1_Channel0_IRQHandler          
+DMA1_Channel1_IRQHandler         
+DMA1_Channel2_IRQHandler         
+DMA1_Channel3_IRQHandler         
+DMA1_Channel4_IRQHandler          
+ENET_IRQHandler                  
+ENET_WKUP_IRQHandler             
+CAN1_TX_IRQHandler                
+CAN1_RX0_IRQHandler              
+CAN1_RX1_IRQHandler               
+CAN1_EWMC_IRQHandler               
+USBFS_IRQHandler                  
+DMA1_Channel5_IRQHandler          
+DMA1_Channel6_IRQHandler          
+DMA1_Channel7_IRQHandler          
+USART5_IRQHandler                 
+I2C2_EV_IRQHandler               
+I2C2_ER_IRQHandler                
+USBHS_EP1_Out_IRQHandler    
+USBHS_EP1_In_IRQHandler     
+USBHS_WKUP_IRQHandler             
+USBHS_IRQHandler                  
+DCI_IRQHandler                                    
+TRNG_IRQHandler                  
+FPU_IRQHandler                    
+UART6_IRQHandler                  
+UART7_IRQHandler                  
+SPI3_IRQHandler                   
+SPI4_IRQHandler                   
+SPI5_IRQHandler                                     
+TLI_IRQHandler                    
+TLI_ER_IRQHandler                 
+IPA_IRQHandler                    
+
+                B       .
+                ENDP
+
+                ALIGN
+
+; user Initial Stack & Heap
+
+                IF      :DEF:__MICROLIB
+
+                EXPORT  __initial_sp
+                EXPORT  __heap_base
+                EXPORT  __heap_limit
+
+                ELSE
+
+                IMPORT  __use_two_region_memory
+                EXPORT  __user_initial_stackheap
+
+__user_initial_stackheap PROC
+                LDR     R0, =  Heap_Mem
+                LDR     R1, =(Stack_Mem + Stack_Size)
+                LDR     R2, = (Heap_Mem +  Heap_Size)
+                LDR     R3, = Stack_Mem
+                BX      LR
+                ENDP
+
+                ALIGN
+
+                ENDIF
+
+                END

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/IAR/startup_gd32f405_425.s
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/IAR/startup_gd32f405_425.s
@@ -1,0 +1,602 @@
+;/*!
+;    \file    startup_gd32f405_425.s
+;    \brief   start up file
+;
+;    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+;    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+;    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+;    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+;*/
+;
+;/*
+;    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+;
+;    Redistribution and use in source and binary forms, with or without modification, 
+;are permitted provided that the following conditions are met:
+;
+;    1. Redistributions of source code must retain the above copyright notice, this 
+;       list of conditions and the following disclaimer.
+;    2. Redistributions in binary form must reproduce the above copyright notice, 
+;       this list of conditions and the following disclaimer in the documentation 
+;       and/or other materials provided with the distribution.
+;    3. Neither the name of the copyright holder nor the names of its contributors 
+;       may be used to endorse or promote products derived from this software without 
+;       specific prior written permission.
+;
+;    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+;AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+;WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+;IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+;INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+;NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+;PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+;WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+;ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+;OF SUCH DAMAGE.
+;*/
+
+        MODULE  ?cstartup
+
+        ;; Forward declaration of sections.
+        SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(2)
+
+        EXTERN  __iar_program_start
+        EXTERN  SystemInit
+        PUBLIC  __vector_table
+
+        DATA
+__vector_table
+        DCD     sfe(CSTACK)                         ; top of stack
+        DCD     Reset_Handler                       ; Vector Number 1,Reset Handler
+
+        DCD     NMI_Handler                         ; Vector Number 2,NMI Handler
+        DCD     HardFault_Handler                   ; Vector Number 3,Hard Fault Handler
+        DCD     MemManage_Handler                   ; Vector Number 4,MPU Fault Handler
+        DCD     BusFault_Handler                    ; Vector Number 5,Bus Fault Handler
+        DCD     UsageFault_Handler                  ; Vector Number 6,Usage Fault Handler
+        DCD     0                                   ; Reserved
+        DCD     0                                   ; Reserved
+        DCD     0                                   ; Reserved
+        DCD     0                                   ; Reserved
+        DCD     SVC_Handler                         ; Vector Number 11,SVCall Handler
+        DCD     DebugMon_Handler                    ; Vector Number 12,Debug Monitor Handler
+        DCD     0                                   ; Reserved
+        DCD     PendSV_Handler                      ; Vector Number 14,PendSV Handler
+        DCD     SysTick_Handler                     ; Vector Number 15,SysTick Handler
+
+        ; External Interrupts
+                DCD     WWDGT_IRQHandler                  ; 16:Window Watchdog Timer
+                DCD     LVD_IRQHandler                    ; 17:LVD through EXTI Line detect
+                DCD     TAMPER_STAMP_IRQHandler           ; 18:Tamper and TimeStamp through EXTI Line detect
+                DCD     RTC_WKUP_IRQHandler               ; 19:RTC Wakeup through EXTI Line
+                DCD     FMC_IRQHandler                    ; 20:FMC
+                DCD     RCU_CTC_IRQHandler                ; 21:RCU and CTC
+                DCD     EXTI0_IRQHandler                  ; 22:EXTI Line 0
+                DCD     EXTI1_IRQHandler                  ; 23:EXTI Line 1
+                DCD     EXTI2_IRQHandler                  ; 24:EXTI Line 2
+                DCD     EXTI3_IRQHandler                  ; 25:EXTI Line 3
+                DCD     EXTI4_IRQHandler                  ; 26:EXTI Line 4
+                DCD     DMA0_Channel0_IRQHandler          ; 27:DMA0 Channel0
+                DCD     DMA0_Channel1_IRQHandler          ; 28:DMA0 Channel1
+                DCD     DMA0_Channel2_IRQHandler          ; 29:DMA0 Channel2
+                DCD     DMA0_Channel3_IRQHandler          ; 30:DMA0 Channel3
+                DCD     DMA0_Channel4_IRQHandler          ; 31:DMA0 Channel4
+                DCD     DMA0_Channel5_IRQHandler          ; 32:DMA0 Channel5
+                DCD     DMA0_Channel6_IRQHandler          ; 33:DMA0 Channel6
+                DCD     ADC_IRQHandler                    ; 34:ADC
+                DCD     CAN0_TX_IRQHandler                ; 35:CAN0 TX
+                DCD     CAN0_RX0_IRQHandler               ; 36:CAN0 RX0
+                DCD     CAN0_RX1_IRQHandler               ; 37:CAN0 RX1
+                DCD     CAN0_EWMC_IRQHandler              ; 38:CAN0 EWMC
+                DCD     EXTI5_9_IRQHandler                ; 39:EXTI5 to EXTI9
+                DCD     TIMER0_BRK_TIMER8_IRQHandler      ; 40:TIMER0 Break and TIMER8
+                DCD     TIMER0_UP_TIMER9_IRQHandler       ; 41:TIMER0 Update and TIMER9
+                DCD     TIMER0_TRG_CMT_TIMER10_IRQHandler ; 42:TIMER0 Trigger and Commucation and TIMER10
+                DCD     TIMER0_Channel_IRQHandler         ; 43:TIMER0 Capture Compare
+                DCD     TIMER1_IRQHandler                 ; 44:TIMER1
+                DCD     TIMER2_IRQHandler                 ; 45:TIMER2
+                DCD     TIMER3_IRQHandler                 ; 46:TIMER3
+                DCD     I2C0_EV_IRQHandler                ; 47:I2C0 Event
+                DCD     I2C0_ER_IRQHandler                ; 48:I2C0 Error
+                DCD     I2C1_EV_IRQHandler                ; 49:I2C1 Event
+                DCD     I2C1_ER_IRQHandler                ; 50:I2C1 Error
+                DCD     SPI0_IRQHandler                   ; 51:SPI0
+                DCD     SPI1_IRQHandler                   ; 52:SPI1
+                DCD     USART0_IRQHandler                 ; 53:USART0
+                DCD     USART1_IRQHandler                 ; 54:USART1
+                DCD     USART2_IRQHandler                 ; 55:USART2
+                DCD     EXTI10_15_IRQHandler              ; 56:EXTI10 to EXTI15
+                DCD     RTC_Alarm_IRQHandler              ; 57:RTC Alarm
+                DCD     USBFS_WKUP_IRQHandler             ; 58:USBFS Wakeup
+                DCD     TIMER7_BRK_TIMER11_IRQHandler     ; 59:TIMER7 Break and TIMER11
+                DCD     TIMER7_UP_TIMER12_IRQHandler      ; 60:TIMER7 Update and TIMER12
+                DCD     TIMER7_TRG_CMT_TIMER13_IRQHandler ; 61:TIMER7 Trigger and Commucation and TIMER13
+                DCD     TIMER7_Channel_IRQHandler         ; 62:TIMER7 Capture Compare
+                DCD     DMA0_Channel7_IRQHandler          ; 63:DMA0 Channel7
+                DCD     0                                 ; 64:Reserved
+                DCD     SDIO_IRQHandler                   ; 65:SDIO
+                DCD     TIMER4_IRQHandler                 ; 66:TIMER4
+                DCD     SPI2_IRQHandler                   ; 67:SPI2
+                DCD     UART3_IRQHandler                  ; 68:UART3
+                DCD     UART4_IRQHandler                  ; 69:UART4
+                DCD     TIMER5_DAC_IRQHandler             ; 70:TIMER5 and DAC0 DAC1 Underrun error
+                DCD     TIMER6_IRQHandler                 ; 71:TIMER6
+                DCD     DMA1_Channel0_IRQHandler          ; 72:DMA1 Channel0
+                DCD     DMA1_Channel1_IRQHandler          ; 73:DMA1 Channel1
+                DCD     DMA1_Channel2_IRQHandler          ; 74:DMA1 Channel2
+                DCD     DMA1_Channel3_IRQHandler          ; 75:DMA1 Channel3
+                DCD     DMA1_Channel4_IRQHandler          ; 76:DMA1 Channel4
+                DCD     0                                 ; 77:Reserved
+                DCD     0                                 ; 78:Reserved
+                DCD     CAN1_TX_IRQHandler                ; 79:CAN1 TX
+                DCD     CAN1_RX0_IRQHandler               ; 80:CAN1 RX0
+                DCD     CAN1_RX1_IRQHandler               ; 81:CAN1 RX1
+                DCD     CAN1_EWMC_IRQHandler              ; 82:CAN1 EWMC
+                DCD     USBFS_IRQHandler                  ; 83:USBFS
+                DCD     DMA1_Channel5_IRQHandler          ; 84:DMA1 Channel5
+                DCD     DMA1_Channel6_IRQHandler          ; 85:DMA1 Channel6
+                DCD     DMA1_Channel7_IRQHandler          ; 86:DMA1 Channel7
+                DCD     USART5_IRQHandler                 ; 87:USART5
+                DCD     I2C2_EV_IRQHandler                ; 88:I2C2 Event
+                DCD     I2C2_ER_IRQHandler                ; 89:I2C2 Error
+                DCD     USBHS_EP1_Out_IRQHandler          ; 90:USBHS Endpoint 1 Out 
+                DCD     USBHS_EP1_In_IRQHandler           ; 91:USBHS Endpoint 1 in
+                DCD     USBHS_WKUP_IRQHandler             ; 92:USBHS Wakeup through EXTI Line
+                DCD     USBHS_IRQHandler                  ; 93:USBHS
+                DCD     DCI_IRQHandler                    ; 94:DCI
+                DCD     0                                 ; 95:Reserved
+                DCD     TRNG_IRQHandler                   ; 96:TRNG
+                DCD     FPU_IRQHandler                    ; 97:FPU
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Default interrupt handlers.
+;;
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:NOROOT:REORDER(2)
+Reset_Handler
+        LDR     R0, =SystemInit
+        BLX     R0
+        LDR     R0, =__iar_program_start
+        BX      R0
+        
+        PUBWEAK NMI_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+NMI_Handler
+        B NMI_Handler
+       
+        PUBWEAK HardFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+HardFault_Handler
+        B HardFault_Handler
+       
+        PUBWEAK MemManage_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+MemManage_Handler
+        B MemManage_Handler
+
+        PUBWEAK BusFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+BusFault_Handler
+        B BusFault_Handler
+
+        PUBWEAK UsageFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UsageFault_Handler
+        B UsageFault_Handler
+        
+        PUBWEAK SVC_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SVC_Handler
+        B SVC_Handler
+       
+        PUBWEAK DebugMon_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DebugMon_Handler
+        B DebugMon_Handler
+        
+        PUBWEAK PendSV_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PendSV_Handler
+        B PendSV_Handler
+        
+        PUBWEAK SysTick_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SysTick_Handler
+        B SysTick_Handler
+        
+        PUBWEAK WWDGT_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+WWDGT_IRQHandler
+        B WWDGT_IRQHandler
+        
+        PUBWEAK LVD_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+LVD_IRQHandler
+        B LVD_IRQHandler
+        
+        PUBWEAK TAMPER_STAMP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TAMPER_STAMP_IRQHandler
+        B TAMPER_STAMP_IRQHandler
+        
+        PUBWEAK RTC_WKUP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RTC_WKUP_IRQHandler
+        B RTC_WKUP_IRQHandler
+        
+        PUBWEAK FMC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+FMC_IRQHandler
+        B FMC_IRQHandler
+        
+        PUBWEAK RCU_CTC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RCU_CTC_IRQHandler
+        B RCU_CTC_IRQHandler
+        
+        PUBWEAK EXTI0_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI0_IRQHandler
+        B EXTI0_IRQHandler
+        
+        PUBWEAK EXTI1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI1_IRQHandler
+        B EXTI1_IRQHandler
+        
+        PUBWEAK EXTI2_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI2_IRQHandler                  
+        B EXTI2_IRQHandler                  
+        
+        PUBWEAK EXTI3_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI3_IRQHandler
+        B EXTI3_IRQHandler
+        
+        PUBWEAK EXTI4_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI4_IRQHandler
+        B EXTI4_IRQHandler
+        
+        PUBWEAK DMA0_Channel0_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel0_IRQHandler
+        B DMA0_Channel0_IRQHandler
+        
+        PUBWEAK DMA0_Channel1_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel1_IRQHandler          
+        B DMA0_Channel1_IRQHandler          
+        
+        PUBWEAK DMA0_Channel2_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel2_IRQHandler          
+        B DMA0_Channel2_IRQHandler          
+        
+        PUBWEAK DMA0_Channel3_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel3_IRQHandler          
+        B DMA0_Channel3_IRQHandler          
+        
+        PUBWEAK DMA0_Channel4_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel4_IRQHandler          
+        B DMA0_Channel4_IRQHandler          
+        
+        PUBWEAK DMA0_Channel5_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel5_IRQHandler          
+        B DMA0_Channel5_IRQHandler          
+        
+        PUBWEAK DMA0_Channel6_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel6_IRQHandler          
+        B DMA0_Channel6_IRQHandler                
+        
+        PUBWEAK ADC_IRQHandler                    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+ADC_IRQHandler                    
+        B ADC_IRQHandler                    
+        
+        PUBWEAK CAN0_TX_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN0_TX_IRQHandler                
+        B CAN0_TX_IRQHandler                
+        
+        PUBWEAK CAN0_RX0_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN0_RX0_IRQHandler               
+        B CAN0_RX0_IRQHandler               
+        
+        PUBWEAK CAN0_RX1_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN0_RX1_IRQHandler               
+        B CAN0_RX1_IRQHandler               
+      
+        PUBWEAK CAN0_EWMC_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN0_EWMC_IRQHandler               
+        B CAN0_EWMC_IRQHandler               
+        
+        PUBWEAK EXTI5_9_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI5_9_IRQHandler                
+        B EXTI5_9_IRQHandler                
+        
+        PUBWEAK TIMER0_BRK_TIMER8_IRQHandler    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER0_BRK_TIMER8_IRQHandler    
+        B TIMER0_BRK_TIMER8_IRQHandler    
+        
+        PUBWEAK TIMER0_UP_TIMER9_IRQHandler   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER0_UP_TIMER9_IRQHandler   
+        B TIMER0_UP_TIMER9_IRQHandler   
+        
+        PUBWEAK TIMER0_TRG_CMT_TIMER10_IRQHandler 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER0_TRG_CMT_TIMER10_IRQHandler 
+        B TIMER0_TRG_CMT_TIMER10_IRQHandler 
+        
+        PUBWEAK TIMER0_Channel_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER0_Channel_IRQHandler         
+        B TIMER0_Channel_IRQHandler         
+        
+        PUBWEAK TIMER1_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER1_IRQHandler                 
+        B TIMER1_IRQHandler                 
+        
+        PUBWEAK TIMER2_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER2_IRQHandler
+        B TIMER2_IRQHandler                 
+
+        PUBWEAK TIMER3_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER3_IRQHandler                 
+        B TIMER3_IRQHandler
+
+        PUBWEAK I2C0_EV_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C0_EV_IRQHandler                
+        B I2C0_EV_IRQHandler                
+
+        PUBWEAK I2C0_ER_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C0_ER_IRQHandler
+        B I2C0_ER_IRQHandler                
+
+        PUBWEAK I2C1_EV_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C1_EV_IRQHandler                
+        B I2C1_EV_IRQHandler                
+
+        PUBWEAK I2C1_ER_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C1_ER_IRQHandler                
+        B I2C1_ER_IRQHandler                
+
+        PUBWEAK SPI0_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI0_IRQHandler                   
+        B SPI0_IRQHandler                   
+
+        PUBWEAK SPI1_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI1_IRQHandler                   
+        B SPI1_IRQHandler
+
+        PUBWEAK USART0_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART0_IRQHandler                 
+        B USART0_IRQHandler                 
+
+        PUBWEAK USART1_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART1_IRQHandler                 
+        B USART1_IRQHandler                 
+
+        PUBWEAK USART2_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART2_IRQHandler                
+        B USART2_IRQHandler
+
+        PUBWEAK EXTI10_15_IRQHandler              
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI10_15_IRQHandler              
+        B EXTI10_15_IRQHandler              
+
+        PUBWEAK RTC_Alarm_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RTC_Alarm_IRQHandler             
+        B RTC_Alarm_IRQHandler             
+
+        PUBWEAK USBFS_WKUP_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBFS_WKUP_IRQHandler             
+        B USBFS_WKUP_IRQHandler             
+
+        PUBWEAK TIMER7_BRK_TIMER11_IRQHandler   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER7_BRK_TIMER11_IRQHandler   
+        B TIMER7_BRK_TIMER11_IRQHandler   
+
+        PUBWEAK TIMER7_UP_TIMER12_IRQHandler  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER7_UP_TIMER12_IRQHandler  
+        B TIMER7_UP_TIMER12_IRQHandler  
+
+        PUBWEAK TIMER7_TRG_CMT_TIMER13_IRQHandler 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER7_TRG_CMT_TIMER13_IRQHandler 
+        B TIMER7_TRG_CMT_TIMER13_IRQHandler 
+
+        PUBWEAK TIMER7_Channel_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER7_Channel_IRQHandler         
+        B TIMER7_Channel_IRQHandler         
+
+        PUBWEAK DMA0_Channel7_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel7_IRQHandler         
+        B DMA0_Channel7_IRQHandler         
+
+        PUBWEAK SDIO_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SDIO_IRQHandler                   
+        B SDIO_IRQHandler                   
+
+        PUBWEAK TIMER4_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER4_IRQHandler                 
+        B TIMER4_IRQHandler                 
+
+        PUBWEAK SPI2_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI2_IRQHandler                  
+        B SPI2_IRQHandler                  
+
+        PUBWEAK UART3_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UART3_IRQHandler                  
+        B UART3_IRQHandler                  
+
+        PUBWEAK UART4_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UART4_IRQHandler                  
+        B UART4_IRQHandler                  
+
+        PUBWEAK TIMER5_DAC_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER5_DAC_IRQHandler             
+        B TIMER5_DAC_IRQHandler             
+
+        PUBWEAK TIMER6_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER6_IRQHandler                
+        B TIMER6_IRQHandler                
+
+        PUBWEAK DMA1_Channel0_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel0_IRQHandler          
+        B DMA1_Channel0_IRQHandler          
+
+        PUBWEAK DMA1_Channel1_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel1_IRQHandler          
+        B DMA1_Channel1_IRQHandler          
+
+        PUBWEAK DMA1_Channel2_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel2_IRQHandler         
+        B DMA1_Channel2_IRQHandler         
+
+        PUBWEAK DMA1_Channel3_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel3_IRQHandler         
+        B DMA1_Channel3_IRQHandler         
+
+        PUBWEAK DMA1_Channel4_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel4_IRQHandler          
+        B DMA1_Channel4_IRQHandler          
+
+        PUBWEAK CAN1_TX_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN1_TX_IRQHandler                
+        B CAN1_TX_IRQHandler                
+
+        PUBWEAK CAN1_RX0_IRQHandler              
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN1_RX0_IRQHandler              
+        B CAN1_RX0_IRQHandler              
+
+        PUBWEAK CAN1_RX1_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN1_RX1_IRQHandler               
+        B CAN1_RX1_IRQHandler               
+
+        PUBWEAK CAN1_EWMC_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN1_EWMC_IRQHandler               
+        B CAN1_EWMC_IRQHandler               
+
+        PUBWEAK USBFS_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBFS_IRQHandler                  
+        B USBFS_IRQHandler                  
+
+        PUBWEAK DMA1_Channel5_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel5_IRQHandler          
+        B DMA1_Channel5_IRQHandler          
+
+        PUBWEAK DMA1_Channel6_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel6_IRQHandler          
+        B DMA1_Channel6_IRQHandler          
+
+        PUBWEAK DMA1_Channel7_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel7_IRQHandler          
+        B DMA1_Channel7_IRQHandler          
+
+        PUBWEAK USART5_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART5_IRQHandler                 
+        B USART5_IRQHandler                 
+
+        PUBWEAK I2C2_EV_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C2_EV_IRQHandler               
+        B I2C2_EV_IRQHandler               
+
+        PUBWEAK I2C2_ER_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C2_ER_IRQHandler                
+        B I2C2_ER_IRQHandler                
+
+        PUBWEAK USBHS_EP1_Out_IRQHandler    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBHS_EP1_Out_IRQHandler    
+        B USBHS_EP1_Out_IRQHandler    
+
+        PUBWEAK USBHS_EP1_In_IRQHandler     
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBHS_EP1_In_IRQHandler     
+        B USBHS_EP1_In_IRQHandler     
+
+        PUBWEAK USBHS_WKUP_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBHS_WKUP_IRQHandler             
+        B USBHS_WKUP_IRQHandler             
+
+        PUBWEAK USBHS_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBHS_IRQHandler                  
+        B USBHS_IRQHandler                  
+
+        PUBWEAK DCI_IRQHandler                    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DCI_IRQHandler                    
+        B DCI_IRQHandler                    
+
+        PUBWEAK TRNG_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TRNG_IRQHandler                  
+        B TRNG_IRQHandler                  
+
+        PUBWEAK FPU_IRQHandler                    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+FPU_IRQHandler                    
+        B FPU_IRQHandler                    
+
+        END

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/IAR/startup_gd32f407_427.s
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/IAR/startup_gd32f407_427.s
@@ -1,0 +1,617 @@
+;/*!
+;    \file    startup_gd32f407_427.s
+;    \brief   start up file
+;
+;    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+;    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+;    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+;    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+;*/
+;
+;/*
+;    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+;
+;    Redistribution and use in source and binary forms, with or without modification, 
+;are permitted provided that the following conditions are met:
+;
+;    1. Redistributions of source code must retain the above copyright notice, this 
+;       list of conditions and the following disclaimer.
+;    2. Redistributions in binary form must reproduce the above copyright notice, 
+;       this list of conditions and the following disclaimer in the documentation 
+;       and/or other materials provided with the distribution.
+;    3. Neither the name of the copyright holder nor the names of its contributors 
+;       may be used to endorse or promote products derived from this software without 
+;       specific prior written permission.
+;
+;    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+;AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+;WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+;IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+;INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+;NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+;PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+;WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+;ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+;OF SUCH DAMAGE.
+;*/
+
+        MODULE  ?cstartup
+
+        ;; Forward declaration of sections.
+        SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(2)
+
+        EXTERN  __iar_program_start
+        EXTERN  SystemInit
+        PUBLIC  __vector_table
+
+        DATA
+__vector_table
+        DCD     sfe(CSTACK)                         ; top of stack
+        DCD     Reset_Handler                       ; Vector Number 1,Reset Handler
+
+        DCD     NMI_Handler                         ; Vector Number 2,NMI Handler
+        DCD     HardFault_Handler                   ; Vector Number 3,Hard Fault Handler
+        DCD     MemManage_Handler                   ; Vector Number 4,MPU Fault Handler
+        DCD     BusFault_Handler                    ; Vector Number 5,Bus Fault Handler
+        DCD     UsageFault_Handler                  ; Vector Number 6,Usage Fault Handler
+        DCD     0                                   ; Reserved
+        DCD     0                                   ; Reserved
+        DCD     0                                   ; Reserved
+        DCD     0                                   ; Reserved
+        DCD     SVC_Handler                         ; Vector Number 11,SVCall Handler
+        DCD     DebugMon_Handler                    ; Vector Number 12,Debug Monitor Handler
+        DCD     0                                   ; Reserved
+        DCD     PendSV_Handler                      ; Vector Number 14,PendSV Handler
+        DCD     SysTick_Handler                     ; Vector Number 15,SysTick Handler
+
+        ; External Interrupts
+                DCD     WWDGT_IRQHandler                  ; 16:Window Watchdog Timer
+                DCD     LVD_IRQHandler                    ; 17:LVD through EXTI Line detect
+                DCD     TAMPER_STAMP_IRQHandler           ; 18:Tamper and TimeStamp through EXTI Line detect
+                DCD     RTC_WKUP_IRQHandler               ; 19:RTC Wakeup through EXTI Line
+                DCD     FMC_IRQHandler                    ; 20:FMC
+                DCD     RCU_CTC_IRQHandler                ; 21:RCU and CTC
+                DCD     EXTI0_IRQHandler                  ; 22:EXTI Line 0
+                DCD     EXTI1_IRQHandler                  ; 23:EXTI Line 1
+                DCD     EXTI2_IRQHandler                  ; 24:EXTI Line 2
+                DCD     EXTI3_IRQHandler                  ; 25:EXTI Line 3
+                DCD     EXTI4_IRQHandler                  ; 26:EXTI Line 4
+                DCD     DMA0_Channel0_IRQHandler          ; 27:DMA0 Channel0
+                DCD     DMA0_Channel1_IRQHandler          ; 28:DMA0 Channel1
+                DCD     DMA0_Channel2_IRQHandler          ; 29:DMA0 Channel2
+                DCD     DMA0_Channel3_IRQHandler          ; 30:DMA0 Channel3
+                DCD     DMA0_Channel4_IRQHandler          ; 31:DMA0 Channel4
+                DCD     DMA0_Channel5_IRQHandler          ; 32:DMA0 Channel5
+                DCD     DMA0_Channel6_IRQHandler          ; 33:DMA0 Channel6
+                DCD     ADC_IRQHandler                    ; 34:ADC
+                DCD     CAN0_TX_IRQHandler                ; 35:CAN0 TX
+                DCD     CAN0_RX0_IRQHandler               ; 36:CAN0 RX0
+                DCD     CAN0_RX1_IRQHandler               ; 37:CAN0 RX1
+                DCD     CAN0_EWMC_IRQHandler              ; 38:CAN0 EWMC
+                DCD     EXTI5_9_IRQHandler                ; 39:EXTI5 to EXTI9
+                DCD     TIMER0_BRK_TIMER8_IRQHandler      ; 40:TIMER0 Break and TIMER8
+                DCD     TIMER0_UP_TIMER9_IRQHandler       ; 41:TIMER0 Update and TIMER9
+                DCD     TIMER0_TRG_CMT_TIMER10_IRQHandler ; 42:TIMER0 Trigger and Commucation and TIMER10
+                DCD     TIMER0_Channel_IRQHandler         ; 43:TIMER0 Capture Compare
+                DCD     TIMER1_IRQHandler                 ; 44:TIMER1
+                DCD     TIMER2_IRQHandler                 ; 45:TIMER2
+                DCD     TIMER3_IRQHandler                 ; 46:TIMER3
+                DCD     I2C0_EV_IRQHandler                ; 47:I2C0 Event
+                DCD     I2C0_ER_IRQHandler                ; 48:I2C0 Error
+                DCD     I2C1_EV_IRQHandler                ; 49:I2C1 Event
+                DCD     I2C1_ER_IRQHandler                ; 50:I2C1 Error
+                DCD     SPI0_IRQHandler                   ; 51:SPI0
+                DCD     SPI1_IRQHandler                   ; 52:SPI1
+                DCD     USART0_IRQHandler                 ; 53:USART0
+                DCD     USART1_IRQHandler                 ; 54:USART1
+                DCD     USART2_IRQHandler                 ; 55:USART2
+                DCD     EXTI10_15_IRQHandler              ; 56:EXTI10 to EXTI15
+                DCD     RTC_Alarm_IRQHandler              ; 57:RTC Alarm
+                DCD     USBFS_WKUP_IRQHandler             ; 58:USBFS Wakeup
+                DCD     TIMER7_BRK_TIMER11_IRQHandler     ; 59:TIMER7 Break and TIMER11
+                DCD     TIMER7_UP_TIMER12_IRQHandler      ; 60:TIMER7 Update and TIMER12
+                DCD     TIMER7_TRG_CMT_TIMER13_IRQHandler ; 61:TIMER7 Trigger and Commucation and TIMER13
+                DCD     TIMER7_Channel_IRQHandler         ; 62:TIMER7 Channel Capture Compare
+                DCD     DMA0_Channel7_IRQHandler          ; 63:DMA0 Channel7
+                DCD     EXMC_IRQHandler                   ; 64:EXMC
+                DCD     SDIO_IRQHandler                   ; 65:SDIO
+                DCD     TIMER4_IRQHandler                 ; 66:TIMER4
+                DCD     SPI2_IRQHandler                   ; 67:SPI2
+                DCD     UART3_IRQHandler                  ; 68:UART3
+                DCD     UART4_IRQHandler                  ; 69:UART4
+                DCD     TIMER5_DAC_IRQHandler             ; 70:TIMER5 and DAC0 DAC1 Underrun error
+                DCD     TIMER6_IRQHandler                 ; 71:TIMER6
+                DCD     DMA1_Channel0_IRQHandler          ; 72:DMA1 Channel0
+                DCD     DMA1_Channel1_IRQHandler          ; 73:DMA1 Channel1
+                DCD     DMA1_Channel2_IRQHandler          ; 74:DMA1 Channel2
+                DCD     DMA1_Channel3_IRQHandler          ; 75:DMA1 Channel3
+                DCD     DMA1_Channel4_IRQHandler          ; 76:DMA1 Channel4
+                DCD     ENET_IRQHandler                   ; 77:Ethernet
+                DCD     ENET_WKUP_IRQHandler              ; 78:Ethernet Wakeup through EXTI Line
+                DCD     CAN1_TX_IRQHandler                ; 79:CAN1 TX
+                DCD     CAN1_RX0_IRQHandler               ; 80:CAN1 RX0
+                DCD     CAN1_RX1_IRQHandler               ; 81:CAN1 RX1
+                DCD     CAN1_EWMC_IRQHandler              ; 82:CAN1 EWMC
+                DCD     USBFS_IRQHandler                  ; 83:USBFS
+                DCD     DMA1_Channel5_IRQHandler          ; 84:DMA1 Channel5
+                DCD     DMA1_Channel6_IRQHandler          ; 85:DMA1 Channel6
+                DCD     DMA1_Channel7_IRQHandler          ; 86:DMA1 Channel7
+                DCD     USART5_IRQHandler                 ; 87:USART5
+                DCD     I2C2_EV_IRQHandler                ; 88:I2C2 Event
+                DCD     I2C2_ER_IRQHandler                ; 89:I2C2 Error
+                DCD     USBHS_EP1_Out_IRQHandler          ; 90:USBHS Endpoint 1 Out 
+                DCD     USBHS_EP1_In_IRQHandler           ; 91:USBHS Endpoint 1 in
+                DCD     USBHS_WKUP_IRQHandler             ; 92:USBHS Wakeup through EXTI Line
+                DCD     USBHS_IRQHandler                  ; 93:USBHS
+                DCD     DCI_IRQHandler                    ; 94:DCI
+                DCD     0                                 ; 95:Reserved
+                DCD     TRNG_IRQHandler                   ; 96:TRNG
+                DCD     FPU_IRQHandler                    ; 97:FPU
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Default interrupt handlers.
+;;
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:NOROOT:REORDER(2)
+Reset_Handler
+        LDR     R0, =SystemInit
+        BLX     R0
+        LDR     R0, =__iar_program_start
+        BX      R0
+        
+        PUBWEAK NMI_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+NMI_Handler
+        B NMI_Handler
+       
+        PUBWEAK HardFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+HardFault_Handler
+        B HardFault_Handler
+       
+        PUBWEAK MemManage_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+MemManage_Handler
+        B MemManage_Handler
+
+        PUBWEAK BusFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+BusFault_Handler
+        B BusFault_Handler
+
+        PUBWEAK UsageFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UsageFault_Handler
+        B UsageFault_Handler
+        
+        PUBWEAK SVC_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SVC_Handler
+        B SVC_Handler
+       
+        PUBWEAK DebugMon_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DebugMon_Handler
+        B DebugMon_Handler
+        
+        PUBWEAK PendSV_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PendSV_Handler
+        B PendSV_Handler
+        
+        PUBWEAK SysTick_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SysTick_Handler
+        B SysTick_Handler
+        
+        PUBWEAK WWDGT_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+WWDGT_IRQHandler
+        B WWDGT_IRQHandler
+        
+        PUBWEAK LVD_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+LVD_IRQHandler
+        B LVD_IRQHandler
+        
+        PUBWEAK TAMPER_STAMP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TAMPER_STAMP_IRQHandler
+        B TAMPER_STAMP_IRQHandler
+        
+        PUBWEAK RTC_WKUP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RTC_WKUP_IRQHandler
+        B RTC_WKUP_IRQHandler
+        
+        PUBWEAK FMC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+FMC_IRQHandler
+        B FMC_IRQHandler
+        
+        PUBWEAK RCU_CTC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RCU_CTC_IRQHandler
+        B RCU_CTC_IRQHandler
+        
+        PUBWEAK EXTI0_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI0_IRQHandler
+        B EXTI0_IRQHandler
+        
+        PUBWEAK EXTI1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI1_IRQHandler
+        B EXTI1_IRQHandler
+        
+        PUBWEAK EXTI2_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI2_IRQHandler                  
+        B EXTI2_IRQHandler                  
+        
+        PUBWEAK EXTI3_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI3_IRQHandler
+        B EXTI3_IRQHandler
+        
+        PUBWEAK EXTI4_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI4_IRQHandler
+        B EXTI4_IRQHandler
+        
+        PUBWEAK DMA0_Channel0_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel0_IRQHandler
+        B DMA0_Channel0_IRQHandler
+        
+        PUBWEAK DMA0_Channel1_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel1_IRQHandler          
+        B DMA0_Channel1_IRQHandler          
+        
+        PUBWEAK DMA0_Channel2_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel2_IRQHandler          
+        B DMA0_Channel2_IRQHandler          
+        
+        PUBWEAK DMA0_Channel3_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel3_IRQHandler          
+        B DMA0_Channel3_IRQHandler          
+        
+        PUBWEAK DMA0_Channel4_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel4_IRQHandler          
+        B DMA0_Channel4_IRQHandler          
+        
+        PUBWEAK DMA0_Channel5_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel5_IRQHandler          
+        B DMA0_Channel5_IRQHandler          
+        
+        PUBWEAK DMA0_Channel6_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel6_IRQHandler          
+        B DMA0_Channel6_IRQHandler                
+        
+        PUBWEAK ADC_IRQHandler                    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+ADC_IRQHandler                    
+        B ADC_IRQHandler                    
+        
+        PUBWEAK CAN0_TX_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN0_TX_IRQHandler                
+        B CAN0_TX_IRQHandler                
+        
+        PUBWEAK CAN0_RX0_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN0_RX0_IRQHandler               
+        B CAN0_RX0_IRQHandler               
+        
+        PUBWEAK CAN0_RX1_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN0_RX1_IRQHandler               
+        B CAN0_RX1_IRQHandler               
+      
+        PUBWEAK CAN0_EWMC_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN0_EWMC_IRQHandler               
+        B CAN0_EWMC_IRQHandler               
+        
+        PUBWEAK EXTI5_9_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI5_9_IRQHandler                
+        B EXTI5_9_IRQHandler                
+        
+        PUBWEAK TIMER0_BRK_TIMER8_IRQHandler    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER0_BRK_TIMER8_IRQHandler    
+        B TIMER0_BRK_TIMER8_IRQHandler    
+        
+        PUBWEAK TIMER0_UP_TIMER9_IRQHandler   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER0_UP_TIMER9_IRQHandler   
+        B TIMER0_UP_TIMER9_IRQHandler   
+        
+        PUBWEAK TIMER0_TRG_CMT_TIMER10_IRQHandler 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER0_TRG_CMT_TIMER10_IRQHandler 
+        B TIMER0_TRG_CMT_TIMER10_IRQHandler 
+        
+        PUBWEAK TIMER0_Channel_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER0_Channel_IRQHandler         
+        B TIMER0_Channel_IRQHandler         
+        
+        PUBWEAK TIMER1_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER1_IRQHandler                 
+        B TIMER1_IRQHandler                 
+        
+        PUBWEAK TIMER2_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER2_IRQHandler
+        B TIMER2_IRQHandler                 
+
+        PUBWEAK TIMER3_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER3_IRQHandler                 
+        B TIMER3_IRQHandler
+
+        PUBWEAK I2C0_EV_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C0_EV_IRQHandler                
+        B I2C0_EV_IRQHandler                
+
+        PUBWEAK I2C0_ER_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C0_ER_IRQHandler
+        B I2C0_ER_IRQHandler                
+
+        PUBWEAK I2C1_EV_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C1_EV_IRQHandler                
+        B I2C1_EV_IRQHandler                
+
+        PUBWEAK I2C1_ER_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C1_ER_IRQHandler                
+        B I2C1_ER_IRQHandler                
+
+        PUBWEAK SPI0_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI0_IRQHandler                   
+        B SPI0_IRQHandler                   
+
+        PUBWEAK SPI1_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI1_IRQHandler                   
+        B SPI1_IRQHandler
+
+        PUBWEAK USART0_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART0_IRQHandler                 
+        B USART0_IRQHandler                 
+
+        PUBWEAK USART1_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART1_IRQHandler                 
+        B USART1_IRQHandler                 
+
+        PUBWEAK USART2_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART2_IRQHandler                
+        B USART2_IRQHandler
+
+        PUBWEAK EXTI10_15_IRQHandler              
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI10_15_IRQHandler              
+        B EXTI10_15_IRQHandler              
+
+        PUBWEAK RTC_Alarm_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RTC_Alarm_IRQHandler             
+        B RTC_Alarm_IRQHandler             
+
+        PUBWEAK USBFS_WKUP_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBFS_WKUP_IRQHandler             
+        B USBFS_WKUP_IRQHandler             
+
+        PUBWEAK TIMER7_BRK_TIMER11_IRQHandler   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER7_BRK_TIMER11_IRQHandler   
+        B TIMER7_BRK_TIMER11_IRQHandler   
+
+        PUBWEAK TIMER7_UP_TIMER12_IRQHandler  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER7_UP_TIMER12_IRQHandler  
+        B TIMER7_UP_TIMER12_IRQHandler  
+
+        PUBWEAK TIMER7_TRG_CMT_TIMER13_IRQHandler 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER7_TRG_CMT_TIMER13_IRQHandler 
+        B TIMER7_TRG_CMT_TIMER13_IRQHandler 
+
+        PUBWEAK TIMER7_Channel_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER7_Channel_IRQHandler         
+        B TIMER7_Channel_IRQHandler         
+
+        PUBWEAK DMA0_Channel7_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel7_IRQHandler         
+        B DMA0_Channel7_IRQHandler         
+
+        PUBWEAK EXMC_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXMC_IRQHandler                   
+        B EXMC_IRQHandler                   
+
+        PUBWEAK SDIO_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SDIO_IRQHandler                   
+        B SDIO_IRQHandler                   
+
+        PUBWEAK TIMER4_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER4_IRQHandler                 
+        B TIMER4_IRQHandler                 
+
+        PUBWEAK SPI2_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI2_IRQHandler                  
+        B SPI2_IRQHandler                  
+
+        PUBWEAK UART3_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UART3_IRQHandler                  
+        B UART3_IRQHandler                  
+
+        PUBWEAK UART4_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UART4_IRQHandler                  
+        B UART4_IRQHandler                  
+
+        PUBWEAK TIMER5_DAC_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER5_DAC_IRQHandler             
+        B TIMER5_DAC_IRQHandler             
+
+        PUBWEAK TIMER6_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER6_IRQHandler                
+        B TIMER6_IRQHandler                
+
+        PUBWEAK DMA1_Channel0_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel0_IRQHandler          
+        B DMA1_Channel0_IRQHandler          
+
+        PUBWEAK DMA1_Channel1_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel1_IRQHandler          
+        B DMA1_Channel1_IRQHandler          
+
+        PUBWEAK DMA1_Channel2_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel2_IRQHandler         
+        B DMA1_Channel2_IRQHandler         
+
+        PUBWEAK DMA1_Channel3_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel3_IRQHandler         
+        B DMA1_Channel3_IRQHandler         
+
+        PUBWEAK DMA1_Channel4_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel4_IRQHandler          
+        B DMA1_Channel4_IRQHandler          
+
+        PUBWEAK ENET_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+ENET_IRQHandler                  
+        B ENET_IRQHandler                  
+        
+        PUBWEAK ENET_WKUP_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+ENET_WKUP_IRQHandler             
+        B ENET_WKUP_IRQHandler             
+
+        PUBWEAK CAN1_TX_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN1_TX_IRQHandler                
+        B CAN1_TX_IRQHandler                
+
+        PUBWEAK CAN1_RX0_IRQHandler              
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN1_RX0_IRQHandler              
+        B CAN1_RX0_IRQHandler              
+
+        PUBWEAK CAN1_RX1_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN1_RX1_IRQHandler               
+        B CAN1_RX1_IRQHandler               
+
+        PUBWEAK CAN1_EWMC_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN1_EWMC_IRQHandler               
+        B CAN1_EWMC_IRQHandler               
+
+        PUBWEAK USBFS_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBFS_IRQHandler                  
+        B USBFS_IRQHandler                  
+
+        PUBWEAK DMA1_Channel5_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel5_IRQHandler          
+        B DMA1_Channel5_IRQHandler          
+
+        PUBWEAK DMA1_Channel6_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel6_IRQHandler          
+        B DMA1_Channel6_IRQHandler          
+
+        PUBWEAK DMA1_Channel7_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel7_IRQHandler          
+        B DMA1_Channel7_IRQHandler          
+
+        PUBWEAK USART5_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART5_IRQHandler                 
+        B USART5_IRQHandler                 
+
+        PUBWEAK I2C2_EV_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C2_EV_IRQHandler               
+        B I2C2_EV_IRQHandler               
+
+        PUBWEAK I2C2_ER_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C2_ER_IRQHandler                
+        B I2C2_ER_IRQHandler                
+
+        PUBWEAK USBHS_EP1_Out_IRQHandler    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBHS_EP1_Out_IRQHandler    
+        B USBHS_EP1_Out_IRQHandler    
+
+        PUBWEAK USBHS_EP1_In_IRQHandler     
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBHS_EP1_In_IRQHandler     
+        B USBHS_EP1_In_IRQHandler     
+
+        PUBWEAK USBHS_WKUP_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBHS_WKUP_IRQHandler             
+        B USBHS_WKUP_IRQHandler             
+
+        PUBWEAK USBHS_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBHS_IRQHandler                  
+        B USBHS_IRQHandler                  
+
+        PUBWEAK DCI_IRQHandler                    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DCI_IRQHandler                    
+        B DCI_IRQHandler                    
+
+        PUBWEAK TRNG_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TRNG_IRQHandler                  
+        B TRNG_IRQHandler                  
+
+        PUBWEAK FPU_IRQHandler                    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+FPU_IRQHandler                    
+        B FPU_IRQHandler                    
+
+        END

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/IAR/startup_gd32f450_470.s
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/IAR/startup_gd32f450_470.s
@@ -1,0 +1,666 @@
+;/*!
+;    \file    startup_gd32f450_470.s
+;    \brief   start up file
+;
+;    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+;    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+;    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+;    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+;*/
+;
+;/*
+;    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+;
+;    Redistribution and use in source and binary forms, with or without modification, 
+;are permitted provided that the following conditions are met:
+;
+;    1. Redistributions of source code must retain the above copyright notice, this 
+;       list of conditions and the following disclaimer.
+;    2. Redistributions in binary form must reproduce the above copyright notice, 
+;       this list of conditions and the following disclaimer in the documentation 
+;       and/or other materials provided with the distribution.
+;    3. Neither the name of the copyright holder nor the names of its contributors 
+;       may be used to endorse or promote products derived from this software without 
+;       specific prior written permission.
+;
+;    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+;AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+;WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+;IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+;INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+;NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+;PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+;WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+;ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+;OF SUCH DAMAGE.
+;*/
+
+        MODULE  ?cstartup
+
+        ;; Forward declaration of sections.
+        SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(2)
+
+        EXTERN  __iar_program_start
+        EXTERN  SystemInit
+        PUBLIC  __vector_table
+
+        DATA
+__vector_table
+        DCD     sfe(CSTACK)                         ; top of stack
+        DCD     Reset_Handler                       ; Vector Number 1,Reset Handler
+
+        DCD     NMI_Handler                         ; Vector Number 2,NMI Handler
+        DCD     HardFault_Handler                   ; Vector Number 3,Hard Fault Handler
+        DCD     MemManage_Handler                   ; Vector Number 4,MPU Fault Handler
+        DCD     BusFault_Handler                    ; Vector Number 5,Bus Fault Handler
+        DCD     UsageFault_Handler                  ; Vector Number 6,Usage Fault Handler
+        DCD     0                                   ; Reserved
+        DCD     0                                   ; Reserved
+        DCD     0                                   ; Reserved
+        DCD     0                                   ; Reserved
+        DCD     SVC_Handler                         ; Vector Number 11,SVCall Handler
+        DCD     DebugMon_Handler                    ; Vector Number 12,Debug Monitor Handler
+        DCD     0                                   ; Reserved
+        DCD     PendSV_Handler                      ; Vector Number 14,PendSV Handler
+        DCD     SysTick_Handler                     ; Vector Number 15,SysTick Handler
+
+        ; External Interrupts
+                DCD     WWDGT_IRQHandler                  ; 16:Window Watchdog Timer
+                DCD     LVD_IRQHandler                    ; 17:LVD through EXTI Line detect
+                DCD     TAMPER_STAMP_IRQHandler           ; 18:Tamper and TimeStamp through EXTI Line detect
+                DCD     RTC_WKUP_IRQHandler               ; 19:RTC Wakeup through EXTI Line
+                DCD     FMC_IRQHandler                    ; 20:FMC
+                DCD     RCU_CTC_IRQHandler                ; 21:RCU and CTC
+                DCD     EXTI0_IRQHandler                  ; 22:EXTI Line 0
+                DCD     EXTI1_IRQHandler                  ; 23:EXTI Line 1
+                DCD     EXTI2_IRQHandler                  ; 24:EXTI Line 2
+                DCD     EXTI3_IRQHandler                  ; 25:EXTI Line 3
+                DCD     EXTI4_IRQHandler                  ; 26:EXTI Line 4
+                DCD     DMA0_Channel0_IRQHandler          ; 27:DMA0 Channel0
+                DCD     DMA0_Channel1_IRQHandler          ; 28:DMA0 Channel1
+                DCD     DMA0_Channel2_IRQHandler          ; 29:DMA0 Channel2
+                DCD     DMA0_Channel3_IRQHandler          ; 30:DMA0 Channel3
+                DCD     DMA0_Channel4_IRQHandler          ; 31:DMA0 Channel4
+                DCD     DMA0_Channel5_IRQHandler          ; 32:DMA0 Channel5
+                DCD     DMA0_Channel6_IRQHandler          ; 33:DMA0 Channel6
+                DCD     ADC_IRQHandler                    ; 34:ADC
+                DCD     CAN0_TX_IRQHandler                ; 35:CAN0 TX
+                DCD     CAN0_RX0_IRQHandler               ; 36:CAN0 RX0
+                DCD     CAN0_RX1_IRQHandler               ; 37:CAN0 RX1
+                DCD     CAN0_EWMC_IRQHandler              ; 38:CAN0 EWMC
+                DCD     EXTI5_9_IRQHandler                ; 39:EXTI5 to EXTI9
+                DCD     TIMER0_BRK_TIMER8_IRQHandler      ; 40:TIMER0 Break and TIMER8
+                DCD     TIMER0_UP_TIMER9_IRQHandler       ; 41:TIMER0 Update and TIMER9
+                DCD     TIMER0_TRG_CMT_TIMER10_IRQHandler ; 42:TIMER0 Trigger and Commucation and TIMER10
+                DCD     TIMER0_Channel_IRQHandler         ; 43:TIMER0 Channel Capture Compare
+                DCD     TIMER1_IRQHandler                 ; 44:TIMER1
+                DCD     TIMER2_IRQHandler                 ; 45:TIMER2
+                DCD     TIMER3_IRQHandler                 ; 46:TIMER3
+                DCD     I2C0_EV_IRQHandler                ; 47:I2C0 Event
+                DCD     I2C0_ER_IRQHandler                ; 48:I2C0 Error
+                DCD     I2C1_EV_IRQHandler                ; 49:I2C1 Event
+                DCD     I2C1_ER_IRQHandler                ; 50:I2C1 Error
+                DCD     SPI0_IRQHandler                   ; 51:SPI0
+                DCD     SPI1_IRQHandler                   ; 52:SPI1
+                DCD     USART0_IRQHandler                 ; 53:USART0
+                DCD     USART1_IRQHandler                 ; 54:USART1
+                DCD     USART2_IRQHandler                 ; 55:USART2
+                DCD     EXTI10_15_IRQHandler              ; 56:EXTI10 to EXTI15
+                DCD     RTC_Alarm_IRQHandler              ; 57:RTC Alarm
+                DCD     USBFS_WKUP_IRQHandler             ; 58:USBFS Wakeup
+                DCD     TIMER7_BRK_TIMER11_IRQHandler     ; 59:TIMER7 Break and TIMER11
+                DCD     TIMER7_UP_TIMER12_IRQHandler      ; 60:TIMER7 Update and TIMER12
+                DCD     TIMER7_TRG_CMT_TIMER13_IRQHandler ; 61:TIMER7 Trigger and Commucation and TIMER13
+                DCD     TIMER7_Channel_IRQHandler         ; 62:TIMER7 Channel Capture Compare
+                DCD     DMA0_Channel7_IRQHandler          ; 63:DMA0 Channel7
+                DCD     EXMC_IRQHandler                   ; 64:EXMC
+                DCD     SDIO_IRQHandler                   ; 65:SDIO
+                DCD     TIMER4_IRQHandler                 ; 66:TIMER4
+                DCD     SPI2_IRQHandler                   ; 67:SPI2
+                DCD     UART3_IRQHandler                  ; 68:UART3
+                DCD     UART4_IRQHandler                  ; 69:UART4
+                DCD     TIMER5_DAC_IRQHandler             ; 70:TIMER5 and DAC0 DAC1 Underrun error
+                DCD     TIMER6_IRQHandler                 ; 71:TIMER6
+                DCD     DMA1_Channel0_IRQHandler          ; 72:DMA1 Channel0
+                DCD     DMA1_Channel1_IRQHandler          ; 73:DMA1 Channel1
+                DCD     DMA1_Channel2_IRQHandler          ; 74:DMA1 Channel2
+                DCD     DMA1_Channel3_IRQHandler          ; 75:DMA1 Channel3
+                DCD     DMA1_Channel4_IRQHandler          ; 76:DMA1 Channel4
+                DCD     ENET_IRQHandler                   ; 77:Ethernet
+                DCD     ENET_WKUP_IRQHandler              ; 78:Ethernet Wakeup through EXTI Line
+                DCD     CAN1_TX_IRQHandler                ; 79:CAN1 TX
+                DCD     CAN1_RX0_IRQHandler               ; 80:CAN1 RX0
+                DCD     CAN1_RX1_IRQHandler               ; 81:CAN1 RX1
+                DCD     CAN1_EWMC_IRQHandler              ; 82:CAN1 EWMC
+                DCD     USBFS_IRQHandler                  ; 83:USBFS
+                DCD     DMA1_Channel5_IRQHandler          ; 84:DMA1 Channel5
+                DCD     DMA1_Channel6_IRQHandler          ; 85:DMA1 Channel6
+                DCD     DMA1_Channel7_IRQHandler          ; 86:DMA1 Channel7
+                DCD     USART5_IRQHandler                 ; 87:USART5
+                DCD     I2C2_EV_IRQHandler                ; 88:I2C2 Event
+                DCD     I2C2_ER_IRQHandler                ; 89:I2C2 Error
+                DCD     USBHS_EP1_Out_IRQHandler          ; 90:USBHS Endpoint 1 Out 
+                DCD     USBHS_EP1_In_IRQHandler           ; 91:USBHS Endpoint 1 in
+                DCD     USBHS_WKUP_IRQHandler             ; 92:USBHS Wakeup through EXTI Line
+                DCD     USBHS_IRQHandler                  ; 93:USBHS
+                DCD     DCI_IRQHandler                    ; 94:DCI
+                DCD     0                                 ; 95:Reserved
+                DCD     TRNG_IRQHandler                   ; 96:TRNG
+                DCD     FPU_IRQHandler                    ; 97:FPU
+                DCD     UART6_IRQHandler                  ; 98:UART6
+                DCD     UART7_IRQHandler                  ; 99:UART7
+                DCD     SPI3_IRQHandler                   ; 100:SPI3
+                DCD     SPI4_IRQHandler                   ; 101:SPI4
+                DCD     SPI5_IRQHandler                   ; 102:SPI5
+                DCD     0                                 ; 103:Reserved
+                DCD     TLI_IRQHandler                    ; 104:TLI
+                DCD     TLI_ER_IRQHandler                 ; 105:TLI Error
+                DCD     IPA_IRQHandler                    ; 106:IPA
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Default interrupt handlers.
+;;
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:NOROOT:REORDER(2)
+Reset_Handler
+        LDR     R0, =SystemInit
+        BLX     R0
+        LDR     R0, =__iar_program_start
+        BX      R0
+        
+        PUBWEAK NMI_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+NMI_Handler
+        B NMI_Handler
+       
+        PUBWEAK HardFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+HardFault_Handler
+        B HardFault_Handler
+       
+        PUBWEAK MemManage_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+MemManage_Handler
+        B MemManage_Handler
+
+        PUBWEAK BusFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+BusFault_Handler
+        B BusFault_Handler
+
+        PUBWEAK UsageFault_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UsageFault_Handler
+        B UsageFault_Handler
+        
+        PUBWEAK SVC_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SVC_Handler
+        B SVC_Handler
+       
+        PUBWEAK DebugMon_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DebugMon_Handler
+        B DebugMon_Handler
+        
+        PUBWEAK PendSV_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+PendSV_Handler
+        B PendSV_Handler
+        
+        PUBWEAK SysTick_Handler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SysTick_Handler
+        B SysTick_Handler
+        
+        PUBWEAK WWDGT_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+WWDGT_IRQHandler
+        B WWDGT_IRQHandler
+        
+        PUBWEAK LVD_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+LVD_IRQHandler
+        B LVD_IRQHandler
+        
+        PUBWEAK TAMPER_STAMP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TAMPER_STAMP_IRQHandler
+        B TAMPER_STAMP_IRQHandler
+        
+        PUBWEAK RTC_WKUP_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RTC_WKUP_IRQHandler
+        B RTC_WKUP_IRQHandler
+        
+        PUBWEAK FMC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+FMC_IRQHandler
+        B FMC_IRQHandler
+        
+        PUBWEAK RCU_CTC_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RCU_CTC_IRQHandler
+        B RCU_CTC_IRQHandler
+        
+        PUBWEAK EXTI0_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI0_IRQHandler
+        B EXTI0_IRQHandler
+        
+        PUBWEAK EXTI1_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI1_IRQHandler
+        B EXTI1_IRQHandler
+        
+        PUBWEAK EXTI2_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI2_IRQHandler                  
+        B EXTI2_IRQHandler                  
+        
+        PUBWEAK EXTI3_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI3_IRQHandler
+        B EXTI3_IRQHandler
+        
+        PUBWEAK EXTI4_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI4_IRQHandler
+        B EXTI4_IRQHandler
+        
+        PUBWEAK DMA0_Channel0_IRQHandler
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel0_IRQHandler
+        B DMA0_Channel0_IRQHandler
+        
+        PUBWEAK DMA0_Channel1_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel1_IRQHandler          
+        B DMA0_Channel1_IRQHandler          
+        
+        PUBWEAK DMA0_Channel2_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel2_IRQHandler          
+        B DMA0_Channel2_IRQHandler          
+        
+        PUBWEAK DMA0_Channel3_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel3_IRQHandler          
+        B DMA0_Channel3_IRQHandler          
+        
+        PUBWEAK DMA0_Channel4_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel4_IRQHandler          
+        B DMA0_Channel4_IRQHandler          
+        
+        PUBWEAK DMA0_Channel5_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel5_IRQHandler          
+        B DMA0_Channel5_IRQHandler          
+        
+        PUBWEAK DMA0_Channel6_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel6_IRQHandler          
+        B DMA0_Channel6_IRQHandler                
+        
+        PUBWEAK ADC_IRQHandler                    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+ADC_IRQHandler                    
+        B ADC_IRQHandler                    
+        
+        PUBWEAK CAN0_TX_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN0_TX_IRQHandler                
+        B CAN0_TX_IRQHandler                
+        
+        PUBWEAK CAN0_RX0_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN0_RX0_IRQHandler               
+        B CAN0_RX0_IRQHandler               
+        
+        PUBWEAK CAN0_RX1_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN0_RX1_IRQHandler               
+        B CAN0_RX1_IRQHandler               
+      
+        PUBWEAK CAN0_EWMC_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN0_EWMC_IRQHandler               
+        B CAN0_EWMC_IRQHandler               
+        
+        PUBWEAK EXTI5_9_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI5_9_IRQHandler                
+        B EXTI5_9_IRQHandler                
+        
+        PUBWEAK TIMER0_BRK_TIMER8_IRQHandler    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER0_BRK_TIMER8_IRQHandler    
+        B TIMER0_BRK_TIMER8_IRQHandler    
+        
+        PUBWEAK TIMER0_UP_TIMER9_IRQHandler   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER0_UP_TIMER9_IRQHandler   
+        B TIMER0_UP_TIMER9_IRQHandler   
+        
+        PUBWEAK TIMER0_TRG_CMT_TIMER10_IRQHandler 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER0_TRG_CMT_TIMER10_IRQHandler 
+        B TIMER0_TRG_CMT_TIMER10_IRQHandler 
+        
+        PUBWEAK TIMER0_Channel_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER0_Channel_IRQHandler         
+        B TIMER0_Channel_IRQHandler         
+        
+        PUBWEAK TIMER1_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER1_IRQHandler                 
+        B TIMER1_IRQHandler                 
+        
+        PUBWEAK TIMER2_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER2_IRQHandler
+        B TIMER2_IRQHandler                 
+
+        PUBWEAK TIMER3_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER3_IRQHandler                 
+        B TIMER3_IRQHandler
+
+        PUBWEAK I2C0_EV_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C0_EV_IRQHandler                
+        B I2C0_EV_IRQHandler                
+
+        PUBWEAK I2C0_ER_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C0_ER_IRQHandler
+        B I2C0_ER_IRQHandler                
+
+        PUBWEAK I2C1_EV_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C1_EV_IRQHandler                
+        B I2C1_EV_IRQHandler                
+
+        PUBWEAK I2C1_ER_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C1_ER_IRQHandler                
+        B I2C1_ER_IRQHandler                
+
+        PUBWEAK SPI0_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI0_IRQHandler                   
+        B SPI0_IRQHandler                   
+
+        PUBWEAK SPI1_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI1_IRQHandler                   
+        B SPI1_IRQHandler
+
+        PUBWEAK USART0_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART0_IRQHandler                 
+        B USART0_IRQHandler                 
+
+        PUBWEAK USART1_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART1_IRQHandler                 
+        B USART1_IRQHandler                 
+
+        PUBWEAK USART2_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART2_IRQHandler                
+        B USART2_IRQHandler
+
+        PUBWEAK EXTI10_15_IRQHandler              
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXTI10_15_IRQHandler              
+        B EXTI10_15_IRQHandler              
+
+        PUBWEAK RTC_Alarm_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+RTC_Alarm_IRQHandler             
+        B RTC_Alarm_IRQHandler             
+
+        PUBWEAK USBFS_WKUP_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBFS_WKUP_IRQHandler             
+        B USBFS_WKUP_IRQHandler             
+
+        PUBWEAK TIMER7_BRK_TIMER11_IRQHandler   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER7_BRK_TIMER11_IRQHandler   
+        B TIMER7_BRK_TIMER11_IRQHandler   
+
+        PUBWEAK TIMER7_UP_TIMER12_IRQHandler  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER7_UP_TIMER12_IRQHandler  
+        B TIMER7_UP_TIMER12_IRQHandler  
+
+        PUBWEAK TIMER7_TRG_CMT_TIMER13_IRQHandler 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER7_TRG_CMT_TIMER13_IRQHandler 
+        B TIMER7_TRG_CMT_TIMER13_IRQHandler 
+
+        PUBWEAK TIMER7_Channel_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER7_Channel_IRQHandler         
+        B TIMER7_Channel_IRQHandler         
+
+        PUBWEAK DMA0_Channel7_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA0_Channel7_IRQHandler         
+        B DMA0_Channel7_IRQHandler         
+
+        PUBWEAK EXMC_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+EXMC_IRQHandler                   
+        B EXMC_IRQHandler                   
+
+        PUBWEAK SDIO_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SDIO_IRQHandler                   
+        B SDIO_IRQHandler                   
+
+        PUBWEAK TIMER4_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER4_IRQHandler                 
+        B TIMER4_IRQHandler                 
+
+        PUBWEAK SPI2_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI2_IRQHandler                  
+        B SPI2_IRQHandler                  
+
+        PUBWEAK UART3_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UART3_IRQHandler                  
+        B UART3_IRQHandler                  
+
+        PUBWEAK UART4_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UART4_IRQHandler                  
+        B UART4_IRQHandler                  
+
+        PUBWEAK TIMER5_DAC_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER5_DAC_IRQHandler             
+        B TIMER5_DAC_IRQHandler             
+
+        PUBWEAK TIMER6_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TIMER6_IRQHandler                
+        B TIMER6_IRQHandler                
+
+        PUBWEAK DMA1_Channel0_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel0_IRQHandler          
+        B DMA1_Channel0_IRQHandler          
+
+        PUBWEAK DMA1_Channel1_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel1_IRQHandler          
+        B DMA1_Channel1_IRQHandler          
+
+        PUBWEAK DMA1_Channel2_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel2_IRQHandler         
+        B DMA1_Channel2_IRQHandler         
+
+        PUBWEAK DMA1_Channel3_IRQHandler         
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel3_IRQHandler         
+        B DMA1_Channel3_IRQHandler         
+
+        PUBWEAK DMA1_Channel4_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel4_IRQHandler          
+        B DMA1_Channel4_IRQHandler          
+
+        PUBWEAK ENET_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+ENET_IRQHandler                  
+        B ENET_IRQHandler                  
+        
+        PUBWEAK ENET_WKUP_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+ENET_WKUP_IRQHandler             
+        B ENET_WKUP_IRQHandler             
+
+        PUBWEAK CAN1_TX_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN1_TX_IRQHandler                
+        B CAN1_TX_IRQHandler                
+
+        PUBWEAK CAN1_RX0_IRQHandler              
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN1_RX0_IRQHandler              
+        B CAN1_RX0_IRQHandler              
+
+        PUBWEAK CAN1_RX1_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN1_RX1_IRQHandler               
+        B CAN1_RX1_IRQHandler               
+
+        PUBWEAK CAN1_EWMC_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+CAN1_EWMC_IRQHandler               
+        B CAN1_EWMC_IRQHandler               
+
+        PUBWEAK USBFS_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBFS_IRQHandler                  
+        B USBFS_IRQHandler                  
+
+        PUBWEAK DMA1_Channel5_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel5_IRQHandler          
+        B DMA1_Channel5_IRQHandler          
+
+        PUBWEAK DMA1_Channel6_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel6_IRQHandler          
+        B DMA1_Channel6_IRQHandler          
+
+        PUBWEAK DMA1_Channel7_IRQHandler          
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DMA1_Channel7_IRQHandler          
+        B DMA1_Channel7_IRQHandler          
+
+        PUBWEAK USART5_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USART5_IRQHandler                 
+        B USART5_IRQHandler                 
+
+        PUBWEAK I2C2_EV_IRQHandler               
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C2_EV_IRQHandler               
+        B I2C2_EV_IRQHandler               
+
+        PUBWEAK I2C2_ER_IRQHandler                
+        SECTION .text:CODE:NOROOT:REORDER(1)
+I2C2_ER_IRQHandler                
+        B I2C2_ER_IRQHandler                
+
+        PUBWEAK USBHS_EP1_Out_IRQHandler    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBHS_EP1_Out_IRQHandler    
+        B USBHS_EP1_Out_IRQHandler    
+
+        PUBWEAK USBHS_EP1_In_IRQHandler     
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBHS_EP1_In_IRQHandler     
+        B USBHS_EP1_In_IRQHandler     
+
+        PUBWEAK USBHS_WKUP_IRQHandler             
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBHS_WKUP_IRQHandler             
+        B USBHS_WKUP_IRQHandler             
+
+        PUBWEAK USBHS_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+USBHS_IRQHandler                  
+        B USBHS_IRQHandler                  
+
+        PUBWEAK DCI_IRQHandler                    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+DCI_IRQHandler                    
+        B DCI_IRQHandler                    
+
+        PUBWEAK TRNG_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TRNG_IRQHandler                  
+        B TRNG_IRQHandler                  
+
+        PUBWEAK FPU_IRQHandler                    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+FPU_IRQHandler                    
+        B FPU_IRQHandler                    
+
+        PUBWEAK UART6_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UART6_IRQHandler                  
+        B UART6_IRQHandler                  
+
+        PUBWEAK UART7_IRQHandler                  
+        SECTION .text:CODE:NOROOT:REORDER(1)
+UART7_IRQHandler                  
+        B UART7_IRQHandler                  
+
+        PUBWEAK SPI3_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI3_IRQHandler                   
+        B SPI3_IRQHandler                   
+
+        PUBWEAK SPI4_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI4_IRQHandler                   
+        B SPI4_IRQHandler                   
+
+        PUBWEAK SPI5_IRQHandler                   
+        SECTION .text:CODE:NOROOT:REORDER(1)
+SPI5_IRQHandler                   
+        B SPI5_IRQHandler                   
+
+        PUBWEAK TLI_IRQHandler                    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TLI_IRQHandler                    
+        B TLI_IRQHandler                    
+
+        PUBWEAK TLI_ER_IRQHandler                 
+        SECTION .text:CODE:NOROOT:REORDER(1)
+TLI_ER_IRQHandler                 
+        B TLI_ER_IRQHandler                 
+
+        PUBWEAK IPA_IRQHandler                    
+        SECTION .text:CODE:NOROOT:REORDER(1)
+IPA_IRQHandler                    
+        B IPA_IRQHandler                    
+        END

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/system_gd32f4xx.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx/Source/system_gd32f4xx.c
@@ -1,0 +1,1153 @@
+/*!
+    \file  system_gd32f4xx.c
+    \brief CMSIS Cortex-M4 Device Peripheral Access Layer Source File for
+           GD32F4xx Device Series
+*/
+
+/* Copyright (c) 2012 ARM LIMITED
+
+   All rights reserved.
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+   - Neither the name of ARM nor the names of its contributors may be used
+     to endorse or promote products derived from this software without
+     specific prior written permission.
+   *
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL COPYRIGHT HOLDERS AND CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+   ---------------------------------------------------------------------------*/
+
+/* This file refers the CMSIS standard, some adjustments are made according to GigaDevice chips */
+
+#include "gd32f4xx.h"
+
+/* system frequency define */
+#define __IRC16M          (IRC16M_VALUE)            /* internal 16 MHz RC oscillator frequency */
+#define __HXTAL           (HXTAL_VALUE)             /* high speed crystal oscillator frequency */
+#define __SYS_OSC_CLK     (__IRC16M)                /* main oscillator frequency */
+
+/* select a system clock by uncommenting the following line */
+//#define __SYSTEM_CLOCK_IRC16M                   (uint32_t)(__IRC16M)
+//#define __SYSTEM_CLOCK_HXTAL                    (uint32_t)(__HXTAL)
+//#define __SYSTEM_CLOCK_120M_PLL_IRC16M          (uint32_t)(120000000)
+//#define __SYSTEM_CLOCK_120M_PLL_8M_HXTAL        (uint32_t)(120000000)
+//#define __SYSTEM_CLOCK_120M_PLL_25M_HXTAL       (uint32_t)(120000000)
+//#define __SYSTEM_CLOCK_168M_PLL_IRC16M          (uint32_t)(168000000)
+//#define __SYSTEM_CLOCK_168M_PLL_8M_HXTAL        (uint32_t)(168000000)
+//#define __SYSTEM_CLOCK_168M_PLL_25M_HXTAL       (uint32_t)(168000000)
+//#define __SYSTEM_CLOCK_200M_PLL_IRC16M          (uint32_t)(200000000)
+//#define __SYSTEM_CLOCK_200M_PLL_8M_HXTAL        (uint32_t)(200000000)
+#define __SYSTEM_CLOCK_200M_PLL_25M_HXTAL       (uint32_t)(200000000)
+//#define __SYSTEM_CLOCK_240M_PLL_IRC16M          (uint32_t)(240000000)
+//#define __SYSTEM_CLOCK_240M_PLL_8M_HXTAL        (uint32_t)(240000000)
+//#define __SYSTEM_CLOCK_240M_PLL_25M_HXTAL       (uint32_t)(240000000)
+
+#define RCU_MODIFY(__delay)     do{                                     \
+                                    volatile uint32_t i;                \
+                                    if(0 != __delay){                   \
+                                        RCU_CFG0 |= RCU_AHB_CKSYS_DIV2; \
+                                        for(i=0; i<__delay; i++){       \
+                                        }                               \
+                                        RCU_CFG0 |= RCU_AHB_CKSYS_DIV4; \
+                                        for(i=0; i<__delay; i++){       \
+                                        }                               \
+                                    }                                   \
+                                }while(0)
+
+#define SEL_IRC16M      0x00U
+#define SEL_HXTAL       0x01U
+#define SEL_PLLP        0x02U
+                        
+/* set the system clock frequency and declare the system clock configuration function */
+#ifdef __SYSTEM_CLOCK_IRC16M
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_IRC16M;
+static void system_clock_16m_irc16m(void);
+#elif defined (__SYSTEM_CLOCK_HXTAL)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_HXTAL;
+static void system_clock_hxtal(void);
+#elif defined (__SYSTEM_CLOCK_120M_PLL_IRC16M)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_120M_PLL_IRC16M;
+static void system_clock_120m_irc16m(void);
+#elif defined (__SYSTEM_CLOCK_120M_PLL_8M_HXTAL)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_120M_PLL_8M_HXTAL;
+static void system_clock_120m_8m_hxtal(void);
+#elif defined (__SYSTEM_CLOCK_120M_PLL_25M_HXTAL)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_120M_PLL_25M_HXTAL;
+static void system_clock_120m_25m_hxtal(void);
+#elif defined (__SYSTEM_CLOCK_168M_PLL_IRC16M)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_168M_PLL_IRC16M;
+static void system_clock_168m_irc16m(void);
+#elif defined (__SYSTEM_CLOCK_168M_PLL_8M_HXTAL)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_168M_PLL_8M_HXTAL;
+static void system_clock_168m_8m_hxtal(void);
+#elif defined (__SYSTEM_CLOCK_168M_PLL_25M_HXTAL)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_168M_PLL_25M_HXTAL;
+static void system_clock_168m_25m_hxtal(void);
+#elif defined (__SYSTEM_CLOCK_200M_PLL_IRC16M)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_200M_PLL_IRC16M;
+static void system_clock_200m_irc16m(void);
+#elif defined (__SYSTEM_CLOCK_200M_PLL_8M_HXTAL)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_200M_PLL_8M_HXTAL;
+static void system_clock_200m_8m_hxtal(void);
+#elif defined (__SYSTEM_CLOCK_200M_PLL_25M_HXTAL)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_200M_PLL_25M_HXTAL;
+static void system_clock_200m_25m_hxtal(void);
+#elif defined (__SYSTEM_CLOCK_240M_PLL_IRC16M)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_240M_PLL_IRC16M;
+static void system_clock_240m_irc16m(void);
+#elif defined (__SYSTEM_CLOCK_240M_PLL_8M_HXTAL)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_240M_PLL_8M_HXTAL;
+static void system_clock_240m_8m_hxtal(void);
+#elif defined (__SYSTEM_CLOCK_240M_PLL_25M_HXTAL)
+uint32_t SystemCoreClock = __SYSTEM_CLOCK_240M_PLL_25M_HXTAL;
+static void system_clock_240m_25m_hxtal(void);
+
+#endif /* __SYSTEM_CLOCK_IRC16M */
+
+/* configure the system clock */
+static void system_clock_config(void);
+
+/*!
+    \brief      setup the microcontroller system, initialize the system
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void SystemInit (void)
+{
+    /* FPU settings */
+#if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
+    SCB->CPACR |= ((3UL << 10*2)|(3UL << 11*2));  /* set CP10 and CP11 Full Access */
+#endif
+    /* Reset the RCU clock configuration to the default reset state */
+    /* Set IRC16MEN bit */
+    RCU_CTL |= RCU_CTL_IRC16MEN;
+    while(0U == (RCU_CTL & RCU_CTL_IRC16MSTB)){
+    }
+    RCU_MODIFY(0x50);
+    
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    
+    /* Reset HXTALEN, CKMEN and PLLEN bits */
+    RCU_CTL &= ~(RCU_CTL_PLLEN | RCU_CTL_CKMEN | RCU_CTL_HXTALEN);
+
+    /* Reset HSEBYP bit */
+    RCU_CTL &= ~(RCU_CTL_HXTALBPS);
+    
+    /* Reset CFG0 register */
+    RCU_CFG0 = 0x00000000U;
+
+    /* wait until IRC16M is selected as system clock */
+    while(0 != (RCU_CFG0 & RCU_SCSS_IRC16M)){
+    }
+
+    /* Reset PLLCFGR register */
+    RCU_PLL = 0x24003010U;
+
+    /* Disable all interrupts */
+    RCU_INT = 0x00000000U;
+         
+    /* Configure the System clock source, PLL Multiplier and Divider factors, 
+        AHB/APBx prescalers and Flash settings */
+    system_clock_config();
+}
+/*!
+    \brief      configure the system clock
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_config(void)
+{
+#ifdef __SYSTEM_CLOCK_IRC16M
+    system_clock_16m_irc16m();
+#elif defined (__SYSTEM_CLOCK_HXTAL)
+    system_clock_hxtal();
+#elif defined (__SYSTEM_CLOCK_120M_PLL_IRC16M)
+    system_clock_120m_irc16m();
+#elif defined (__SYSTEM_CLOCK_120M_PLL_8M_HXTAL)
+    system_clock_120m_8m_hxtal();
+#elif defined (__SYSTEM_CLOCK_120M_PLL_25M_HXTAL)
+    system_clock_120m_25m_hxtal();
+#elif defined (__SYSTEM_CLOCK_168M_PLL_IRC16M)
+    system_clock_168m_irc16m();
+#elif defined (__SYSTEM_CLOCK_168M_PLL_8M_HXTAL)
+    system_clock_168m_8m_hxtal();
+#elif defined (__SYSTEM_CLOCK_168M_PLL_25M_HXTAL)
+    system_clock_168m_25m_hxtal();
+#elif defined (__SYSTEM_CLOCK_200M_PLL_IRC16M)
+    system_clock_200m_irc16m();
+#elif defined (__SYSTEM_CLOCK_200M_PLL_8M_HXTAL)
+    system_clock_200m_8m_hxtal();
+#elif defined (__SYSTEM_CLOCK_200M_PLL_25M_HXTAL)
+    system_clock_200m_25m_hxtal();
+#elif defined (__SYSTEM_CLOCK_240M_PLL_IRC16M)
+    system_clock_240m_irc16m();
+#elif defined (__SYSTEM_CLOCK_240M_PLL_8M_HXTAL)
+    system_clock_240m_8m_hxtal();
+#elif defined (__SYSTEM_CLOCK_240M_PLL_25M_HXTAL)
+    system_clock_240m_25m_hxtal();
+#endif /* __SYSTEM_CLOCK_IRC16M */   
+}
+
+#ifdef __SYSTEM_CLOCK_IRC16M
+/*!
+    \brief      configure the system clock to 16M by IRC16M
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_16m_irc16m(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable IRC16M */
+    RCU_CTL |= RCU_CTL_IRC16MEN;
+    
+    /* wait until IRC16M is stable or the startup time is longer than IRC16M_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_IRC16MSTB);
+    }while((0U == stab_flag) && (IRC16M_STARTUP_TIMEOUT != timeout));
+    
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_IRC16MSTB)){
+        while(1){
+        }
+    }
+    
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV1;
+    /* APB1 = AHB */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV1;
+    
+    /* select IRC16M as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_IRC16M;
+    
+    /* wait until IRC16M is selected as system clock */
+    while(0 != (RCU_CFG0 & RCU_SCSS_IRC16M)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_HXTAL)
+/*!
+    \brief      configure the system clock to HXTAL
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_hxtal(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable HXTAL */
+    RCU_CTL |= RCU_CTL_HXTALEN;
+    
+    /* wait until HXTAL is stable or the startup time is longer than HXTAL_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_HXTALSTB);
+    }while((0U == stab_flag) && (HXTAL_STARTUP_TIMEOUT != timeout));
+    
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_HXTALSTB)){
+        while(1){
+        }
+    }
+    
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV1;
+    /* APB1 = AHB */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV1;
+    
+    /* select HXTAL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_HXTAL;
+    
+    /* wait until HXTAL is selected as system clock */
+    while(0 == (RCU_CFG0 & RCU_SCSS_HXTAL)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_120M_PLL_IRC16M)
+/*!
+    \brief      configure the system clock to 120M by PLL which selects IRC16M as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_120m_irc16m(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable IRC16M */
+    RCU_CTL |= RCU_CTL_IRC16MEN;
+
+    /* wait until IRC16M is stable or the startup time is longer than IRC16M_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_IRC16MSTB);
+    }while((0U == stab_flag) && (IRC16M_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_IRC16MSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* IRC16M is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 16, PLL_N = 240, PLL_P = 2, PLL_Q = 5 */ 
+    RCU_PLL = (16U | (240U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_IRC16M) | (5U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 120 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_120M_PLL_8M_HXTAL)
+/*!
+    \brief      configure the system clock to 120M by PLL which selects HXTAL(8M) as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_120m_8m_hxtal(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable HXTAL */
+    RCU_CTL |= RCU_CTL_HXTALEN;
+
+    /* wait until HXTAL is stable or the startup time is longer than HXTAL_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_HXTALSTB);
+    }while((0U == stab_flag) && (HXTAL_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_HXTALSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* HXTAL is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 8, PLL_N = 240, PLL_P = 2, PLL_Q = 5 */ 
+    RCU_PLL = (8U | (240U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_HXTAL) | (5U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 120 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_120M_PLL_25M_HXTAL)
+/*!
+    \brief      configure the system clock to 120M by PLL which selects HXTAL(25M) as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_120m_25m_hxtal(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable HXTAL */
+    RCU_CTL |= RCU_CTL_HXTALEN;
+
+    /* wait until HXTAL is stable or the startup time is longer than HXTAL_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_HXTALSTB);
+    }while((0U == stab_flag) && (HXTAL_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_HXTALSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* HXTAL is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 25, PLL_N = 240, PLL_P = 2, PLL_Q = 5 */ 
+    RCU_PLL = (25U | (240U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_HXTAL) | (5U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 120 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_168M_PLL_IRC16M)
+/*!
+    \brief      configure the system clock to 168M by PLL which selects IRC16M as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_168m_irc16m(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable IRC16M */
+    RCU_CTL |= RCU_CTL_IRC16MEN;
+
+    /* wait until IRC16M is stable or the startup time is longer than IRC16M_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_IRC16MSTB);
+    }while((0U == stab_flag) && (IRC16M_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_IRC16MSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* IRC16M is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 16, PLL_N = 336, PLL_P = 2, PLL_Q = 7 */ 
+    RCU_PLL = (16U | (336U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_IRC16M) | (7U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 168 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_168M_PLL_8M_HXTAL)
+/*!
+    \brief      configure the system clock to 168M by PLL which selects HXTAL(8M) as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_168m_8m_hxtal(void)
+{
+    uint32_t timeout = 0U;
+    
+    /* enable HXTAL */
+    RCU_CTL |= RCU_CTL_HXTALEN;
+
+    /* wait until HXTAL is stable or the startup time is longer than HXTAL_STARTUP_TIMEOUT */
+    while((0U == (RCU_CTL & RCU_CTL_HXTALSTB)) && (HXTAL_STARTUP_TIMEOUT != timeout++)){
+    }
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_HXTALSTB)){
+        while(1){
+        }
+    }
+
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+    /* HXTAL is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 8, PLL_N = 336, PLL_P = 2, PLL_Q = 7 */ 
+    RCU_PLL = (8U | (336 << 6U) | (((2 >> 1U) -1U) << 16U) |
+                   (RCU_PLLSRC_HXTAL) | (7 << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+  
+    /* Enable the high-drive to extend the clock frequency to 168 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    }
+
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_168M_PLL_25M_HXTAL)
+/*!
+    \brief      configure the system clock to 168M by PLL which selects HXTAL(25M) as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_168m_25m_hxtal(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable HXTAL */
+    RCU_CTL |= RCU_CTL_HXTALEN;
+
+    /* wait until HXTAL is stable or the startup time is longer than HXTAL_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_HXTALSTB);
+    }while((0U == stab_flag) && (HXTAL_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_HXTALSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* HXTAL is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 25, PLL_N = 336, PLL_P = 2, PLL_Q = 7 */ 
+    RCU_PLL = (25U | (336U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_HXTAL) | (7U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 168 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_200M_PLL_IRC16M)
+/*!
+    \brief      configure the system clock to 200M by PLL which selects IRC16M as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_200m_irc16m(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable IRC16M */
+    RCU_CTL |= RCU_CTL_IRC16MEN;
+
+    /* wait until IRC16M is stable or the startup time is longer than IRC16M_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_IRC16MSTB);
+    }while((0U == stab_flag) && (IRC16M_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_IRC16MSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* IRC16M is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 16, PLL_N = 400, PLL_P = 2, PLL_Q = 9 */ 
+    RCU_PLL = (16U | (400U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_IRC16M) | (9U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 200 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_200M_PLL_8M_HXTAL)
+/*!
+    \brief      configure the system clock to 200M by PLL which selects HXTAL(8M) as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_200m_8m_hxtal(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable HXTAL */
+    RCU_CTL |= RCU_CTL_HXTALEN;
+
+    /* wait until HXTAL is stable or the startup time is longer than HXTAL_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_HXTALSTB);
+    }while((0U == stab_flag) && (HXTAL_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_HXTALSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* HXTAL is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 8, PLL_N = 400, PLL_P = 2, PLL_Q = 9 */ 
+    RCU_PLL = (8U | (400U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_HXTAL) | (9U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 200 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_200M_PLL_25M_HXTAL)
+/*!
+    \brief      configure the system clock to 200M by PLL which selects HXTAL(25M) as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_200m_25m_hxtal(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable HXTAL */
+    RCU_CTL |= RCU_CTL_HXTALEN;
+
+    /* wait until HXTAL is stable or the startup time is longer than HXTAL_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_HXTALSTB);
+    }while((0U == stab_flag) && (HXTAL_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_HXTALSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* HXTAL is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 25, PLL_N = 400, PLL_P = 2, PLL_Q = 9 */ 
+    RCU_PLL = (25U | (400U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_HXTAL) | (9U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 200 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_240M_PLL_IRC16M)
+/*!
+    \brief      configure the system clock to 240M by PLL which selects IRC16M as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_240m_irc16m(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable IRC16M */
+    RCU_CTL |= RCU_CTL_IRC16MEN;
+
+    /* wait until IRC16M is stable or the startup time is longer than IRC16M_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_IRC16MSTB);
+    }while((0U == stab_flag) && (IRC16M_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_IRC16MSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* IRC16M is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 16, PLL_N = 480, PLL_P = 2, PLL_Q = 10 */ 
+    RCU_PLL = (16U | (480U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_IRC16M) | (10U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 240 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_240M_PLL_8M_HXTAL)
+/*!
+    \brief      configure the system clock to 240M by PLL which selects HXTAL(8M) as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_240m_8m_hxtal(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable HXTAL */
+    RCU_CTL |= RCU_CTL_HXTALEN;
+
+    /* wait until HXTAL is stable or the startup time is longer than HXTAL_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_HXTALSTB);
+    }while((0U == stab_flag) && (HXTAL_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_HXTALSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* HXTAL is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 8, PLL_N = 480, PLL_P = 2, PLL_Q = 10 */ 
+    RCU_PLL = (8U | (480U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_HXTAL) | (10U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 240 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+
+#elif defined (__SYSTEM_CLOCK_240M_PLL_25M_HXTAL)
+/*!
+    \brief      configure the system clock to 240M by PLL which selects HXTAL(25M) as its clock source
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void system_clock_240m_25m_hxtal(void)
+{
+    uint32_t timeout = 0U;
+    uint32_t stab_flag = 0U;
+    
+    /* enable HXTAL */
+    RCU_CTL |= RCU_CTL_HXTALEN;
+
+    /* wait until HXTAL is stable or the startup time is longer than HXTAL_STARTUP_TIMEOUT */
+    do{
+        timeout++;
+        stab_flag = (RCU_CTL & RCU_CTL_HXTALSTB);
+    }while((0U == stab_flag) && (HXTAL_STARTUP_TIMEOUT != timeout));
+
+    /* if fail */
+    if(0U == (RCU_CTL & RCU_CTL_HXTALSTB)){
+        while(1){
+        }
+    }
+         
+    RCU_APB1EN |= RCU_APB1EN_PMUEN;
+    PMU_CTL |= PMU_CTL_LDOVS;
+
+    /* HXTAL is stable */
+    /* AHB = SYSCLK */
+    RCU_CFG0 |= RCU_AHB_CKSYS_DIV1;
+    /* APB2 = AHB/2 */
+    RCU_CFG0 |= RCU_APB2_CKAHB_DIV2;
+    /* APB1 = AHB/4 */
+    RCU_CFG0 |= RCU_APB1_CKAHB_DIV4;
+
+    /* Configure the main PLL, PSC = 25, PLL_N = 480, PLL_P = 2, PLL_Q = 10 */ 
+    RCU_PLL = (25U | (480U << 6U) | (((2U >> 1U) - 1U) << 16U) |
+                   (RCU_PLLSRC_HXTAL) | (10U << 24U));
+
+    /* enable PLL */
+    RCU_CTL |= RCU_CTL_PLLEN;
+
+    /* wait until PLL is stable */
+    while(0U == (RCU_CTL & RCU_CTL_PLLSTB)){
+    }
+    
+    /* Enable the high-drive to extend the clock frequency to 240 Mhz */
+    PMU_CTL |= PMU_CTL_HDEN;
+    while(0U == (PMU_CS & PMU_CS_HDRF)){
+    }
+    
+    /* select the high-drive mode */
+    PMU_CTL |= PMU_CTL_HDS;
+    while(0U == (PMU_CS & PMU_CS_HDSRF)){
+    } 
+    
+    /* select PLL as system clock */
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+    RCU_CFG0 |= RCU_CKSYSSRC_PLLP;
+
+    /* wait until PLL is selected as system clock */
+    while(0U == (RCU_CFG0 & RCU_SCSS_PLLP)){
+    }
+}
+#endif /* __SYSTEM_CLOCK_IRC16M */
+/*!
+    \brief      update the SystemCoreClock with current core clock retrieved from cpu registers
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void SystemCoreClockUpdate(void)
+{
+    uint32_t sws;
+    uint32_t pllpsc, plln, pllsel, pllp, ck_src, idx, clk_exp;
+    
+    /* exponent of AHB, APB1 and APB2 clock divider */
+    const uint8_t ahb_exp[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
+
+    sws = GET_BITS(RCU_CFG0, 2, 3);
+    switch(sws){
+    /* IRC16M is selected as CK_SYS */
+    case SEL_IRC16M:
+        SystemCoreClock = IRC16M_VALUE;
+        break;
+    /* HXTAL is selected as CK_SYS */
+    case SEL_HXTAL:
+        SystemCoreClock = HXTAL_VALUE;
+        break;
+    /* PLLP is selected as CK_SYS */
+    case SEL_PLLP:
+        /* get the value of PLLPSC[5:0] */
+        pllpsc = GET_BITS(RCU_PLL, 0U, 5U);
+        plln = GET_BITS(RCU_PLL, 6U, 14U);
+        pllp = (GET_BITS(RCU_PLL, 16U, 17U) + 1U) * 2U;
+        /* PLL clock source selection, HXTAL or IRC8M/2 */
+        pllsel = (RCU_PLL & RCU_PLL_PLLSEL);
+        if (RCU_PLLSRC_HXTAL == pllsel) {
+            ck_src = HXTAL_VALUE;
+        } else {
+            ck_src = IRC16M_VALUE;
+        }
+        SystemCoreClock = ((ck_src / pllpsc) * plln) / pllp;
+        break;
+    /* IRC16M is selected as CK_SYS */
+    default:
+        SystemCoreClock = IRC16M_VALUE;
+        break;
+    }
+    /* calculate AHB clock frequency */
+    idx = GET_BITS(RCU_CFG0, 4, 7);
+    clk_exp = ahb_exp[idx];
+    SystemCoreClock = SystemCoreClock >> clk_exp;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_adc.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_adc.h
@@ -1,0 +1,516 @@
+/*!
+    \file    gd32f4xx_adc.h
+    \brief   definitions for the ADC
+    
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_ADC_H
+#define GD32F4XX_ADC_H
+
+#include "gd32f4xx.h"
+
+/* ADC definitions */
+#define ADC0                            ADC_BASE
+#define ADC1                            (ADC_BASE + 0x100U)
+#define ADC2                            (ADC_BASE + 0x200U)
+
+/* registers definitions */
+#define ADC_STAT(adcx)                  REG32((adcx) + 0x00U)             /*!< ADC status register */
+#define ADC_CTL0(adcx)                  REG32((adcx) + 0x04U)             /*!< ADC control register 0 */
+#define ADC_CTL1(adcx)                  REG32((adcx) + 0x08U)             /*!< ADC control register 1 */
+#define ADC_SAMPT0(adcx)                REG32((adcx) + 0x0CU)             /*!< ADC sampling time register 0 */
+#define ADC_SAMPT1(adcx)                REG32((adcx) + 0x10U)             /*!< ADC sampling time register 1 */
+#define ADC_IOFF0(adcx)                 REG32((adcx) + 0x14U)             /*!< ADC inserted channel data offset register 0 */
+#define ADC_IOFF1(adcx)                 REG32((adcx) + 0x18U)             /*!< ADC inserted channel data offset register 1 */
+#define ADC_IOFF2(adcx)                 REG32((adcx) + 0x1CU)             /*!< ADC inserted channel data offset register 2 */
+#define ADC_IOFF3(adcx)                 REG32((adcx) + 0x20U)             /*!< ADC inserted channel data offset register 3 */
+#define ADC_WDHT(adcx)                  REG32((adcx) + 0x24U)             /*!< ADC watchdog high threshold register */
+#define ADC_WDLT(adcx)                  REG32((adcx) + 0x28U)             /*!< ADC watchdog low threshold register */
+#define ADC_RSQ0(adcx)                  REG32((adcx) + 0x2CU)             /*!< ADC regular sequence register 0 */
+#define ADC_RSQ1(adcx)                  REG32((adcx) + 0x30U)             /*!< ADC regular sequence register 1 */
+#define ADC_RSQ2(adcx)                  REG32((adcx) + 0x34U)             /*!< ADC regular sequence register 2 */
+#define ADC_ISQ(adcx)                   REG32((adcx) + 0x38U)             /*!< ADC inserted sequence register */
+#define ADC_IDATA0(adcx)                REG32((adcx) + 0x3CU)             /*!< ADC inserted data register 0 */
+#define ADC_IDATA1(adcx)                REG32((adcx) + 0x40U)             /*!< ADC inserted data register 1 */
+#define ADC_IDATA2(adcx)                REG32((adcx) + 0x44U)             /*!< ADC inserted data register 2 */
+#define ADC_IDATA3(adcx)                REG32((adcx) + 0x48U)             /*!< ADC inserted data register 3 */
+#define ADC_RDATA(adcx)                 REG32((adcx) + 0x4CU)             /*!< ADC regular data register */
+#define ADC_OVSAMPCTL(adcx)             REG32((adcx) + 0x80U)             /*!< ADC oversampling control register */
+#define ADC_SSTAT                       REG32((ADC_BASE) + 0x300U)        /*!< ADC summary status register */
+#define ADC_SYNCCTL                     REG32((ADC_BASE) + 0x304U)        /*!< ADC synchronization control register */
+#define ADC_SYNCDATA                    REG32((ADC_BASE) + 0x308U)        /*!< ADC synchronization regular data register */
+
+/* bits definitions */
+/* ADC_STAT */
+#define ADC_STAT_WDE                    BIT(0)                           /*!< analog watchdog event flag */
+#define ADC_STAT_EOC                    BIT(1)                           /*!< end of conversion */
+#define ADC_STAT_EOIC                   BIT(2)                           /*!< inserted channel end of conversion */
+#define ADC_STAT_STIC                   BIT(3)                           /*!< inserted channel start flag */
+#define ADC_STAT_STRC                   BIT(4)                           /*!< regular channel start flag */
+#define ADC_STAT_ROVF                   BIT(5)                           /*!< regular data register overflow */
+
+/* ADC_CTL0 */
+#define ADC_CTL0_WDCHSEL                BITS(0,4)                        /*!< analog watchdog channel select bits */
+#define ADC_CTL0_EOCIE                  BIT(5)                           /*!< interrupt enable for EOC */
+#define ADC_CTL0_WDEIE                  BIT(6)                           /*!< analog watchdog interrupt enable */
+#define ADC_CTL0_EOICIE                 BIT(7)                           /*!< interrupt enable for inserted channels */
+#define ADC_CTL0_SM                     BIT(8)                           /*!< scan mode */
+#define ADC_CTL0_WDSC                   BIT(9)                           /*!< when in scan mode, analog watchdog is effective on a single channel */
+#define ADC_CTL0_ICA                    BIT(10)                          /*!< automatic inserted group conversion */
+#define ADC_CTL0_DISRC                  BIT(11)                          /*!< discontinuous mode on regular channels */
+#define ADC_CTL0_DISIC                  BIT(12)                          /*!< discontinuous mode on inserted channels */
+#define ADC_CTL0_DISNUM                 BITS(13,15)                      /*!< discontinuous mode channel count */
+#define ADC_CTL0_IWDEN                  BIT(22)                          /*!< analog watchdog enable on inserted channels */
+#define ADC_CTL0_RWDEN                  BIT(23)                          /*!< analog watchdog enable on regular channels */
+#define ADC_CTL0_DRES                   BITS(24,25)                      /*!< ADC data resolution */
+#define ADC_CTL0_ROVFIE                 BIT(26)                          /*!< interrupt enable for ROVF */ 
+
+/* ADC_CTL1 */
+#define ADC_CTL1_ADCON                  BIT(0)                           /*!< ADC converter on */
+#define ADC_CTL1_CTN                    BIT(1)                           /*!< continuous conversion */
+#define ADC_CTL1_CLB                    BIT(2)                           /*!< ADC calibration */
+#define ADC_CTL1_RSTCLB                 BIT(3)                           /*!< reset calibration */
+#define ADC_CTL1_DMA                    BIT(8)                           /*!< direct memory access mode */
+#define ADC_CTL1_DDM                    BIT(9)                           /*!< DMA disable mode */
+#define ADC_CTL1_EOCM                   BIT(10)                          /*!< end of conversion mode */
+#define ADC_CTL1_DAL                    BIT(11)                          /*!< data alignment */
+#define ADC_CTL1_ETSIC                  BITS(16,19)                      /*!< external event select for inserted group */
+#define ADC_CTL1_ETMIC                  BITS(20,21)                      /*!< external trigger conversion mode for inserted channels */
+#define ADC_CTL1_SWICST                 BIT(22)                          /*!< start conversion of inserted channels */
+#define ADC_CTL1_ETSRC                  BITS(24,27)                      /*!< external event select for regular group */
+#define ADC_CTL1_ETMRC                  BITS(28,29)                      /*!< external trigger conversion mode for regular channels */
+#define ADC_CTL1_SWRCST                 BIT(30)                          /*!< start conversion of regular channels */
+
+/* ADC_SAMPTx x=0..1 */
+#define ADC_SAMPTX_SPTN                 BITS(0,2)                        /*!< channel x sample time selection */
+
+/* ADC_IOFFx x=0..3 */
+#define ADC_IOFFX_IOFF                  BITS(0,11)                       /*!< data offset for inserted channel x */
+
+/* ADC_WDHT */
+#define ADC_WDHT_WDHT                   BITS(0,11)                       /*!< analog watchdog high threshold */
+
+/* ADC_WDLT */
+#define ADC_WDLT_WDLT                   BITS(0,11)                       /*!< analog watchdog low threshold */
+
+/* ADC_RSQx */
+#define ADC_RSQX_RSQN                   BITS(0,4)                        /*!< x conversion in regular sequence */
+#define ADC_RSQ0_RL                     BITS(20,23)                      /*!< regular channel sequence length */
+
+/* ADC_ISQ */
+#define ADC_ISQ_ISQN                    BITS(0,4)                        /*!< x conversion in regular sequence */
+#define ADC_ISQ_IL                      BITS(20,21)                      /*!< inserted sequence length */
+
+/* ADC_IDATAx x=0..3*/
+#define ADC_IDATAX_IDATAN               BITS(0,15)                       /*!< inserted data x */
+
+/* ADC_RDATA */
+#define ADC_RDATA_RDATA                 BITS(0,15)                       /*!< regular data */
+
+/* ADC_OVSAMPCTL */
+#define ADC_OVSAMPCTL_OVSEN             BIT(0)                           /*!< oversampling enable */
+#define ADC_OVSAMPCTL_OVSR              BITS(2,4)                        /*!< oversampling ratio */
+#define ADC_OVSAMPCTL_OVSS              BITS(5,8)                        /*!< oversampling shift */
+#define ADC_OVSAMPCTL_TOVS              BIT(9)                           /*!< triggered oversampling */
+
+/* ADC_SSTAT */
+#define ADC_SSTAT_WDE0                  BIT(0)                           /*!< the mirror image of the WDE bit of ADC0 */
+#define ADC_SSTAT_EOC0                  BIT(1)                           /*!< the mirror image of the EOC bit of ADC0 */
+#define ADC_SSTAT_EOIC0                 BIT(2)                           /*!< the mirror image of the EOIC bit of ADC0 */
+#define ADC_SSTAT_STIC0                 BIT(3)                           /*!< the mirror image of the STIC bit of ADC0 */
+#define ADC_SSTAT_STRC0                 BIT(4)                           /*!< the mirror image of the STRC bit of ADC0 */
+#define ADC_SSTAT_ROVF0                 BIT(5)                           /*!< the mirror image of the ROVF bit of ADC0 */
+#define ADC_SSTAT_WDE1                  BIT(8)                           /*!< the mirror image of the WDE bit of ADC1 */
+#define ADC_SSTAT_EOC1                  BIT(9)                           /*!< the mirror image of the EOC bit of ADC1 */
+#define ADC_SSTAT_EOIC1                 BIT(10)                          /*!< the mirror image of the EOIC bit of ADC1 */
+#define ADC_SSTAT_STIC1                 BIT(11)                          /*!< the mirror image of the STIC bit of ADC1 */
+#define ADC_SSTAT_STRC1                 BIT(12)                          /*!< the mirror image of the STRC bit of ADC1 */
+#define ADC_SSTAT_ROVF1                 BIT(13)                          /*!< the mirror image of the ROVF bit of ADC1 */
+#define ADC_SSTAT_WDE2                  BIT(16)                          /*!< the mirror image of the WDE bit of ADC2 */
+#define ADC_SSTAT_EOC2                  BIT(17)                          /*!< the mirror image of the EOC bit of ADC2 */
+#define ADC_SSTAT_EOIC2                 BIT(18)                          /*!< the mirror image of the EOIC bit of ADC2 */
+#define ADC_SSTAT_STIC2                 BIT(19)                          /*!< the mirror image of the STIC bit of ADC2 */
+#define ADC_SSTAT_STRC2                 BIT(20)                          /*!< the mirror image of the STRC bit of ADC2 */
+#define ADC_SSTAT_ROVF2                 BIT(21)                          /*!< the mirror image of the ROVF bit of ADC2 */
+
+/* ADC_SYNCCTL */
+#define ADC_SYNCCTL_SYNCM               BITS(0,4)                        /*!< ADC synchronization mode */
+#define ADC_SYNCCTL_SYNCDLY             BITS(8,11)                       /*!< ADC synchronization delay */
+#define ADC_SYNCCTL_SYNCDDM             BIT(13)                          /*!< ADC synchronization DMA disable mode */
+#define ADC_SYNCCTL_SYNCDMA             BITS(14,15)                      /*!< ADC synchronization DMA mode selection */
+#define ADC_SYNCCTL_ADCCK               BITS(16,18)                      /*!< ADC clock */
+#define ADC_SYNCCTL_VBATEN              BIT(22)                          /*!< channel 18 (1/4 voltate of external battery) enable of ADC0 */
+#define ADC_SYNCCTL_TSVREN              BIT(23)                          /*!< channel 16 (temperature sensor) and 17 (internal reference voltage) enable of ADC0 */
+
+/* ADC_SYNCDATA */
+#define ADC_SYNCDATA_SYNCDATA0          BITS(0,15)                       /*!< regular data1 in ADC synchronization mode */
+#define ADC_SYNCDATA_SYNCDATA1          BITS(16,31)                      /*!< regular data2 in ADC synchronization mode */
+
+/* constants definitions */
+/* ADC status flag */
+#define ADC_FLAG_WDE                    ADC_STAT_WDE                     /*!< analog watchdog event flag */
+#define ADC_FLAG_EOC                    ADC_STAT_EOC                     /*!< end of conversion */
+#define ADC_FLAG_EOIC                   ADC_STAT_EOIC                    /*!< inserted channel end of conversion */
+#define ADC_FLAG_STIC                   ADC_STAT_STIC                    /*!< inserted channel start flag */
+#define ADC_FLAG_STRC                   ADC_STAT_STRC                    /*!< regular channel start flag */
+#define ADC_FLAG_ROVF                   ADC_STAT_ROVF                    /*!< regular data register overflow */
+
+/* adc_ctl0 register value */
+#define CTL0_DISNUM(regval)             (BITS(13,15) & ((uint32_t)(regval) << 13))   /*!< write value to ADC_CTL0_DISNUM bit field */
+
+/* ADC special function definitions */
+#define ADC_SCAN_MODE                   ADC_CTL0_SM                   /*!< scan mode */
+#define ADC_INSERTED_CHANNEL_AUTO       ADC_CTL0_ICA                  /*!< inserted channel group convert automatically */
+#define ADC_CONTINUOUS_MODE             ADC_CTL1_CTN                  /*!< continuous mode */
+
+/* temperature sensor channel, internal reference voltage channel, VBAT channel */
+#define ADC_VBAT_CHANNEL_SWITCH         ADC_SYNCCTL_VBATEN                  /*!< VBAT channel */
+#define ADC_TEMP_VREF_CHANNEL_SWITCH    ADC_SYNCCTL_TSVREN                  /*!< Vref and Vtemp channel */
+
+/* ADC synchronization mode */
+#define SYNCCTL_SYNCM(regval)              (BITS(0,4) & ((uint32_t)(regval)))    /*!< write value to ADC_CTL0_SYNCM bit field */
+#define ADC_SYNC_MODE_INDEPENDENT                           SYNCCTL_SYNCM(0)     /*!< ADC synchronization mode disabled.All the ADCs work independently */
+#define ADC_DAUL_REGULAL_PARALLEL_INSERTED_PARALLEL         SYNCCTL_SYNCM(1)     /*!< ADC0 and ADC1 work in combined regular parallel & inserted parallel mode. ADC2 works independently */
+#define ADC_DAUL_REGULAL_PARALLEL_INSERTED_ROTATION         SYNCCTL_SYNCM(2)     /*!< ADC0 and ADC1 work in combined regular parallel & trigger rotation mode. ADC2 works independently */
+#define ADC_DAUL_INSERTED_PARALLEL                          SYNCCTL_SYNCM(5)     /*!< ADC0 and ADC1 work in inserted parallel mode. ADC2 works independently */
+#define ADC_DAUL_REGULAL_PARALLEL                           SYNCCTL_SYNCM(6)     /*!< ADC0 and ADC1 work in regular parallel mode. ADC2 works independently */
+#define ADC_DAUL_REGULAL_FOLLOW_UP                          SYNCCTL_SYNCM(7)     /*!< ADC0 and ADC1 work in follow-up mode. ADC2 works independently */
+#define ADC_DAUL_INSERTED_TRRIGGER_ROTATION                 SYNCCTL_SYNCM(9)     /*!< ADC0 and ADC1 work in trigger rotation mode. ADC2 works independently */
+#define ADC_ALL_REGULAL_PARALLEL_INSERTED_PARALLEL          SYNCCTL_SYNCM(17)    /*!< all ADCs work in combined regular parallel & inserted parallel mode */
+#define ADC_ALL_REGULAL_PARALLEL_INSERTED_ROTATION          SYNCCTL_SYNCM(18)    /*!< all ADCs work in combined regular parallel & trigger rotation mode */
+#define ADC_ALL_INSERTED_PARALLEL                           SYNCCTL_SYNCM(21)    /*!< all ADCs work in inserted parallel mode */
+#define ADC_ALL_REGULAL_PARALLEL                            SYNCCTL_SYNCM(22)    /*!< all ADCs work in regular parallel mode */
+#define ADC_ALL_REGULAL_FOLLOW_UP                           SYNCCTL_SYNCM(23)    /*!< all ADCs work in follow-up mode */
+#define ADC_ALL_INSERTED_TRRIGGER_ROTATION                  SYNCCTL_SYNCM(25)    /*!< all ADCs work in trigger rotation mode */
+
+/* ADC data alignment */
+#define ADC_DATAALIGN_RIGHT             ((uint32_t)0x00000000U)                  /*!< LSB alignment */
+#define ADC_DATAALIGN_LEFT              ADC_CTL1_DAL                             /*!< MSB alignment */
+
+/* external trigger mode for regular and inserted  channel */
+#define EXTERNAL_TRIGGER_DISABLE        ((uint32_t)0x00000000U)           /*!< external trigger disable */
+#define EXTERNAL_TRIGGER_RISING         ((uint32_t)0x00000001U)           /*!< rising edge of external trigger */
+#define EXTERNAL_TRIGGER_FALLING        ((uint32_t)0x00000002U)           /*!< falling edge of external trigger */
+#define EXTERNAL_TRIGGER_RISING_FALLING ((uint32_t)0x00000003U)           /*!< rising and falling edge of external trigger */
+
+/* ADC external trigger select for regular channel */
+#define CTL1_ETSRC(regval)              (BITS(24,27) & ((uint32_t)(regval) << 24))
+#define ADC_EXTTRIG_REGULAR_T0_CH0      CTL1_ETSRC(0)                    /*!< timer 0 CC0 event select */
+#define ADC_EXTTRIG_REGULAR_T0_CH1      CTL1_ETSRC(1)                    /*!< timer 0 CC1 event select */
+#define ADC_EXTTRIG_REGULAR_T0_CH2      CTL1_ETSRC(2)                    /*!< timer 0 CC2 event select */
+#define ADC_EXTTRIG_REGULAR_T1_CH1      CTL1_ETSRC(3)                    /*!< timer 1 CC1 event select */
+#define ADC_EXTTRIG_REGULAR_T1_CH2      CTL1_ETSRC(4)                    /*!< timer 1 CC2 event select */
+#define ADC_EXTTRIG_REGULAR_T1_CH3      CTL1_ETSRC(5)                    /*!< timer 1 CC3 event select */
+#define ADC_EXTTRIG_REGULAR_T1_TRGO     CTL1_ETSRC(6)                    /*!< timer 1 TRGO event select */
+#define ADC_EXTTRIG_REGULAR_T2_CH0      CTL1_ETSRC(7)                    /*!< timer 2 CC0 event select */
+#define ADC_EXTTRIG_REGULAR_T2_TRGO     CTL1_ETSRC(8)                    /*!< timer 2 TRGO event select */
+#define ADC_EXTTRIG_REGULAR_T3_CH3      CTL1_ETSRC(9)                    /*!< timer 3 CC3 event select */
+#define ADC_EXTTRIG_REGULAR_T4_CH0      CTL1_ETSRC(10)                   /*!< timer 4 CC0 event select */
+#define ADC_EXTTRIG_REGULAR_T4_CH1      CTL1_ETSRC(11)                   /*!< timer 4 CC1 event select */
+#define ADC_EXTTRIG_REGULAR_T4_CH2      CTL1_ETSRC(12)                   /*!< timer 4 CC2 event select */
+#define ADC_EXTTRIG_REGULAR_T7_CH0      CTL1_ETSRC(13)                   /*!< timer 7 CC0 event select */
+#define ADC_EXTTRIG_REGULAR_T7_TRGO     CTL1_ETSRC(14)                   /*!< timer 7 TRGO event select */
+#define ADC_EXTTRIG_REGULAR_EXTI_11     CTL1_ETSRC(15)                   /*!< extiline 11 select  */
+
+/* ADC external trigger select for inserted channel */
+#define CTL1_ETSIC(regval)              (BITS(16,19) & ((uint32_t)(regval) << 16))
+#define ADC_EXTTRIG_INSERTED_T0_CH3     CTL1_ETSIC(0)                    /*!< timer0 capture compare 3 */
+#define ADC_EXTTRIG_INSERTED_T0_TRGO    CTL1_ETSIC(1)                    /*!< timer0 TRGO event */
+#define ADC_EXTTRIG_INSERTED_T1_CH0     CTL1_ETSIC(2)                    /*!< timer1 capture compare 0 */
+#define ADC_EXTTRIG_INSERTED_T1_TRGO    CTL1_ETSIC(3)                    /*!< timer1 TRGO event */
+#define ADC_EXTTRIG_INSERTED_T2_CH1     CTL1_ETSIC(4)                    /*!< timer2 capture compare 1 */
+#define ADC_EXTTRIG_INSERTED_T2_CH3     CTL1_ETSIC(5)                    /*!< timer2 capture compare 3 */
+#define ADC_EXTTRIG_INSERTED_T3_CH0     CTL1_ETSIC(6)                    /*!< timer3 capture compare 0 */
+#define ADC_EXTTRIG_INSERTED_T3_CH1     CTL1_ETSIC(7)                    /*!< timer3 capture compare 1 */
+#define ADC_EXTTRIG_INSERTED_T3_CH2     CTL1_ETSIC(8)                    /*!< timer3 capture compare 2 */
+#define ADC_EXTTRIG_INSERTED_T3_TRGO    CTL1_ETSIC(9)                    /*!< timer3 capture compare TRGO */
+#define ADC_EXTTRIG_INSERTED_T4_CH3     CTL1_ETSIC(10)                   /*!< timer4 capture compare 3 */
+#define ADC_EXTTRIG_INSERTED_T4_TRGO    CTL1_ETSIC(11)                   /*!< timer4 capture compare TRGO */
+#define ADC_EXTTRIG_INSERTED_T7_CH1     CTL1_ETSIC(12)                   /*!< timer7 capture compare 1 */
+#define ADC_EXTTRIG_INSERTED_T7_CH2     CTL1_ETSIC(13)                   /*!< timer7 capture compare 2 */
+#define ADC_EXTTRIG_INSERTED_T7_CH3     CTL1_ETSIC(14)                   /*!< timer7 capture compare 3 */
+#define ADC_EXTTRIG_INSERTED_EXTI_15    CTL1_ETSIC(15)                   /*!< external interrupt line 15 */
+
+/* ADC channel sample time */
+#define SAMPTX_SPT(regval)               (BITS(0,2) & ((uint32_t)(regval) << 0))     /*!< write value to ADC_SAMPTX_SPT bit field */
+#define ADC_SAMPLETIME_3                 SAMPTX_SPT(0)                  /*!< 3 sampling cycles */
+#define ADC_SAMPLETIME_15                SAMPTX_SPT(1)                  /*!< 15 sampling cycles */
+#define ADC_SAMPLETIME_28                SAMPTX_SPT(2)                  /*!< 28 sampling cycles */
+#define ADC_SAMPLETIME_56                SAMPTX_SPT(3)                  /*!< 56 sampling cycles */
+#define ADC_SAMPLETIME_84                SAMPTX_SPT(4)                  /*!< 84 sampling cycles */
+#define ADC_SAMPLETIME_112               SAMPTX_SPT(5)                  /*!< 112 sampling cycles */
+#define ADC_SAMPLETIME_144               SAMPTX_SPT(6)                  /*!< 144 sampling cycles */
+#define ADC_SAMPLETIME_480               SAMPTX_SPT(7)                  /*!< 480 sampling cycles */
+
+/* adc_ioffx register value */
+#define IOFFX_IOFF(regval)               (BITS(0,11) & ((uint32_t)(regval) << 0))    /*!< write value to ADC_IOFFX_IOFF bit field */
+
+/* adc_wdht register value */
+#define WDHT_WDHT(regval)                (BITS(0,11) & ((uint32_t)(regval) << 0))    /*!< write value to ADC_WDHT_WDHT bit field */
+
+/* adc_wdlt register value */
+#define WDLT_WDLT(regval)                (BITS(0,11) & ((uint32_t)(regval) << 0))    /*!< write value to ADC_WDLT_WDLT bit field */
+
+/* adc_rsqx register value */
+#define RSQ0_RL(regval)                  (BITS(20,23) & ((uint32_t)(regval) << 20))  /*!< write value to ADC_RSQ0_RL bit field */
+
+/* adc_isq register value */
+#define ISQ_IL(regval)                   (BITS(20,21) & ((uint32_t)(regval) << 20))  /*!< write value to ADC_ISQ_IL bit field */
+
+/* adc_ovsampctl register value */
+/* ADC resolution */
+#define CTL0_DRES(regval)                (BITS(24,25) & ((uint32_t)(regval) << 24))  /*!< write value to ADC_CTL0_DRES bit field */
+#define ADC_RESOLUTION_12B               CTL0_DRES(0)                                /*!< 12-bit ADC resolution */
+#define ADC_RESOLUTION_10B               CTL0_DRES(1)                                /*!< 10-bit ADC resolution */
+#define ADC_RESOLUTION_8B                CTL0_DRES(2)                                /*!< 8-bit ADC resolution */
+#define ADC_RESOLUTION_6B                CTL0_DRES(3)                                /*!< 6-bit ADC resolution */
+
+/* oversampling shift */
+#define OVSAMPCTL_OVSS(regval)           (BITS(5,8) & ((uint32_t)(regval) << 5))     /*!< write value to ADC_OVSAMPCTL_OVSS bit field */
+#define ADC_OVERSAMPLING_SHIFT_NONE      OVSAMPCTL_OVSS(0)                           /*!< no oversampling shift */
+#define ADC_OVERSAMPLING_SHIFT_1B        OVSAMPCTL_OVSS(1)                           /*!< 1-bit oversampling shift */
+#define ADC_OVERSAMPLING_SHIFT_2B        OVSAMPCTL_OVSS(2)                           /*!< 2-bit oversampling shift */
+#define ADC_OVERSAMPLING_SHIFT_3B        OVSAMPCTL_OVSS(3)                           /*!< 3-bit oversampling shift */
+#define ADC_OVERSAMPLING_SHIFT_4B        OVSAMPCTL_OVSS(4)                           /*!< 4-bit oversampling shift */
+#define ADC_OVERSAMPLING_SHIFT_5B        OVSAMPCTL_OVSS(5)                           /*!< 5-bit oversampling shift */
+#define ADC_OVERSAMPLING_SHIFT_6B        OVSAMPCTL_OVSS(6)                           /*!< 6-bit oversampling shift */
+#define ADC_OVERSAMPLING_SHIFT_7B        OVSAMPCTL_OVSS(7)                           /*!< 7-bit oversampling shift */
+#define ADC_OVERSAMPLING_SHIFT_8B        OVSAMPCTL_OVSS(8)                           /*!< 8-bit oversampling shift */
+
+/* oversampling ratio */
+#define OVSAMPCTL_OVSR(regval)           (BITS(2,4) & ((uint32_t)(regval) << 2))     /*!< write value to ADC_OVSAMPCTL_OVSR bit field */
+#define ADC_OVERSAMPLING_RATIO_MUL2      OVSAMPCTL_OVSR(0)                           /*!< oversampling ratio multiple 2 */
+#define ADC_OVERSAMPLING_RATIO_MUL4      OVSAMPCTL_OVSR(1)                           /*!< oversampling ratio multiple 4 */
+#define ADC_OVERSAMPLING_RATIO_MUL8      OVSAMPCTL_OVSR(2)                           /*!< oversampling ratio multiple 8 */
+#define ADC_OVERSAMPLING_RATIO_MUL16     OVSAMPCTL_OVSR(3)                           /*!< oversampling ratio multiple 16 */
+#define ADC_OVERSAMPLING_RATIO_MUL32     OVSAMPCTL_OVSR(4)                           /*!< oversampling ratio multiple 32 */
+#define ADC_OVERSAMPLING_RATIO_MUL64     OVSAMPCTL_OVSR(5)                           /*!< oversampling ratio multiple 64 */
+#define ADC_OVERSAMPLING_RATIO_MUL128    OVSAMPCTL_OVSR(6)                           /*!< oversampling ratio multiple 128 */
+#define ADC_OVERSAMPLING_RATIO_MUL256    OVSAMPCTL_OVSR(7)                           /*!< oversampling ratio multiple 256 */
+
+/* triggered Oversampling */
+#define ADC_OVERSAMPLING_ALL_CONVERT     ((uint32_t)0x00000000U)                     /*!< all oversampled conversions for a channel are done consecutively after a trigger */
+#define ADC_OVERSAMPLING_ONE_CONVERT     ADC_OVSAMPCTL_TOVS                          /*!< each oversampled conversion for a channel needs a trigger */
+
+/* ADC channel group definitions */
+#define ADC_REGULAR_CHANNEL              ((uint8_t)0x01U)                            /*!< adc regular channel group */
+#define ADC_INSERTED_CHANNEL             ((uint8_t)0x02U)                            /*!< adc inserted channel group */
+#define ADC_REGULAR_INSERTED_CHANNEL     ((uint8_t)0x03U)                            /*!< both regular and inserted channel group */
+#define ADC_CHANNEL_DISCON_DISABLE       ((uint8_t)0x04U)                            /*!< disable discontinuous mode of regular & inserted channel */
+
+/* ADC inserted channel definitions */
+#define ADC_INSERTED_CHANNEL_0          ((uint8_t)0x00U)                  /*!< adc inserted channel 0 */
+#define ADC_INSERTED_CHANNEL_1          ((uint8_t)0x01U)                  /*!< adc inserted channel 1 */
+#define ADC_INSERTED_CHANNEL_2          ((uint8_t)0x02U)                  /*!< adc inserted channel 2 */
+#define ADC_INSERTED_CHANNEL_3          ((uint8_t)0x03U)                  /*!< adc inserted channel 3 */
+
+/* ADC channel definitions */
+#define ADC_CHANNEL_0                   ((uint8_t)0x00U)                  /*!< ADC channel 0 */
+#define ADC_CHANNEL_1                   ((uint8_t)0x01U)                  /*!< ADC channel 1 */
+#define ADC_CHANNEL_2                   ((uint8_t)0x02U)                  /*!< ADC channel 2 */
+#define ADC_CHANNEL_3                   ((uint8_t)0x03U)                  /*!< ADC channel 3 */
+#define ADC_CHANNEL_4                   ((uint8_t)0x04U)                  /*!< ADC channel 4 */
+#define ADC_CHANNEL_5                   ((uint8_t)0x05U)                  /*!< ADC channel 5 */
+#define ADC_CHANNEL_6                   ((uint8_t)0x06U)                  /*!< ADC channel 6 */
+#define ADC_CHANNEL_7                   ((uint8_t)0x07U)                  /*!< ADC channel 7 */
+#define ADC_CHANNEL_8                   ((uint8_t)0x08U)                  /*!< ADC channel 8 */
+#define ADC_CHANNEL_9                   ((uint8_t)0x09U)                  /*!< ADC channel 9 */
+#define ADC_CHANNEL_10                  ((uint8_t)0x0AU)                  /*!< ADC channel 10 */
+#define ADC_CHANNEL_11                  ((uint8_t)0x0BU)                  /*!< ADC channel 11 */
+#define ADC_CHANNEL_12                  ((uint8_t)0x0CU)                  /*!< ADC channel 12 */
+#define ADC_CHANNEL_13                  ((uint8_t)0x0DU)                  /*!< ADC channel 13 */
+#define ADC_CHANNEL_14                  ((uint8_t)0x0EU)                  /*!< ADC channel 14 */
+#define ADC_CHANNEL_15                  ((uint8_t)0x0FU)                  /*!< ADC channel 15 */
+#define ADC_CHANNEL_16                  ((uint8_t)0x10U)                  /*!< ADC channel 16 */
+#define ADC_CHANNEL_17                  ((uint8_t)0x11U)                  /*!< ADC channel 17 */
+#define ADC_CHANNEL_18                  ((uint8_t)0x12U)                  /*!< ADC channel 18 */
+
+/* ADC interrupt flag */
+#define ADC_INT_WDE                     ADC_CTL0_WDEIE                    /*!< analog watchdog event interrupt */
+#define ADC_INT_EOC                     ADC_CTL0_EOCIE                    /*!< end of group conversion interrupt */
+#define ADC_INT_EOIC                    ADC_CTL0_EOICIE                   /*!< end of inserted group conversion interrupt */
+#define ADC_INT_ROVF                    ADC_CTL0_ROVFIE                   /*!< regular data register overflow */
+
+/* ADC interrupt flag */
+#define ADC_INT_FLAG_WDE                ADC_STAT_WDE                      /*!< analog watchdog event interrupt */
+#define ADC_INT_FLAG_EOC                ADC_STAT_EOC                      /*!< end of group conversion interrupt */
+#define ADC_INT_FLAG_EOIC               ADC_STAT_EOIC                     /*!< end of inserted group conversion interrupt */
+#define ADC_INT_FLAG_ROVF               ADC_STAT_ROVF                     /*!< regular data register overflow */
+
+/* configure the ADC clock for all the ADCs */
+#define SYNCCTL_ADCCK(regval)           (BITS(16,18) & ((uint32_t)(regval) << 16))
+#define ADC_ADCCK_PCLK2_DIV2            SYNCCTL_ADCCK(0)                 /*!< PCLK2 div2 */
+#define ADC_ADCCK_PCLK2_DIV4            SYNCCTL_ADCCK(1)                 /*!< PCLK2 div4 */
+#define ADC_ADCCK_PCLK2_DIV6            SYNCCTL_ADCCK(2)                 /*!< PCLK2 div6 */
+#define ADC_ADCCK_PCLK2_DIV8            SYNCCTL_ADCCK(3)                 /*!< PCLK2 div8 */
+#define ADC_ADCCK_HCLK_DIV5             SYNCCTL_ADCCK(4)                 /*!< HCLK div5 */
+#define ADC_ADCCK_HCLK_DIV6             SYNCCTL_ADCCK(5)                 /*!< HCLK div6 */
+#define ADC_ADCCK_HCLK_DIV10            SYNCCTL_ADCCK(6)                 /*!< HCLK div10 */
+#define ADC_ADCCK_HCLK_DIV20            SYNCCTL_ADCCK(7)                 /*!< HCLK div20 */
+
+/* ADC synchronization delay */
+#define ADC_SYNC_DELAY_5CYCLE                               ((uint32_t)0x00000000U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 5 ADC clock cycles. */
+#define ADC_SYNC_DELAY_6CYCLE                               ((uint32_t)0x00000100U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 6 ADC clock cycles. */
+#define ADC_SYNC_DELAY_7CYCLE                               ((uint32_t)0x00000200U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 7 ADC clock cycles. */
+#define ADC_SYNC_DELAY_8CYCLE                               ((uint32_t)0x00000300U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 8 ADC clock cycles. */
+#define ADC_SYNC_DELAY_9CYCLE                               ((uint32_t)0x00000400U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 9 ADC clock cycles. */
+#define ADC_SYNC_DELAY_10CYCLE                              ((uint32_t)0x00000500U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 10 ADC clock cycles. */
+#define ADC_SYNC_DELAY_11CYCLE                              ((uint32_t)0x00000600U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 11 ADC clock cycles. */
+#define ADC_SYNC_DELAY_12CYCLE                              ((uint32_t)0x00000700U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 12 ADC clock cycles. */
+#define ADC_SYNC_DELAY_13CYCLE                              ((uint32_t)0x00000800U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 13 ADC clock cycles. */
+#define ADC_SYNC_DELAY_14CYCLE                              ((uint32_t)0x00000900U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 14 ADC clock cycles. */
+#define ADC_SYNC_DELAY_15CYCLE                              ((uint32_t)0x00000A00U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 15 ADC clock cycles. */
+#define ADC_SYNC_DELAY_16CYCLE                              ((uint32_t)0x00000B00U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 16 ADC clock cycles. */
+#define ADC_SYNC_DELAY_17CYCLE                              ((uint32_t)0x00000C00U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 17 ADC clock cycles. */
+#define ADC_SYNC_DELAY_18CYCLE                              ((uint32_t)0x00000D00U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 18 ADC clock cycles. */
+#define ADC_SYNC_DELAY_19CYCLE                              ((uint32_t)0x00000E00U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 19 ADC clock cycles. */
+#define ADC_SYNC_DELAY_20CYCLE                              ((uint32_t)0x00000F00U)    /*!< the delay between 2 sampling phases in ADC synchronization modes to 20 ADC clock cycles. */
+
+/* ADC synchronization DMA mode selection */
+#define ADC_SYNC_DMA_DISABLE                                ((uint32_t)0x00000000U)    /*!< ADC synchronization DMA disabled */
+#define ADC_SYNC_DMA_MODE0                                  ((uint32_t)0x00004000U)    /*!< ADC synchronization DMA mode 0 */
+#define ADC_SYNC_DMA_MODE1                                  ((uint32_t)0x00008000U)    /*!< ADC synchronization DMA mode 1 */
+
+/* end of conversion mode */
+#define ADC_EOC_SET_SEQUENCE                                ((uint8_t)0x00U)           /*!< only at the end of a sequence of regular conversions, the EOC bit is set */
+#define ADC_EOC_SET_CONVERSION                              ((uint8_t)0x01U)           /*!< at the end of each regular conversion, the EOC bit is set */
+
+/* function declarations */
+/* initialization config */
+/* reset ADC */
+void adc_deinit(void);
+/* configure the ADC clock for all the ADCs */
+void adc_clock_config(uint32_t prescaler);
+/* enable or disable ADC special function */
+void adc_special_function_config(uint32_t adc_periph , uint32_t function , ControlStatus newvalue);
+/* configure ADC data alignment */
+void adc_data_alignment_config(uint32_t adc_periph , uint32_t data_alignment);
+/* enable ADC interface */
+void adc_enable(uint32_t adc_periph);
+/* disable ADC interface */
+void adc_disable(uint32_t adc_periph);
+/* ADC calibration and reset calibration */
+void adc_calibration_enable(uint32_t adc_periph);
+/* configure temperature sensor and internal reference voltage channel or VBAT channel function */
+void adc_channel_16_to_18(uint32_t function, ControlStatus newvalue);
+/* configure ADC resolution */
+void adc_resolution_config(uint32_t adc_periph, uint32_t resolution);
+/* configure ADC oversample mode */
+void adc_oversample_mode_config(uint32_t adc_periph, uint32_t mode, uint16_t shift, uint8_t ratio);
+/* enable ADC oversample mode */
+void adc_oversample_mode_enable(uint32_t adc_periph);
+/* disable ADC oversample mode */
+void adc_oversample_mode_disable(uint32_t adc_periph);
+
+/* DMA config */
+/* enable DMA request */
+void adc_dma_mode_enable(uint32_t adc_periph);
+/* disable DMA request */
+void adc_dma_mode_disable(uint32_t adc_periph);
+/* when DMA=1, the DMA engine issues a request at end of each regular conversion */
+void adc_dma_request_after_last_enable(uint32_t adc_periph);
+/* the DMA engine is disabled after the end of transfer signal from DMA controller is detected */
+void adc_dma_request_after_last_disable(uint32_t adc_periph);
+
+/* regular group and inserted group config */
+/* configure ADC discontinuous mode */
+void adc_discontinuous_mode_config(uint32_t adc_periph , uint8_t adc_channel_group , uint8_t length);
+/* configure the length of regular channel group or inserted channel group */
+void adc_channel_length_config(uint32_t adc_periph , uint8_t adc_channel_group , uint32_t length);
+/* configure ADC regular channel */
+void adc_regular_channel_config(uint32_t adc_periph , uint8_t rank , uint8_t adc_channel , uint32_t sample_time);
+/* configure ADC inserted channel */
+void adc_inserted_channel_config(uint32_t adc_periph , uint8_t rank , uint8_t adc_channel , uint32_t sample_time);
+/* configure ADC inserted channel offset */
+void adc_inserted_channel_offset_config(uint32_t adc_periph , uint8_t inserted_channel , uint16_t offset);
+/* configure ADC external trigger source */
+void adc_external_trigger_source_config(uint32_t adc_periph , uint8_t adc_channel_group , uint32_t external_trigger_source);
+/* enable ADC external trigger */
+void adc_external_trigger_config(uint32_t adc_periph , uint8_t adc_channel_group , uint32_t trigger_mode);
+/* enable ADC software trigger */
+void adc_software_trigger_enable(uint32_t adc_periph , uint8_t adc_channel_group);
+/* configure end of conversion mode */
+void adc_end_of_conversion_config(uint32_t adc_periph , uint8_t end_selection);
+
+/* get channel data */
+/* read ADC regular group data register */
+uint16_t adc_regular_data_read(uint32_t adc_periph);
+/* read ADC inserted group data register */
+uint16_t adc_inserted_data_read(uint32_t adc_periph , uint8_t inserted_channel);
+
+/* watchdog config */
+/* disable ADC analog watchdog single channel */
+void adc_watchdog_single_channel_disable(uint32_t adc_periph );
+/* enable ADC analog watchdog single channel */
+void adc_watchdog_single_channel_enable(uint32_t adc_periph , uint8_t adc_channel);
+/* configure ADC analog watchdog group channel */
+void adc_watchdog_group_channel_enable(uint32_t adc_periph , uint8_t adc_channel_group);
+/* disable ADC analog watchdog */
+void adc_watchdog_disable(uint32_t adc_periph , uint8_t adc_channel_group);
+/* configure ADC analog watchdog threshold */
+void adc_watchdog_threshold_config(uint32_t adc_periph , uint16_t low_threshold , uint16_t high_threshold);
+
+/* interrupt & flag functions */
+/* get the ADC flag bits */
+FlagStatus adc_flag_get(uint32_t adc_periph , uint32_t adc_flag);
+/* clear the ADC flag bits */
+void adc_flag_clear(uint32_t adc_periph , uint32_t adc_flag);
+/* get the bit state of ADCx software start conversion */
+FlagStatus adc_regular_software_startconv_flag_get(uint32_t adc_periph);
+/* get the bit state of ADCx software inserted channel start conversion */
+FlagStatus adc_inserted_software_startconv_flag_get(uint32_t adc_periph);
+/* get the ADC interrupt bits */
+FlagStatus adc_interrupt_flag_get(uint32_t adc_periph , uint32_t adc_interrupt);
+/* clear the ADC flag */
+void adc_interrupt_flag_clear(uint32_t adc_periph , uint32_t adc_interrupt);
+/* enable ADC interrupt */
+void adc_interrupt_enable(uint32_t adc_periph , uint32_t adc_interrupt);
+/* disable ADC interrupt */
+void adc_interrupt_disable(uint32_t adc_periph , uint32_t adc_interrupt);
+
+/* ADC synchronization */
+/* configure the ADC sync mode */
+void adc_sync_mode_config(uint32_t sync_mode);
+/* configure the delay between 2 sampling phases in ADC sync modes */
+void adc_sync_delay_config(uint32_t sample_delay);
+/* configure ADC sync DMA mode selection */
+void adc_sync_dma_config(uint32_t dma_mode );
+/* configure ADC sync DMA engine is disabled after the end of transfer signal from DMA controller is detected */
+void adc_sync_dma_request_after_last_enable(void);
+/* configure ADC sync DMA engine issues requests according to the SYNCDMA bits */
+void adc_sync_dma_request_after_last_disable(void);
+/* read ADC sync regular data register */
+uint32_t adc_sync_regular_data_read(void);
+
+#endif /* GD32F4XX_ADC_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_can.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_can.h
@@ -1,0 +1,750 @@
+/*!
+    \file    gd32f4xx_can.h
+    \brief   definitions for the CAN
+    
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2019-11-27, V2.0.1, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+
+#ifndef GD32F4XX_CAN_H
+#define GD32F4XX_CAN_H
+
+#include "gd32f4xx.h"
+
+/* CAN definitions */
+#define CAN0                               CAN_BASE                           /*!< CAN0 base address */
+#define CAN1                               (CAN0 + 0x00000400U)               /*!< CAN1 base address */
+
+/* registers definitions */
+#define CAN_CTL(canx)                      REG32((canx) + 0x00000000U)        /*!< CAN control register */
+#define CAN_STAT(canx)                     REG32((canx) + 0x00000004U)        /*!< CAN status register */
+#define CAN_TSTAT(canx)                    REG32((canx) + 0x00000008U)        /*!< CAN transmit status register*/
+#define CAN_RFIFO0(canx)                   REG32((canx) + 0x0000000CU)        /*!< CAN receive FIFO0 register */
+#define CAN_RFIFO1(canx)                   REG32((canx) + 0x00000010U)        /*!< CAN receive FIFO1 register */
+#define CAN_INTEN(canx)                    REG32((canx) + 0x00000014U)        /*!< CAN interrupt enable register */
+#define CAN_ERR(canx)                      REG32((canx) + 0x00000018U)        /*!< CAN error register */
+#define CAN_BT(canx)                       REG32((canx) + 0x0000001CU)        /*!< CAN bit timing register */
+#define CAN_TMI0(canx)                     REG32((canx) + 0x00000180U)        /*!< CAN transmit mailbox0 identifier register */
+#define CAN_TMP0(canx)                     REG32((canx) + 0x00000184U)        /*!< CAN transmit mailbox0 property register */
+#define CAN_TMDATA00(canx)                 REG32((canx) + 0x00000188U)        /*!< CAN transmit mailbox0 data0 register */
+#define CAN_TMDATA10(canx)                 REG32((canx) + 0x0000018CU)        /*!< CAN transmit mailbox0 data1 register */
+#define CAN_TMI1(canx)                     REG32((canx) + 0x00000190U)        /*!< CAN transmit mailbox1 identifier register */
+#define CAN_TMP1(canx)                     REG32((canx) + 0x00000194U)        /*!< CAN transmit mailbox1 property register */
+#define CAN_TMDATA01(canx)                 REG32((canx) + 0x00000198U)        /*!< CAN transmit mailbox1 data0 register */
+#define CAN_TMDATA11(canx)                 REG32((canx) + 0x0000019CU)        /*!< CAN transmit mailbox1 data1 register */
+#define CAN_TMI2(canx)                     REG32((canx) + 0x000001A0U)        /*!< CAN transmit mailbox2 identifier register */
+#define CAN_TMP2(canx)                     REG32((canx) + 0x000001A4U)        /*!< CAN transmit mailbox2 property register */
+#define CAN_TMDATA02(canx)                 REG32((canx) + 0x000001A8U)        /*!< CAN transmit mailbox2 data0 register */
+#define CAN_TMDATA12(canx)                 REG32((canx) + 0x000001ACU)        /*!< CAN transmit mailbox2 data1 register */
+#define CAN_RFIFOMI0(canx)                 REG32((canx) + 0x000001B0U)        /*!< CAN receive FIFO0 mailbox identifier register */
+#define CAN_RFIFOMP0(canx)                 REG32((canx) + 0x000001B4U)        /*!< CAN receive FIFO0 mailbox property register */
+#define CAN_RFIFOMDATA00(canx)             REG32((canx) + 0x000001B8U)        /*!< CAN receive FIFO0 mailbox data0 register */
+#define CAN_RFIFOMDATA10(canx)             REG32((canx) + 0x000001BCU)        /*!< CAN receive FIFO0 mailbox data1 register */
+#define CAN_RFIFOMI1(canx)                 REG32((canx) + 0x000001C0U)        /*!< CAN receive FIFO1 mailbox identifier register */
+#define CAN_RFIFOMP1(canx)                 REG32((canx) + 0x000001C4U)        /*!< CAN receive FIFO1 mailbox property register */
+#define CAN_RFIFOMDATA01(canx)             REG32((canx) + 0x000001C8U)        /*!< CAN receive FIFO1 mailbox data0 register */
+#define CAN_RFIFOMDATA11(canx)             REG32((canx) + 0x000001CCU)        /*!< CAN receive FIFO1 mailbox data1 register */
+#define CAN_FCTL(canx)                     REG32((canx) + 0x00000200U)        /*!< CAN filter control register */
+#define CAN_FMCFG(canx)                    REG32((canx) + 0x00000204U)        /*!< CAN filter mode register */
+#define CAN_FSCFG(canx)                    REG32((canx) + 0x0000020CU)        /*!< CAN filter scale register */
+#define CAN_FAFIFO(canx)                   REG32((canx) + 0x00000214U)        /*!< CAN filter associated FIFO register */
+#define CAN_FW(canx)                       REG32((canx) + 0x0000021CU)        /*!< CAN filter working register */
+#define CAN_F0DATA0(canx)                  REG32((canx) + 0x00000240U)        /*!< CAN filter 0 data 0 register */
+#define CAN_F1DATA0(canx)                  REG32((canx) + 0x00000248U)        /*!< CAN filter 1 data 0 register */
+#define CAN_F2DATA0(canx)                  REG32((canx) + 0x00000250U)        /*!< CAN filter 2 data 0 register */
+#define CAN_F3DATA0(canx)                  REG32((canx) + 0x00000258U)        /*!< CAN filter 3 data 0 register */
+#define CAN_F4DATA0(canx)                  REG32((canx) + 0x00000260U)        /*!< CAN filter 4 data 0 register */
+#define CAN_F5DATA0(canx)                  REG32((canx) + 0x00000268U)        /*!< CAN filter 5 data 0 register */
+#define CAN_F6DATA0(canx)                  REG32((canx) + 0x00000270U)        /*!< CAN filter 6 data 0 register */
+#define CAN_F7DATA0(canx)                  REG32((canx) + 0x00000278U)        /*!< CAN filter 7 data 0 register */
+#define CAN_F8DATA0(canx)                  REG32((canx) + 0x00000280U)        /*!< CAN filter 8 data 0 register */
+#define CAN_F9DATA0(canx)                  REG32((canx) + 0x00000288U)        /*!< CAN filter 9 data 0 register */
+#define CAN_F10DATA0(canx)                 REG32((canx) + 0x00000290U)        /*!< CAN filter 10 data 0 register */
+#define CAN_F11DATA0(canx)                 REG32((canx) + 0x00000298U)        /*!< CAN filter 11 data 0 register */
+#define CAN_F12DATA0(canx)                 REG32((canx) + 0x000002A0U)        /*!< CAN filter 12 data 0 register */
+#define CAN_F13DATA0(canx)                 REG32((canx) + 0x000002A8U)        /*!< CAN filter 13 data 0 register */
+#define CAN_F14DATA0(canx)                 REG32((canx) + 0x000002B0U)        /*!< CAN filter 14 data 0 register */
+#define CAN_F15DATA0(canx)                 REG32((canx) + 0x000002B8U)        /*!< CAN filter 15 data 0 register */
+#define CAN_F16DATA0(canx)                 REG32((canx) + 0x000002C0U)        /*!< CAN filter 16 data 0 register */
+#define CAN_F17DATA0(canx)                 REG32((canx) + 0x000002C8U)        /*!< CAN filter 17 data 0 register */
+#define CAN_F18DATA0(canx)                 REG32((canx) + 0x000002D0U)        /*!< CAN filter 18 data 0 register */
+#define CAN_F19DATA0(canx)                 REG32((canx) + 0x000002D8U)        /*!< CAN filter 19 data 0 register */
+#define CAN_F20DATA0(canx)                 REG32((canx) + 0x000002E0U)        /*!< CAN filter 20 data 0 register */
+#define CAN_F21DATA0(canx)                 REG32((canx) + 0x000002E8U)        /*!< CAN filter 21 data 0 register */
+#define CAN_F22DATA0(canx)                 REG32((canx) + 0x000002F0U)        /*!< CAN filter 22 data 0 register */
+#define CAN_F23DATA0(canx)                 REG32((canx) + 0x000003F8U)        /*!< CAN filter 23 data 0 register */
+#define CAN_F24DATA0(canx)                 REG32((canx) + 0x00000300U)        /*!< CAN filter 24 data 0 register */
+#define CAN_F25DATA0(canx)                 REG32((canx) + 0x00000308U)        /*!< CAN filter 25 data 0 register */
+#define CAN_F26DATA0(canx)                 REG32((canx) + 0x00000310U)        /*!< CAN filter 26 data 0 register */
+#define CAN_F27DATA0(canx)                 REG32((canx) + 0x00000318U)        /*!< CAN filter 27 data 0 register */
+#define CAN_F0DATA1(canx)                  REG32((canx) + 0x00000244U)        /*!< CAN filter 0 data 1 register */
+#define CAN_F1DATA1(canx)                  REG32((canx) + 0x0000024CU)        /*!< CAN filter 1 data 1 register */
+#define CAN_F2DATA1(canx)                  REG32((canx) + 0x00000254U)        /*!< CAN filter 2 data 1 register */
+#define CAN_F3DATA1(canx)                  REG32((canx) + 0x0000025CU)        /*!< CAN filter 3 data 1 register */
+#define CAN_F4DATA1(canx)                  REG32((canx) + 0x00000264U)        /*!< CAN filter 4 data 1 register */
+#define CAN_F5DATA1(canx)                  REG32((canx) + 0x0000026CU)        /*!< CAN filter 5 data 1 register */
+#define CAN_F6DATA1(canx)                  REG32((canx) + 0x00000274U)        /*!< CAN filter 6 data 1 register */
+#define CAN_F7DATA1(canx)                  REG32((canx) + 0x0000027CU)        /*!< CAN filter 7 data 1 register */
+#define CAN_F8DATA1(canx)                  REG32((canx) + 0x00000284U)        /*!< CAN filter 8 data 1 register */
+#define CAN_F9DATA1(canx)                  REG32((canx) + 0x0000028CU)        /*!< CAN filter 9 data 1 register */
+#define CAN_F10DATA1(canx)                 REG32((canx) + 0x00000294U)        /*!< CAN filter 10 data 1 register */
+#define CAN_F11DATA1(canx)                 REG32((canx) + 0x0000029CU)        /*!< CAN filter 11 data 1 register */
+#define CAN_F12DATA1(canx)                 REG32((canx) + 0x000002A4U)        /*!< CAN filter 12 data 1 register */
+#define CAN_F13DATA1(canx)                 REG32((canx) + 0x000002ACU)        /*!< CAN filter 13 data 1 register */
+#define CAN_F14DATA1(canx)                 REG32((canx) + 0x000002B4U)        /*!< CAN filter 14 data 1 register */
+#define CAN_F15DATA1(canx)                 REG32((canx) + 0x000002BCU)        /*!< CAN filter 15 data 1 register */
+#define CAN_F16DATA1(canx)                 REG32((canx) + 0x000002C4U)        /*!< CAN filter 16 data 1 register */
+#define CAN_F17DATA1(canx)                 REG32((canx) + 0x0000024CU)        /*!< CAN filter 17 data 1 register */
+#define CAN_F18DATA1(canx)                 REG32((canx) + 0x000002D4U)        /*!< CAN filter 18 data 1 register */
+#define CAN_F19DATA1(canx)                 REG32((canx) + 0x000002DCU)        /*!< CAN filter 19 data 1 register */
+#define CAN_F20DATA1(canx)                 REG32((canx) + 0x000002E4U)        /*!< CAN filter 20 data 1 register */
+#define CAN_F21DATA1(canx)                 REG32((canx) + 0x000002ECU)        /*!< CAN filter 21 data 1 register */
+#define CAN_F22DATA1(canx)                 REG32((canx) + 0x000002F4U)        /*!< CAN filter 22 data 1 register */
+#define CAN_F23DATA1(canx)                 REG32((canx) + 0x000002FCU)        /*!< CAN filter 23 data 1 register */
+#define CAN_F24DATA1(canx)                 REG32((canx) + 0x00000304U)        /*!< CAN filter 24 data 1 register */
+#define CAN_F25DATA1(canx)                 REG32((canx) + 0x0000030CU)        /*!< CAN filter 25 data 1 register */
+#define CAN_F26DATA1(canx)                 REG32((canx) + 0x00000314U)        /*!< CAN filter 26 data 1 register */
+#define CAN_F27DATA1(canx)                 REG32((canx) + 0x0000031CU)        /*!< CAN filter 27 data 1 register */
+
+/* CAN transmit mailbox bank */
+#define CAN_TMI(canx, bank)                REG32((canx) + 0x180U + ((bank) * 0x10U))        /*!< CAN transmit mailbox identifier register */
+#define CAN_TMP(canx, bank)                REG32((canx) + 0x184U + ((bank) * 0x10U))        /*!< CAN transmit mailbox property register */
+#define CAN_TMDATA0(canx, bank)            REG32((canx) + 0x188U + ((bank) * 0x10U))        /*!< CAN transmit mailbox data0 register */
+#define CAN_TMDATA1(canx, bank)            REG32((canx) + 0x18CU + ((bank) * 0x10U))        /*!< CAN transmit mailbox data1 register */
+
+/* CAN filter bank */
+#define CAN_FDATA0(canx, bank)             REG32((canx) + 0x240U + ((bank) * 0x8U) + 0x0U)  /*!< CAN filter data 0 register */
+#define CAN_FDATA1(canx, bank)             REG32((canx) + 0x240U + ((bank) * 0x8U) + 0x4U)  /*!< CAN filter data 1 register */
+
+/* CAN receive FIFO mailbox bank */
+#define CAN_RFIFOMI(canx, bank)            REG32((canx) + 0x1B0U + ((bank) * 0x10U))        /*!< CAN receive FIFO mailbox identifier register */
+#define CAN_RFIFOMP(canx, bank)            REG32((canx) + 0x1B4U + ((bank) * 0x10U))        /*!< CAN receive FIFO mailbox property register */
+#define CAN_RFIFOMDATA0(canx, bank)        REG32((canx) + 0x1B8U + ((bank) * 0x10U))        /*!< CAN receive FIFO mailbox data0 register */
+#define CAN_RFIFOMDATA1(canx, bank)        REG32((canx) + 0x1BCU + ((bank) * 0x10U))        /*!< CAN receive FIFO mailbox data1 register */
+
+/* bits definitions */
+/* CAN_CTL */
+#define CAN_CTL_IWMOD                      BIT(0)                       /*!< initial working mode */
+#define CAN_CTL_SLPWMOD                    BIT(1)                       /*!< sleep working mode */
+#define CAN_CTL_TFO                        BIT(2)                       /*!< transmit FIFO order */
+#define CAN_CTL_RFOD                       BIT(3)                       /*!< receive FIFO overwrite disable */
+#define CAN_CTL_ARD                        BIT(4)                       /*!< automatic retransmission disable */
+#define CAN_CTL_AWU                        BIT(5)                       /*!< automatic wakeup */
+#define CAN_CTL_ABOR                       BIT(6)                       /*!< automatic bus-off recovery */
+#define CAN_CTL_TTC                        BIT(7)                       /*!< time triggered communication */
+#define CAN_CTL_SWRST                      BIT(15)                      /*!< CAN software reset */
+#define CAN_CTL_DFZ                        BIT(16)                      /*!< CAN debug freeze */
+
+/* CAN_STAT */
+#define CAN_STAT_IWS                       BIT(0)                       /*!< initial working state */
+#define CAN_STAT_SLPWS                     BIT(1)                       /*!< sleep working state */
+#define CAN_STAT_ERRIF                     BIT(2)                       /*!< error interrupt flag*/
+#define CAN_STAT_WUIF                      BIT(3)                       /*!< status change interrupt flag of wakeup from sleep working mode */
+#define CAN_STAT_SLPIF                     BIT(4)                       /*!< status change interrupt flag of sleep working mode entering */
+#define CAN_STAT_TS                        BIT(8)                       /*!< transmitting state */
+#define CAN_STAT_RS                        BIT(9)                       /*!< receiving state */
+#define CAN_STAT_LASTRX                    BIT(10)                      /*!< last sample value of rx pin */
+#define CAN_STAT_RXL                       BIT(11)                      /*!< CAN rx signal */
+
+/* CAN_TSTAT */
+#define CAN_TSTAT_MTF0                     BIT(0)                       /*!< mailbox0 transmit finished */
+#define CAN_TSTAT_MTFNERR0                 BIT(1)                       /*!< mailbox0 transmit finished and no error */
+#define CAN_TSTAT_MAL0                     BIT(2)                       /*!< mailbox0 arbitration lost */
+#define CAN_TSTAT_MTE0                     BIT(3)                       /*!< mailbox0 transmit error */
+#define CAN_TSTAT_MST0                     BIT(7)                       /*!< mailbox0 stop transmitting */
+#define CAN_TSTAT_MTF1                     BIT(8)                       /*!< mailbox1 transmit finished */
+#define CAN_TSTAT_MTFNERR1                 BIT(9)                       /*!< mailbox1 transmit finished and no error */
+#define CAN_TSTAT_MAL1                     BIT(10)                      /*!< mailbox1 arbitration lost */
+#define CAN_TSTAT_MTE1                     BIT(11)                      /*!< mailbox1 transmit error */
+#define CAN_TSTAT_MST1                     BIT(15)                      /*!< mailbox1 stop transmitting */
+#define CAN_TSTAT_MTF2                     BIT(16)                      /*!< mailbox2 transmit finished */
+#define CAN_TSTAT_MTFNERR2                 BIT(17)                      /*!< mailbox2 transmit finished and no error */
+#define CAN_TSTAT_MAL2                     BIT(18)                      /*!< mailbox2 arbitration lost */
+#define CAN_TSTAT_MTE2                     BIT(19)                      /*!< mailbox2 transmit error */
+#define CAN_TSTAT_MST2                     BIT(23)                      /*!< mailbox2 stop transmitting */
+#define CAN_TSTAT_NUM                      BITS(24,25)                  /*!< mailbox number */
+#define CAN_TSTAT_TME0                     BIT(26)                      /*!< transmit mailbox0 empty */
+#define CAN_TSTAT_TME1                     BIT(27)                      /*!< transmit mailbox1 empty */
+#define CAN_TSTAT_TME2                     BIT(28)                      /*!< transmit mailbox2 empty */
+#define CAN_TSTAT_TMLS0                    BIT(29)                      /*!< last sending priority flag for mailbox0 */
+#define CAN_TSTAT_TMLS1                    BIT(30)                      /*!< last sending priority flag for mailbox1 */
+#define CAN_TSTAT_TMLS2                    BIT(31)                      /*!< last sending priority flag for mailbox2 */
+
+/* CAN_RFIFO0 */
+#define CAN_RFIFO0_RFL0                    BITS(0,1)                    /*!< receive FIFO0 length */
+#define CAN_RFIFO0_RFF0                    BIT(3)                       /*!< receive FIFO0 full */
+#define CAN_RFIFO0_RFO0                    BIT(4)                       /*!< receive FIFO0 overfull */
+#define CAN_RFIFO0_RFD0                    BIT(5)                       /*!< receive FIFO0 dequeue */
+
+/* CAN_RFIFO1 */
+#define CAN_RFIFO1_RFL1                    BITS(0,1)                    /*!< receive FIFO1 length */
+#define CAN_RFIFO1_RFF1                    BIT(3)                       /*!< receive FIFO1 full */
+#define CAN_RFIFO1_RFO1                    BIT(4)                       /*!< receive FIFO1 overfull */
+#define CAN_RFIFO1_RFD1                    BIT(5)                       /*!< receive FIFO1 dequeue */
+
+/* CAN_INTEN */
+#define CAN_INTEN_TMEIE                    BIT(0)                       /*!< transmit mailbox empty interrupt enable */
+#define CAN_INTEN_RFNEIE0                  BIT(1)                       /*!< receive FIFO0 not empty interrupt enable */
+#define CAN_INTEN_RFFIE0                   BIT(2)                       /*!< receive FIFO0 full interrupt enable */
+#define CAN_INTEN_RFOIE0                   BIT(3)                       /*!< receive FIFO0 overfull interrupt enable */
+#define CAN_INTEN_RFNEIE1                  BIT(4)                       /*!< receive FIFO1 not empty interrupt enable */
+#define CAN_INTEN_RFFIE1                   BIT(5)                       /*!< receive FIFO1 full interrupt enable */
+#define CAN_INTEN_RFOIE1                   BIT(6)                       /*!< receive FIFO1 overfull interrupt enable */
+#define CAN_INTEN_WERRIE                   BIT(8)                       /*!< warning error interrupt enable */
+#define CAN_INTEN_PERRIE                   BIT(9)                       /*!< passive error interrupt enable */
+#define CAN_INTEN_BOIE                     BIT(10)                      /*!< bus-off interrupt enable */
+#define CAN_INTEN_ERRNIE                   BIT(11)                      /*!< error number interrupt enable */
+#define CAN_INTEN_ERRIE                    BIT(15)                      /*!< error interrupt enable */
+#define CAN_INTEN_WIE                      BIT(16)                      /*!< wakeup interrupt enable */
+#define CAN_INTEN_SLPWIE                   BIT(17)                      /*!< sleep working interrupt enable */
+
+/* CAN_ERR */
+#define CAN_ERR_WERR                       BIT(0)                       /*!< warning error */
+#define CAN_ERR_PERR                       BIT(1)                       /*!< passive error */
+#define CAN_ERR_BOERR                      BIT(2)                       /*!< bus-off error */
+#define CAN_ERR_ERRN                       BITS(4,6)                    /*!< error number */
+#define CAN_ERR_TECNT                      BITS(16,23)                  /*!< transmit error count */
+#define CAN_ERR_RECNT                      BITS(24,31)                  /*!< receive error count */
+
+/* CAN_BT */
+#define CAN_BT_BAUDPSC                     BITS(0,9)                    /*!< baudrate prescaler */
+#define CAN_BT_BS1                         BITS(16,19)                  /*!< bit segment 1 */
+#define CAN_BT_BS2                         BITS(20,22)                  /*!< bit segment 2 */
+#define CAN_BT_SJW                         BITS(24,25)                  /*!< resynchronization jump width */
+#define CAN_BT_LCMOD                       BIT(30)                      /*!< loopback communication mode */
+#define CAN_BT_SCMOD                       BIT(31)                      /*!< silent communication mode */
+
+/* CAN_TMIx */
+#define CAN_TMI_TEN                        BIT(0)                       /*!< transmit enable */
+#define CAN_TMI_FT                         BIT(1)                       /*!< frame type */
+#define CAN_TMI_FF                         BIT(2)                       /*!< frame format */
+#define CAN_TMI_EFID                       BITS(3,31)                   /*!< the frame identifier */
+#define CAN_TMI_SFID                       BITS(21,31)                  /*!< the frame identifier */
+
+/* CAN_TMPx */
+#define CAN_TMP_DLENC                      BITS(0,3)                    /*!< data length code */
+#define CAN_TMP_TSEN                       BIT(8)                       /*!< time stamp enable */
+#define CAN_TMP_TS                         BITS(16,31)                  /*!< time stamp */
+
+/* CAN_TMDATA0x */
+#define CAN_TMDATA0_DB0                    BITS(0,7)                    /*!< transmit data byte 0 */
+#define CAN_TMDATA0_DB1                    BITS(8,15)                   /*!< transmit data byte 1 */
+#define CAN_TMDATA0_DB2                    BITS(16,23)                  /*!< transmit data byte 2 */
+#define CAN_TMDATA0_DB3                    BITS(24,31)                  /*!< transmit data byte 3 */
+
+/* CAN_TMDATA1x */
+#define CAN_TMDATA1_DB4                    BITS(0,7)                    /*!< transmit data byte 4 */
+#define CAN_TMDATA1_DB5                    BITS(8,15)                   /*!< transmit data byte 5 */
+#define CAN_TMDATA1_DB6                    BITS(16,23)                  /*!< transmit data byte 6 */
+#define CAN_TMDATA1_DB7                    BITS(24,31)                  /*!< transmit data byte 7 */
+
+/* CAN_RFIFOMIx */
+#define CAN_RFIFOMI_FT                     BIT(1)                       /*!< frame type */
+#define CAN_RFIFOMI_FF                     BIT(2)                       /*!< frame format */
+#define CAN_RFIFOMI_EFID                   BITS(3,31)                   /*!< the frame identifier */
+#define CAN_RFIFOMI_SFID                   BITS(21,31)                  /*!< the frame identifier */
+
+/* CAN_RFIFOMPx */
+#define CAN_RFIFOMP_DLENC                  BITS(0,3)                    /*!< receive data length code */
+#define CAN_RFIFOMP_FI                     BITS(8,15)                   /*!< filter index */
+#define CAN_RFIFOMP_TS                     BITS(16,31)                  /*!< time stamp */
+
+/* CAN_RFIFOMDATA0x */
+#define CAN_RFIFOMDATA0_DB0                BITS(0,7)                    /*!< receive data byte 0 */
+#define CAN_RFIFOMDATA0_DB1                BITS(8,15)                   /*!< receive data byte 1 */
+#define CAN_RFIFOMDATA0_DB2                BITS(16,23)                  /*!< receive data byte 2 */
+#define CAN_RFIFOMDATA0_DB3                BITS(24,31)                  /*!< receive data byte 3 */
+
+/* CAN_RFIFOMDATA1x */
+#define CAN_RFIFOMDATA1_DB4                BITS(0,7)                    /*!< receive data byte 4 */
+#define CAN_RFIFOMDATA1_DB5                BITS(8,15)                   /*!< receive data byte 5 */
+#define CAN_RFIFOMDATA1_DB6                BITS(16,23)                  /*!< receive data byte 6 */
+#define CAN_RFIFOMDATA1_DB7                BITS(24,31)                  /*!< receive data byte 7 */
+
+/* CAN_FCTL */
+#define CAN_FCTL_FLD                       BIT(0)                       /*!< filter lock disable */
+#define CAN_FCTL_HBC1F                     BITS(8,13)                   /*!< header bank of CAN1 filter */
+
+/* CAN_FMCFG */
+#define CAN_FMCFG_FMOD(regval)             BIT(regval)                  /*!< filter mode, list or mask */
+
+/* CAN_FSCFG */
+#define CAN_FSCFG_FS(regval)               BIT(regval)                  /*!< filter scale, 32 bits or 16 bits */
+
+/* CAN_FAFIFO */
+#define CAN_FAFIFOR_FAF(regval)            BIT(regval)                  /*!< filter associated with FIFO */
+
+/* CAN_FW */
+#define CAN_FW_FW(regval)                  BIT(regval)                  /*!< filter working */
+
+/* CAN_FxDATAy */
+#define CAN_FDATA_FD(regval)               BIT(regval)                  /*!< filter data */
+
+/* constants definitions */
+/* define the CAN bit position and its register index offset */
+#define CAN_REGIDX_BIT(regidx, bitpos)              (((uint32_t)(regidx) << 6) | (uint32_t)(bitpos))
+#define CAN_REG_VAL(canx, offset)                   (REG32((canx) + ((uint32_t)(offset) >> 6)))
+#define CAN_BIT_POS(val)                            ((uint32_t)(val) & 0x1FU)
+
+#define CAN_REGIDX_BITS(regidx, bitpos0, bitpos1)   (((uint32_t)(regidx) << 12) | ((uint32_t)(bitpos0) << 6) | (uint32_t)(bitpos1))
+#define CAN_REG_VALS(canx, offset)                  (REG32((canx) + ((uint32_t)(offset) >> 12)))
+#define CAN_BIT_POS0(val)                           (((uint32_t)(val) >> 6) & 0x1FU)
+#define CAN_BIT_POS1(val)                           ((uint32_t)(val) & 0x1FU)
+
+/* register offset */
+#define STAT_REG_OFFSET                    ((uint8_t)0x04U)             /*!< STAT register offset */
+#define TSTAT_REG_OFFSET                   ((uint8_t)0x08U)             /*!< TSTAT register offset */
+#define RFIFO0_REG_OFFSET                  ((uint8_t)0x0CU)             /*!< RFIFO0 register offset */
+#define RFIFO1_REG_OFFSET                  ((uint8_t)0x10U)             /*!< RFIFO1 register offset */
+#define ERR_REG_OFFSET                     ((uint8_t)0x18U)             /*!< ERR register offset */
+
+/* CAN flags */
+typedef enum {
+    /* flags in STAT register */
+    CAN_FLAG_RXL      = CAN_REGIDX_BIT(STAT_REG_OFFSET, 11U),           /*!< RX level */
+    CAN_FLAG_LASTRX   = CAN_REGIDX_BIT(STAT_REG_OFFSET, 10U),           /*!< last sample value of RX pin */
+    CAN_FLAG_RS       = CAN_REGIDX_BIT(STAT_REG_OFFSET, 9U),            /*!< receiving state */
+    CAN_FLAG_TS       = CAN_REGIDX_BIT(STAT_REG_OFFSET, 8U),            /*!< transmitting state */
+    CAN_FLAG_SLPIF    = CAN_REGIDX_BIT(STAT_REG_OFFSET, 4U),            /*!< status change flag of entering sleep working mode */
+    CAN_FLAG_WUIF     = CAN_REGIDX_BIT(STAT_REG_OFFSET, 3U),            /*!< status change flag of wakeup from sleep working mode */
+    CAN_FLAG_ERRIF    = CAN_REGIDX_BIT(STAT_REG_OFFSET, 2U),            /*!< error flag */
+    CAN_FLAG_SLPWS    = CAN_REGIDX_BIT(STAT_REG_OFFSET, 1U),            /*!< sleep working state */
+    CAN_FLAG_IWS      = CAN_REGIDX_BIT(STAT_REG_OFFSET, 0U),            /*!< initial working state */
+    /* flags in TSTAT register */
+    CAN_FLAG_TMLS2    = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 31U),          /*!< transmit mailbox 2 last sending in TX FIFO */
+    CAN_FLAG_TMLS1    = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 30U),          /*!< transmit mailbox 1 last sending in TX FIFO */
+    CAN_FLAG_TMLS0    = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 29U),          /*!< transmit mailbox 0 last sending in TX FIFO */
+    CAN_FLAG_TME2     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 28U),          /*!< transmit mailbox 2 empty */
+    CAN_FLAG_TME1     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 27U),          /*!< transmit mailbox 1 empty */
+    CAN_FLAG_TME0     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 26U),          /*!< transmit mailbox 0 empty */
+    CAN_FLAG_MTE2     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 19U),          /*!< mailbox 2 transmit error */
+    CAN_FLAG_MTE1     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 11U),          /*!< mailbox 1 transmit error */
+    CAN_FLAG_MTE0     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 3U),           /*!< mailbox 0 transmit error */
+    CAN_FLAG_MAL2     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 18U),          /*!< mailbox 2 arbitration lost */
+    CAN_FLAG_MAL1     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 10U),          /*!< mailbox 1 arbitration lost */
+    CAN_FLAG_MAL0     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 2U),           /*!< mailbox 0 arbitration lost */
+    CAN_FLAG_MTFNERR2 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 17U),          /*!< mailbox 2 transmit finished with no error */
+    CAN_FLAG_MTFNERR1 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 9U),           /*!< mailbox 1 transmit finished with no error */
+    CAN_FLAG_MTFNERR0 = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 1U),           /*!< mailbox 0 transmit finished with no error */
+    CAN_FLAG_MTF2     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 16U),          /*!< mailbox 2 transmit finished */
+    CAN_FLAG_MTF1     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 8U),           /*!< mailbox 1 transmit finished */
+    CAN_FLAG_MTF0     = CAN_REGIDX_BIT(TSTAT_REG_OFFSET, 0U),           /*!< mailbox 0 transmit finished */
+    /* flags in RFIFO0 register */
+    CAN_FLAG_RFO0     = CAN_REGIDX_BIT(RFIFO0_REG_OFFSET, 4U),          /*!< receive FIFO0 overfull */
+    CAN_FLAG_RFF0     = CAN_REGIDX_BIT(RFIFO0_REG_OFFSET, 3U),          /*!< receive FIFO0 full */
+    /* flags in RFIFO1 register */
+    CAN_FLAG_RFO1     = CAN_REGIDX_BIT(RFIFO1_REG_OFFSET, 4U),          /*!< receive FIFO1 overfull */
+    CAN_FLAG_RFF1     = CAN_REGIDX_BIT(RFIFO1_REG_OFFSET, 3U),          /*!< receive FIFO1 full */
+    /* flags in ERR register */
+    CAN_FLAG_BOERR    = CAN_REGIDX_BIT(ERR_REG_OFFSET, 2U),             /*!< bus-off error */
+    CAN_FLAG_PERR     = CAN_REGIDX_BIT(ERR_REG_OFFSET, 1U),             /*!< passive error */
+    CAN_FLAG_WERR     = CAN_REGIDX_BIT(ERR_REG_OFFSET, 0U),             /*!< warning error */
+} can_flag_enum;
+
+/* CAN interrupt flags */
+typedef enum {
+    /* interrupt flags in STAT register */
+    CAN_INT_FLAG_SLPIF = CAN_REGIDX_BITS(STAT_REG_OFFSET, 4U, 17U),     /*!< status change interrupt flag of sleep working mode entering */
+    CAN_INT_FLAG_WUIF  = CAN_REGIDX_BITS(STAT_REG_OFFSET, 3U, 16),      /*!< status change interrupt flag of wakeup from sleep working mode */
+    CAN_INT_FLAG_ERRIF = CAN_REGIDX_BITS(STAT_REG_OFFSET, 2U, 15),      /*!< error interrupt flag */
+    /* interrupt flags in TSTAT register */
+    CAN_INT_FLAG_MTF2  = CAN_REGIDX_BITS(TSTAT_REG_OFFSET, 16U, 0U),    /*!< mailbox 2 transmit finished interrupt flag */
+    CAN_INT_FLAG_MTF1  = CAN_REGIDX_BITS(TSTAT_REG_OFFSET, 8U, 0U),     /*!< mailbox 1 transmit finished interrupt flag */
+    CAN_INT_FLAG_MTF0  = CAN_REGIDX_BITS(TSTAT_REG_OFFSET, 0U, 0U),     /*!< mailbox 0 transmit finished interrupt flag */
+    /* interrupt flags in RFIFO0 register */
+    CAN_INT_FLAG_RFO0  = CAN_REGIDX_BITS(RFIFO0_REG_OFFSET, 4U, 3U),    /*!< receive FIFO0 overfull interrupt flag */
+    CAN_INT_FLAG_RFF0  = CAN_REGIDX_BITS(RFIFO0_REG_OFFSET, 3U, 2U),    /*!< receive FIFO0 full interrupt flag */
+    CAN_INT_FLAG_RFL0  = CAN_REGIDX_BITS(RFIFO0_REG_OFFSET, 2U, 1U),    /*!< receive FIFO0 not empty interrupt flag */
+    /* interrupt flags in RFIFO0 register */
+    CAN_INT_FLAG_RFO1  = CAN_REGIDX_BITS(RFIFO1_REG_OFFSET, 4U, 6U),    /*!< receive FIFO1 overfull interrupt flag */
+    CAN_INT_FLAG_RFF1  = CAN_REGIDX_BITS(RFIFO1_REG_OFFSET, 3U, 5U),    /*!< receive FIFO1 full interrupt flag */
+    CAN_INT_FLAG_RFL1  = CAN_REGIDX_BITS(RFIFO1_REG_OFFSET, 2U, 4U),    /*!< receive FIFO1 not empty interrupt flag */
+    /* interrupt flags in ERR register */
+    CAN_INT_FLAG_ERRN  = CAN_REGIDX_BITS(ERR_REG_OFFSET, 3U, 11U),      /*!< error number interrupt flag */
+    CAN_INT_FLAG_BOERR = CAN_REGIDX_BITS(ERR_REG_OFFSET, 2U, 10U),      /*!< bus-off error interrupt flag */
+    CAN_INT_FLAG_PERR  = CAN_REGIDX_BITS(ERR_REG_OFFSET, 1U, 9U),       /*!< passive error interrupt flag */
+    CAN_INT_FLAG_WERR  = CAN_REGIDX_BITS(ERR_REG_OFFSET, 0U, 8U),       /*!< warning error interrupt flag */
+} can_interrupt_flag_enum;
+
+/* CAN initiliaze parameters structure */
+typedef struct {
+    uint8_t working_mode;                                               /*!< CAN working mode */
+    uint8_t resync_jump_width;                                          /*!< CAN resynchronization jump width */
+    uint8_t time_segment_1;                                             /*!< time segment 1 */
+    uint8_t time_segment_2;                                             /*!< time segment 2 */
+    ControlStatus time_triggered;                                       /*!< time triggered communication mode */
+    ControlStatus auto_bus_off_recovery;                                /*!< automatic bus-off recovery */
+    ControlStatus auto_wake_up;                                         /*!< automatic wake-up mode */
+    ControlStatus auto_retrans;                                         /*!< automatic retransmission mode disable */
+    ControlStatus rec_fifo_overwrite;                                   /*!< receive FIFO overwrite mode disable */
+    ControlStatus trans_fifo_order;                                     /*!< transmit FIFO order */
+    uint16_t prescaler;                                                 /*!< baudrate prescaler */
+} can_parameter_struct;
+
+/* CAN transmit message structure */
+typedef struct {
+    uint32_t tx_sfid;                                                   /*!< standard format frame identifier */
+    uint32_t tx_efid;                                                   /*!< extended format frame identifier */
+    uint8_t tx_ff;                                                      /*!< format of frame, standard or extended format */
+    uint8_t tx_ft;                                                      /*!< type of frame, data or remote */
+    uint8_t tx_dlen;                                                    /*!< data length */
+    uint8_t tx_data[8];                                                 /*!< transmit data */
+} can_trasnmit_message_struct;
+
+/* CAN receive message structure */
+typedef struct {
+    uint32_t rx_sfid;                                                   /*!< standard format frame identifier */
+    uint32_t rx_efid;                                                   /*!< extended format frame identifier */
+    uint8_t rx_ff;                                                      /*!< format of frame, standard or extended format */
+    uint8_t rx_ft;                                                      /*!< type of frame, data or remote */
+    uint8_t rx_dlen;                                                    /*!< data length */
+    uint8_t rx_data[8];                                                 /*!< receive data */
+    uint8_t rx_fi;                                                      /*!< filtering index */
+} can_receive_message_struct;
+
+/* CAN filter parameters structure */
+typedef struct {
+    uint16_t filter_list_high;                                          /*!< filter list number high bits */
+    uint16_t filter_list_low;                                           /*!< filter list number low bits */
+    uint16_t filter_mask_high;                                          /*!< filter mask number high bits */
+    uint16_t filter_mask_low;                                           /*!< filter mask number low bits */
+    uint16_t filter_fifo_number;                                        /*!< receive FIFO associated with the filter */
+    uint16_t filter_number;                                             /*!< filter number */
+    uint16_t filter_mode;                                               /*!< filter mode, list or mask */
+    uint16_t filter_bits;                                               /*!< filter scale */
+    ControlStatus filter_enable;                                        /*!< filter work or not */
+} can_filter_parameter_struct;
+
+/* CAN errors */
+typedef enum {
+    CAN_ERROR_NONE = 0,                                                 /*!< no error */
+    CAN_ERROR_FILL,                                                     /*!< fill error */
+    CAN_ERROR_FORMATE,                                                  /*!< format error */
+    CAN_ERROR_ACK,                                                      /*!< ACK error */
+    CAN_ERROR_BITRECESSIVE,                                             /*!< bit recessive error */
+    CAN_ERROR_BITDOMINANTER,                                            /*!< bit dominant error */
+    CAN_ERROR_CRC,                                                      /*!< CRC error */
+    CAN_ERROR_SOFTWARECFG,                                              /*!< software configure */
+} can_error_enum;
+
+/* transmit states */
+typedef enum {
+    CAN_TRANSMIT_FAILED = 0U,                                           /*!< CAN transmitted failure */
+    CAN_TRANSMIT_OK = 1U,                                               /*!< CAN transmitted success */
+    CAN_TRANSMIT_PENDING = 2U,                                          /*!< CAN transmitted pending */
+    CAN_TRANSMIT_NOMAILBOX = 4U,                                        /*!< no empty mailbox to be used for CAN */
+} can_transmit_state_enum;
+
+typedef enum {
+    CAN_INIT_STRUCT = 0,                                                /* CAN initiliaze parameters struct */
+    CAN_FILTER_STRUCT,                                                  /* CAN filter parameters struct */
+    CAN_TX_MESSAGE_STRUCT,                                              /* CAN transmit message struct */
+    CAN_RX_MESSAGE_STRUCT,                                              /* CAN receive message struct */
+} can_struct_type_enum;
+
+/* CAN baudrate prescaler */
+#define BT_BAUDPSC(regval)                 (BITS(0,9) & ((uint32_t)(regval) << 0))
+
+/* CAN bit segment 1 */
+#define BT_BS1(regval)                     (BITS(16,19) & ((uint32_t)(regval) << 16))
+
+/* CAN bit segment 2 */
+#define BT_BS2(regval)                     (BITS(20,22) & ((uint32_t)(regval) << 20))
+
+/* CAN resynchronization jump width */
+#define BT_SJW(regval)                     (BITS(24,25) & ((uint32_t)(regval) << 24))
+
+/* CAN communication mode */
+#define BT_MODE(regval)                    (BITS(30,31) & ((uint32_t)(regval) << 30))
+
+/* CAN FDATA high 16 bits */
+#define FDATA_MASK_HIGH(regval)            (BITS(16,31) & ((uint32_t)(regval) << 16))
+
+/* CAN FDATA low 16 bits */
+#define FDATA_MASK_LOW(regval)             (BITS(0,15) & ((uint32_t)(regval) << 0))
+
+/* CAN1 filter start bank_number */
+#define FCTL_HBC1F(regval)                 (BITS(8,13) & ((uint32_t)(regval) << 8))
+
+/* CAN transmit mailbox extended identifier */
+#define TMI_EFID(regval)                   (BITS(3,31) & ((uint32_t)(regval) << 3))
+
+/* CAN transmit mailbox standard identifier */
+#define TMI_SFID(regval)                   (BITS(21,31) & ((uint32_t)(regval) << 21))
+
+/* transmit data byte 0 */
+#define TMDATA0_DB0(regval)                (BITS(0,7) & ((uint32_t)(regval) << 0))
+
+/* transmit data byte 1 */
+#define TMDATA0_DB1(regval)                (BITS(8,15) & ((uint32_t)(regval) << 8))
+
+/* transmit data byte 2 */
+#define TMDATA0_DB2(regval)                (BITS(16,23) & ((uint32_t)(regval) << 16))
+
+/* transmit data byte 3 */
+#define TMDATA0_DB3(regval)                (BITS(24,31) & ((uint32_t)(regval) << 24))
+
+/* transmit data byte 4 */
+#define TMDATA1_DB4(regval)                (BITS(0,7) & ((uint32_t)(regval) << 0))
+
+/* transmit data byte 5 */
+#define TMDATA1_DB5(regval)                (BITS(8,15) & ((uint32_t)(regval) << 8))
+
+/* transmit data byte 6 */
+#define TMDATA1_DB6(regval)                (BITS(16,23) & ((uint32_t)(regval) << 16))
+
+/* transmit data byte 7 */
+#define TMDATA1_DB7(regval)                (BITS(24,31) & ((uint32_t)(regval) << 24))
+
+/* receive mailbox extended identifier */
+#define GET_RFIFOMI_EFID(regval)           GET_BITS((uint32_t)(regval), 3U, 31U)
+
+/* receive mailbox standard identifier */
+#define GET_RFIFOMI_SFID(regval)           GET_BITS((uint32_t)(regval), 21U, 31U)
+
+/* receive data length */
+#define GET_RFIFOMP_DLENC(regval)          GET_BITS((uint32_t)(regval), 0U, 3U)
+
+/* the index of the filter by which the frame is passed */
+#define GET_RFIFOMP_FI(regval)             GET_BITS((uint32_t)(regval), 8U, 15U)
+
+/* receive data byte 0 */
+#define GET_RFIFOMDATA0_DB0(regval)        GET_BITS((uint32_t)(regval), 0U, 7U)
+
+/* receive data byte 1 */
+#define GET_RFIFOMDATA0_DB1(regval)        GET_BITS((uint32_t)(regval), 8U, 15U)
+
+/* receive data byte 2 */
+#define GET_RFIFOMDATA0_DB2(regval)        GET_BITS((uint32_t)(regval), 16U, 23U)
+
+/* receive data byte 3 */
+#define GET_RFIFOMDATA0_DB3(regval)        GET_BITS((uint32_t)(regval), 24U, 31U)
+
+/* receive data byte 4 */
+#define GET_RFIFOMDATA1_DB4(regval)        GET_BITS((uint32_t)(regval), 0U, 7U)
+
+/* receive data byte 5 */
+#define GET_RFIFOMDATA1_DB5(regval)        GET_BITS((uint32_t)(regval), 8U, 15U)
+
+/* receive data byte 6 */
+#define GET_RFIFOMDATA1_DB6(regval)        GET_BITS((uint32_t)(regval), 16U, 23U)
+
+/* receive data byte 7 */
+#define GET_RFIFOMDATA1_DB7(regval)        GET_BITS((uint32_t)(regval), 24U, 31U)
+
+/* error number */
+#define GET_ERR_ERRN(regval)               GET_BITS((uint32_t)(regval), 4U, 6U)
+
+/* transmit error count */
+#define GET_ERR_TECNT(regval)              GET_BITS((uint32_t)(regval), 16U, 23U)
+
+/* receive  error count */
+#define GET_ERR_RECNT(regval)              GET_BITS((uint32_t)(regval), 24U, 31U)
+
+/* CAN errors */
+#define ERR_ERRN(regval)                   (BITS(4,6) & ((uint32_t)(regval) << 4))
+#define CAN_ERRN_0                         ERR_ERRN(0U)                 /*!< no error */
+#define CAN_ERRN_1                         ERR_ERRN(1U)                 /*!< fill error */
+#define CAN_ERRN_2                         ERR_ERRN(2U)                 /*!< format error */
+#define CAN_ERRN_3                         ERR_ERRN(3U)                 /*!< ACK error */
+#define CAN_ERRN_4                         ERR_ERRN(4U)                 /*!< bit recessive error */
+#define CAN_ERRN_5                         ERR_ERRN(5U)                 /*!< bit dominant error */
+#define CAN_ERRN_6                         ERR_ERRN(6U)                 /*!< CRC error */
+#define CAN_ERRN_7                         ERR_ERRN(7U)                 /*!< software error */
+
+#define CAN_STATE_PENDING                  ((uint32_t)0x00000000U)      /*!< CAN pending */
+
+/* CAN communication mode */
+#define CAN_NORMAL_MODE                    ((uint8_t)0x00U)             /*!< normal communication mode */
+#define CAN_LOOPBACK_MODE                  ((uint8_t)0x01U)             /*!< loopback communication mode */
+#define CAN_SILENT_MODE                    ((uint8_t)0x02U)             /*!< silent communication mode */
+#define CAN_SILENT_LOOPBACK_MODE           ((uint8_t)0x03U)             /*!< loopback and silent communication mode */
+
+/* CAN resynchronisation jump width */
+#define CAN_BT_SJW_1TQ                     ((uint8_t)0x00U)             /*!< 1 time quanta */
+#define CAN_BT_SJW_2TQ                     ((uint8_t)0x01U)             /*!< 2 time quanta */
+#define CAN_BT_SJW_3TQ                     ((uint8_t)0x02U)             /*!< 3 time quanta */
+#define CAN_BT_SJW_4TQ                     ((uint8_t)0x03U)             /*!< 4 time quanta */
+
+/* CAN time segment 1 */
+#define CAN_BT_BS1_1TQ                     ((uint8_t)0x00U)             /*!< 1 time quanta */
+#define CAN_BT_BS1_2TQ                     ((uint8_t)0x01U)             /*!< 2 time quanta */
+#define CAN_BT_BS1_3TQ                     ((uint8_t)0x02U)             /*!< 3 time quanta */
+#define CAN_BT_BS1_4TQ                     ((uint8_t)0x03U)             /*!< 4 time quanta */
+#define CAN_BT_BS1_5TQ                     ((uint8_t)0x04U)             /*!< 5 time quanta */
+#define CAN_BT_BS1_6TQ                     ((uint8_t)0x05U)             /*!< 6 time quanta */
+#define CAN_BT_BS1_7TQ                     ((uint8_t)0x06U)             /*!< 7 time quanta */
+#define CAN_BT_BS1_8TQ                     ((uint8_t)0x07U)             /*!< 8 time quanta */
+#define CAN_BT_BS1_9TQ                     ((uint8_t)0x08U)             /*!< 9 time quanta */
+#define CAN_BT_BS1_10TQ                    ((uint8_t)0x09U)             /*!< 10 time quanta */
+#define CAN_BT_BS1_11TQ                    ((uint8_t)0x0AU)             /*!< 11 time quanta */
+#define CAN_BT_BS1_12TQ                    ((uint8_t)0x0BU)             /*!< 12 time quanta */
+#define CAN_BT_BS1_13TQ                    ((uint8_t)0x0CU)             /*!< 13 time quanta */
+#define CAN_BT_BS1_14TQ                    ((uint8_t)0x0DU)             /*!< 14 time quanta */
+#define CAN_BT_BS1_15TQ                    ((uint8_t)0x0EU)             /*!< 15 time quanta */
+#define CAN_BT_BS1_16TQ                    ((uint8_t)0x0FU)             /*!< 16 time quanta */
+
+/* CAN time segment 2 */
+#define CAN_BT_BS2_1TQ                     ((uint8_t)0x00U)             /*!< 1 time quanta */
+#define CAN_BT_BS2_2TQ                     ((uint8_t)0x01U)             /*!< 2 time quanta */
+#define CAN_BT_BS2_3TQ                     ((uint8_t)0x02U)             /*!< 3 time quanta */
+#define CAN_BT_BS2_4TQ                     ((uint8_t)0x03U)             /*!< 4 time quanta */
+#define CAN_BT_BS2_5TQ                     ((uint8_t)0x04U)             /*!< 5 time quanta */
+#define CAN_BT_BS2_6TQ                     ((uint8_t)0x05U)             /*!< 6 time quanta */
+#define CAN_BT_BS2_7TQ                     ((uint8_t)0x06U)             /*!< 7 time quanta */
+#define CAN_BT_BS2_8TQ                     ((uint8_t)0x07U)             /*!< 8 time quanta */
+
+/* CAN mailbox number */
+#define CAN_MAILBOX0                       ((uint8_t)0x00U)             /*!< mailbox0 */
+#define CAN_MAILBOX1                       ((uint8_t)0x01U)             /*!< mailbox1 */
+#define CAN_MAILBOX2                       ((uint8_t)0x02U)             /*!< mailbox2 */
+#define CAN_NOMAILBOX                      ((uint8_t)0x03U)             /*!< no mailbox empty */
+
+/* CAN frame format */
+#define CAN_FF_STANDARD                    ((uint32_t)0x00000000U)      /*!< standard frame */
+#define CAN_FF_EXTENDED                    ((uint32_t)0x00000004U)      /*!< extended frame */
+
+/* CAN receive FIFO */
+#define CAN_FIFO0                          ((uint8_t)0x00U)             /*!< receive FIFO0 */
+#define CAN_FIFO1                          ((uint8_t)0x01U)             /*!< receive FIFO1 */
+
+/* frame number of receive FIFO */
+#define CAN_RFIF_RFL_MASK                  ((uint32_t)0x00000003U)      /*!< mask for frame number in receive FIFOx */
+
+#define CAN_SFID_MASK                      ((uint32_t)0x000007FFU)      /*!< mask of standard identifier */
+#define CAN_EFID_MASK                      ((uint32_t)0x1FFFFFFFU)      /*!< mask of extended identifier */
+
+/* CAN working mode */
+#define CAN_MODE_INITIALIZE                ((uint8_t)0x01U)             /*!< CAN initialize mode */
+#define CAN_MODE_NORMAL                    ((uint8_t)0x02U)             /*!< CAN normal mode */
+#define CAN_MODE_SLEEP                     ((uint8_t)0x04U)             /*!< CAN sleep mode */
+
+/* filter bits */
+#define CAN_FILTERBITS_16BIT               ((uint8_t)0x00U)             /*!< CAN filter 16 bits */
+#define CAN_FILTERBITS_32BIT               ((uint8_t)0x01U)             /*!< CAN filter 32 bits */
+
+/* filter mode */
+#define CAN_FILTERMODE_MASK                ((uint8_t)0x00U)             /*!< mask mode */
+#define CAN_FILTERMODE_LIST                ((uint8_t)0x01U)             /*!< list mode */
+
+/* filter 16 bits mask */
+#define CAN_FILTER_MASK_16BITS             ((uint32_t)0x0000FFFFU)      /*!< can filter 16 bits mask */
+
+/* frame type */
+#define CAN_FT_DATA                        ((uint32_t)0x00000000U)      /*!< data frame */
+#define CAN_FT_REMOTE                      ((uint32_t)0x00000002U)      /*!< remote frame */
+
+/* CAN timeout */
+#define CAN_TIMEOUT                        ((uint32_t)0x0000FFFFU)      /*!< timeout value */
+
+/* interrupt enable bits */
+#define CAN_INT_TME                        CAN_INTEN_TMEIE              /*!< transmit mailbox empty interrupt enable */
+#define CAN_INT_RFNE0                      CAN_INTEN_RFNEIE0            /*!< receive FIFO0 not empty interrupt enable */
+#define CAN_INT_RFF0                       CAN_INTEN_RFFIE0             /*!< receive FIFO0 full interrupt enable */
+#define CAN_INT_RFO0                       CAN_INTEN_RFOIE0             /*!< receive FIFO0 overfull interrupt enable */
+#define CAN_INT_RFNE1                      CAN_INTEN_RFNEIE1            /*!< receive FIFO1 not empty interrupt enable */
+#define CAN_INT_RFF1                       CAN_INTEN_RFFIE1             /*!< receive FIFO1 full interrupt enable */
+#define CAN_INT_RFO1                       CAN_INTEN_RFOIE1             /*!< receive FIFO1 overfull interrupt enable */
+#define CAN_INT_WERR                       CAN_INTEN_WERRIE             /*!< warning error interrupt enable */
+#define CAN_INT_PERR                       CAN_INTEN_PERRIE             /*!< passive error interrupt enable */
+#define CAN_INT_BO                         CAN_INTEN_BOIE               /*!< bus-off interrupt enable */
+#define CAN_INT_ERRN                       CAN_INTEN_ERRNIE             /*!< error number interrupt enable */
+#define CAN_INT_ERR                        CAN_INTEN_ERRIE              /*!< error interrupt enable */
+#define CAN_INT_WAKEUP                     CAN_INTEN_WIE                /*!< wakeup interrupt enable */
+#define CAN_INT_SLPW                       CAN_INTEN_SLPWIE             /*!< sleep working interrupt enable */
+
+/* function declarations */
+/* initialization functions */
+/* deinitialize CAN */
+void can_deinit(uint32_t can_periph);
+/* initialize CAN structure */
+void can_struct_para_init(can_struct_type_enum type, void *p_struct);
+/* initialize CAN */
+ErrStatus can_init(uint32_t can_periph, can_parameter_struct *can_parameter_init);
+/* CAN filter initialization */
+void can_filter_init(can_filter_parameter_struct *can_filter_parameter_init);
+
+/* function configuration */
+/* set can1 filter start bank number */
+void can1_filter_start_bank(uint8_t start_bank);
+/* enable functions */
+/* CAN debug freeze enable */
+void can_debug_freeze_enable(uint32_t can_periph);
+/* CAN debug freeze disable */
+void can_debug_freeze_disable(uint32_t can_periph);
+/* CAN time trigger mode enable */
+void can_time_trigger_mode_enable(uint32_t can_periph);
+/* CAN time trigger mode disable */
+void can_time_trigger_mode_disable(uint32_t can_periph);
+
+/* transmit functions */
+/* transmit CAN message */
+uint8_t can_message_transmit(uint32_t can_periph, can_trasnmit_message_struct *transmit_message);
+/* get CAN transmit state */
+can_transmit_state_enum can_transmit_states(uint32_t can_periph, uint8_t mailbox_number);
+/* stop CAN transmission */
+void can_transmission_stop(uint32_t can_periph, uint8_t mailbox_number);
+/* CAN receive message */
+void can_message_receive(uint32_t can_periph, uint8_t fifo_number, can_receive_message_struct *receive_message);
+/* CAN release FIFO */
+void can_fifo_release(uint32_t can_periph, uint8_t fifo_number);
+/* CAN receive message length */
+uint8_t can_receive_message_length_get(uint32_t can_periph, uint8_t fifo_number);
+/* CAN working mode */
+ErrStatus can_working_mode_set(uint32_t can_periph, uint8_t working_mode);
+/* CAN wakeup from sleep mode */
+ErrStatus can_wakeup(uint32_t can_periph);
+
+/* CAN get error type */
+can_error_enum can_error_get(uint32_t can_periph);
+/* get CAN receive error number */
+uint8_t can_receive_error_number_get(uint32_t can_periph);
+/* get CAN transmit error number */
+uint8_t can_transmit_error_number_get(uint32_t can_periph);
+
+/* interrupt & flag functions */
+/* CAN get flag state */
+FlagStatus can_flag_get(uint32_t can_periph, can_flag_enum flag);
+/* CAN clear flag state */
+void can_flag_clear(uint32_t can_periph, can_flag_enum flag);
+/* CAN interrupt enable */
+void can_interrupt_enable(uint32_t can_periph, uint32_t interrupt);
+/* CAN interrupt disable */
+void can_interrupt_disable(uint32_t can_periph, uint32_t interrupt);
+/* CAN get interrupt flag state */
+FlagStatus can_interrupt_flag_get(uint32_t can_periph, can_interrupt_flag_enum flag);
+/* CAN clear interrupt flag state */
+void can_interrupt_flag_clear(uint32_t can_periph, can_interrupt_flag_enum flag);
+
+#endif /* GD32F4XX_CAN_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_crc.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_crc.h
@@ -1,0 +1,81 @@
+/*!
+    \file    gd32f4xx_crc.h
+    \brief   definitions for the CRC
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_CRC_H
+#define GD32F4XX_CRC_H
+
+#include "gd32f4xx.h"
+
+/* CRC definitions */
+#define CRC                            CRC_BASE                        /*!< CRC base address */
+
+/* registers definitions */
+#define CRC_DATA                       REG32(CRC + 0x00000000U)        /*!< CRC data register */
+#define CRC_FDATA                      REG32(CRC + 0x00000004U)        /*!< CRC free data register */
+#define CRC_CTL                        REG32(CRC + 0x00000008U)        /*!< CRC control register */
+
+/* bits definitions */
+/* CRC_DATA */
+#define CRC_DATA_DATA                  BITS(0,31)                      /*!< CRC calculation result bits */
+
+/* CRC_FDATA */
+#define CRC_FDATA_FDATA                BITS(0,7)                       /*!< CRC free data bits */
+
+/* CRC_CTL */
+#define CRC_CTL_RST                    BIT(0)                          /*!< CRC reset CRC_DATA register bit */
+
+
+/* function declarations */
+/* deinit CRC calculation unit */
+void crc_deinit(void);
+
+/* reset data register(CRC_DATA) to the value of 0xFFFFFFFF */
+void crc_data_register_reset(void);
+/* read the value of the data register */
+uint32_t crc_data_register_read(void);
+
+/* read the value of the free data register */
+uint8_t crc_free_data_register_read(void);
+/* write data to the free data register */
+void crc_free_data_register_write(uint8_t free_data);
+
+/* calculate the CRC value of a 32-bit data */
+uint32_t crc_single_data_calculate(uint32_t sdata);
+/* calculate the CRC value of an array of 32-bit values */
+uint32_t crc_block_data_calculate(uint32_t array[], uint32_t size);
+
+#endif /* GD32F4XX_CRC_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_ctc.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_ctc.h
@@ -1,0 +1,185 @@
+/*!
+    \file    gd32f4xx_ctc.h
+    \brief   definitions for the CTC
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_CTC_H
+#define GD32F4XX_CTC_H
+
+#include "gd32f4xx.h"
+
+/* CTC definitions */
+#define CTC                          CTC_BASE
+
+/* registers definitions */
+#define CTC_CTL0                     REG32((CTC) + 0x00U)      /*!< CTC control register 0 */
+#define CTC_CTL1                     REG32((CTC) + 0x04U)      /*!< CTC control register 1 */
+#define CTC_STAT                     REG32((CTC) + 0x08U)      /*!< CTC status register */
+#define CTC_INTC                     REG32((CTC) + 0x0CU)      /*!< CTC interrupt clear register */
+
+/* bits definitions */
+/* CTC_CTL0 */
+#define CTC_CTL0_CKOKIE              BIT(0)                    /*!< clock trim OK(CKOKIF) interrupt enable */ 
+#define CTC_CTL0_CKWARNIE            BIT(1)                    /*!< clock trim warning(CKWARNIF) interrupt enable */
+#define CTC_CTL0_ERRIE               BIT(2)                    /*!< error(ERRIF) interrupt enable */
+#define CTC_CTL0_EREFIE              BIT(3)                    /*!< EREFIF interrupt enable */
+#define CTC_CTL0_CNTEN               BIT(5)                    /*!< CTC counter enable */
+#define CTC_CTL0_AUTOTRIM            BIT(6)                    /*!< hardware automatically trim mode */
+#define CTC_CTL0_SWREFPUL            BIT(7)                    /*!< software reference source sync pulse */
+#define CTC_CTL0_TRIMVALUE           BITS(8,13)                /*!< IRC48M trim value */
+
+/* CTC_CTL1 */
+#define CTC_CTL1_RLVALUE             BITS(0,15)                /*!< CTC counter reload value */
+#define CTC_CTL1_CKLIM               BITS(16,23)               /*!< clock trim base limit value */
+#define CTC_CTL1_REFPSC              BITS(24,26)               /*!< reference signal source prescaler */
+#define CTC_CTL1_REFSEL              BITS(28,29)               /*!< reference signal source selection */
+#define CTC_CTL1_REFPOL              BIT(31)                   /*!< reference signal source polarity */
+
+/* CTC_STAT */
+#define CTC_STAT_CKOKIF              BIT(0)                    /*!< clock trim OK interrupt flag */
+#define CTC_STAT_CKWARNIF            BIT(1)                    /*!< clock trim warning interrupt flag */
+#define CTC_STAT_ERRIF               BIT(2)                    /*!< error interrupt flag */
+#define CTC_STAT_EREFIF              BIT(3)                    /*!< expect reference interrupt flag */
+#define CTC_STAT_CKERR               BIT(8)                    /*!< clock trim error bit */
+#define CTC_STAT_REFMISS             BIT(9)                    /*!< reference sync pulse miss */
+#define CTC_STAT_TRIMERR             BIT(10)                   /*!< trim value error bit */
+#define CTC_STAT_REFDIR              BIT(15)                   /*!< CTC trim counter direction when reference sync pulse occurred */
+#define CTC_STAT_REFCAP              BITS(16,31)               /*!< CTC counter capture when reference sync pulse occurred */
+
+/* CTC_INTC */
+#define CTC_INTC_CKOKIC              BIT(0)                    /*!< CKOKIF interrupt clear bit */
+#define CTC_INTC_CKWARNIC            BIT(1)                    /*!< CKWARNIF interrupt clear bit */
+#define CTC_INTC_ERRIC               BIT(2)                    /*!< ERRIF interrupt clear bit */
+#define CTC_INTC_EREFIC              BIT(3)                    /*!< EREFIF interrupt clear bit */
+
+/* constants definitions */
+/* hardware automatically trim mode definitions */
+#define CTC_HARDWARE_TRIM_MODE_ENABLE                    CTC_CTL0_AUTOTRIM            /*!< hardware automatically trim mode enable*/
+#define CTC_HARDWARE_TRIM_MODE_DISABLE                   ((uint32_t)0x00000000U)      /*!< hardware automatically trim mode disable*/
+
+/* reference signal source polarity definitions */
+#define CTC_REFSOURCE_POLARITY_FALLING                   CTC_CTL1_REFPOL              /*!< reference signal source polarity is falling edge*/
+#define CTC_REFSOURCE_POLARITY_RISING                    ((uint32_t)0x00000000U)      /*!< reference signal source polarity is rising edge*/
+
+/* reference signal source selection definitions */
+#define CTL1_REFSEL(regval)                              (BITS(28,29) & ((uint32_t)(regval) << 28))
+#define CTC_REFSOURCE_GPIO                               CTL1_REFSEL(0)               /*!< GPIO is selected */
+#define CTC_REFSOURCE_LXTAL                              CTL1_REFSEL(1)               /*!< LXTAL is clock selected */
+
+/* reference signal source prescaler definitions */
+#define CTL1_REFPSC(regval)                              (BITS(24,26) & ((uint32_t)(regval) << 24))
+#define CTC_REFSOURCE_PSC_OFF                            CTL1_REFPSC(0)               /*!< reference signal not divided */
+#define CTC_REFSOURCE_PSC_DIV2                           CTL1_REFPSC(1)               /*!< reference signal divided by 2 */
+#define CTC_REFSOURCE_PSC_DIV4                           CTL1_REFPSC(2)               /*!< reference signal divided by 4 */
+#define CTC_REFSOURCE_PSC_DIV8                           CTL1_REFPSC(3)               /*!< reference signal divided by 8 */
+#define CTC_REFSOURCE_PSC_DIV16                          CTL1_REFPSC(4)               /*!< reference signal divided by 16 */
+#define CTC_REFSOURCE_PSC_DIV32                          CTL1_REFPSC(5)               /*!< reference signal divided by 32 */
+#define CTC_REFSOURCE_PSC_DIV64                          CTL1_REFPSC(6)               /*!< reference signal divided by 64 */
+#define CTC_REFSOURCE_PSC_DIV128                         CTL1_REFPSC(7)               /*!< reference signal divided by 128 */
+
+/* CTC interrupt enable definitions */
+#define CTC_INT_CKOK                                     CTC_CTL0_CKOKIE             /*!< clock trim OK interrupt enable */
+#define CTC_INT_CKWARN                                   CTC_CTL0_CKWARNIE           /*!< clock trim warning interrupt enable */
+#define CTC_INT_ERR                                      CTC_CTL0_ERRIE              /*!< error interrupt enable */
+#define CTC_INT_EREF                                     CTC_CTL0_EREFIE             /*!< expect reference interrupt enable */
+
+/* CTC interrupt source definitions */
+#define CTC_INT_FLAG_CKOK                                CTC_STAT_CKOKIF             /*!< clock trim OK interrupt flag */
+#define CTC_INT_FLAG_CKWARN                              CTC_STAT_CKWARNIF           /*!< clock trim warning interrupt flag */
+#define CTC_INT_FLAG_ERR                                 CTC_STAT_ERRIF              /*!< error interrupt flag */
+#define CTC_INT_FLAG_EREF                                CTC_STAT_EREFIF             /*!< expect reference interrupt flag */
+#define CTC_INT_FLAG_CKERR                               CTC_STAT_CKERR              /*!< clock trim error bit */
+#define CTC_INT_FLAG_REFMISS                             CTC_STAT_REFMISS            /*!< reference sync pulse miss */
+#define CTC_INT_FLAG_TRIMERR                             CTC_STAT_TRIMERR            /*!< trim value error */
+
+/* CTC flag definitions */
+#define CTC_FLAG_CKOK                                    CTC_STAT_CKOKIF             /*!< clock trim OK flag */
+#define CTC_FLAG_CKWARN                                  CTC_STAT_CKWARNIF           /*!< clock trim warning flag */
+#define CTC_FLAG_ERR                                     CTC_STAT_ERRIF              /*!< error flag */
+#define CTC_FLAG_EREF                                    CTC_STAT_EREFIF             /*!< expect reference flag */
+#define CTC_FLAG_CKERR                                   CTC_STAT_CKERR              /*!< clock trim error bit */
+#define CTC_FLAG_REFMISS                                 CTC_STAT_REFMISS            /*!< reference sync pulse miss */
+#define CTC_FLAG_TRIMERR                                 CTC_STAT_TRIMERR            /*!< trim value error bit */
+
+/* function declarations */
+/* reset ctc clock trim controller */
+void ctc_deinit(void);
+/* enable CTC trim counter */
+void ctc_counter_enable(void);
+/* disable CTC trim counter */
+void ctc_counter_disable(void);
+
+/* configure the IRC48M trim value */
+void ctc_irc48m_trim_value_config(uint8_t trim_value);
+/* generate software reference source sync pulse */
+void ctc_software_refsource_pulse_generate(void);
+/* configure hardware automatically trim mode */
+void ctc_hardware_trim_mode_config(uint32_t hardmode);
+
+/* configure reference signal source polarity */
+void ctc_refsource_polarity_config(uint32_t polarity);
+/* select reference signal source */
+void ctc_refsource_signal_select(uint32_t refs);
+/* configure reference signal source prescaler */
+void ctc_refsource_prescaler_config(uint32_t prescaler);
+/* configure clock trim base limit value */
+void ctc_clock_limit_value_config(uint8_t limit_value);
+/* configure CTC counter reload value */
+void ctc_counter_reload_value_config(uint16_t reload_value);
+
+/* read CTC counter capture value when reference sync pulse occurred */
+uint16_t ctc_counter_capture_value_read(void);
+/* read CTC trim counter direction when reference sync pulse occurred */
+FlagStatus ctc_counter_direction_read(void);
+/* read CTC counter reload value */
+uint16_t ctc_counter_reload_value_read(void);
+/* read the IRC48M trim value */
+uint8_t ctc_irc48m_trim_value_read(void);
+
+/* interrupt & flag functions */
+/* enable the CTC interrupt */
+void ctc_interrupt_enable(uint32_t interrupt);
+/* disable the CTC interrupt */
+void ctc_interrupt_disable(uint32_t interrupt);
+/* get CTC interrupt flag */
+FlagStatus ctc_interrupt_flag_get(uint32_t int_flag); 
+/* clear CTC interrupt flag */
+void ctc_interrupt_flag_clear(uint32_t int_flag);
+/* get CTC flag */
+FlagStatus ctc_flag_get(uint32_t flag);
+/* clear CTC flag */
+void ctc_flag_clear(uint32_t flag);
+
+#endif /* GD32F4XX_CTC_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_dac.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_dac.h
@@ -1,0 +1,271 @@
+/*!
+    \file    gd32f4xx_dac.h
+    \brief   definitions for the DAC
+    
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_DAC_H
+#define GD32F4XX_DAC_H
+
+#include "gd32f4xx.h"
+
+/* DACx(x=0,1) definitions */
+#define DAC                     DAC_BASE
+#define DAC0                    0U
+#define DAC1                    1U
+
+/* registers definitions */
+#define DAC_CTL                 REG32(DAC + 0x00U)          /*!< DAC control register */
+#define DAC_SWT                 REG32(DAC + 0x04U)          /*!< DAC software trigger register */
+#define DAC0_R12DH              REG32(DAC + 0x08U)          /*!< DAC0 12-bit right-aligned data holding register */
+#define DAC0_L12DH              REG32(DAC + 0x0CU)          /*!< DAC0 12-bit left-aligned data holding register */
+#define DAC0_R8DH               REG32(DAC + 0x10U)          /*!< DAC0 8-bit right-aligned data holding register */
+#define DAC1_R12DH              REG32(DAC + 0x14U)          /*!< DAC1 12-bit right-aligned data holding register */
+#define DAC1_L12DH              REG32(DAC + 0x18U)          /*!< DAC1 12-bit left-aligned data holding register */
+#define DAC1_R8DH               REG32(DAC + 0x1CU)          /*!< DAC1 8-bit right-aligned data holding register */
+#define DACC_R12DH              REG32(DAC + 0x20U)          /*!< DAC concurrent mode 12-bit right-aligned data holding register */
+#define DACC_L12DH              REG32(DAC + 0x24U)          /*!< DAC concurrent mode 12-bit left-aligned data holding register */
+#define DACC_R8DH               REG32(DAC + 0x28U)          /*!< DAC concurrent mode 8-bit right-aligned data holding register */
+#define DAC0_DO                 REG32(DAC + 0x2CU)          /*!< DAC0 data output register */
+#define DAC1_DO                 REG32(DAC + 0x30U)          /*!< DAC1 data output register */
+#define DAC_STAT                REG32(DAC + 0x34U)          /*!< DAC status register */
+
+/* bits definitions */
+/* DAC_CTL */
+#define DAC_CTL_DEN0            BIT(0)                      /*!< DAC0 enable/disable bit */
+#define DAC_CTL_DBOFF0          BIT(1)                      /*!< DAC0 output buffer turn on/turn off bit */
+#define DAC_CTL_DTEN0           BIT(2)                      /*!< DAC0 trigger enable/disable bit */
+#define DAC_CTL_DTSEL0          BITS(3,5)                   /*!< DAC0 trigger source selection enable/disable bits */
+#define DAC_CTL_DWM0            BITS(6,7)                   /*!< DAC0 noise wave mode */
+#define DAC_CTL_DWBW0           BITS(8,11)                  /*!< DAC0 noise wave bit width */
+#define DAC_CTL_DDMAEN0         BIT(12)                     /*!< DAC0 DMA enable/disable bit */
+#define DAC_CTL_DDUDRIE0        BIT(13)                     /*!< DAC0 DMA underrun interrupt enable/disable bit */
+#define DAC_CTL_DEN1            BIT(16)                     /*!< DAC1 enable/disable bit */ 
+#define DAC_CTL_DBOFF1          BIT(17)                     /*!< DAC1 output buffer turn on/turn off bit */
+#define DAC_CTL_DTEN1           BIT(18)                     /*!< DAC1 trigger enable/disable bit */
+#define DAC_CTL_DTSEL1          BITS(19,21)                 /*!< DAC1 trigger source selection enable/disable bits */
+#define DAC_CTL_DWM1            BITS(22,23)                 /*!< DAC1 noise wave mode */
+#define DAC_CTL_DWBW1           BITS(24,27)                 /*!< DAC1 noise wave bit width */
+#define DAC_CTL_DDMAEN1         BIT(28)                     /*!< DAC1 DMA enable/disable bit */
+#define DAC_CTL_DDUDRIE1        BIT(29)                     /*!< DAC1 DMA underrun interrupt enable/disable bit */
+
+/* DAC_SWT */
+#define DAC_SWT_SWTR0           BIT(0)                      /*!< DAC0 software trigger bit, cleared by hardware */
+#define DAC_SWT_SWTR1           BIT(1)                      /*!< DAC1 software trigger bit, cleared by hardware */
+
+/* DAC0_R12DH */
+#define DAC0_R12DH_DAC0_DH      BITS(0,11)                  /*!< DAC0 12-bit right-aligned data bits */
+
+/* DAC0_L12DH */
+#define DAC0_L12DH_DAC0_DH      BITS(4,15)                  /*!< DAC0 12-bit left-aligned data bits */
+
+/* DAC0_R8DH */
+#define DAC0_R8DH_DAC0_DH       BITS(0,7)                   /*!< DAC0 8-bit right-aligned data bits */
+
+/* DAC1_R12DH */
+#define DAC1_R12DH_DAC1_DH      BITS(0,11)                  /*!< DAC1 12-bit right-aligned data bits */
+
+/* DAC1_L12DH */
+#define DAC1_L12DH_DAC1_DH      BITS(4,15)                  /*!< DAC1 12-bit left-aligned data bits */
+
+/* DAC1_R8DH */
+#define DAC1_R8DH_DAC1_DH       BITS(0,7)                   /*!< DAC1 8-bit right-aligned data bits */
+
+/* DACC_R12DH */
+#define DACC_R12DH_DAC0_DH      BITS(0,11)                  /*!< DAC concurrent mode DAC0 12-bit right-aligned data bits */
+#define DACC_R12DH_DAC1_DH      BITS(16,27)                 /*!< DAC concurrent mode DAC1 12-bit right-aligned data bits */
+
+/* DACC_L12DH */
+#define DACC_L12DH_DAC0_DH      BITS(4,15)                  /*!< DAC concurrent mode DAC0 12-bit left-aligned data bits */
+#define DACC_L12DH_DAC1_DH      BITS(20,31)                 /*!< DAC concurrent mode DAC1 12-bit left-aligned data bits */
+
+/* DACC_R8DH */
+#define DACC_R8DH_DAC0_DH       BITS(0,7)                   /*!< DAC concurrent mode DAC0 8-bit right-aligned data bits */
+#define DACC_R8DH_DAC1_DH       BITS(8,15)                  /*!< DAC concurrent mode DAC1 8-bit right-aligned data bits */
+
+/* DAC0_DO */
+#define DAC0_DO_DAC0_DO         BITS(0,11)                  /*!< DAC0 12-bit output data bits */
+
+/* DAC1_DO */
+#define DAC1_DO_DAC1_DO         BITS(0,11)                  /*!< DAC1 12-bit output data bits */
+
+/* DAC_STAT */
+#define DAC_STAT_DDUDR0         BIT(13)                     /*!< DAC0 DMA underrun flag */
+#define DAC_STAT_DDUDR1         BIT(29)                     /*!< DAC1 DMA underrun flag */
+
+/* constants definitions */
+/* DAC trigger source */
+#define CTL_DTSEL(regval)       (BITS(3,5) & ((uint32_t)(regval) << 3))
+#define DAC_TRIGGER_T5_TRGO     CTL_DTSEL(0)                /*!< TIMER5 TRGO */
+#define DAC_TRIGGER_T7_TRGO     CTL_DTSEL(1)                /*!< TIMER7 TRGO */
+#define DAC_TRIGGER_T6_TRGO     CTL_DTSEL(2)                /*!< TIMER6 TRGO */
+#define DAC_TRIGGER_T4_TRGO     CTL_DTSEL(3)                /*!< TIMER4 TRGO */
+#define DAC_TRIGGER_T1_TRGO     CTL_DTSEL(4)                /*!< TIMER1 TRGO */
+#define DAC_TRIGGER_T3_TRGO     CTL_DTSEL(5)                /*!< TIMER3 TRGO */
+#define DAC_TRIGGER_EXTI_9      CTL_DTSEL(6)                /*!< EXTI interrupt line9 event */
+#define DAC_TRIGGER_SOFTWARE    CTL_DTSEL(7)                /*!< software trigger */
+
+/* DAC noise wave mode */
+#define CTL_DWM(regval)         (BITS(6,7) & ((uint32_t)(regval) << 6))
+#define DAC_WAVE_DISABLE        CTL_DWM(0)                  /*!< wave disable */
+#define DAC_WAVE_MODE_LFSR      CTL_DWM(1)                  /*!< LFSR noise mode */
+#define DAC_WAVE_MODE_TRIANGLE  CTL_DWM(2)                  /*!< triangle noise mode */
+
+/* DAC noise wave bit width */
+#define DWBW(regval)            (BITS(8,11) & ((uint32_t)(regval) << 8))
+#define DAC_WAVE_BIT_WIDTH_1    DWBW(0)                     /*!< bit width of the wave signal is 1 */
+#define DAC_WAVE_BIT_WIDTH_2    DWBW(1)                     /*!< bit width of the wave signal is 2 */
+#define DAC_WAVE_BIT_WIDTH_3    DWBW(2)                     /*!< bit width of the wave signal is 3 */
+#define DAC_WAVE_BIT_WIDTH_4    DWBW(3)                     /*!< bit width of the wave signal is 4 */
+#define DAC_WAVE_BIT_WIDTH_5    DWBW(4)                     /*!< bit width of the wave signal is 5 */
+#define DAC_WAVE_BIT_WIDTH_6    DWBW(5)                     /*!< bit width of the wave signal is 6 */
+#define DAC_WAVE_BIT_WIDTH_7    DWBW(6)                     /*!< bit width of the wave signal is 7 */
+#define DAC_WAVE_BIT_WIDTH_8    DWBW(7)                     /*!< bit width of the wave signal is 8 */
+#define DAC_WAVE_BIT_WIDTH_9    DWBW(8)                     /*!< bit width of the wave signal is 9 */
+#define DAC_WAVE_BIT_WIDTH_10   DWBW(9)                     /*!< bit width of the wave signal is 10 */
+#define DAC_WAVE_BIT_WIDTH_11   DWBW(10)                    /*!< bit width of the wave signal is 11 */
+#define DAC_WAVE_BIT_WIDTH_12   DWBW(11)                    /*!< bit width of the wave signal is 12 */
+
+/* unmask LFSR bits in DAC LFSR noise mode */
+#define DAC_LFSR_BIT0           DAC_WAVE_BIT_WIDTH_1        /*!< unmask the LFSR bit0 */
+#define DAC_LFSR_BITS1_0        DAC_WAVE_BIT_WIDTH_2        /*!< unmask the LFSR bits[1:0] */
+#define DAC_LFSR_BITS2_0        DAC_WAVE_BIT_WIDTH_3        /*!< unmask the LFSR bits[2:0] */
+#define DAC_LFSR_BITS3_0        DAC_WAVE_BIT_WIDTH_4        /*!< unmask the LFSR bits[3:0] */
+#define DAC_LFSR_BITS4_0        DAC_WAVE_BIT_WIDTH_5        /*!< unmask the LFSR bits[4:0] */
+#define DAC_LFSR_BITS5_0        DAC_WAVE_BIT_WIDTH_6        /*!< unmask the LFSR bits[5:0] */
+#define DAC_LFSR_BITS6_0        DAC_WAVE_BIT_WIDTH_7        /*!< unmask the LFSR bits[6:0] */
+#define DAC_LFSR_BITS7_0        DAC_WAVE_BIT_WIDTH_8        /*!< unmask the LFSR bits[7:0] */
+#define DAC_LFSR_BITS8_0        DAC_WAVE_BIT_WIDTH_9        /*!< unmask the LFSR bits[8:0] */
+#define DAC_LFSR_BITS9_0        DAC_WAVE_BIT_WIDTH_10       /*!< unmask the LFSR bits[9:0] */
+#define DAC_LFSR_BITS10_0       DAC_WAVE_BIT_WIDTH_11       /*!< unmask the LFSR bits[10:0] */
+#define DAC_LFSR_BITS11_0       DAC_WAVE_BIT_WIDTH_12       /*!< unmask the LFSR bits[11:0] */
+
+/* DAC data alignment */
+#define DATA_ALIGN(regval)      (BITS(0,1) & ((uint32_t)(regval) << 0))
+#define DAC_ALIGN_12B_R         DATA_ALIGN(0)               /*!< data right 12 bit alignment */
+#define DAC_ALIGN_12B_L         DATA_ALIGN(1)               /*!< data left 12 bit alignment */
+#define DAC_ALIGN_8B_R          DATA_ALIGN(2)               /*!< data right 8 bit alignment */
+
+/* triangle amplitude in DAC triangle noise mode */
+#define DAC_TRIANGLE_AMPLITUDE_1    DAC_WAVE_BIT_WIDTH_1    /*!< triangle amplitude is 1 */
+#define DAC_TRIANGLE_AMPLITUDE_3    DAC_WAVE_BIT_WIDTH_2    /*!< triangle amplitude is 3 */
+#define DAC_TRIANGLE_AMPLITUDE_7    DAC_WAVE_BIT_WIDTH_3    /*!< triangle amplitude is 7 */
+#define DAC_TRIANGLE_AMPLITUDE_15   DAC_WAVE_BIT_WIDTH_4    /*!< triangle amplitude is 15 */
+#define DAC_TRIANGLE_AMPLITUDE_31   DAC_WAVE_BIT_WIDTH_5    /*!< triangle amplitude is 31 */
+#define DAC_TRIANGLE_AMPLITUDE_63   DAC_WAVE_BIT_WIDTH_6    /*!< triangle amplitude is 63 */
+#define DAC_TRIANGLE_AMPLITUDE_127  DAC_WAVE_BIT_WIDTH_7    /*!< triangle amplitude is 127 */
+#define DAC_TRIANGLE_AMPLITUDE_255  DAC_WAVE_BIT_WIDTH_8    /*!< triangle amplitude is 255 */
+#define DAC_TRIANGLE_AMPLITUDE_511  DAC_WAVE_BIT_WIDTH_9    /*!< triangle amplitude is 511 */
+#define DAC_TRIANGLE_AMPLITUDE_1023 DAC_WAVE_BIT_WIDTH_10   /*!< triangle amplitude is 1023 */
+#define DAC_TRIANGLE_AMPLITUDE_2047 DAC_WAVE_BIT_WIDTH_11   /*!< triangle amplitude is 2047 */
+#define DAC_TRIANGLE_AMPLITUDE_4095 DAC_WAVE_BIT_WIDTH_12   /*!< triangle amplitude is 4095 */
+
+/* function declarations */
+/* initialization functions */
+/* deinitialize DAC */
+void dac_deinit(void);
+/* enable DAC */
+void dac_enable(uint32_t dac_periph);
+/* disable DAC */
+void dac_disable(uint32_t dac_periph);
+/* enable DAC DMA */
+void dac_dma_enable(uint32_t dac_periph);
+/* disable DAC DMA */
+void dac_dma_disable(uint32_t dac_periph); 
+/* enable DAC output buffer */
+void dac_output_buffer_enable(uint32_t dac_periph);
+/* disable DAC output buffer */
+void dac_output_buffer_disable(uint32_t dac_periph);
+/* get the last data output value */
+uint16_t dac_output_value_get(uint32_t dac_periph);
+/* set DAC data holding register value */
+void dac_data_set(uint32_t dac_periph, uint32_t dac_align, uint16_t data);
+
+/* DAC trigger configuration */
+/* enable DAC trigger */
+void dac_trigger_enable(uint32_t dac_periph);
+/* disable DAC trigger */
+void dac_trigger_disable(uint32_t dac_periph);
+/* configure DAC trigger source */
+void dac_trigger_source_config(uint32_t dac_periph, uint32_t triggersource);
+/* enable DAC software trigger */
+void dac_software_trigger_enable(uint32_t dac_periph);
+/* disable DAC software trigger */
+void dac_software_trigger_disable(uint32_t dac_periph);
+
+/* DAC wave mode configuration */
+/* configure DAC wave mode */
+void dac_wave_mode_config(uint32_t dac_periph, uint32_t wave_mode);
+/* configure DAC wave bit width */
+void dac_wave_bit_width_config(uint32_t dac_periph, uint32_t bit_width);
+/* configure DAC LFSR noise mode */
+void dac_lfsr_noise_config(uint32_t dac_periph, uint32_t unmask_bits);
+/* configure DAC triangle noise mode */
+void dac_triangle_noise_config(uint32_t dac_periph, uint32_t amplitude);
+
+/* DAC concurrent mode configuration */
+/* enable DAC concurrent mode */
+void dac_concurrent_enable(void);
+/* disable DAC concurrent mode */
+void dac_concurrent_disable(void);
+/* enable DAC concurrent software trigger */
+void dac_concurrent_software_trigger_enable(void);
+/* disable DAC concurrent software trigger */
+void dac_concurrent_software_trigger_disable(void);
+/* enable DAC concurrent buffer function */
+void dac_concurrent_output_buffer_enable(void);
+/* disable DAC concurrent buffer function */
+void dac_concurrent_output_buffer_disable(void);
+/* set DAC concurrent mode data holding register value */
+void dac_concurrent_data_set(uint32_t dac_align, uint16_t data0, uint16_t data1);
+/* enable DAC concurrent interrupt */
+void dac_concurrent_interrupt_enable(void);
+/* disable DAC concurrent interrupt */
+void dac_concurrent_interrupt_disable(void);
+
+/* DAC interrupt configuration */
+/* get the specified DAC flag(DAC DMA underrun flag) */
+FlagStatus dac_flag_get(uint32_t dac_periph);
+/* clear the specified DAC flag(DAC DMA underrun flag) */
+void dac_flag_clear(uint32_t dac_periph);
+/* enable DAC interrupt(DAC DMA underrun interrupt) */
+void dac_interrupt_enable(uint32_t dac_periph);
+/* disable DAC interrupt(DAC DMA underrun interrupt) */
+void dac_interrupt_disable(uint32_t dac_periph);
+/* get the specified DAC interrupt flag(DAC DMA underrun interrupt flag) */
+FlagStatus dac_interrupt_flag_get(uint32_t dac_periph);
+/* clear the specified DAC interrupt flag(DAC DMA underrun interrupt flag) */
+void dac_interrupt_flag_clear(uint32_t dac_periph);
+
+#endif /* GD32F4XX_DAC_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_dbg.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_dbg.h
@@ -1,0 +1,153 @@
+/*!
+    \file    gd32f4xx_dbg.h
+    \brief   definitions for the DBG
+    
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_DBG_H
+#define GD32F4XX_DBG_H
+
+#include "gd32f4xx.h"
+
+/* DBG definitions */
+#define DBG                      DBG_BASE
+
+/* registers definitions */
+#define DBG_ID                   REG32(DBG + 0x00U)         /*!< DBG_ID code register */
+#define DBG_CTL0                 REG32(DBG + 0x04U)         /*!< DBG control register 0 */
+#define DBG_CTL1                 REG32(DBG + 0x08U)         /*!< DBG control register 1 */
+#define DBG_CTL2                 REG32(DBG + 0x0CU)         /*!< DBG control register 2 */
+
+/* bits definitions */
+/* DBG_ID */
+#define DBG_ID_ID_CODE           BITS(0,31)                 /*!< DBG ID code values */
+
+/* DBG_CTL0 */
+#define DBG_CTL0_SLP_HOLD        BIT(0)                     /*!< keep debugger connection during sleep mode */
+#define DBG_CTL0_DSLP_HOLD       BIT(1)                     /*!< keep debugger connection during deepsleep mode */
+#define DBG_CTL0_STB_HOLD        BIT(2)                     /*!< keep debugger connection during standby mode */
+#define DBG_CTL0_TRACE_IOEN      BIT(5)                     /*!< enable trace pin assignment */
+
+/* DBG_CTL1 */
+#define DBG_CTL1_TIMER1_HOLD     BIT(0)                     /*!< hold TIMER1 counter when core is halted */
+#define DBG_CTL1_TIMER2_HOLD     BIT(1)                     /*!< hold TIMER2 counter when core is halted */
+#define DBG_CTL1_TIMER3_HOLD     BIT(2)                     /*!< hold TIMER3 counter when core is halted */
+#define DBG_CTL1_TIMER4_HOLD     BIT(3)                     /*!< hold TIMER4 counter when core is halted */
+#define DBG_CTL1_TIMER5_HOLD     BIT(4)                     /*!< hold TIMER5 counter when core is halted */
+#define DBG_CTL1_TIMER6_HOLD     BIT(5)                     /*!< hold TIMER6 counter when core is halted */
+#define DBG_CTL1_TIMER11_HOLD    BIT(6)                     /*!< hold TIMER11 counter when core is halted */
+#define DBG_CTL1_TIMER12_HOLD    BIT(7)                     /*!< hold TIMER12 counter when core is halted */
+#define DBG_CTL1_TIMER13_HOLD    BIT(8)                     /*!< hold TIMER13 counter when core is halted */
+#define DBG_CTL1_RTC_HOLD        BIT(10)                    /*!< hold RTC calendar and wakeup counter when core is halted */
+#define DBG_CTL1_WWDGT_HOLD      BIT(11)                    /*!< debug WWDGT kept when core is halted */
+#define DBG_CTL1_FWDGT_HOLD      BIT(12)                    /*!< debug FWDGT kept when core is halted */
+#define DBG_CTL1_I2C0_HOLD       BIT(21)                    /*!< hold I2C0 smbus when core is halted */
+#define DBG_CTL1_I2C1_HOLD       BIT(22)                    /*!< hold I2C1 smbus when core is halted */
+#define DBG_CTL1_I2C2_HOLD       BIT(23)                    /*!< hold I2C2 smbus when core is halted */
+#define DBG_CTL1_CAN0_HOLD       BIT(25)                    /*!< debug CAN0 kept when core is halted */
+#define DBG_CTL1_CAN1_HOLD       BIT(26)                    /*!< debug CAN1 kept when core is halted */
+
+/* DBG_CTL2 */
+#define DBG_CTL2_TIMER0_HOLD     BIT(0)                     /*!< hold TIMER0 counter when core is halted */
+#define DBG_CTL2_TIMER7_HOLD     BIT(1)                     /*!< hold TIMER7 counter when core is halted */
+#define DBG_CTL2_TIMER8_HOLD     BIT(16)                    /*!< hold TIMER8 counter when core is halted */
+#define DBG_CTL2_TIMER9_HOLD     BIT(17)                    /*!< hold TIMER9 counter when core is halted */
+#define DBG_CTL2_TIMER10_HOLD    BIT(18)                    /*!< hold TIMER10 counter when core is halted */
+
+/* constants definitions */
+#define DBG_LOW_POWER_SLEEP      DBG_CTL0_SLP_HOLD          /*!< keep debugger connection during sleep mode */
+#define DBG_LOW_POWER_DEEPSLEEP  DBG_CTL0_DSLP_HOLD         /*!< keep debugger connection during deepsleep mode */
+#define DBG_LOW_POWER_STANDBY    DBG_CTL0_STB_HOLD          /*!< keep debugger connection during standby mode */
+
+/* define the peripheral debug hold bit position and its register index offset */
+#define DBG_REGIDX_BIT(regidx, bitpos)      (((regidx) << 6) | (bitpos))
+#define DBG_REG_VAL(periph)                 (REG32(DBG + ((uint32_t)(periph) >> 6)))
+#define DBG_BIT_POS(val)                    ((uint32_t)(val) & 0x1FU)
+
+/* register index */
+enum dbg_reg_idx
+{
+    DBG_IDX_CTL0  = 0x04U,
+    DBG_IDX_CTL1  = 0x08U,
+    DBG_IDX_CTL2  = 0x0CU
+};
+
+typedef enum
+{
+    DBG_TIMER1_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL1, 0U),                    /*!< hold TIMER1 counter when core is halted */
+    DBG_TIMER2_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL1, 1U),                    /*!< hold TIMER2 counter when core is halted */
+    DBG_TIMER3_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL1, 2U),                    /*!< hold TIMER3 counter when core is halted */
+    DBG_TIMER4_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL1, 3U),                    /*!< hold TIMER4 counter when core is halted */
+    DBG_TIMER5_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL1, 4U),                    /*!< hold TIMER5 counter when core is halted */
+    DBG_TIMER6_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL1, 5U),                    /*!< hold TIMER6 counter when core is halted */
+    DBG_TIMER11_HOLD           = DBG_REGIDX_BIT(DBG_IDX_CTL1, 6U),                    /*!< hold TIMER11 counter when core is halted */
+    DBG_TIMER12_HOLD           = DBG_REGIDX_BIT(DBG_IDX_CTL1, 7U),                    /*!< hold TIMER12 counter when core is halted */
+    DBG_TIMER13_HOLD           = DBG_REGIDX_BIT(DBG_IDX_CTL1, 8U),                    /*!< hold TIMER13 counter when core is halted */
+    DBG_RTC_HOLD               = DBG_REGIDX_BIT(DBG_IDX_CTL1, 10U),                   /*!< hold RTC calendar and wakeup counter when core is halted */
+    DBG_WWDGT_HOLD             = DBG_REGIDX_BIT(DBG_IDX_CTL1, 11U),                   /*!< debug WWDGT kept when core is halted */
+    DBG_FWDGT_HOLD             = DBG_REGIDX_BIT(DBG_IDX_CTL1, 12U),                   /*!< debug FWDGT kept when core is halted */
+    DBG_I2C0_HOLD              = DBG_REGIDX_BIT(DBG_IDX_CTL1, 21U),                   /*!< hold I2C0 smbus when core is halted */
+    DBG_I2C1_HOLD              = DBG_REGIDX_BIT(DBG_IDX_CTL1, 22U),                   /*!< hold I2C1 smbus when core is halted */
+    DBG_I2C2_HOLD              = DBG_REGIDX_BIT(DBG_IDX_CTL1, 23U),                   /*!< hold I2C2 smbus when core is halted */
+    DBG_CAN0_HOLD              = DBG_REGIDX_BIT(DBG_IDX_CTL1, 25U),                   /*!< debug CAN0 kept when core is halted */
+    DBG_CAN1_HOLD              = DBG_REGIDX_BIT(DBG_IDX_CTL1, 26U),                   /*!< debug CAN1 kept when core is halted */
+    DBG_TIMER0_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL2, 0U),                    /*!< hold TIMER0 counter when core is halted */
+    DBG_TIMER7_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL2, 1U),                    /*!< hold TIMER7 counter when core is halted */
+    DBG_TIMER8_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL2, 16U),                   /*!< hold TIMER8 counter when core is halted */
+    DBG_TIMER9_HOLD            = DBG_REGIDX_BIT(DBG_IDX_CTL2, 17U),                   /*!< hold TIMER9 counter when core is halted */
+    DBG_TIMER10_HOLD           = DBG_REGIDX_BIT(DBG_IDX_CTL2, 18U)                    /*!< hold TIMER10 counter when core is halted */
+}dbg_periph_enum;
+
+/* function declarations */
+/* deinitialize the DBG */
+void dbg_deinit(void);
+/* read DBG_ID code register */
+uint32_t dbg_id_get(void);
+
+/* enable low power behavior when the MCU is in debug mode */
+void dbg_low_power_enable(uint32_t dbg_low_power);
+/* disable low power behavior when the MCU is in debug mode */
+void dbg_low_power_disable(uint32_t dbg_low_power);
+
+/* enable peripheral behavior when the MCU is in debug mode */
+void dbg_periph_enable(dbg_periph_enum dbg_periph);
+/* disable peripheral behavior when the MCU is in debug mode */
+void dbg_periph_disable(dbg_periph_enum dbg_periph);
+
+/* enable trace pin assignment */
+void dbg_trace_pin_enable(void);
+/* disable trace pin assignment */
+void dbg_trace_pin_disable(void);
+
+#endif /* GD32F4XX_DBG_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_dci.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_dci.h
@@ -1,0 +1,239 @@
+/*!
+    \file    gd32f4xx_dci.h
+    \brief   definitions for the DCI
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_DCI_H
+#define GD32F4XX_DCI_H
+
+#include "gd32f4xx.h"
+
+/* DCI definitions */
+#define DCI                       DCI_BASE
+
+/* registers definitions */
+#define DCI_CTL                   REG32(DCI + 0x00U) /*!< DCI control register */
+#define DCI_STAT0                 REG32(DCI + 0x04U) /*!< DCI status register 0 */
+#define DCI_STAT1                 REG32(DCI + 0x08U) /*!< DCI status register 1 */
+#define DCI_INTEN                 REG32(DCI + 0x0CU) /*!< DCI interrupt enable register */
+#define DCI_INTF                  REG32(DCI + 0x10U) /*!< DCI interrupt flag register */
+#define DCI_INTC                  REG32(DCI + 0x14U) /*!< DCI interrupt clear register */
+#define DCI_SC                    REG32(DCI + 0x18U) /*!< DCI synchronization codes register */
+#define DCI_SCUMSK                REG32(DCI + 0x1CU) /*!< DCI synchronization codes unmask register */
+#define DCI_CWSPOS                REG32(DCI + 0x20U) /*!< DCI cropping window start position register */
+#define DCI_CWSZ                  REG32(DCI + 0x24U) /*!< DCI cropping window size register */
+#define DCI_DATA                  REG32(DCI + 0x28U) /*!< DCI data register */
+
+/* bits definitions */
+/* DCI_CTL */
+#define DCI_CTL_CAP               BIT(0)             /*!< capture enable */
+#define DCI_CTL_SNAP              BIT(1)             /*!< snapshot mode */
+#define DCI_CTL_WDEN              BIT(2)             /*!< window enable */
+#define DCI_CTL_JM                BIT(3)             /*!< JPEG mode */
+#define DCI_CTL_ESM               BIT(4)             /*!< embedded synchronous mode */
+#define DCI_CTL_CKS               BIT(5)             /*!< clock polarity selection */
+#define DCI_CTL_HPS               BIT(6)             /*!< horizontal polarity selection */
+#define DCI_CTL_VPS               BIT(7)             /*!< vertical polarity selection */
+#define DCI_CTL_FR                BITS(8,9)          /*!< frame rate */
+#define DCI_CTL_DCIF              BITS(10,11)        /*!< digital camera interface format */
+#define DCI_CTL_DCIEN             BIT(14)            /*!< DCI enable */
+
+/* DCI_STAT0 */
+#define DCI_STAT0_HS              BIT(0)            /*!< HS line status */
+#define DCI_STAT0_VS              BIT(1)            /*!< VS line status */
+#define DCI_STAT0_FV              BIT(2)            /*!< FIFO valid */
+
+/* DCI_STAT1 */
+#define DCI_STAT1_EFF             BIT(0)            /*!< end of frame flag */
+#define DCI_STAT1_OVRF            BIT(1)            /*!< FIFO overrun flag */
+#define DCI_STAT1_ESEF            BIT(2)            /*!< embedded synchronous error flag */
+#define DCI_STAT1_VSF             BIT(3)            /*!< vsync flag */
+#define DCI_STAT1_ELF             BIT(4)            /*!< end of line flag */
+
+/* DCI_INTEN */
+#define DCI_INTEN_EFIE            BIT(0)            /*!< end of frame interrupt enable */
+#define DCI_INTEN_OVRIE           BIT(1)            /*!< FIFO overrun interrupt enable */
+#define DCI_INTEN_ESEIE           BIT(2)            /*!< embedded synchronous error interrupt enable */
+#define DCI_INTEN_VSIE            BIT(3)            /*!< vsync interrupt enable */
+#define DCI_INTEN_ELIE            BIT(4)            /*!< end of line interrupt enable */
+
+/* DCI_INTF */
+#define DCI_INTF_EFIF             BIT(0)            /*!< end of frame interrupt flag */
+#define DCI_INTF_OVRIF            BIT(1)            /*!< FIFO overrun interrupt flag */
+#define DCI_INTF_ESEIF            BIT(2)            /*!< embedded synchronous error interrupt flag */
+#define DCI_INTF_VSIF             BIT(3)            /*!< vsync interrupt flag  */
+#define DCI_INTF_ELIF             BIT(4)            /*!< end of line interrupt flag */
+
+/* DCI_INTC */
+#define DCI_INTC_EFFC             BIT(0)            /*!< clear end of frame flag */
+#define DCI_INTC_OVRFC            BIT(1)            /*!< clear FIFO overrun flag */
+#define DCI_INTC_ESEFC            BIT(2)            /*!< clear embedded synchronous error flag */
+#define DCI_INTC_VSFC             BIT(3)            /*!< vsync flag clear */
+#define DCI_INTC_ELFC             BIT(4)            /*!< end of line flag clear */
+
+/* DCI_SC */
+#define DCI_SC_FS                 BITS(0,7)         /*!< frame start code in embedded synchronous mode */
+#define DCI_SC_LS                 BITS(8,15)        /*!< line start code in embedded synchronous mode */
+#define DCI_SC_LE                 BITS(16,23)       /*!< line end code in embedded synchronous mode */
+#define DCI_SC_FE                 BITS(24,31)       /*!< frame end code in embedded synchronous mode */
+
+/* DCI_SCUNMSK */
+#define DCI_SCUMSK_FSM            BITS(0,7)         /*!< frame start code unmask bits in embedded synchronous mode */
+#define DCI_SCUMSK_LSM            BITS(8,15)        /*!< line start code unmask bits in embedded synchronous mode */
+#define DCI_SCUMSK_LEM            BITS(16,23)       /*!< line end code unmask bits in embedded synchronous mode */
+#define DCI_SCUMSK_FEM            BITS(24,31)       /*!< frame end code unmask bits in embedded synchronous mode */
+
+/* DCI_CWSPOS */
+#define DCI_CWSPOS_WHSP           BITS(0,13)        /*!< window horizontal start position */
+#define DCI_CWSPOS_WVSP           BITS(16,28)       /*!< window vertical start position */
+
+/* DCI_CWSZ */
+#define DCI_CWSZ_WHSZ             BITS(0,13)        /*!< window horizontal size */
+#define DCI_CWSZ_WVSZ             BITS(16,29)       /*!< window vertical size */
+
+/* constants definitions */
+/* DCI parameter structure definitions */
+typedef struct
+{   
+    uint32_t capture_mode;                                           /*!< DCI capture mode: continuous or snapshot */
+    uint32_t clock_polarity;                                         /*!< clock polarity selection */
+    uint32_t hsync_polarity;                                         /*!< horizontal polarity selection */
+    uint32_t vsync_polarity;                                         /*!< vertical polarity selection */
+    uint32_t frame_rate;                                             /*!< frame capture rate */
+    uint32_t interface_format;                                       /*!< digital camera interface format */
+}dci_parameter_struct;                                                         
+
+#define DCI_CAPTURE_MODE_CONTINUOUS   ((uint32_t)0x00000000U)        /*!< continuous capture mode */
+#define DCI_CAPTURE_MODE_SNAPSHOT     DCI_CTL_SNAP                   /*!< snapshot capture mode */
+
+#define DCI_CK_POLARITY_FALLING       ((uint32_t)0x00000000U)        /*!< capture at falling edge */
+#define DCI_CK_POLARITY_RISING        DCI_CTL_CKS                    /*!< capture at rising edge */
+
+#define DCI_HSYNC_POLARITY_LOW        ((uint32_t)0x00000000U)        /*!< low level during blanking period */
+#define DCI_HSYNC_POLARITY_HIGH       DCI_CTL_HPS                    /*!< high level during blanking period */
+
+#define DCI_VSYNC_POLARITY_LOW        ((uint32_t)0x00000000U)        /*!< low level during blanking period */
+#define DCI_VSYNC_POLARITY_HIGH       DCI_CTL_VPS                    /*!< high level during blanking period*/
+ 
+#define CTL_FR(regval)                (BITS(8,9)&((uint32_t)(regval) << 8U))    
+#define DCI_FRAME_RATE_ALL            CTL_FR(0)                      /*!< capture all frames */
+#define DCI_FRAME_RATE_1_2            CTL_FR(1)                      /*!< capture one in 2 frames */
+#define DCI_FRAME_RATE_1_4            CTL_FR(2)                      /*!< capture one in 4 frames */
+
+#define CTL_DCIF(regval)              (BITS(10,11)&((uint32_t)(regval) << 10U)) 
+#define DCI_INTERFACE_FORMAT_8BITS    CTL_DCIF(0)                    /*!< 8-bit data on every pixel clock */
+#define DCI_INTERFACE_FORMAT_10BITS   CTL_DCIF(1)                    /*!< 10-bit data on every pixel clock */
+#define DCI_INTERFACE_FORMAT_12BITS   CTL_DCIF(2)                    /*!< 12-bit data on every pixel clock */
+#define DCI_INTERFACE_FORMAT_14BITS   CTL_DCIF(3)                    /*!< 14-bit data on every pixel clock */
+
+/* DCI interrupt constants definitions */
+#define DCI_INT_EF                    BIT(0)                         /*!< end of frame interrupt */
+#define DCI_INT_OVR                   BIT(1)                         /*!< FIFO overrun interrupt */
+#define DCI_INT_ESE                   BIT(2)                         /*!< embedded synchronous error interrupt */
+#define DCI_INT_VSYNC                 BIT(3)                         /*!< vsync interrupt */
+#define DCI_INT_EL                    BIT(4)                         /*!< end of line interrupt */
+
+/* DCI interrupt flag definitions */
+#define DCI_INT_FLAG_EF               BIT(0)                         /*!< end of frame interrupt flag */
+#define DCI_INT_FLAG_OVR              BIT(1)                         /*!< FIFO overrun interrupt flag */
+#define DCI_INT_FLAG_ESE              BIT(2)                         /*!< embedded synchronous error interrupt flag */
+#define DCI_INT_FLAG_VSYNC            BIT(3)                         /*!< vsync interrupt flag */
+#define DCI_INT_FLAG_EL               BIT(4)                         /*!< end of line interrupt flag */
+
+/* DCI flag definitions */  
+#define DCI_FLAG_HS                   DCI_STAT0_HS                   /*!< HS line status */
+#define DCI_FLAG_VS                   DCI_STAT0_VS                   /*!< VS line status */
+#define DCI_FLAG_FV                   DCI_STAT0_FV                   /*!< FIFO valid */
+#define DCI_FLAG_EF                   (DCI_STAT1_EFF | BIT(31))      /*!< end of frame flag */
+#define DCI_FLAG_OVR                  (DCI_STAT1_OVRF | BIT(31))     /*!< FIFO overrun flag */
+#define DCI_FLAG_ESE                  (DCI_STAT1_ESEF | BIT(31))     /*!< embedded synchronous error flag */
+#define DCI_FLAG_VSYNC                (DCI_STAT1_VSF | BIT(31))      /*!< vsync flag */
+#define DCI_FLAG_EL                   (DCI_STAT1_ELF | BIT(31))      /*!< end of line flag */
+
+/* function declarations */
+/* initialization functions */
+/* DCI deinit */
+void dci_deinit(void);
+/* initialize DCI registers */
+void dci_init(dci_parameter_struct* dci_struct);
+
+/* enable DCI function */
+void dci_enable(void);
+/* disable DCI function */
+void dci_disable(void);
+/* enable DCI capture */
+void dci_capture_enable(void);
+/* disable DCI capture */
+void dci_capture_disable(void);
+/* enable DCI jpeg mode */
+void dci_jpeg_enable(void);
+/* disable DCI jpeg mode */
+void dci_jpeg_disable(void);
+
+/* function configuration */
+/* enable cropping window function */
+void dci_crop_window_enable(void);
+/* disable cropping window function */
+void dci_crop_window_disable(void);
+/* configure DCI cropping window */
+void dci_crop_window_config(uint16_t start_x, uint16_t start_y, uint16_t size_width, uint16_t size_height);
+
+/* enable embedded synchronous mode */
+void dci_embedded_sync_enable(void);
+/* disable embedded synchronous mode */
+void dci_embedded_sync_disable(void);
+/* configure synchronous codes in embedded synchronous mode */
+void dci_sync_codes_config(uint8_t frame_start, uint8_t line_start, uint8_t line_end, uint8_t frame_end);
+/* configure synchronous codes unmask in embedded synchronous mode */
+void dci_sync_codes_unmask_config(uint8_t frame_start, uint8_t line_start, uint8_t line_end, uint8_t frame_end);
+
+/* read DCI data register */
+uint32_t dci_data_read(void);
+
+/* interrupt & flag functions */
+/* get specified flag */
+FlagStatus dci_flag_get(uint32_t flag);
+/* enable specified DCI interrupt */
+void dci_interrupt_enable(uint32_t interrupt);
+/* disable specified DCI interrupt */
+void dci_interrupt_disable(uint32_t interrupt);
+
+
+/* get specified interrupt flag */
+FlagStatus dci_interrupt_flag_get(uint32_t int_flag);
+/* clear specified interrupt flag */
+void dci_interrupt_flag_clear(uint32_t int_flag);
+
+#endif /* GD32F4XX_DCI_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_dma.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_dma.h
@@ -1,0 +1,428 @@
+/*!
+    \file    gd32f4xx_dma.h
+    \brief   definitions for the DMA
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_DMA_H
+#define GD32F4XX_DMA_H
+
+#include "gd32f4xx.h"
+
+/* DMA definitions */
+#define DMA0                              (DMA_BASE)                          /*!< DMA0 base address */
+#define DMA1                              (DMA_BASE + 0x00000400U)            /*!< DMA1 base address */
+
+/* registers definitions */
+#define DMA_INTF0(dmax)                    REG32((dmax) + 0x00000000U)        /*!< DMA interrupt flag register 0 */
+#define DMA_INTF1(dmax)                    REG32((dmax) + 0x00000004U)        /*!< DMA interrupt flag register 1 */
+#define DMA_INTC0(dmax)                    REG32((dmax) + 0x00000008U)        /*!< DMA interrupt flag clear register 0 */
+#define DMA_INTC1(dmax)                    REG32((dmax) + 0x0000000CU)        /*!< DMA interrupt flag clear register 1 */
+
+#define DMA_CH0CTL(dmax)                   REG32((dmax) + 0x00000010U)        /*!< DMA channel 0 control register */
+#define DMA_CH0CNT(dmax)                   REG32((dmax) + 0x00000014U)        /*!< DMA channel 0 counter register */
+#define DMA_CH0PADDR(dmax)                 REG32((dmax) + 0x00000018U)        /*!< DMA channel 0 peripheral base address register */
+#define DMA_CH0M0ADDR(dmax)                REG32((dmax) + 0x0000001CU)        /*!< DMA channel 0 memory 0 base address register */
+#define DMA_CH0M1ADDR(dmax)                REG32((dmax) + 0x00000020U)        /*!< DMA channel 0 memory 1 base address register */
+#define DMA_CH0FCTL(dmax)                  REG32((dmax) + 0x00000024U)        /*!< DMA channel 0 FIFO control register */
+
+#define DMA_CH1CTL(dmax)                   REG32((dmax) + 0x00000028U)        /*!< DMA channel 1 control register */
+#define DMA_CH1CNT(dmax)                   REG32((dmax) + 0x0000002CU)        /*!< DMA channel 1 counter register */
+#define DMA_CH1PADDR(dmax)                 REG32((dmax) + 0x00000030U)        /*!< DMA channel 1 peripheral base address register */
+#define DMA_CH1M0ADDR(dmax)                REG32((dmax) + 0x00000034U)        /*!< DMA channel 1 memory 0 base address register */
+#define DMA_CH1M1ADDR(dmax)                REG32((dmax) + 0x00000038U)        /*!< DMA channel 1 memory 1 base address register */
+#define DMA_CH1FCTL(dmax)                  REG32((dmax) + 0x0000003CU)        /*!< DMA channel 1 FIFO control register */
+
+#define DMA_CH2CTL(dmax)                   REG32((dmax) + 0x00000040U)        /*!< DMA channel 2 control register */
+#define DMA_CH2CNT(dmax)                   REG32((dmax) + 0x00000044U)        /*!< DMA channel 2 counter register */
+#define DMA_CH2PADDR(dmax)                 REG32((dmax) + 0x00000048U)        /*!< DMA channel 2 peripheral base address register */
+#define DMA_CH2M0ADDR(dmax)                REG32((dmax) + 0x0000004CU)        /*!< DMA channel 2 memory 0 base address register */
+#define DMA_CH2M1ADDR(dmax)                REG32((dmax) + 0x00000050U)        /*!< DMA channel 2 memory 1 base address register */
+#define DMA_CH2FCTL(dmax)                  REG32((dmax) + 0x00000054U)        /*!< DMA channel 2 FIFO control register */
+
+#define DMA_CH3CTL(dmax)                   REG32((dmax) + 0x00000058U)        /*!< DMA channel 3 control register */
+#define DMA_CH3CNT(dmax)                   REG32((dmax) + 0x0000005CU)        /*!< DMA channel 3 counter register */
+#define DMA_CH3PADDR(dmax)                 REG32((dmax) + 0x00000060U)        /*!< DMA channel 3 peripheral base address register */
+#define DMA_CH3M0ADDR(dmax)                REG32((dmax) + 0x00000064U)        /*!< DMA channel 3 memory 0 base address register */
+#define DMA_CH3M1ADDR(dmax)                REG32((dmax) + 0x00000068U)        /*!< DMA channel 3 memory 1 base address register */
+#define DMA_CH3FCTL(dmax)                  REG32((dmax) + 0x0000006CU)        /*!< DMA channel 3 FIFO control register */
+
+#define DMA_CH4CTL(dmax)                   REG32((dmax) + 0x00000070U)        /*!< DMA channel 4 control register */
+#define DMA_CH4CNT(dmax)                   REG32((dmax) + 0x00000074U)        /*!< DMA channel 4 counter register */
+#define DMA_CH4PADDR(dmax)                 REG32((dmax) + 0x00000078U)        /*!< DMA channel 4 peripheral base address register */
+#define DMA_CH4M0ADDR(dmax)                REG32((dmax) + 0x0000007CU)        /*!< DMA channel 4 memory 0 base address register */
+#define DMA_CH4M1ADDR(dmax)                REG32((dmax) + 0x00000080U)        /*!< DMA channel 4 memory 1 base address register */
+#define DMA_CH4FCTL(dmax)                  REG32((dmax) + 0x00000084U)        /*!< DMA channel 4 FIFO control register */
+
+#define DMA_CH5CTL(dmax)                   REG32((dmax) + 0x00000088U)        /*!< DMA channel 5 control register */
+#define DMA_CH5CNT(dmax)                   REG32((dmax) + 0x0000008CU)        /*!< DMA channel 5 counter register */
+#define DMA_CH5PADDR(dmax)                 REG32((dmax) + 0x00000090U)        /*!< DMA channel 5 peripheral base address register */
+#define DMA_CH5M0ADDR(dmax)                REG32((dmax) + 0x00000094U)        /*!< DMA channel 5 memory 0 base address register */
+#define DMA_CH5M1ADDR(dmax)                REG32((dmax) + 0x00000098U)        /*!< DMA channel 5 memory 1 base address register */
+#define DMA_CH5FCTL(dmax)                  REG32((dmax) + 0x0000009CU)        /*!< DMA channel 5 FIFO control register */
+
+#define DMA_CH6CTL(dmax)                   REG32((dmax) + 0x000000A0U)        /*!< DMA channel 6 control register */
+#define DMA_CH6CNT(dmax)                   REG32((dmax) + 0x000000A4U)        /*!< DMA channel 6 counter register */
+#define DMA_CH6PADDR(dmax)                 REG32((dmax) + 0x000000A8U)        /*!< DMA channel 6 peripheral base address register */
+#define DMA_CH6M0ADDR(dmax)                REG32((dmax) + 0x000000ACU)        /*!< DMA channel 6 memory 0 base address register */
+#define DMA_CH6M1ADDR(dmax)                REG32((dmax) + 0x000000B0U)        /*!< DMA channel 6 memory 1 base address register */
+#define DMA_CH6FCTL(dmax)                  REG32((dmax) + 0x000000B4U)        /*!< DMA channel 6 FIFO control register */
+
+#define DMA_CH7CTL(dmax)                   REG32((dmax) + 0x000000B8U)        /*!< DMA channel 7 control register */
+#define DMA_CH7CNT(dmax)                   REG32((dmax) + 0x000000BCU)        /*!< DMA channel 7 counter register */
+#define DMA_CH7PADDR(dmax)                 REG32((dmax) + 0x000000C0U)        /*!< DMA channel 7 peripheral base address register */
+#define DMA_CH7M0ADDR(dmax)                REG32((dmax) + 0x000000C4U)        /*!< DMA channel 7 memory 0 base address register */
+#define DMA_CH7M1ADDR(dmax)                REG32((dmax) + 0x000000C8U)        /*!< DMA channel 7 memory 1 base address register */
+#define DMA_CH7FCTL(dmax)                  REG32((dmax) + 0x000000CCU)        /*!< DMA channel 7 FIFO control register */
+
+/* bits definitions */
+/* DMA_INTF */
+#define DMA_INTF_FEEIF                    BIT(0)                        /*!< FIFO error and exception flag */
+#define DMA_INTF_SDEIF                    BIT(2)                        /*!< single data mode exception flag */
+#define DMA_INTF_TAEIF                    BIT(3)                        /*!< transfer access error flag */
+#define DMA_INTF_HTFIF                    BIT(4)                        /*!< half transfer finish flag */
+#define DMA_INTF_FTFIF                    BIT(5)                        /*!< full transger finish flag */
+
+/* DMA_INTC */
+#define DMA_INTC_FEEIFC                   BIT(0)                        /*!< clear FIFO error and exception flag */
+#define DMA_INTC_SDEIFC                   BIT(2)                        /*!< clear single data mode exception flag */
+#define DMA_INTC_TAEIFC                   BIT(3)                        /*!< clear single data mode exception flag */
+#define DMA_INTC_HTFIFC                   BIT(4)                        /*!< clear half transfer finish flag */
+#define DMA_INTC_FTFIFC                   BIT(5)                        /*!< clear full transger finish flag */
+
+/* DMA_CHxCTL,x=0..7 */
+#define DMA_CHXCTL_CHEN                   BIT(0)                        /*!< channel x enable */
+#define DMA_CHXCTL_SDEIE                  BIT(1)                        /*!< enable bit for channel x single data mode exception interrupt */
+#define DMA_CHXCTL_TAEIE                  BIT(2)                        /*!< enable bit for channel x tranfer access error interrupt */
+#define DMA_CHXCTL_HTFIE                  BIT(3)                        /*!< enable bit for channel x half transfer finish interrupt */
+#define DMA_CHXCTL_FTFIE                  BIT(4)                        /*!< enable bit for channel x full transfer finish interrupt */
+#define DMA_CHXCTL_TFCS                   BIT(5)                        /*!< transfer flow controller select */
+#define DMA_CHXCTL_TM                     BITS(6,7)                     /*!< transfer mode */
+#define DMA_CHXCTL_CMEN                   BIT(8)                        /*!< circulation mode */
+#define DMA_CHXCTL_PNAGA                  BIT(9)                        /*!< next address generation algorithm of peripheral */
+#define DMA_CHXCTL_MNAGA                  BIT(10)                       /*!< next address generation algorithm of memory */
+#define DMA_CHXCTL_PWIDTH                 BITS(11,12)                   /*!< transfer width of peipheral */
+#define DMA_CHXCTL_MWIDTH                 BITS(13,14)                   /*!< transfer width of memory */
+#define DMA_CHXCTL_PAIF                   BIT(15)                       /*!< peripheral address increment fixed */
+#define DMA_CHXCTL_PRIO                   BITS(16,17)                   /*!< priority level */
+#define DMA_CHXCTL_SBMEN                  BIT(18)                       /*!< switch-buffer mode enable */
+#define DMA_CHXCTL_MBS                    BIT(19)                       /*!< memory buffer select */
+#define DMA_CHXCTL_PBURST                 BITS(21,22)                   /*!< transfer burst type of peripheral */
+#define DMA_CHXCTL_MBURST                 BITS(23,24)                   /*!< transfer burst type of memory */
+#define DMA_CHXCTL_PERIEN                 BITS(25,27)                   /*!< peripheral enable */
+
+/* DMA_CHxCNT,x=0..7 */
+#define DMA_CHXCNT_CNT                    BITS(0,15)                    /*!< transfer counter */
+
+/* DMA_CHxPADDR,x=0..7 */
+#define DMA_CHXPADDR_PADDR                BITS(0,31)                    /*!< peripheral base address */
+
+/* DMA_CHxM0ADDR,x=0..7 */
+#define DMA_CHXM0ADDR_M0ADDR              BITS(0,31)                    /*!< memory 0 base address */
+
+/* DMA_CHxM1ADDR,x=0..7 */
+#define DMA_CHXM1ADDR_M0ADDR              BITS(0,31)                    /*!< memory 1 base address */
+
+/* DMA_CHxFCTL,x=0..7 */
+#define DMA_CHXFCTL_FCCV                  BITS(0,1)                     /*!< FIFO counter critical value */
+#define DMA_CHXFCTL_MDMEN                 BIT(2)                        /*!< multi-data mode enable */
+#define DMA_CHXFCTL_FCNT                  BITS(3,5)                     /*!< FIFO counter */
+#define DMA_CHXFCTL_FEEIE                 BIT(7)                        /*!< FIFO exception interrupt enable */
+
+/* constants definitions */
+/* DMA channel select */
+typedef enum 
+{
+    DMA_CH0 = 0,                                    /*!< DMA Channel 0 */
+    DMA_CH1,                                        /*!< DMA Channel 1 */
+    DMA_CH2,                                        /*!< DMA Channel 2 */
+    DMA_CH3,                                        /*!< DMA Channel 3 */
+    DMA_CH4,                                        /*!< DMA Channel 4 */
+    DMA_CH5,                                        /*!< DMA Channel 5 */
+    DMA_CH6,                                        /*!< DMA Channel 6 */
+    DMA_CH7                                         /*!< DMA Channel 7 */
+} dma_channel_enum;
+
+/* DMA peripheral select */
+typedef enum 
+{
+    DMA_SUBPERI0 = 0,                               /*!< DMA Peripheral 0 */
+    DMA_SUBPERI1,                                   /*!< DMA Peripheral 1 */
+    DMA_SUBPERI2,                                   /*!< DMA Peripheral 2 */
+    DMA_SUBPERI3,                                   /*!< DMA Peripheral 3 */
+    DMA_SUBPERI4,                                   /*!< DMA Peripheral 4 */
+    DMA_SUBPERI5,                                   /*!< DMA Peripheral 5 */
+    DMA_SUBPERI6,                                   /*!< DMA Peripheral 6 */
+    DMA_SUBPERI7                                    /*!< DMA Peripheral 7 */
+} dma_subperipheral_enum;
+
+/* DMA multidata mode initialize struct */
+typedef struct
+{
+    uint32_t periph_addr;                           /*!< peripheral base address */
+    uint32_t periph_width;                          /*!< transfer data size of peripheral */
+    uint32_t periph_inc;                            /*!< peripheral increasing mode */  
+
+    uint32_t memory0_addr;                          /*!< memory 0 base address */
+    uint32_t memory_width;                          /*!< transfer data size of memory */
+    uint32_t memory_inc;                            /*!< memory increasing mode */
+
+    uint32_t memory_burst_width;                    /*!< multi data mode enable */
+    uint32_t periph_burst_width;                    /*!< multi data mode enable */
+    uint32_t critical_value;                        /*!< FIFO critical */
+
+    uint32_t circular_mode;                         /*!< DMA circular mode */
+    uint32_t direction;                             /*!< channel data transfer direction */
+    uint32_t number;                                /*!< channel transfer number */
+    uint32_t priority;                              /*!< channel priority level */
+}dma_multi_data_parameter_struct;
+
+/* DMA singledata mode initialize struct */
+typedef struct
+{
+    uint32_t periph_addr;                           /*!< peripheral base address */
+    uint32_t periph_inc;                            /*!< peripheral increasing mode */  
+
+    uint32_t memory0_addr;                          /*!< memory 0 base address */
+    uint32_t memory_inc;                            /*!< memory increasing mode */
+
+    uint32_t periph_memory_width;                   /*!< transfer data size of peripheral */
+
+    uint32_t circular_mode;                         /*!< DMA circular mode */
+    uint32_t direction;                             /*!< channel data transfer direction */
+    uint32_t number;                                /*!< channel transfer number */
+    uint32_t priority;                              /*!< channel priority level */
+} dma_single_data_parameter_struct;
+
+#define DMA_FLAG_ADD(flag,channel)        ((uint32_t)((flag)<<((((uint32_t)(channel)*6U))+((uint32_t)(((uint32_t)(channel)) >> 1U)&0x01U)*4U)))   /*!< DMA channel flag shift */
+
+/* DMA_register address */
+#define DMA_CHCTL(dma,channel)            REG32(((dma) + 0x10U) + 0x18U*(channel))  /*!< the address of DMA channel CHXCTL register  */
+#define DMA_CHCNT(dma,channel)            REG32(((dma) + 0x14U) + 0x18U*(channel))  /*!< the address of DMA channel CHXCNT register */
+#define DMA_CHPADDR(dma,channel)          REG32(((dma) + 0x18U) + 0x18U*(channel))  /*!< the address of DMA channel CHXPADDR register */
+#define DMA_CHM0ADDR(dma,channel)         REG32(((dma) + 0x1CU) + 0x18U*(channel))  /*!< the address of DMA channel CHXM0ADDR register */
+#define DMA_CHM1ADDR(dma,channel)         REG32(((dma) + 0x20U) + 0x18U*(channel))  /*!< the address of DMA channel CHXM1ADDR register */
+#define DMA_CHFCTL(dma,channel)           REG32(((dma) + 0x24U) + 0x18U*(channel))  /*!< the address of DMA channel CHXMADDR register */
+
+/* peripheral select */
+#define CHCTL_PERIEN(regval)              (BITS(25,27) & ((uint32_t)(regval) << 25))
+#define DMA_PERIPH_0_SELECT               CHCTL_PERIEN(0)                           /*!< peripheral 0 select */
+#define DMA_PERIPH_1_SELECT               CHCTL_PERIEN(1)                           /*!< peripheral 1 select */
+#define DMA_PERIPH_2_SELECT               CHCTL_PERIEN(2)                           /*!< peripheral 2 select */
+#define DMA_PERIPH_3_SELECT               CHCTL_PERIEN(3)                           /*!< peripheral 3 select */
+#define DMA_PERIPH_4_SELECT               CHCTL_PERIEN(4)                           /*!< peripheral 4 select */
+#define DMA_PERIPH_5_SELECT               CHCTL_PERIEN(5)                           /*!< peripheral 5 select */
+#define DMA_PERIPH_6_SELECT               CHCTL_PERIEN(6)                           /*!< peripheral 6 select */
+#define DMA_PERIPH_7_SELECT               CHCTL_PERIEN(7)                           /*!< peripheral 7 select */
+
+/* burst type of memory */
+#define CHCTL_MBURST(regval)              (BITS(23,24) & ((uint32_t)(regval) << 23))
+#define DMA_MEMORY_BURST_SINGLE           CHCTL_MBURST(0)                           /*!< single burst */
+#define DMA_MEMORY_BURST_4_BEAT           CHCTL_MBURST(1)                           /*!< 4-beat burst */
+#define DMA_MEMORY_BURST_8_BEAT           CHCTL_MBURST(2)                           /*!< 8-beat burst */
+#define DMA_MEMORY_BURST_16_BEAT          CHCTL_MBURST(3)                           /*!< 16-beat burst */
+
+/* burst type of peripheral */
+#define CHCTL_PBURST(regval)              (BITS(21,22) & ((uint32_t)(regval) << 21))
+#define DMA_PERIPH_BURST_SINGLE           CHCTL_PBURST(0)                           /*!< single burst */
+#define DMA_PERIPH_BURST_4_BEAT           CHCTL_PBURST(1)                           /*!< 4-beat burst */
+#define DMA_PERIPH_BURST_8_BEAT           CHCTL_PBURST(2)                           /*!< 8-beat burst */
+#define DMA_PERIPH_BURST_16_BEAT          CHCTL_PBURST(3)                           /*!< 16-beat burst */
+
+/* channel priority level */
+#define CHCTL_PRIO(regval)                (BITS(16,17) & ((uint32_t)(regval) << 16))
+#define DMA_PRIORITY_LOW                  CHCTL_PRIO(0)                             /*!< low priority */
+#define DMA_PRIORITY_MEDIUM               CHCTL_PRIO(1)                             /*!< medium priority */
+#define DMA_PRIORITY_HIGH                 CHCTL_PRIO(2)                             /*!< high priority */
+#define DMA_PRIORITY_ULTRA_HIGH           CHCTL_PRIO(3)                             /*!< ultra high priority */
+
+/* transfer data width of memory */
+#define CHCTL_MWIDTH(regval)              (BITS(13,14) & ((uint32_t)(regval) << 13))
+#define DMA_MEMORY_WIDTH_8BIT             CHCTL_MWIDTH(0)                           /*!< transfer data width of memory is 8-bit */
+#define DMA_MEMORY_WIDTH_16BIT            CHCTL_MWIDTH(1)                           /*!< transfer data width of memory is 16-bit */
+#define DMA_MEMORY_WIDTH_32BIT            CHCTL_MWIDTH(2)                           /*!< transfer data width of memory is 32-bit */
+
+/* transfer data width of peripheral */
+#define CHCTL_PWIDTH(regval)              (BITS(11,12) & ((uint32_t)(regval) << 11))
+#define DMA_PERIPH_WIDTH_8BIT             CHCTL_PWIDTH(0)                           /*!< transfer data width of peripheral is 8-bit */
+#define DMA_PERIPH_WIDTH_16BIT            CHCTL_PWIDTH(1)                           /*!< transfer data width of peripheral is 16-bit */
+#define DMA_PERIPH_WIDTH_32BIT            CHCTL_PWIDTH(2)                           /*!< transfer data width of peripheral is 32-bit */
+
+/* channel transfer mode */
+#define CHCTL_TM(regval)                  (BITS(6,7) & ((uint32_t)(regval) << 6))
+#define DMA_PERIPH_TO_MEMORY              CHCTL_TM(0)                               /*!< read from peripheral and write to memory */
+#define DMA_MEMORY_TO_PERIPH              CHCTL_TM(1)                               /*!< read from memory and write to peripheral */
+#define DMA_MEMORY_TO_MEMORY              CHCTL_TM(2)                               /*!< read from memory and write to memory */
+
+/* FIFO counter critical value */
+#define CHFCTL_FCCV(regval)               (BITS(0,1) & ((uint32_t)(regval) << 0))
+#define DMA_FIFO_1_WORD                   CHFCTL_FCCV(0)                            /*!< critical value 1 word */
+#define DMA_FIFO_2_WORD                   CHFCTL_FCCV(1)                            /*!< critical value 2 word */
+#define DMA_FIFO_3_WORD                   CHFCTL_FCCV(2)                            /*!< critical value 3 word */
+#define DMA_FIFO_4_WORD                   CHFCTL_FCCV(3)                            /*!< critical value 4 word */
+
+/* memory select */
+#define DMA_MEMORY_0                      ((uint32_t)0x00000000U)                   /*!< select memory 0 */
+#define DMA_MEMORY_1                      ((uint32_t)0x00000001U)                   /*!< select memory 1 */
+
+/* DMA circular mode */
+#define DMA_CIRCULAR_MODE_ENABLE          ((uint32_t)0x00000000U)                   /*!< circular mode enable */
+#define DMA_CIRCULAR_MODE_DISABLE         ((uint32_t)0x00000001U)                   /*!< circular mode disable */
+
+/* DMA flow controller select */
+#define DMA_FLOW_CONTROLLER_DMA           ((uint32_t)0x00000000U)                   /*!< DMA is the flow controler */
+#define DMA_FLOW_CONTROLLER_PERI          ((uint32_t)0x00000001U)                   /*!< peripheral is the flow controler */
+
+/* peripheral increasing mode */
+#define DMA_PERIPH_INCREASE_ENABLE        ((uint32_t)0x00000000U)                   /*!< next address of peripheral is increasing address mode */
+#define DMA_PERIPH_INCREASE_DISABLE       ((uint32_t)0x00000001U)                   /*!< next address of peripheral is fixed address mode */
+#define DMA_PERIPH_INCREASE_FIX           ((uint32_t)0x00000002U)                   /*!< next address of peripheral is increasing fixed */
+
+/* memory increasing mode */
+#define DMA_MEMORY_INCREASE_ENABLE        ((uint32_t)0x00000000U)                   /*!< next address of memory is increasing address mode */
+#define DMA_MEMORY_INCREASE_DISABLE       ((uint32_t)0x00000001U)                   /*!< next address of memory is fixed address mode */
+
+/* FIFO status */
+#define DMA_FIFO_STATUS_NODATA            ((uint32_t)0x00000000U)                   /*!< the data in the FIFO less than 1 word */
+#define DMA_FIFO_STATUS_1_WORD            ((uint32_t)0x00000001U)                   /*!< the data in the FIFO more than 1 word, less than 2 words */
+#define DMA_FIFO_STATUS_2_WORD            ((uint32_t)0x00000002U)                   /*!< the data in the FIFO more than 2 word, less than 3 words */
+#define DMA_FIFO_STATUS_3_WORD            ((uint32_t)0x00000003U)                   /*!< the data in the FIFO more than 3 word, less than 4 words */
+#define DMA_FIFO_STATUS_EMPTY             ((uint32_t)0x00000004U)                   /*!< the data in the FIFO is empty */
+#define DMA_FIFO_STATUS_FULL              ((uint32_t)0x00000005U)                   /*!< the data in the FIFO is full */
+
+/* DMA reset value */
+#define DMA_CHCTL_RESET_VALUE             ((uint32_t)0x00000000U)                   /*!< the reset value of DMA channel CHXCTL register */
+#define DMA_CHCNT_RESET_VALUE             ((uint32_t)0x00000000U)                   /*!< the reset value of DMA channel CHXCNT register */
+#define DMA_CHPADDR_RESET_VALUE           ((uint32_t)0x00000000U)                   /*!< the reset value of DMA channel CHXPADDR register */
+#define DMA_CHMADDR_RESET_VALUE           ((uint32_t)0x00000000U)                   /*!< the reset value of DMA channel CHXMADDR register */
+#define DMA_CHINTF_RESET_VALUE            ((uint32_t)0x0000003DU)                   /*!< clear DMA channel CHXINTFS register */
+#define DMA_CHFCTL_RESET_VALUE            ((uint32_t)0x00000000U)                   /*!< the reset value of DMA channel CHXFCTL register */
+
+/* DMA_INTF register */
+/* interrupt flag bits */
+#define DMA_INT_FLAG_FEE                  DMA_INTF_FEEIF                            /*!< FIFO error and exception flag */
+#define DMA_INT_FLAG_SDE                  DMA_INTF_SDEIF                            /*!< single data mode exception flag */
+#define DMA_INT_FLAG_TAE                  DMA_INTF_TAEIF                            /*!< transfer access error flag */
+#define DMA_INT_FLAG_HTF                  DMA_INTF_HTFIF                            /*!< half transfer finish flag */
+#define DMA_INT_FLAG_FTF                  DMA_INTF_FTFIF                            /*!< full transfer finish flag */
+
+/* flag bits */
+#define DMA_FLAG_FEE                      DMA_INTF_FEEIF                            /*!< FIFO error and exception flag */
+#define DMA_FLAG_SDE                      DMA_INTF_SDEIF                            /*!< single data mode exception flag */
+#define DMA_FLAG_TAE                      DMA_INTF_TAEIF                            /*!< transfer access error flag */
+#define DMA_FLAG_HTF                      DMA_INTF_HTFIF                            /*!< half transfer finish flag */
+#define DMA_FLAG_FTF                      DMA_INTF_FTFIF                            /*!< full transfer finish flag */
+
+
+/* function declarations */
+/* DMA deinitialization and initialization functions */
+/* deinitialize DMA a channel registers */
+void dma_deinit(uint32_t dma_periph, dma_channel_enum channelx);
+/* initialize the DMA single data mode parameters struct with the default values */
+void dma_single_data_para_struct_init(dma_single_data_parameter_struct* init_struct);
+/* initialize the DMA multi data mode parameters struct with the default values */
+void dma_multi_data_para_struct_init(dma_multi_data_parameter_struct* init_struct);
+/* DMA single data mode initialize */
+void dma_single_data_mode_init(uint32_t dma_periph, dma_channel_enum channelx, dma_single_data_parameter_struct* init_struct);
+/* DMA multi data mode initialize */
+void dma_multi_data_mode_init(uint32_t dma_periph, dma_channel_enum channelx, dma_multi_data_parameter_struct* init_struct);
+
+/* DMA configuration functions */
+/* set DMA peripheral base address */
+void dma_periph_address_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t address);
+/* set DMA Memory base address */
+void dma_memory_address_config(uint32_t dma_periph, dma_channel_enum channelx, uint8_t memory_flag, uint32_t address);
+
+/* set the number of remaining data to be transferred by the DMA */
+void dma_transfer_number_config(uint32_t dma_periph,dma_channel_enum channelx, uint32_t number);
+/* get the number of remaining data to be transferred by the DMA */
+uint32_t dma_transfer_number_get(uint32_t dma_periph, dma_channel_enum channelx);
+
+/* configure priority level of DMA channel */
+void dma_priority_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t priority);
+
+/* configure transfer burst beats of memory */
+void dma_memory_burst_beats_config (uint32_t dma_periph, dma_channel_enum channelx, uint32_t mbeat);
+/* configure transfer burst beats of peripheral */
+void dma_periph_burst_beats_config (uint32_t dma_periph, dma_channel_enum channelx, uint32_t pbeat);
+/* configure transfer data size of memory */
+void dma_memory_width_config (uint32_t dma_periph, dma_channel_enum channelx, uint32_t msize);
+/* configure transfer data size of peripheral */
+void dma_periph_width_config (uint32_t dma_periph, dma_channel_enum channelx, uint32_t psize);
+
+/* configure next address increasement algorithm of memory */
+void dma_memory_address_generation_config(uint32_t dma_periph, dma_channel_enum channelx, uint8_t generation_algorithm);
+/* configure next address increasement algorithm of peripheral */
+void dma_peripheral_address_generation_config(uint32_t dma_periph, dma_channel_enum channelx, uint8_t generation_algorithm);
+
+/* enable DMA circulation mode */
+void dma_circulation_enable(uint32_t dma_periph, dma_channel_enum channelx);
+/* disable DMA circulation mode */
+void dma_circulation_disable(uint32_t dma_periph, dma_channel_enum channelx);
+/* enable DMA channel */
+void dma_channel_enable(uint32_t dma_periph, dma_channel_enum channelx);
+/* disable DMA channel */
+void dma_channel_disable(uint32_t dma_periph, dma_channel_enum channelx);
+
+/* configure the direction of data transfer on the channel */
+void dma_transfer_direction_config(uint32_t dma_periph, dma_channel_enum channelx, uint8_t direction);
+
+/* DMA switch buffer mode config */
+void dma_switch_buffer_mode_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t memory1_addr, uint32_t memory_select);
+/* DMA using memory get */
+uint32_t dma_using_memory_get(uint32_t dma_periph, dma_channel_enum channelx);
+
+/* DMA channel peripheral select */
+void dma_channel_subperipheral_select(uint32_t dma_periph, dma_channel_enum channelx, dma_subperipheral_enum sub_periph);
+/* DMA flow controller configure */
+void dma_flow_controller_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t controller);
+/* DMA flow controller enable */
+void dma_switch_buffer_mode_enable(uint32_t dma_periph, dma_channel_enum channelx, ControlStatus newvalue);
+/* DMA FIFO status get */
+uint32_t dma_fifo_status_get(uint32_t dma_periph, dma_channel_enum channelx);
+
+/* flag and interrupt functions */
+/* check DMA flag is set or not */
+FlagStatus dma_flag_get(uint32_t dma_periph, dma_channel_enum channelx, uint32_t flag);
+/* clear DMA a channel flag */
+void dma_flag_clear(uint32_t dma_periph, dma_channel_enum channelx, uint32_t flag);
+/* enable DMA interrupt */
+void dma_interrupt_enable(uint32_t dma_periph, dma_channel_enum channelx, uint32_t source);
+/* disable DMA interrupt */
+void dma_interrupt_disable(uint32_t dma_periph, dma_channel_enum channelx, uint32_t source);
+/* check DMA flag is set or not */
+FlagStatus dma_interrupt_flag_get(uint32_t dma_periph, dma_channel_enum channelx, uint32_t interrupt);
+/* clear DMA a channel flag */
+void dma_interrupt_flag_clear(uint32_t dma_periph, dma_channel_enum channelx, uint32_t interrupt);
+
+#endif /* GD32F4XX_DMA_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_enet.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_enet.h
@@ -1,0 +1,1681 @@
+/*!
+    \file    gd32f4xx_enet.h
+    \brief   definitions for the ENET
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_ENET_H
+#define GD32F4XX_ENET_H
+
+#include "gd32f4xx.h"
+#include <stdlib.h>
+
+#define IF_USE_EXTERNPHY_LIB             0
+#if (1 == IF_USE_EXTERNPHY_LIB)
+#include "phy.h"
+#endif
+
+#ifndef ENET_RXBUF_NUM
+#define ENET_RXBUF_NUM                   5U                                     /*!< ethernet Rx DMA descriptor number */
+#endif
+
+#ifndef ENET_TXBUF_NUM
+#define ENET_TXBUF_NUM                   5U                                     /*!< ethernet Tx DMA descriptor number */
+#endif
+
+#ifndef ENET_RXBUF_SIZE
+#define ENET_RXBUF_SIZE                  ENET_MAX_FRAME_SIZE                    /*!< ethernet receive buffer size */
+#endif
+
+#ifndef ENET_TXBUF_SIZE
+#define ENET_TXBUF_SIZE                  ENET_MAX_FRAME_SIZE                    /*!< ethernet transmit buffer size */
+#endif
+
+//#define SELECT_DESCRIPTORS_ENHANCED_MODE 
+
+//#define USE_DELAY
+
+#ifndef _PHY_H_
+#define DP83848                          0
+#define LAN8700                          1
+#define PHY_TYPE                         DP83848
+
+#define PHY_ADDRESS                      ((uint16_t)1U)                         /*!< phy address determined by the hardware */
+
+/* PHY read write timeouts */ 
+#define PHY_READ_TO                      ((uint32_t)0x0004FFFFU)                /*!< PHY read timeout */
+#define PHY_WRITE_TO                     ((uint32_t)0x0004FFFFU)                /*!< PHY write timeout */
+
+/* PHY delay */
+#define PHY_RESETDELAY                   ((uint32_t)0x008FFFFFU)                /*!< PHY reset delay */
+#define PHY_CONFIGDELAY                  ((uint32_t)0x00FFFFFFU)                /*!< PHY configure delay */
+
+/* PHY register address */ 
+#define PHY_REG_BCR                      0U                                     /*!< tranceiver basic control register */
+#define PHY_REG_BSR                      1U                                     /*!< tranceiver basic status register */
+
+/* PHY basic control register */
+#define PHY_RESET                        ((uint16_t)0x8000)                     /*!< PHY reset */
+#define PHY_LOOPBACK                     ((uint16_t)0x4000)                     /*!< enable phy loop-back mode */
+#define PHY_FULLDUPLEX_100M              ((uint16_t)0x2100)                     /*!< configure speed to 100 Mbit/s and the full-duplex mode */
+#define PHY_HALFDUPLEX_100M              ((uint16_t)0x2000)                     /*!< configure speed to 100 Mbit/s and the half-duplex mode */
+#define PHY_FULLDUPLEX_10M               ((uint16_t)0x0100)                     /*!< configure speed to 10 Mbit/s and the full-duplex mode */
+#define PHY_HALFDUPLEX_10M               ((uint16_t)0x0000)                     /*!< configure speed to 10 Mbit/s and the half-duplex mode */
+#define PHY_AUTONEGOTIATION              ((uint16_t)0x1000)                     /*!< enable auto-negotiation function */
+#define PHY_RESTART_AUTONEGOTIATION      ((uint16_t)0x0200)                     /*!< restart auto-negotiation function */
+#define PHY_POWERDOWN                    ((uint16_t)0x0800)                     /*!< enable the power down mode */
+#define PHY_ISOLATE                      ((uint16_t)0x0400)                     /*!< isolate PHY from MII */
+
+/* PHY basic status register */
+#define PHY_AUTONEGO_COMPLETE            ((uint16_t)0x0020)                     /*!< auto-negotioation process completed */
+#define PHY_LINKED_STATUS                ((uint16_t)0x0004)                     /*!< valid link established */
+#define PHY_JABBER_DETECTION             ((uint16_t)0x0002)                     /*!< jabber condition detected */
+
+#if(PHY_TYPE == LAN8700) 
+#define PHY_SR                           31U                                    /*!< tranceiver status register */
+#define PHY_SPEED_STATUS                 ((uint16_t)0x0004)                     /*!< configured information of speed: 10Mbit/s */
+#define PHY_DUPLEX_STATUS                ((uint16_t)0x0010)                     /*!< configured information of duplex: full-duplex */
+#elif(PHY_TYPE == DP83848)
+#define PHY_SR                           16U                                    /*!< tranceiver status register */
+#define PHY_SPEED_STATUS                 ((uint16_t)0x0002)                     /*!< configured information of speed: 10Mbit/s */
+#define PHY_DUPLEX_STATUS                ((uint16_t)0x0004)                     /*!< configured information of duplex: full-duplex */
+#endif /* PHY_TYPE */
+
+#endif /* _PHY_H_ */
+
+
+/* ENET definitions */
+#define ENET                             ENET_BASE
+
+/* registers definitions */
+#define ENET_MAC_CFG                     REG32((ENET) + 0x0000U)                  /*!< ethernet MAC configuration register */
+#define ENET_MAC_FRMF                    REG32((ENET) + 0x0004U)                  /*!< ethernet MAC frame filter register */
+#define ENET_MAC_HLH                     REG32((ENET) + 0x0008U)                  /*!< ethernet MAC hash list high register */
+#define ENET_MAC_HLL                     REG32((ENET) + 0x000CU)                  /*!< ethernet MAC hash list low register */
+#define ENET_MAC_PHY_CTL                 REG32((ENET) + 0x0010U)                  /*!< ethernet MAC PHY control register */
+#define ENET_MAC_PHY_DATA                REG32((ENET) + 0x0014U)                  /*!< ethernet MAC PHY data register */
+#define ENET_MAC_FCTL                    REG32((ENET) + 0x0018U)                  /*!< ethernet MAC flow control register */
+#define ENET_MAC_VLT                     REG32((ENET) + 0x001CU)                  /*!< ethernet MAC VLAN tag register */
+#define ENET_MAC_RWFF                    REG32((ENET) + 0x0028U)                  /*!< ethernet MAC remote wakeup frame filter register */
+#define ENET_MAC_WUM                     REG32((ENET) + 0x002CU)                  /*!< ethernet MAC wakeup management register */
+#define ENET_MAC_DBG                     REG32((ENET) + 0x0034U)                  /*!< ethernet MAC debug register */
+#define ENET_MAC_INTF                    REG32((ENET) + 0x0038U)                  /*!< ethernet MAC interrupt flag register */
+#define ENET_MAC_INTMSK                  REG32((ENET) + 0x003CU)                  /*!< ethernet MAC interrupt mask register */
+#define ENET_MAC_ADDR0H                  REG32((ENET) + 0x0040U)                  /*!< ethernet MAC address 0 high register */
+#define ENET_MAC_ADDR0L                  REG32((ENET) + 0x0044U)                  /*!< ethernet MAC address 0 low register */
+#define ENET_MAC_ADDR1H                  REG32((ENET) + 0x0048U)                  /*!< ethernet MAC address 1 high register */
+#define ENET_MAC_ADDR1L                  REG32((ENET) + 0x004CU)                  /*!< ethernet MAC address 1 low register */
+#define ENET_MAC_ADDT2H                  REG32((ENET) + 0x0050U)                  /*!< ethernet MAC address 2 high register */
+#define ENET_MAC_ADDR2L                  REG32((ENET) + 0x0054U)                  /*!< ethernet MAC address 2 low register */
+#define ENET_MAC_ADDR3H                  REG32((ENET) + 0x0058U)                  /*!< ethernet MAC address 3 high register */
+#define ENET_MAC_ADDR3L                  REG32((ENET) + 0x005CU)                  /*!< ethernet MAC address 3 low register */
+#define ENET_MAC_FCTH                    REG32((ENET) + 0x1080U)                /*!< ethernet MAC flow control threshold register */
+
+#define ENET_MSC_CTL                     REG32((ENET) + 0x0100U)                 /*!< ethernet MSC control register */
+#define ENET_MSC_RINTF                   REG32((ENET) + 0x0104U)                 /*!< ethernet MSC receive interrupt flag register */
+#define ENET_MSC_TINTF                   REG32((ENET) + 0x0108U)                 /*!< ethernet MSC transmit interrupt flag register */
+#define ENET_MSC_RINTMSK                 REG32((ENET) + 0x010CU)                 /*!< ethernet MSC receive interrupt mask register */
+#define ENET_MSC_TINTMSK                 REG32((ENET) + 0x0110U)                 /*!< ethernet MSC transmit interrupt mask register */
+#define ENET_MSC_SCCNT                   REG32((ENET) + 0x014CU)                 /*!< ethernet MSC transmitted good frames after a single collision counter register */
+#define ENET_MSC_MSCCNT                  REG32((ENET) + 0x0150U)                 /*!< ethernet MSC transmitted good frames after more than a single collision counter register */
+#define ENET_MSC_TGFCNT                  REG32((ENET) + 0x0168U)                 /*!< ethernet MSC transmitted good frames counter register */
+#define ENET_MSC_RFCECNT                 REG32((ENET) + 0x0194U)                 /*!< ethernet MSC received frames with CRC error counter register */
+#define ENET_MSC_RFAECNT                 REG32((ENET) + 0x0198U)                 /*!< ethernet MSC received frames with alignment error counter register */
+#define ENET_MSC_RGUFCNT                 REG32((ENET) + 0x01C4U)                 /*!< ethernet MSC received good unicast frames counter register */
+
+#define ENET_PTP_TSCTL                   REG32((ENET) + 0x0700U)                 /*!< ethernet PTP time stamp control register */
+#define ENET_PTP_SSINC                   REG32((ENET) + 0x0704U)                 /*!< ethernet PTP subsecond increment register */ 
+#define ENET_PTP_TSH                     REG32((ENET) + 0x0708U)                 /*!< ethernet PTP time stamp high register */
+#define ENET_PTP_TSL                     REG32((ENET) + 0x070CU)                 /*!< ethernet PTP time stamp low register */
+#define ENET_PTP_TSUH                    REG32((ENET) + 0x0710U)                 /*!< ethernet PTP time stamp update high register */
+#define ENET_PTP_TSUL                    REG32((ENET) + 0x0714U)                 /*!< ethernet PTP time stamp update low register */
+#define ENET_PTP_TSADDEND                REG32((ENET) + 0x0718U)                 /*!< ethernet PTP time stamp addend register */
+#define ENET_PTP_ETH                     REG32((ENET) + 0x071CU)                 /*!< ethernet PTP expected time high register */
+#define ENET_PTP_ETL                     REG32((ENET) + 0x0720U)                 /*!< ethernet PTP expected time low register */
+#define ENET_PTP_TSF                     REG32((ENET) + 0x0728U)                 /*!< ethernet PTP time stamp flag register */
+#define ENET_PTP_PPSCTL                  REG32((ENET) + 0x072CU)                 /*!< ethernet PTP PPS control register */
+
+#define ENET_DMA_BCTL                    REG32((ENET) + 0x1000U)                /*!< ethernet DMA bus control register */
+#define ENET_DMA_TPEN                    REG32((ENET) + 0x1004U)                /*!< ethernet DMA transmit poll enable register */ 
+#define ENET_DMA_RPEN                    REG32((ENET) + 0x1008U)                /*!< ethernet DMA receive poll enable register */
+#define ENET_DMA_RDTADDR                 REG32((ENET) + 0x100CU)                /*!< ethernet DMA receive descriptor table address register */
+#define ENET_DMA_TDTADDR                 REG32((ENET) + 0x1010U)                /*!< ethernet DMA transmit descriptor table address register */
+#define ENET_DMA_STAT                    REG32((ENET) + 0x1014U)                /*!< ethernet DMA status register */
+#define ENET_DMA_CTL                     REG32((ENET) + 0x1018U)                /*!< ethernet DMA control register */
+#define ENET_DMA_INTEN                   REG32((ENET) + 0x101CU)                /*!< ethernet DMA interrupt enable register */
+#define ENET_DMA_MFBOCNT                 REG32((ENET) + 0x1020U)                /*!< ethernet DMA missed frame and buffer overflow counter register */
+#define ENET_DMA_RSWDC                   REG32((ENET) + 0x1024U)                /*!< ethernet DMA receive state watchdog counter register */
+#define ENET_DMA_CTDADDR                 REG32((ENET) + 0x1048U)                /*!< ethernet DMA current transmit descriptor address register */ 
+#define ENET_DMA_CRDADDR                 REG32((ENET) + 0x104CU)                /*!< ethernet DMA current receive descriptor address register */
+#define ENET_DMA_CTBADDR                 REG32((ENET) + 0x1050U)                /*!< ethernet DMA current transmit buffer address register */
+#define ENET_DMA_CRBADDR                 REG32((ENET) + 0x1054U)                /*!< ethernet DMA current receive buffer address register */
+
+/* bits definitions */
+/* ENET_MAC_CFG */
+#define ENET_MAC_CFG_REN                 BIT(2)                                 /*!< receiver enable */
+#define ENET_MAC_CFG_TEN                 BIT(3)                                 /*!< transmitter enable */
+#define ENET_MAC_CFG_DFC                 BIT(4)                                 /*!< defferal check */
+#define ENET_MAC_CFG_BOL                 BITS(5,6)                              /*!< back-off limit */
+#define ENET_MAC_CFG_APCD                BIT(7)                                 /*!< automatic pad/CRC drop */
+#define ENET_MAC_CFG_RTD                 BIT(9)                                 /*!< retry disable */
+#define ENET_MAC_CFG_IPFCO               BIT(10)                                /*!< IP frame checksum offload */
+#define ENET_MAC_CFG_DPM                 BIT(11)                                /*!< duplex mode */
+#define ENET_MAC_CFG_LBM                 BIT(12)                                /*!< loopback mode */
+#define ENET_MAC_CFG_ROD                 BIT(13)                                /*!< receive own disable */
+#define ENET_MAC_CFG_SPD                 BIT(14)                                /*!< fast eneternet speed */
+#define ENET_MAC_CFG_CSD                 BIT(16)                                /*!< carrier sense disable */
+#define ENET_MAC_CFG_IGBS                BITS(17,19)                            /*!< inter-frame gap bit selection */            
+#define ENET_MAC_CFG_JBD                 BIT(22)                                /*!< jabber disable */
+#define ENET_MAC_CFG_WDD                 BIT(23)                                /*!< watchdog disable */
+#define ENET_MAC_CFG_TFCD                BIT(25)                                /*!< type frame CRC dropping */
+
+/* ENET_MAC_FRMF */
+#define ENET_MAC_FRMF_PM                 BIT(0)                                 /*!< promiscuous mode */
+#define ENET_MAC_FRMF_HUF                BIT(1)                                 /*!< hash unicast filter */
+#define ENET_MAC_FRMF_HMF                BIT(2)                                 /*!< hash multicast filter */ 
+#define ENET_MAC_FRMF_DAIFLT             BIT(3)                                 /*!< destination address inverse filtering enable */ 
+#define ENET_MAC_FRMF_MFD                BIT(4)                                 /*!< multicast filter disable */ 
+#define ENET_MAC_FRMF_BFRMD              BIT(5)                                 /*!< broadcast frame disable */ 
+#define ENET_MAC_FRMF_PCFRM              BITS(6,7)                              /*!< pass control frames */ 
+#define ENET_MAC_FRMF_SAIFLT             BIT(8)                                 /*!< source address inverse filtering */ 
+#define ENET_MAC_FRMF_SAFLT              BIT(9)                                 /*!< source address filter */ 
+#define ENET_MAC_FRMF_HPFLT              BIT(10)                                /*!< hash or perfect filter */ 
+#define ENET_MAC_FRMF_FAR                BIT(31)                                /*!< frames all receive */ 
+  
+/* ENET_MAC_HLH */
+#define ENET_MAC_HLH_HLH                 BITS(0,31)                             /*!< hash list high */
+  
+/* ENET_MAC_HLL */
+#define ENET_MAC_HLL_HLL                 BITS(0,31)                             /*!< hash list low */
+  
+/* ENET_MAC_PHY_CTL */
+#define ENET_MAC_PHY_CTL_PB              BIT(0)                                 /*!< PHY busy */ 
+#define ENET_MAC_PHY_CTL_PW              BIT(1)                                 /*!< PHY write */ 
+#define ENET_MAC_PHY_CTL_CLR             BITS(2,4)                              /*!< clock range */ 
+#define ENET_MAC_PHY_CTL_PR              BITS(6,10)                             /*!< PHY register */ 
+#define ENET_MAC_PHY_CTL_PA              BITS(11,15)                            /*!< PHY address */ 
+    
+/* ENET_MAC_PHY_DATA */
+#define ENET_MAC_PHY_DATA_PD             BITS(0,15)                             /*!< PHY data */
+  
+/* ENET_MAC_FCTL */
+#define ENET_MAC_FCTL_FLCBBKPA           BIT(0)                                 /*!< flow control busy(in full duplex mode)/backpressure activate(in half duplex mode) */
+#define ENET_MAC_FCTL_TFCEN              BIT(1)                                 /*!< transmit flow control enable */
+#define ENET_MAC_FCTL_RFCEN              BIT(2)                                 /*!< receive flow control enable */
+#define ENET_MAC_FCTL_UPFDT              BIT(3)                                 /*!< unicast pause frame detect */
+#define ENET_MAC_FCTL_PLTS               BITS(4,5)                              /*!< pause low threshold */     
+#define ENET_MAC_FCTL_DZQP               BIT(7)                                 /*!< disable zero-quanta pause */
+#define ENET_MAC_FCTL_PTM                BITS(16,31)                            /*!< pause time */
+  
+/* ENET_MAC_VLT */
+#define ENET_MAC_VLT_VLTI                BITS(0,15)                             /*!< VLAN tag identifier(for receive frames) */
+#define ENET_MAC_VLT_VLTC                BIT(16)                                /*!< 12-bit VLAN tag comparison */
+  
+/* ENET_MAC_RWFF */
+#define ENET_MAC_RWFF_DATA               BITS(0,31)                             /*!< wakeup frame filter register data */
+  
+/* ENET_MAC_WUM */ 
+#define ENET_MAC_WUM_PWD                 BIT(0)                                 /*!< power down */
+#define ENET_MAC_WUM_MPEN                BIT(1)                                 /*!< magic packet enable */
+#define ENET_MAC_WUM_WFEN                BIT(2)                                 /*!< wakeup frame enable */
+#define ENET_MAC_WUM_MPKR                BIT(5)                                 /*!< magic packet received */
+#define ENET_MAC_WUM_WUFR                BIT(6)                                 /*!< wakeup frame received */
+#define ENET_MAC_WUM_GU                  BIT(9)                                 /*!< global unicast */
+#define ENET_MAC_WUM_WUFFRPR             BIT(31)                                /*!< wakeup frame filter register pointer reset */
+
+/* ENET_MAC_DBG */ 
+#define ENET_MAC_DBG_MRNI                BIT(0)                                 /*!< MAC receive state not idle */
+#define ENET_MAC_DBG_RXAFS               BITS(1,2)                              /*!< Rx asynchronous FIFO status */
+#define ENET_MAC_DBG_RXFW                BIT(4)                                 /*!< RxFIFO is writing */
+#define ENET_MAC_DBG_RXFRS               BITS(5,6)                              /*!< RxFIFO read operation status */
+#define ENET_MAC_DBG_RXFS                BITS(8,9)                              /*!< RxFIFO state */
+#define ENET_MAC_DBG_MTNI                BIT(16)                                /*!< MAC transmit state not idle */
+#define ENET_MAC_DBG_SOMT                BITS(17,18)                            /*!< status of mac transmitter */
+#define ENET_MAC_DBG_PCS                 BIT(19)                                /*!< pause condition status */
+#define ENET_MAC_DBG_TXFRS               BITS(20,21)                            /*!< TxFIFO read operation status */
+#define ENET_MAC_DBG_TXFW                BIT(22)                                /*!< TxFIFO is writing */
+#define ENET_MAC_DBG_TXFNE               BIT(24)                                /*!< TxFIFO not empty flag */
+#define ENET_MAC_DBG_TXFF                BIT(25)                                /*!< TxFIFO full flag */
+
+/* ENET_MAC_INTF */ 
+#define ENET_MAC_INTF_WUM                BIT(3)                                 /*!< WUM status */
+#define ENET_MAC_INTF_MSC                BIT(4)                                 /*!< MSC status */
+#define ENET_MAC_INTF_MSCR               BIT(5)                                 /*!< MSC receive status */
+#define ENET_MAC_INTF_MSCT               BIT(6)                                 /*!< MSC transmit status */
+#define ENET_MAC_INTF_TMST               BIT(9)                                 /*!< timestamp trigger status */
+
+/* ENET_MAC_INTMSK */
+#define ENET_MAC_INTMSK_WUMIM            BIT(3)                                 /*!< WUM interrupt mask */
+#define ENET_MAC_INTMSK_TMSTIM           BIT(9)                                 /*!< timestamp trigger interrupt mask */
+
+/* ENET_MAC_ADDR0H */
+#define ENET_MAC_ADDR0H_ADDR0H           BITS(0,15)                             /*!< MAC address0 high */
+#define ENET_MAC_ADDR0H_MO               BIT(31)                                /*!< always read 1 and must be kept */
+  
+/* ENET_MAC_ADDR0L */
+#define ENET_MAC_ADDR0L_ADDR0L           BITS(0,31)                             /*!< MAC address0 low */
+  
+/* ENET_MAC_ADDR1H */
+#define ENET_MAC_ADDR1H_ADDR1H           BITS(0,15)                             /*!< MAC address1 high */
+#define ENET_MAC_ADDR1H_MB               BITS(24,29)                            /*!< mask byte */ 
+#define ENET_MAC_ADDR1H_SAF              BIT(30)                                /*!< source address filter */
+#define ENET_MAC_ADDR1H_AFE              BIT(31)                                /*!< address filter enable */
+  
+/* ENET_MAC_ADDR1L */
+#define ENET_MAC_ADDR1L_ADDR1L           BITS(0,31)                             /*!< MAC address1 low */
+  
+/* ENET_MAC_ADDR2H */
+#define ENET_MAC_ADDR2H_ADDR2H           BITS(0,15)                             /*!< MAC address2 high */
+#define ENET_MAC_ADDR2H_MB               BITS(24,29)                            /*!< mask byte */
+#define ENET_MAC_ADDR2H_SAF              BIT(30)                                /*!< source address filter */
+#define ENET_MAC_ADDR2H_AFE              BIT(31)                                /*!< address filter enable */
+  
+/* ENET_MAC_ADDR2L */
+#define ENET_MAC_ADDR2L_ADDR2L           BITS(0,31)                             /*!< MAC address2 low */
+  
+/* ENET_MAC_ADDR3H */
+#define ENET_MAC_ADDR3H_ADDR3H           BITS(0,15)                             /*!< MAC address3 high */
+#define ENET_MAC_ADDR3H_MB               BITS(24,29)                            /*!< mask byte */
+#define ENET_MAC_ADDR3H_SAF              BIT(30)                                /*!< source address filter */
+#define ENET_MAC_ADDR3H_AFE              BIT(31)                                /*!< address filter enable */
+
+/* ENET_MAC_ADDR3L */
+#define ENET_MAC_ADDR3L_ADDR3L           BITS(0,31)                             /*!< MAC address3 low */
+  
+/* ENET_MAC_FCTH */
+#define ENET_MAC_FCTH_RFA                BITS(0,2)                              /*!< threshold of active flow control */
+#define ENET_MAC_FCTH_RFD                BITS(4,6)                              /*!< threshold of deactive flow control */
+ 
+/* ENET_MSC_CTL */
+#define ENET_MSC_CTL_CTR                 BIT(0)                                 /*!< counter reset */
+#define ENET_MSC_CTL_CTSR                BIT(1)                                 /*!< counter stop rollover */
+#define ENET_MSC_CTL_RTOR                BIT(2)                                 /*!< reset on read */
+#define ENET_MSC_CTL_MCFZ                BIT(3)                                 /*!< MSC counter freeze */
+#define ENET_MSC_CTL_PMC                 BIT(4)                                 /*!< preset MSC counter */
+#define ENET_MSC_CTL_AFHPM               BIT(5)                                 /*!< almost full or half preset mode */
+
+/* ENET_MSC_RINTF */
+#define ENET_MSC_RINTF_RFCE              BIT(5)                                 /*!< received frames CRC error */
+#define ENET_MSC_RINTF_RFAE              BIT(6)                                 /*!< received frames alignment error */
+#define ENET_MSC_RINTF_RGUF              BIT(17)                                /*!< receive good unicast frames */
+  
+/* ENET_MSC_TINTF */
+#define ENET_MSC_TINTF_TGFSC             BIT(14)                                /*!< transmitted good frames single collision */
+#define ENET_MSC_TINTF_TGFMSC            BIT(15)                                /*!< transmitted good frames more single collision */
+#define ENET_MSC_TINTF_TGF               BIT(21)                                /*!< transmitted good frames */
+
+/* ENET_MSC_RINTMSK */
+#define ENET_MSC_RINTMSK_RFCEIM          BIT(5)                                 /*!< received frame CRC error interrupt mask */
+#define ENET_MSC_RINTMSK_RFAEIM          BIT(6)                                 /*!< received frames alignment error interrupt mask */
+#define ENET_MSC_RINTMSK_RGUFIM          BIT(17)                                /*!< received good unicast frames interrupt mask */
+  
+/* ENET_MSC_TINTMSK */
+#define ENET_MSC_TINTMSK_TGFSCIM         BIT(14)                                /*!< transmitted good frames single collision interrupt mask */
+#define ENET_MSC_TINTMSK_TGFMSCIM        BIT(15)                                /*!< transmitted good frames more single collision interrupt mask */
+#define ENET_MSC_TINTMSK_TGFIM           BIT(21)                                /*!< transmitted good frames interrupt mask */
+  
+/* ENET_MSC_SCCNT */
+#define ENET_MSC_SCCNT_SCC               BITS(0,31)                             /*!< transmitted good frames single collision counter */
+  
+/* ENET_MSC_MSCCNT */
+#define ENET_MSC_MSCCNT_MSCC             BITS(0,31)                             /*!< transmitted good frames more one single collision counter */
+  
+/* ENET_MSC_TGFCNT */
+#define ENET_MSC_TGFCNT_TGF              BITS(0,31)                             /*!< transmitted good frames counter */
+  
+/* ENET_MSC_RFCECNT */
+#define ENET_MSC_RFCECNT_RFCER           BITS(0,31)                             /*!< received frames with CRC error counter */
+  
+/* ENET_MSC_RFAECNT */
+#define ENET_MSC_RFAECNT_RFAER           BITS(0,31)                             /*!< received frames alignment error counter */
+  
+/* ENET_MSC_RGUFCNT */
+#define ENET_MSC_RGUFCNT_RGUF            BITS(0,31)                             /*!< received good unicast frames counter */
+   
+/* ENET_PTP_TSCTL */
+#define PTP_TSCTL_CKNT(regval)           (BITS(16,17) & ((uint32_t)(regval) << 16))    /*!< write value to ENET_PTP_TSCTL_CKNT bit field */
+
+#define ENET_PTP_TSCTL_TMSEN             BIT(0)                                 /*!< timestamp enable */
+#define ENET_PTP_TSCTL_TMSFCU            BIT(1)                                 /*!< timestamp fine or coarse update */
+#define ENET_PTP_TSCTL_TMSSTI            BIT(2)                                 /*!< timestamp system time initialize */
+#define ENET_PTP_TSCTL_TMSSTU            BIT(3)                                 /*!< timestamp system time update */
+#define ENET_PTP_TSCTL_TMSITEN           BIT(4)                                 /*!< timestamp interrupt trigger enable */
+#define ENET_PTP_TSCTL_TMSARU            BIT(5)                                 /*!< timestamp addend register update */
+#define ENET_PTP_TSCTL_ARFSEN            BIT(8)                                 /*!< all received frames snapshot enable */
+#define ENET_PTP_TSCTL_SCROM             BIT(9)                                 /*!< subsecond counter rollover mode */
+#define ENET_PTP_TSCTL_PFSV              BIT(10)                                /*!< PTP frame snooping version */
+#define ENET_PTP_TSCTL_ESEN              BIT(11)                                /*!< received Ethernet snapshot enable */
+#define ENET_PTP_TSCTL_IP6SEN            BIT(12)                                /*!< received IPv6 snapshot enable */
+#define ENET_PTP_TSCTL_IP4SEN            BIT(13)                                /*!< received IPv4 snapshot enable */
+#define ENET_PTP_TSCTL_ETMSEN            BIT(14)                                /*!< received event type message snapshot enable */
+#define ENET_PTP_TSCTL_MNMSEN            BIT(15)                                /*!< received master node message snapshot enable */
+#define ENET_PTP_TSCTL_CKNT              BITS(16,17)                            /*!< clock node type for time stamp */
+#define ENET_PTP_TSCTL_MAFEN             BIT(18)                                /*!< MAC address filter enable for PTP frame */
+  
+/* ENET_PTP_SSINC */
+#define ENET_PTP_SSINC_STMSSI            BITS(0,7)                              /*!< system time subsecond increment */
+  
+/* ENET_PTP_TSH */
+#define ENET_PTP_TSH_STMS                BITS(0,31)                             /*!< system time second */
+  
+/* ENET_PTP_TSL */
+#define ENET_PTP_TSL_STMSS               BITS(0,30)                             /*!< system time subseconds */
+#define ENET_PTP_TSL_STS                 BIT(31)                                /*!< system time sign */
+  
+/* ENET_PTP_TSUH */
+#define ENET_PTP_TSUH_TMSUS              BITS(0,31)                             /*!< timestamp update seconds */
+  
+/* ENET_PTP_TSUL */
+#define ENET_PTP_TSUL_TMSUSS             BITS(0,30)                             /*!< timestamp update subseconds */
+#define ENET_PTP_TSUL_TMSUPNS            BIT(31)                                /*!< timestamp update positive or negative sign */
+
+/* ENET_PTP_TSADDAND */
+#define ENET_PTP_TSADDAND_TMSA           BITS(0,31)                             /*!< timestamp addend */
+  
+/* ENET_PTP_ETH */
+#define ENET_PTP_ETH_ETSH                BITS(0,31)                             /*!< expected time high */
+  
+/* ENET_PTP_ETL */
+#define ENET_PTP_ETL_ETSL                BITS(0,31)                             /*!< expected time low */
+  
+/* ENET_PTP_TSF */
+#define ENET_PTP_TSF_TSSCO               BIT(0)                                 /*!< timestamp second counter overflow */
+#define ENET_PTP_TSF_TTM                 BIT(1)                                 /*!< target time match */
+  
+/* ENET_PTP_PPSCTL */
+#define ENET_PTP_PPSCTL_PPSOFC           BITS(0,3)                              /*!< PPS output frequency configure */
+
+/* ENET_DMA_BCTL */
+#define ENET_DMA_BCTL_SWR                BIT(0)                                 /*!< software reset */
+#define ENET_DMA_BCTL_DAB                BIT(1)                                 /*!< DMA arbitration */
+#define ENET_DMA_BCTL_DPSL               BITS(2,6)                              /*!< descriptor skip length */
+#define ENET_DMA_BCTL_DFM                BIT(7)                                 /*!< descriptor format mode */
+#define ENET_DMA_BCTL_PGBL               BITS(8,13)                             /*!< programmable burst length */
+#define ENET_DMA_BCTL_RTPR               BITS(14,15)                            /*!< RxDMA and TxDMA transfer priority ratio */
+#define ENET_DMA_BCTL_FB                 BIT(16)                                /*!< fixed Burst */
+#define ENET_DMA_BCTL_RXDP               BITS(17,22)                            /*!< RxDMA PGBL */
+#define ENET_DMA_BCTL_UIP                BIT(23)                                /*!< use independent PGBL */
+#define ENET_DMA_BCTL_FPBL               BIT(24)                                /*!< four times PGBL mode */
+#define ENET_DMA_BCTL_AA                 BIT(25)                                /*!< address-aligned */
+#define ENET_DMA_BCTL_MB                 BIT(26)                                /*!< mixed burst */
+  
+/* ENET_DMA_TPEN */
+#define ENET_DMA_TPEN_TPE                BITS(0,31)                             /*!< transmit poll enable */
+  
+/* ENET_DMA_RPEN */
+#define ENET_DMA_RPEN_RPE                BITS(0,31)                             /*!< receive poll enable  */
+
+/* ENET_DMA_RDTADDR */
+#define ENET_DMA_RDTADDR_SRT             BITS(0,31)                             /*!< start address of receive table */
+  
+/* ENET_DMA_TDTADDR */
+#define ENET_DMA_TDTADDR_STT             BITS(0,31)                             /*!< start address of transmit table */
+  
+/* ENET_DMA_STAT */
+#define ENET_DMA_STAT_TS                 BIT(0)                                 /*!< transmit status */
+#define ENET_DMA_STAT_TPS                BIT(1)                                 /*!< transmit process stopped status */
+#define ENET_DMA_STAT_TBU                BIT(2)                                 /*!< transmit buffer unavailable status */
+#define ENET_DMA_STAT_TJT                BIT(3)                                 /*!< transmit jabber timeout status */
+#define ENET_DMA_STAT_RO                 BIT(4)                                 /*!< receive overflow status */
+#define ENET_DMA_STAT_TU                 BIT(5)                                 /*!< transmit underflow status */
+#define ENET_DMA_STAT_RS                 BIT(6)                                 /*!< receive status */
+#define ENET_DMA_STAT_RBU                BIT(7)                                 /*!< receive buffer unavailable status */
+#define ENET_DMA_STAT_RPS                BIT(8)                                 /*!< receive process stopped status */
+#define ENET_DMA_STAT_RWT                BIT(9)                                 /*!< receive watchdog timeout status */
+#define ENET_DMA_STAT_ET                 BIT(10)                                /*!< early transmit status */
+#define ENET_DMA_STAT_FBE                BIT(13)                                /*!< fatal bus error status */
+#define ENET_DMA_STAT_ER                 BIT(14)                                /*!< early receive status */
+#define ENET_DMA_STAT_AI                 BIT(15)                                /*!< abnormal interrupt summary */
+#define ENET_DMA_STAT_NI                 BIT(16)                                /*!< normal interrupt summary */
+#define ENET_DMA_STAT_RP                 BITS(17,19)                            /*!< receive process state */
+#define ENET_DMA_STAT_TP                 BITS(20,22)                            /*!< transmit process state */
+#define ENET_DMA_STAT_EB                 BITS(23,25)                            /*!< error bits status */
+#define ENET_DMA_STAT_MSC                BIT(27)                                /*!< MSC status */
+#define ENET_DMA_STAT_WUM                BIT(28)                                /*!< WUM status */
+#define ENET_DMA_STAT_TST                BIT(29)                                /*!< timestamp trigger status */
+ 
+/* ENET_DMA_CTL */
+#define ENET_DMA_CTL_SRE                 BIT(1)                                 /*!< start/stop receive enable */
+#define ENET_DMA_CTL_OSF                 BIT(2)                                 /*!< operate on second frame */
+#define ENET_DMA_CTL_RTHC                BITS(3,4)                              /*!< receive threshold control */
+#define ENET_DMA_CTL_FUF                 BIT(6)                                 /*!< forward undersized good frames */
+#define ENET_DMA_CTL_FERF                BIT(7)                                 /*!< forward error frames */
+#define ENET_DMA_CTL_STE                 BIT(13)                                /*!< start/stop transmission enable */
+#define ENET_DMA_CTL_TTHC                BITS(14,16)                            /*!< transmit threshold control */
+#define ENET_DMA_CTL_FTF                 BIT(20)                                /*!< flush transmit FIFO */
+#define ENET_DMA_CTL_TSFD                BIT(21)                                /*!< transmit store-and-forward */
+#define ENET_DMA_CTL_DAFRF               BIT(24)                                /*!< disable flushing of received frames */
+#define ENET_DMA_CTL_RSFD                BIT(25)                                /*!< receive store-and-forward */
+#define ENET_DMA_CTL_DTCERFD             BIT(26)                                /*!< dropping of TCP/IP checksum error frames disable */
+  
+/* ENET_DMA_INTEN */
+#define ENET_DMA_INTEN_TIE               BIT(0)                                 /*!< transmit interrupt enable */
+#define ENET_DMA_INTEN_TPSIE             BIT(1)                                 /*!< transmit process stopped interrupt enable */
+#define ENET_DMA_INTEN_TBUIE             BIT(2)                                 /*!< transmit buffer unavailable interrupt enable */
+#define ENET_DMA_INTEN_TJTIE             BIT(3)                                 /*!< transmit jabber timeout interrupt enable */
+#define ENET_DMA_INTEN_ROIE              BIT(4)                                 /*!< receive overflow interrupt enable */
+#define ENET_DMA_INTEN_TUIE              BIT(5)                                 /*!< transmit underflow interrupt enable */
+#define ENET_DMA_INTEN_RIE               BIT(6)                                 /*!< receive interrupt enable */
+#define ENET_DMA_INTEN_RBUIE             BIT(7)                                 /*!< receive buffer unavailable interrupt enable */
+#define ENET_DMA_INTEN_RPSIE             BIT(8)                                 /*!< receive process stopped interrupt enable */
+#define ENET_DMA_INTEN_RWTIE             BIT(9)                                 /*!< receive watchdog timeout interrupt enable */
+#define ENET_DMA_INTEN_ETIE              BIT(10)                                /*!< early transmit interrupt enable */
+#define ENET_DMA_INTEN_FBEIE             BIT(13)                                /*!< fatal bus error interrupt enable */
+#define ENET_DMA_INTEN_ERIE              BIT(14)                                /*!< early receive interrupt enable */
+#define ENET_DMA_INTEN_AIE               BIT(15)                                /*!< abnormal interrupt summary enable */
+#define ENET_DMA_INTEN_NIE               BIT(16)                                /*!< normal interrupt summary enable */
+  
+/* ENET_DMA_MFBOCNT */
+#define ENET_DMA_MFBOCNT_MSFC            BITS(0,15)                             /*!< missed frames by the controller */
+#define ENET_DMA_MFBOCNT_MSFA            BITS(17,27)                            /*!< missed frames by the application */
+
+/* ENET_DMA_RSWDC */
+#define ENET_DMA_RSWDC_WDCFRS            BITS(0,7)                              /*!< watchdog counter for receive status (RS) */
+
+/* ENET_DMA_CTDADDR */
+#define ENET_DMA_CTDADDR_TDAP            BITS(0,31)                             /*!< transmit descriptor address pointer */
+
+/* ENET_DMA_CRDADDR */
+#define ENET_DMA_CRDADDR_RDAP            BITS(0,31)                             /*!< receive descriptor address pointer */
+  
+/* ENET_DMA_CTBADDR */
+#define ENET_DMA_CTBADDR_TBAP            BITS(0,31)                             /*!< transmit buffer address pointer */
+  
+/* ENET_DMA_CRBADDR */
+#define ENET_DMA_CRBADDR_RBAP            BITS(0,31)                             /*!< receive buffer address pointer */
+
+/* ENET DMA Tx descriptor TDES0 */
+#define ENET_TDES0_DB                    BIT(0)                                 /*!< deferred */
+#define ENET_TDES0_UFE                   BIT(1)                                 /*!< underflow error */
+#define ENET_TDES0_EXD                   BIT(2)                                 /*!< excessive deferral */
+#define ENET_TDES0_COCNT                 BITS(3,6)                              /*!< collision count */
+#define ENET_TDES0_VFRM                  BIT(7)                                 /*!< VLAN frame */
+#define ENET_TDES0_ECO                   BIT(8)                                 /*!< excessive collision */
+#define ENET_TDES0_LCO                   BIT(9)                                 /*!< late collision */
+#define ENET_TDES0_NCA                   BIT(10)                                /*!< no carrier */
+#define ENET_TDES0_LCA                   BIT(11)                                /*!< loss of carrier */
+#define ENET_TDES0_IPPE                  BIT(12)                                /*!< IP payload error */
+#define ENET_TDES0_FRMF                  BIT(13)                                /*!< frame flushed */
+#define ENET_TDES0_JT                    BIT(14)                                /*!< jabber timeout */
+#define ENET_TDES0_ES                    BIT(15)                                /*!< error summary */
+#define ENET_TDES0_IPHE                  BIT(16)                                /*!< IP header error */
+#define ENET_TDES0_TTMSS                 BIT(17)                                /*!< transmit timestamp status */
+#define ENET_TDES0_TCHM                  BIT(20)                                /*!< the second address chained mode */
+#define ENET_TDES0_TERM                  BIT(21)                                /*!< transmit end of ring mode*/
+#define ENET_TDES0_CM                    BITS(22,23)                            /*!< checksum mode */
+#define ENET_TDES0_TTSEN                 BIT(25)                                /*!< transmit timestamp function enable */
+#define ENET_TDES0_DPAD                  BIT(26)                                /*!< disable adding pad */
+#define ENET_TDES0_DCRC                  BIT(27)                                /*!< disable CRC */
+#define ENET_TDES0_FSG                   BIT(28)                                /*!< first segment */
+#define ENET_TDES0_LSG                   BIT(29)                                /*!< last segment */
+#define ENET_TDES0_INTC                  BIT(30)                                /*!< interrupt on completion */
+#define ENET_TDES0_DAV                   BIT(31)                                /*!< DAV bit */
+
+/* ENET DMA Tx descriptor TDES1 */
+#define ENET_TDES1_TB1S                  BITS(0,12)                             /*!< transmit buffer 1 size */
+#define ENET_TDES1_TB2S                  BITS(16,28)                            /*!< transmit buffer 2 size */
+
+/* ENET DMA Tx descriptor TDES2 */
+#define ENET_TDES2_TB1AP                 BITS(0,31)                             /*!< transmit buffer 1 address pointer/transmit frame timestamp low 32-bit value */
+
+/* ENET DMA Tx descriptor TDES3 */
+#define ENET_TDES3_TB2AP                 BITS(0,31)                             /*!< transmit buffer 2 address pointer (or next descriptor address) / transmit frame timestamp high 32-bit value */
+
+#ifdef SELECT_DESCRIPTORS_ENHANCED_MODE
+/* ENET DMA Tx descriptor TDES6 */
+#define ENET_TDES6_TTSL                  BITS(0,31)                             /*!< transmit frame timestamp low 32-bit value */
+
+/* ENET DMA Tx descriptor TDES7 */
+#define ENET_TDES7_TTSH                  BITS(0,31)                             /*!< transmit frame timestamp high 32-bit value */
+#endif /* SELECT_DESCRIPTORS_ENHANCED_MODE */
+
+/* ENET DMA Rx descriptor RDES0 */
+#define ENET_RDES0_PCERR                 BIT(0)                                 /*!< payload checksum error */
+#define ENET_RDES0_EXSV                  BIT(0)                                 /*!< extended status valid */
+#define ENET_RDES0_CERR                  BIT(1)                                 /*!< CRC error */
+#define ENET_RDES0_DBERR                 BIT(2)                                 /*!< dribble bit error */
+#define ENET_RDES0_RERR                  BIT(3)                                 /*!< receive error */
+#define ENET_RDES0_RWDT                  BIT(4)                                 /*!< receive watchdog timeout */
+#define ENET_RDES0_FRMT                  BIT(5)                                 /*!< frame type */
+#define ENET_RDES0_LCO                   BIT(6)                                 /*!< late collision */
+#define ENET_RDES0_IPHERR                BIT(7)                                 /*!< IP frame header error */
+#define ENET_RDES0_TSV                   BIT(7)                                 /*!< timestamp valid */
+#define ENET_RDES0_LDES                  BIT(8)                                 /*!< last descriptor */ 
+#define ENET_RDES0_FDES                  BIT(9)                                 /*!< first descriptor */
+#define ENET_RDES0_VTAG                  BIT(10)                                /*!< VLAN tag */
+#define ENET_RDES0_OERR                  BIT(11)                                /*!< overflow Error */
+#define ENET_RDES0_LERR                  BIT(12)                                /*!< length error */
+#define ENET_RDES0_SAFF                  BIT(13)                                /*!< SA filter fail */
+#define ENET_RDES0_DERR                  BIT(14)                                /*!< descriptor error */
+#define ENET_RDES0_ERRS                  BIT(15)                                /*!< error summary */
+#define ENET_RDES0_FRML                  BITS(16,29)                            /*!< frame length */
+#define ENET_RDES0_DAFF                  BIT(30)                                /*!< destination address filter fail */
+#define ENET_RDES0_DAV                   BIT(31)                                /*!< descriptor available */
+
+/* ENET DMA Rx descriptor RDES1 */ 
+#define ENET_RDES1_RB1S                  BITS(0,12)                             /*!< receive buffer 1 size */
+#define ENET_RDES1_RCHM                  BIT(14)                                /*!< receive chained mode for second address */
+#define ENET_RDES1_RERM                  BIT(15)                                /*!< receive end of ring mode*/
+#define ENET_RDES1_RB2S                  BITS(16,28)                            /*!< receive buffer 2 size */
+#define ENET_RDES1_DINTC                 BIT(31)                                /*!< disable interrupt on completion */
+
+/* ENET DMA Rx descriptor RDES2 */
+#define ENET_RDES2_RB1AP                 BITS(0,31)                             /*!< receive buffer 1 address pointer / receive frame timestamp low 32-bit */
+
+/* ENET DMA Rx descriptor RDES3 */
+#define ENET_RDES3_RB2AP                 BITS(0,31)                             /*!< receive buffer 2 address pointer (next descriptor address)/receive frame timestamp high 32-bit value */
+
+#ifdef SELECT_DESCRIPTORS_ENHANCED_MODE
+/* ENET DMA Rx descriptor RDES4 */
+#define ENET_RDES4_IPPLDT                BITS(0,2)                              /*!< IP frame payload type */
+#define ENET_RDES4_IPHERR                BIT(3)                                 /*!< IP frame header error */
+#define ENET_RDES4_IPPLDERR              BIT(4)                                 /*!< IP frame payload error */
+#define ENET_RDES4_IPCKSB                BIT(5)                                 /*!< IP frame checksum bypassed */
+#define ENET_RDES4_IPF4                  BIT(6)                                 /*!< IP frame in version 4 */
+#define ENET_RDES4_IPF6                  BIT(7)                                 /*!< IP frame in version 6 */
+#define ENET_RDES4_PTPMT                 BITS(8,11)                             /*!< PTP message type */
+#define ENET_RDES4_PTPOEF                BIT(12)                                /*!< PTP on ethernet frame */
+#define ENET_RDES4_PTPVF                 BIT(13)                                /*!< PTP version format */
+
+/* ENET DMA Rx descriptor RDES6 */
+#define ENET_RDES6_RTSL                  BITS(0,31)                             /*!< receive frame timestamp low 32-bit value */
+
+/* ENET DMA Rx descriptor RDES7 */
+#define ENET_RDES7_RTSH                  BITS(0,31)                             /*!< receive frame timestamp high 32-bit value */
+#endif /* SELECT_DESCRIPTORS_ENHANCED_MODE */
+
+/* constants definitions */
+/* define bit position and its register index offset */
+#define ENET_REGIDX_BIT(regidx, bitpos)  (((uint32_t)(regidx) << 6) | (uint32_t)(bitpos))
+#define ENET_REG_VAL(periph)             (REG32(ENET + ((uint32_t)(periph) >> 6)))
+#define ENET_BIT_POS(val)                ((uint32_t)(val) & 0x1FU)
+
+/* ENET clock range judgement */
+#define ENET_RANGE(hclk, n, m)           (((hclk) >= (n))&&((hclk) < (m)))
+
+/* define MAC address configuration and reference address */
+#define ENET_SET_MACADDRH(p)             (((uint32_t)(p)[5] << 8) | (uint32_t)(p)[4])         
+#define ENET_SET_MACADDRL(p)             (((uint32_t)(p)[3] << 24) | ((uint32_t)(p)[2] << 16) | ((uint32_t)(p)[1] << 8) | (uint32_t)(p)[0])
+#define ENET_ADDRH_BASE                  ((ENET) + 0x40U)
+#define ENET_ADDRL_BASE                  ((ENET) + 0x44U)
+#define ENET_GET_MACADDR(offset, n)      ((uint8_t)((REG32((ENET_ADDRL_BASE + (offset)) - (((n) / 4U) * 4U)) >> (8U * ((n) % 4U))) & 0xFFU))
+
+/* register offset */
+#define MAC_FCTL_REG_OFFSET              ((uint16_t)0x0018U)                                /*!< MAC flow control register offset */
+#define MAC_WUM_REG_OFFSET               ((uint16_t)0x002CU)                                /*!< MAC wakeup management register offset */
+#define MAC_INTF_REG_OFFSET              ((uint16_t)0x0038U)                                /*!< MAC interrupt flag register offset */
+#define MAC_INTMSK_REG_OFFSET            ((uint16_t)0x003CU)                                /*!< MAC interrupt mask register offset */
+
+#define MSC_RINTF_REG_OFFSET             ((uint16_t)0x0104U)                                /*!< MSC receive interrupt flag register offset */
+#define MSC_TINTF_REG_OFFSET             ((uint16_t)0x0108U)                                /*!< MSC transmit interrupt flag register offset */
+#define MSC_RINTMSK_REG_OFFSET           ((uint16_t)0x010CU)                                /*!< MSC receive interrupt mask register offset */
+#define MSC_TINTMSK_REG_OFFSET           ((uint16_t)0x0110U)                                /*!< MSC transmit interrupt mask register offset */
+#define MSC_SCCNT_REG_OFFSET             ((uint16_t)0x014CU)                                /*!< MSC transmitted good frames after a single collision counter register offset */
+#define MSC_MSCCNT_REG_OFFSET            ((uint16_t)0x0150U)                                /*!< MSC transmitted good frames after more than a single collision counter register offset */
+#define MSC_TGFCNT_REG_OFFSET            ((uint16_t)0x0168U)                                /*!< MSC transmitted good frames counter register offset */
+#define MSC_RFCECNT_REG_OFFSET           ((uint16_t)0x0194U)                                /*!< MSC received frames with CRC error counter register offset */
+#define MSC_RFAECNT_REG_OFFSET           ((uint16_t)0x0198U)                                /*!< MSC received frames with alignment error counter register offset */
+#define MSC_RGUFCNT_REG_OFFSET           ((uint16_t)0x01C4U)                                /*!< MSC received good unicast frames counter register offset */
+                                                                           
+#define PTP_TSF_REG_OFFSET               ((uint16_t)0x0728U)                                /*!< PTP time stamp flag register offset */
+
+#define DMA_STAT_REG_OFFSET              ((uint16_t)0x1014U)                                /*!< DMA status register offset */
+#define DMA_INTEN_REG_OFFSET             ((uint16_t)0x101CU)                                /*!< DMA interrupt enable register offset */
+#define DMA_TDTADDR_REG_OFFSET           ((uint16_t)0x1010U)                                /*!< DMA transmit descriptor table address register offset */
+#define DMA_CTDADDR_REG_OFFSET           ((uint16_t)0x1048U)                                /*!< DMA current transmit descriptor address register */
+#define DMA_CTBADDR_REG_OFFSET           ((uint16_t)0x1050U)                                /*!< DMA current transmit buffer address register */
+#define DMA_RDTADDR_REG_OFFSET           ((uint16_t)0x100CU)                                /*!< DMA receive descriptor table address register */
+#define DMA_CRDADDR_REG_OFFSET           ((uint16_t)0x104CU)                                /*!< DMA current receive descriptor address register */
+#define DMA_CRBADDR_REG_OFFSET           ((uint16_t)0x1054U)                                /*!< DMA current receive buffer address register */
+
+/* ENET status flag get */
+typedef enum
+{
+    /* ENET_MAC_WUM register */
+    ENET_MAC_FLAG_MPKR              = ENET_REGIDX_BIT(MAC_WUM_REG_OFFSET, 5U),      /*!< magic packet received flag */
+    ENET_MAC_FLAG_WUFR              = ENET_REGIDX_BIT(MAC_WUM_REG_OFFSET, 6U),      /*!< wakeup frame received flag */ 
+    /* ENET_MAC_FCTL register */
+    ENET_MAC_FLAG_FLOWCONTROL       = ENET_REGIDX_BIT(MAC_FCTL_REG_OFFSET, 0U),     /*!< flow control status flag */
+    /* ENET_MAC_INTF register */
+    ENET_MAC_FLAG_WUM               = ENET_REGIDX_BIT(MAC_INTF_REG_OFFSET, 3U),     /*!< WUM status flag */
+    ENET_MAC_FLAG_MSC               = ENET_REGIDX_BIT(MAC_INTF_REG_OFFSET, 4U),     /*!< MSC status flag */
+    ENET_MAC_FLAG_MSCR              = ENET_REGIDX_BIT(MAC_INTF_REG_OFFSET, 5U),     /*!< MSC receive status flag */
+    ENET_MAC_FLAG_MSCT              = ENET_REGIDX_BIT(MAC_INTF_REG_OFFSET, 6U),     /*!< MSC transmit status flag */
+    ENET_MAC_FLAG_TMST              = ENET_REGIDX_BIT(MAC_INTF_REG_OFFSET, 9U),     /*!< timestamp trigger status flag */
+    /* ENET_PTP_TSF register */
+    ENET_PTP_FLAG_TSSCO             = ENET_REGIDX_BIT(PTP_TSF_REG_OFFSET, 0U),      /*!< timestamp second counter overflow flag */  
+    ENET_PTP_FLAG_TTM               = ENET_REGIDX_BIT(PTP_TSF_REG_OFFSET, 1U),      /*!< target time match flag */
+    /* ENET_MSC_RINTF register */
+    ENET_MSC_FLAG_RFCE              = ENET_REGIDX_BIT(MSC_RINTF_REG_OFFSET, 5U),    /*!< received frames CRC error flag */
+    ENET_MSC_FLAG_RFAE              = ENET_REGIDX_BIT(MSC_RINTF_REG_OFFSET, 6U),    /*!< received frames alignment error flag */
+    ENET_MSC_FLAG_RGUF              = ENET_REGIDX_BIT(MSC_RINTF_REG_OFFSET, 17U),   /*!< received good unicast frames flag */
+    /* ENET_MSC_TINTF register */ 
+    ENET_MSC_FLAG_TGFSC             = ENET_REGIDX_BIT(MSC_TINTF_REG_OFFSET, 14U),   /*!< transmitted good frames single collision flag */
+    ENET_MSC_FLAG_TGFMSC            = ENET_REGIDX_BIT(MSC_TINTF_REG_OFFSET, 15U),   /*!< transmitted good frames more single collision flag */
+    ENET_MSC_FLAG_TGF               = ENET_REGIDX_BIT(MSC_TINTF_REG_OFFSET, 21U),   /*!< transmitted good frames flag */
+    /* ENET_DMA_STAT register */
+    ENET_DMA_FLAG_TS                = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 0U),     /*!< transmit status flag */
+    ENET_DMA_FLAG_TPS               = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 1U),     /*!< transmit process stopped status flag */
+    ENET_DMA_FLAG_TBU               = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 2U),     /*!< transmit buffer unavailable status flag */
+    ENET_DMA_FLAG_TJT               = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 3U),     /*!< transmit jabber timeout status flag */
+    ENET_DMA_FLAG_RO                = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 4U),     /*!< receive overflow status flag */
+    ENET_DMA_FLAG_TU                = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 5U),     /*!< transmit underflow status flag */
+    ENET_DMA_FLAG_RS                = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 6U),     /*!< receive status flag */
+    ENET_DMA_FLAG_RBU               = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 7U),     /*!< receive buffer unavailable status flag */
+    ENET_DMA_FLAG_RPS               = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 8U),     /*!< receive process stopped status flag */
+    ENET_DMA_FLAG_RWT               = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 9U),     /*!< receive watchdog timeout status flag */
+    ENET_DMA_FLAG_ET                = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 10U),    /*!< early transmit status flag */
+    ENET_DMA_FLAG_FBE               = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 13U),    /*!< fatal bus error status flag */
+    ENET_DMA_FLAG_ER                = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 14U),    /*!< early receive status flag */
+    ENET_DMA_FLAG_AI                = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 15U),    /*!< abnormal interrupt summary flag */
+    ENET_DMA_FLAG_NI                = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 16U),    /*!< normal interrupt summary flag */
+    ENET_DMA_FLAG_EB_DMA_ERROR      = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 23U),    /*!< error during data transfer by RxDMA/TxDMA flag */
+    ENET_DMA_FLAG_EB_TRANSFER_ERROR = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 24U),    /*!< error during write/read transfer flag */
+    ENET_DMA_FLAG_EB_ACCESS_ERROR   = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 25U),    /*!< error during data buffer/descriptor access flag */
+    ENET_DMA_FLAG_MSC               = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 27U),    /*!< MSC status flag */
+    ENET_DMA_FLAG_WUM               = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 28U),    /*!< WUM status flag */
+    ENET_DMA_FLAG_TST               = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 29U),    /*!< timestamp trigger status flag */                        
+}enet_flag_enum;
+
+/* ENET stutus flag clear */
+typedef enum
+{
+    /* ENET_DMA_STAT register */
+    ENET_DMA_FLAG_TS_CLR            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 0U),     /*!< transmit status flag */
+    ENET_DMA_FLAG_TPS_CLR           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 1U),     /*!< transmit process stopped status flag */
+    ENET_DMA_FLAG_TBU_CLR           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 2U),     /*!< transmit buffer unavailable status flag */
+    ENET_DMA_FLAG_TJT_CLR           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 3U),     /*!< transmit jabber timeout status flag */
+    ENET_DMA_FLAG_RO_CLR            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 4U),     /*!< receive overflow status flag */
+    ENET_DMA_FLAG_TU_CLR            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 5U),     /*!< transmit underflow status flag */
+    ENET_DMA_FLAG_RS_CLR            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 6U),     /*!< receive status flag */
+    ENET_DMA_FLAG_RBU_CLR           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 7U),     /*!< receive buffer unavailable status flag */
+    ENET_DMA_FLAG_RPS_CLR           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 8U),     /*!< receive process stopped status flag */
+    ENET_DMA_FLAG_RWT_CLR           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 9U),     /*!< receive watchdog timeout status flag */
+    ENET_DMA_FLAG_ET_CLR            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 10U),    /*!< early transmit status flag */
+    ENET_DMA_FLAG_FBE_CLR           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 13U),    /*!< fatal bus error status flag */
+    ENET_DMA_FLAG_ER_CLR            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 14U),    /*!< early receive status flag */
+    ENET_DMA_FLAG_AI_CLR            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 15U),    /*!< abnormal interrupt summary flag */
+    ENET_DMA_FLAG_NI_CLR            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 16U),    /*!< normal interrupt summary flag */                       
+}enet_flag_clear_enum;
+
+/* ENET interrupt enable/disable */
+typedef enum
+{
+    /* ENET_MAC_INTMSK register */
+    ENET_MAC_INT_WUMIM              = ENET_REGIDX_BIT(MAC_INTMSK_REG_OFFSET, 3U),   /*!< WUM interrupt mask */
+    ENET_MAC_INT_TMSTIM             = ENET_REGIDX_BIT(MAC_INTMSK_REG_OFFSET, 9U),   /*!< timestamp trigger interrupt mask */
+    /* ENET_MSC_RINTMSK register */ 
+    ENET_MSC_INT_RFCEIM             = ENET_REGIDX_BIT(MSC_RINTMSK_REG_OFFSET, 5U),  /*!< received frame CRC error interrupt mask */
+    ENET_MSC_INT_RFAEIM             = ENET_REGIDX_BIT(MSC_RINTMSK_REG_OFFSET, 6U),  /*!< received frames alignment error interrupt mask */
+    ENET_MSC_INT_RGUFIM             = ENET_REGIDX_BIT(MSC_RINTMSK_REG_OFFSET, 17U), /*!< received good unicast frames interrupt mask */
+    /* ENET_MSC_TINTMSK register */ 
+    ENET_MSC_INT_TGFSCIM            = ENET_REGIDX_BIT(MSC_TINTMSK_REG_OFFSET, 14U), /*!< transmitted good frames single collision interrupt mask */
+    ENET_MSC_INT_TGFMSCIM           = ENET_REGIDX_BIT(MSC_TINTMSK_REG_OFFSET, 15U), /*!< transmitted good frames more single collision interrupt mask */
+    ENET_MSC_INT_TGFIM              = ENET_REGIDX_BIT(MSC_TINTMSK_REG_OFFSET, 21U), /*!< transmitted good frames interrupt mask */
+    /* ENET_DMA_INTEN register */ 
+    ENET_DMA_INT_TIE                = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 0U),    /*!< transmit interrupt enable */
+    ENET_DMA_INT_TPSIE              = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 1U),    /*!< transmit process stopped interrupt enable */
+    ENET_DMA_INT_TBUIE              = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 2U),    /*!< transmit buffer unavailable interrupt enable */
+    ENET_DMA_INT_TJTIE              = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 3U),    /*!< transmit jabber timeout interrupt enable */
+    ENET_DMA_INT_ROIE               = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 4U),    /*!< receive overflow interrupt enable */
+    ENET_DMA_INT_TUIE               = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 5U),    /*!< transmit underflow interrupt enable */
+    ENET_DMA_INT_RIE                = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 6U),    /*!< receive interrupt enable */
+    ENET_DMA_INT_RBUIE              = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 7U),    /*!< receive buffer unavailable interrupt enable */
+    ENET_DMA_INT_RPSIE              = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 8U),    /*!< receive process stopped interrupt enable */
+    ENET_DMA_INT_RWTIE              = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 9U),    /*!< receive watchdog timeout interrupt enable */
+    ENET_DMA_INT_ETIE               = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 10U),   /*!< early transmit interrupt enable */
+    ENET_DMA_INT_FBEIE              = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 13U),   /*!< fatal bus error interrupt enable */
+    ENET_DMA_INT_ERIE               = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 14U),   /*!< early receive interrupt enable */
+    ENET_DMA_INT_AIE                = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 15U),   /*!< abnormal interrupt summary enable */
+    ENET_DMA_INT_NIE                = ENET_REGIDX_BIT(DMA_INTEN_REG_OFFSET, 16U),   /*!< normal interrupt summary enable */
+}enet_int_enum;
+ 
+/* ENET interrupt flag get */
+typedef enum
+{
+    /* ENET_MAC_INTF register */
+    ENET_MAC_INT_FLAG_WUM           = ENET_REGIDX_BIT(MAC_INTF_REG_OFFSET, 3U),     /*!< WUM status flag */
+    ENET_MAC_INT_FLAG_MSC           = ENET_REGIDX_BIT(MAC_INTF_REG_OFFSET, 4U),     /*!< MSC status flag */
+    ENET_MAC_INT_FLAG_MSCR          = ENET_REGIDX_BIT(MAC_INTF_REG_OFFSET, 5U),     /*!< MSC receive status flag */
+    ENET_MAC_INT_FLAG_MSCT          = ENET_REGIDX_BIT(MAC_INTF_REG_OFFSET, 6U),     /*!< MSC transmit status flag */
+    ENET_MAC_INT_FLAG_TMST          = ENET_REGIDX_BIT(MAC_INTF_REG_OFFSET, 9U),     /*!< timestamp trigger status flag */
+    /* ENET_MSC_RINTF register */
+    ENET_MSC_INT_FLAG_RFCE          = ENET_REGIDX_BIT(MSC_RINTF_REG_OFFSET, 5U),    /*!< received frames CRC error flag */
+    ENET_MSC_INT_FLAG_RFAE          = ENET_REGIDX_BIT(MSC_RINTF_REG_OFFSET, 6U),    /*!< received frames alignment error flag */
+    ENET_MSC_INT_FLAG_RGUF          = ENET_REGIDX_BIT(MSC_RINTF_REG_OFFSET, 17U),   /*!< received good unicast frames flag */
+    /* ENET_MSC_TINTF register */
+    ENET_MSC_INT_FLAG_TGFSC         = ENET_REGIDX_BIT(MSC_TINTF_REG_OFFSET, 14U),   /*!< transmitted good frames single collision flag */
+    ENET_MSC_INT_FLAG_TGFMSC        = ENET_REGIDX_BIT(MSC_TINTF_REG_OFFSET, 15U),   /*!< transmitted good frames more single collision flag */
+    ENET_MSC_INT_FLAG_TGF           = ENET_REGIDX_BIT(MSC_TINTF_REG_OFFSET, 21U),   /*!< transmitted good frames flag */
+    /* ENET_DMA_STAT register */
+    ENET_DMA_INT_FLAG_TS            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 0U),     /*!< transmit status flag */
+    ENET_DMA_INT_FLAG_TPS           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 1U),     /*!< transmit process stopped status flag */
+    ENET_DMA_INT_FLAG_TBU           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 2U),     /*!< transmit buffer unavailable status flag */
+    ENET_DMA_INT_FLAG_TJT           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 3U),     /*!< transmit jabber timeout status flag */
+    ENET_DMA_INT_FLAG_RO            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 4U),     /*!< receive overflow status flag */
+    ENET_DMA_INT_FLAG_TU            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 5U),     /*!< transmit underflow status flag */
+    ENET_DMA_INT_FLAG_RS            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 6U),     /*!< receive status flag */
+    ENET_DMA_INT_FLAG_RBU           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 7U),     /*!< receive buffer unavailable status flag */
+    ENET_DMA_INT_FLAG_RPS           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 8U),     /*!< receive process stopped status flag */
+    ENET_DMA_INT_FLAG_RWT           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 9U),     /*!< receive watchdog timeout status flag */
+    ENET_DMA_INT_FLAG_ET            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 10U),    /*!< early transmit status flag */
+    ENET_DMA_INT_FLAG_FBE           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 13U),    /*!< fatal bus error status flag */
+    ENET_DMA_INT_FLAG_ER            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 14U),    /*!< early receive status flag */
+    ENET_DMA_INT_FLAG_AI            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 15U),    /*!< abnormal interrupt summary flag */
+    ENET_DMA_INT_FLAG_NI            = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 16U),    /*!< normal interrupt summary flag */
+    ENET_DMA_INT_FLAG_MSC           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 27U),    /*!< MSC status flag */
+    ENET_DMA_INT_FLAG_WUM           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 28U),    /*!< WUM status flag */
+    ENET_DMA_INT_FLAG_TST           = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 29U),    /*!< timestamp trigger status flag */ 
+}enet_int_flag_enum;
+
+/* ENET interrupt flag clear */
+typedef enum
+{
+    /* ENET_DMA_STAT register */
+    ENET_DMA_INT_FLAG_TS_CLR        = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 0U),     /*!< transmit status flag */
+    ENET_DMA_INT_FLAG_TPS_CLR       = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 1U),     /*!< transmit process stopped status flag */
+    ENET_DMA_INT_FLAG_TBU_CLR       = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 2U),     /*!< transmit buffer unavailable status flag */
+    ENET_DMA_INT_FLAG_TJT_CLR       = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 3U),     /*!< transmit jabber timeout status flag */
+    ENET_DMA_INT_FLAG_RO_CLR        = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 4U),     /*!< receive overflow status flag */
+    ENET_DMA_INT_FLAG_TU_CLR        = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 5U),     /*!< transmit underflow status flag */
+    ENET_DMA_INT_FLAG_RS_CLR        = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 6U),     /*!< receive status flag */
+    ENET_DMA_INT_FLAG_RBU_CLR       = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 7U),     /*!< receive buffer unavailable status flag */
+    ENET_DMA_INT_FLAG_RPS_CLR       = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 8U),     /*!< receive process stopped status flag */
+    ENET_DMA_INT_FLAG_RWT_CLR       = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 9U),     /*!< receive watchdog timeout status flag */
+    ENET_DMA_INT_FLAG_ET_CLR        = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 10U),    /*!< early transmit status flag */
+    ENET_DMA_INT_FLAG_FBE_CLR       = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 13U),    /*!< fatal bus error status flag */
+    ENET_DMA_INT_FLAG_ER_CLR        = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 14U),    /*!< early receive status flag */
+    ENET_DMA_INT_FLAG_AI_CLR        = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 15U),    /*!< abnormal interrupt summary flag */
+    ENET_DMA_INT_FLAG_NI_CLR        = ENET_REGIDX_BIT(DMA_STAT_REG_OFFSET, 16U),    /*!< normal interrupt summary flag */
+}enet_int_flag_clear_enum;
+
+/* current RX/TX descriptor/buffer/descriptor table address get */
+typedef enum
+{
+    ENET_RX_DESC_TABLE              = DMA_RDTADDR_REG_OFFSET,                       /*!< RX descriptor table */
+    ENET_RX_CURRENT_DESC            = DMA_CRDADDR_REG_OFFSET,                       /*!< current RX descriptor */
+    ENET_RX_CURRENT_BUFFER          = DMA_CRBADDR_REG_OFFSET,                       /*!< current RX buffer */
+    ENET_TX_DESC_TABLE              = DMA_TDTADDR_REG_OFFSET,                       /*!< TX descriptor table */
+    ENET_TX_CURRENT_DESC            = DMA_CTDADDR_REG_OFFSET,                       /*!< current TX descriptor */
+    ENET_TX_CURRENT_BUFFER          = DMA_CTBADDR_REG_OFFSET                        /*!< current TX buffer */
+}enet_desc_reg_enum;
+
+/* MAC statistics counter get */
+typedef enum
+{
+    ENET_MSC_TX_SCCNT               = MSC_SCCNT_REG_OFFSET,                         /*!< MSC transmitted good frames after a single collision counter */
+    ENET_MSC_TX_MSCCNT              = MSC_MSCCNT_REG_OFFSET,                        /*!< MSC transmitted good frames after more than a single collision counter */
+    ENET_MSC_TX_TGFCNT              = MSC_TGFCNT_REG_OFFSET,                        /*!< MSC transmitted good frames counter */
+    ENET_MSC_RX_RFCECNT             = MSC_RFCECNT_REG_OFFSET,                       /*!< MSC received frames with CRC error counter */
+    ENET_MSC_RX_RFAECNT             = MSC_RFAECNT_REG_OFFSET,                       /*!< MSC received frames with alignment error counter */
+    ENET_MSC_RX_RGUFCNT             = MSC_RGUFCNT_REG_OFFSET                        /*!< MSC received good unicast frames counter */
+}enet_msc_counter_enum; 
+
+/* function option, used for ENET initialization */
+typedef enum
+{
+    FORWARD_OPTION                  = BIT(0),                                       /*!< configure the frame forward related parameters */
+    DMABUS_OPTION                   = BIT(1),                                       /*!< configure the DMA bus mode related parameters */
+    DMA_MAXBURST_OPTION             = BIT(2),                                       /*!< configure the DMA max burst related parameters */
+    DMA_ARBITRATION_OPTION          = BIT(3),                                       /*!< configure the DMA arbitration related parameters */
+    STORE_OPTION                    = BIT(4),                                       /*!< configure the store forward mode related parameters */
+    DMA_OPTION                      = BIT(5),                                       /*!< configure the DMA control related parameters */
+    VLAN_OPTION                     = BIT(6),                                       /*!< configure the VLAN tag related parameters */
+    FLOWCTL_OPTION                  = BIT(7),                                       /*!< configure the flow control related parameters */
+    HASHH_OPTION                    = BIT(8),                                       /*!< configure the hash list high 32-bit related parameters */
+    HASHL_OPTION                    = BIT(9),                                       /*!< configure the hash list low 32-bit related parameters */
+    FILTER_OPTION                   = BIT(10),                                      /*!< configure the frame filter control related parameters */
+    HALFDUPLEX_OPTION               = BIT(11),                                      /*!< configure the halfduplex related parameters */
+    TIMER_OPTION                    = BIT(12),                                      /*!< configure the frame timer related parameters */
+    INTERFRAMEGAP_OPTION            = BIT(13),                                      /*!< configure the inter frame gap related parameters */
+}enet_option_enum;
+
+/* phy mode and mac loopback configurations */
+typedef enum
+{
+    ENET_AUTO_NEGOTIATION           = 0x01U,                                        /*!< PHY auto negotiation */
+    ENET_100M_FULLDUPLEX            = (ENET_MAC_CFG_SPD | ENET_MAC_CFG_DPM),        /*!< 100Mbit/s, full-duplex */
+    ENET_100M_HALFDUPLEX            = ENET_MAC_CFG_SPD ,                            /*!< 100Mbit/s, half-duplex */
+    ENET_10M_FULLDUPLEX             = ENET_MAC_CFG_DPM,                             /*!< 10Mbit/s, full-duplex */
+    ENET_10M_HALFDUPLEX             = (uint32_t)0x00000000U,                        /*!< 10Mbit/s, half-duplex */
+    ENET_LOOPBACKMODE               = (ENET_MAC_CFG_LBM | ENET_MAC_CFG_DPM)         /*!< MAC in loopback mode at the MII */
+}enet_mediamode_enum;
+
+/* IP frame checksum function */
+typedef enum
+{
+    ENET_NO_AUTOCHECKSUM                = (uint32_t)0x00000000U,                    /*!< disable IP frame checksum function */
+    ENET_AUTOCHECKSUM_DROP_FAILFRAMES   = ENET_MAC_CFG_IPFCO,                       /*!< enable IP frame checksum function */
+    ENET_AUTOCHECKSUM_ACCEPT_FAILFRAMES = (ENET_MAC_CFG_IPFCO|ENET_DMA_CTL_DTCERFD) /*!< enable IP frame checksum function, and the received frame
+                                                                                         with only payload error but no other errors will not be dropped */
+}enet_chksumconf_enum;
+
+/* received frame filter function */
+typedef enum
+{
+    ENET_PROMISCUOUS_MODE           = ENET_MAC_FRMF_PM,                             /*!< promiscuous mode enabled */
+    ENET_RECEIVEALL                 = (int32_t)ENET_MAC_FRMF_FAR,                   /*!< all received frame are forwarded to application */
+    ENET_BROADCAST_FRAMES_PASS      = (uint32_t)0x00000000U,                        /*!< the address filters pass all received broadcast frames */
+    ENET_BROADCAST_FRAMES_DROP      = ENET_MAC_FRMF_BFRMD                           /*!< the address filters filter all incoming broadcast frames */
+}enet_frmrecept_enum;
+
+/* register group value get */
+typedef enum
+{
+    ALL_MAC_REG                     = 0U,                                            /*!< MAC register group */
+    ALL_MSC_REG                     = 22U,                                           /*!< MSC register group */
+    ALL_PTP_REG                     = 33U,                                           /*!< PTP register group */
+    ALL_DMA_REG                     = 44U,                                           /*!< DMA register group */
+}enet_registers_type_enum;
+
+/* dma direction select */
+typedef enum
+{
+    ENET_DMA_TX                     = ENET_DMA_STAT_TP,                             /*!< DMA transmit direction */
+    ENET_DMA_RX                     = ENET_DMA_STAT_RP                              /*!< DMA receive direction */
+}enet_dmadirection_enum;
+
+/* PHY operation direction select */
+typedef enum
+{
+    ENET_PHY_READ                   = (uint32_t)0x00000000,                         /*!< read PHY */
+    ENET_PHY_WRITE                  = ENET_MAC_PHY_CTL_PW                           /*!< write PHY */
+}enet_phydirection_enum;
+
+/* register operation direction select */
+typedef enum
+{
+    ENET_REG_READ,                                                                  /*!< read register */
+    ENET_REG_WRITE                                                                  /*!< write register */
+}enet_regdirection_enum;
+
+/* ENET MAC addresses */ 
+typedef enum
+{
+    ENET_MAC_ADDRESS0               = ((uint32_t)0x00000000),                       /*!< MAC address0 */
+    ENET_MAC_ADDRESS1               = ((uint32_t)0x00000008),                       /*!< MAC address1 */
+    ENET_MAC_ADDRESS2               = ((uint32_t)0x00000010),                       /*!< MAC address2 */
+    ENET_MAC_ADDRESS3               = ((uint32_t)0x00000018)                        /*!< MAC address3 */
+}enet_macaddress_enum;
+
+/* descriptor information */
+typedef enum
+{
+    TXDESC_COLLISION_COUNT,                                                         /*!< the number of collisions occurred before the frame was transmitted */
+    TXDESC_BUFFER_1_ADDR,                                                           /*!< transmit frame buffer 1 address */
+    RXDESC_FRAME_LENGTH,                                                            /*!< the byte length of the received frame that was transferred to the buffer */
+    RXDESC_BUFFER_1_SIZE,                                                           /*!< receive buffer 1 size */
+    RXDESC_BUFFER_2_SIZE,                                                           /*!< receive buffer 2 size */
+    RXDESC_BUFFER_1_ADDR                                                            /*!< receive frame buffer 1 address */
+}enet_descstate_enum;
+
+/* MSC counters preset mode */
+typedef enum
+{
+    ENET_MSC_PRESET_NONE            = 0U,                                           /*!< do not preset MSC counter */
+    ENET_MSC_PRESET_HALF            = ENET_MSC_CTL_PMC,                             /*!< preset all MSC counters to almost-half(0x7FFF FFF0) value */
+    ENET_MSC_PRESET_FULL            = ENET_MSC_CTL_PMC | ENET_MSC_CTL_AFHPM         /*!< preset all MSC counters to almost-full(0xFFFF FFF0) value */
+}enet_msc_preset_enum;
+
+typedef enum{
+    ENET_CKNT_ORDINARY                = PTP_TSCTL_CKNT(0),                          /*!< type of ordinary clock node type for timestamp */
+    ENET_CKNT_BOUNDARY                = PTP_TSCTL_CKNT(1),                          /*!< type of boundary clock node type for timestamp */
+    ENET_CKNT_END_TO_END              = PTP_TSCTL_CKNT(2),                          /*!< type of end-to-end transparent clock node type for timestamp */
+    ENET_CKNT_PEER_TO_PEER            = PTP_TSCTL_CKNT(3),                          /*!< type of peer-to-peer transparent clock node type for timestamp */
+    ENET_PTP_SYSTIME_INIT             = ENET_PTP_TSCTL_TMSSTI,                      /*!< timestamp initialize */
+    ENET_PTP_SYSTIME_UPDATE           = ENET_PTP_TSCTL_TMSSTU,                      /*!< timestamp update */ 
+    ENET_PTP_ADDEND_UPDATE            = ENET_PTP_TSCTL_TMSARU,                      /*!< addend register update */
+    ENET_PTP_FINEMODE                 = (int32_t)(ENET_PTP_TSCTL_TMSFCU| BIT(31)),  /*!< the system timestamp uses the fine method for updating */
+    ENET_PTP_COARSEMODE               = ENET_PTP_TSCTL_TMSFCU,                      /*!< the system timestamp uses the coarse method for updating */
+    ENET_SUBSECOND_DIGITAL_ROLLOVER   = (int32_t)(ENET_PTP_TSCTL_SCROM | BIT(31)),  /*!< digital rollover mode */
+    ENET_SUBSECOND_BINARY_ROLLOVER    = ENET_PTP_TSCTL_SCROM,                       /*!< binary rollover mode */
+    ENET_SNOOPING_PTP_VERSION_2       = (int32_t)(ENET_PTP_TSCTL_PFSV| BIT(31)),    /*!< version 2 */
+    ENET_SNOOPING_PTP_VERSION_1       = ENET_PTP_TSCTL_PFSV,                        /*!< version 1 */
+    ENET_EVENT_TYPE_MESSAGES_SNAPSHOT = (int32_t)(ENET_PTP_TSCTL_ETMSEN| BIT(31)),  /*!< only event type messages are taken snapshot */
+    ENET_ALL_TYPE_MESSAGES_SNAPSHOT   = ENET_PTP_TSCTL_ETMSEN,                      /*!< all type messages are taken snapshot except announce, management and signaling message */
+    ENET_MASTER_NODE_MESSAGE_SNAPSHOT = (int32_t)(ENET_PTP_TSCTL_MNMSEN| BIT(31)),  /*!< snapshot is only take for master node message */
+    ENET_SLAVE_NODE_MESSAGE_SNAPSHOT  = ENET_PTP_TSCTL_MNMSEN,                      /*!< snapshot is only taken for slave node message */
+}enet_ptp_function_enum;
+
+/* structure for initialization of the ENET  */
+typedef struct
+{
+    uint32_t option_enable;                                                         /*!< select which function to configure */
+    uint32_t forward_frame;                                                         /*!< frame forward related parameters */ 
+    uint32_t dmabus_mode;                                                           /*!< DMA bus mode related parameters */
+    uint32_t dma_maxburst;                                                          /*!< DMA max burst related parameters */
+    uint32_t dma_arbitration;                                                       /*!< DMA Tx and Rx arbitration related parameters */
+    uint32_t store_forward_mode;                                                    /*!< store forward mode related parameters */
+    uint32_t dma_function;                                                          /*!< DMA control related parameters */
+    uint32_t vlan_config;                                                           /*!< VLAN tag related parameters */   
+    uint32_t flow_control;                                                          /*!< flow control related parameters */
+    uint32_t hashtable_high;                                                        /*!< hash list high 32-bit related parameters */
+    uint32_t hashtable_low;                                                         /*!< hash list low 32-bit related parameters */
+    uint32_t framesfilter_mode;                                                     /*!< frame filter control related parameters */
+    uint32_t halfduplex_param;                                                      /*!< halfduplex related parameters */            
+    uint32_t timer_config;                                                          /*!< frame timer related parameters */
+    uint32_t interframegap;                                                         /*!< inter frame gap related parameters */
+}enet_initpara_struct;
+
+/* structure for ENET DMA desciptors */ 
+typedef struct  
+{
+    uint32_t status;                                                                /*!< status */
+    uint32_t control_buffer_size;                                                   /*!< control and buffer1, buffer2 lengths */
+    uint32_t buffer1_addr;                                                          /*!< buffer1 address pointer/timestamp low */
+    uint32_t buffer2_next_desc_addr;                                                /*!< buffer2 or next descriptor address pointer/timestamp high */
+
+#ifdef SELECT_DESCRIPTORS_ENHANCED_MODE
+    uint32_t extended_status;                                                       /*!< extended status */
+    uint32_t reserved;                                                              /*!< reserved */
+    uint32_t timestamp_low;                                                         /*!< timestamp low */
+    uint32_t timestamp_high;                                                        /*!< timestamp high */ 
+#endif /* SELECT_DESCRIPTORS_ENHANCED_MODE */ 
+  
+} enet_descriptors_struct;
+
+/* structure of PTP system time */ 
+typedef struct
+{
+    uint32_t second;                                                                /*!< second of system time */
+    uint32_t subsecond;                                                             /*!< subsecond of system time */
+    uint32_t sign;                                                                  /*!< sign of system time */
+}enet_ptp_systime_struct;
+
+/* mac_cfg register value */
+#define MAC_CFG_BOL(regval)                       (BITS(5,6) & ((uint32_t)(regval) << 5))       /*!< write value to ENET_MAC_CFG_BOL bit field */
+#define ENET_BACKOFFLIMIT_10                      MAC_CFG_BOL(0)                                /*!< min (n, 10) */
+#define ENET_BACKOFFLIMIT_8                       MAC_CFG_BOL(1)                                /*!< min (n, 8) */
+#define ENET_BACKOFFLIMIT_4                       MAC_CFG_BOL(2)                                /*!< min (n, 4) */
+#define ENET_BACKOFFLIMIT_1                       MAC_CFG_BOL(3)                                /*!< min (n, 1) */ 
+
+#define MAC_CFG_IGBS(regval)                      (BITS(17,19) & ((uint32_t)(regval) << 17))    /*!< write value to ENET_MAC_CFG_IGBS bit field */
+#define ENET_INTERFRAMEGAP_96BIT                  MAC_CFG_IGBS(0)                               /*!< minimum 96 bit times */ 
+#define ENET_INTERFRAMEGAP_88BIT                  MAC_CFG_IGBS(1)                               /*!< minimum 88 bit times */
+#define ENET_INTERFRAMEGAP_80BIT                  MAC_CFG_IGBS(2)                               /*!< minimum 80 bit times */
+#define ENET_INTERFRAMEGAP_72BIT                  MAC_CFG_IGBS(3)                               /*!< minimum 72 bit times */
+#define ENET_INTERFRAMEGAP_64BIT                  MAC_CFG_IGBS(4)                               /*!< minimum 64 bit times */
+#define ENET_INTERFRAMEGAP_56BIT                  MAC_CFG_IGBS(5)                               /*!< minimum 56 bit times */
+#define ENET_INTERFRAMEGAP_48BIT                  MAC_CFG_IGBS(6)                               /*!< minimum 48 bit times */
+#define ENET_INTERFRAMEGAP_40BIT                  MAC_CFG_IGBS(7)                               /*!< minimum 40 bit times */
+
+#define ENET_TYPEFRAME_CRC_DROP_ENABLE            ENET_MAC_CFG_TFCD                             /*!< FCS field(last 4 bytes) of frame will be dropped before forwarding */
+#define ENET_TYPEFRAME_CRC_DROP_DISABLE           ((uint32_t)0x00000000U)                       /*!< FCS field(last 4 bytes) of frame will not be dropped before forwarding */
+#define ENET_TYPEFRAME_CRC_DROP                   ENET_MAC_CFG_TFCD                             /*!< the function that FCS field(last 4 bytes) of frame will be dropped before forwarding */
+
+#define ENET_WATCHDOG_ENABLE                      ((uint32_t)0x00000000U)                       /*!< the MAC allows no more than 2048 bytes of the frame being received */
+#define ENET_WATCHDOG_DISABLE                     ENET_MAC_CFG_WDD                              /*!< the MAC disables the watchdog timer on the receiver, and can receive frames of up to 16384 bytes */
+ 
+#define ENET_JABBER_ENABLE                        ((uint32_t)0x00000000U)                       /*!< the maximum transmission byte is 2048 */
+#define ENET_JABBER_DISABLE                       ENET_MAC_CFG_JBD                              /*!< the maximum transmission byte can be 16384 */
+
+#define ENET_CARRIERSENSE_ENABLE                  ((uint32_t)0x00000000U)                       /*!< the MAC transmitter generates carrier sense error and aborts the transmission */
+#define ENET_CARRIERSENSE_DISABLE                 ENET_MAC_CFG_CSD                              /*!< the MAC transmitter ignores the MII CRS signal during frame transmission in half-duplex mode */
+ 
+#define ENET_SPEEDMODE_10M                        ((uint32_t)0x00000000U)                       /*!< 10 Mbit/s */
+#define ENET_SPEEDMODE_100M                       ENET_MAC_CFG_SPD                              /*!< 100 Mbit/s */
+
+#define ENET_RECEIVEOWN_ENABLE                    ((uint32_t)0x00000000U)                       /*!< the MAC receives all packets that are given by the PHY while transmitting */
+#define ENET_RECEIVEOWN_DISABLE                   ENET_MAC_CFG_ROD                              /*!< the MAC disables the reception of frames in half-duplex mode */
+
+#define ENET_LOOPBACKMODE_ENABLE                  ENET_MAC_CFG_LBM                              /*!< the MAC operates in loopback mode at the MII */
+#define ENET_LOOPBACKMODE_DISABLE                 ((uint32_t)0x00000000U)                       /*!< the MAC operates in normal mode */
+
+#define ENET_MODE_FULLDUPLEX                      ENET_MAC_CFG_DPM                              /*!< full-duplex mode enable */
+#define ENET_MODE_HALFDUPLEX                      ((uint32_t)0x00000000U)                       /*!< half-duplex mode enable */
+
+#define ENET_CHECKSUMOFFLOAD_ENABLE               ENET_MAC_CFG_IPFCO                            /*!< IP frame checksum offload function enabled for received IP frame */
+#define ENET_CHECKSUMOFFLOAD_DISABLE              ((uint32_t)0x00000000U)                       /*!< the checksum offload function in the receiver is disabled */
+
+#define ENET_RETRYTRANSMISSION_ENABLE             ((uint32_t)0x00000000U)                       /*!< the MAC attempts retries up to 16 times based on the settings of BOL*/
+#define ENET_RETRYTRANSMISSION_DISABLE            ENET_MAC_CFG_RTD                              /*!< the MAC attempts only 1 transmission */
+
+#define ENET_AUTO_PADCRC_DROP_ENABLE              ENET_MAC_CFG_APCD                             /*!< the MAC strips the Pad/FCS field on received frames */
+#define ENET_AUTO_PADCRC_DROP_DISABLE             ((uint32_t)0x00000000U)                       /*!< the MAC forwards all received frames without modify it */
+#define ENET_AUTO_PADCRC_DROP                     ENET_MAC_CFG_APCD                             /*!< the function of the MAC strips the Pad/FCS field on received frames */
+
+#define ENET_DEFERRALCHECK_ENABLE                 ENET_MAC_CFG_DFC                              /*!< the deferral check function is enabled in the MAC */
+#define ENET_DEFERRALCHECK_DISABLE                ((uint32_t)0x00000000U)                       /*!< the deferral check function is disabled */
+
+/* mac_frmf register value */
+#define MAC_FRMF_PCFRM(regval)                    (BITS(6,7) & ((uint32_t)(regval) << 6))       /*!< write value to ENET_MAC_FRMF_PCFRM bit field */
+#define ENET_PCFRM_PREVENT_ALL                    MAC_FRMF_PCFRM(0)                             /*!< MAC prevents all control frames from reaching the application */
+#define ENET_PCFRM_PREVENT_PAUSEFRAME             MAC_FRMF_PCFRM(1)                             /*!< MAC only forwards all other control frames except pause control frame */
+#define ENET_PCFRM_FORWARD_ALL                    MAC_FRMF_PCFRM(2)                             /*!< MAC forwards all control frames to application even if they fail the address filter */
+#define ENET_PCFRM_FORWARD_FILTERED               MAC_FRMF_PCFRM(3)                             /*!< MAC forwards control frames that only pass the address filter */
+ 
+#define ENET_RX_FILTER_DISABLE                    ENET_MAC_FRMF_FAR                             /*!< all received frame are forwarded to application */
+#define ENET_RX_FILTER_ENABLE                     ((uint32_t)0x00000000U)                       /*!< only the frame passed the filter can be forwarded to application */
+ 
+#define ENET_SRC_FILTER_NORMAL_ENABLE             ENET_MAC_FRMF_SAFLT                           /*!< filter source address */
+#define ENET_SRC_FILTER_INVERSE_ENABLE            (ENET_MAC_FRMF_SAFLT | ENET_MAC_FRMF_SAIFLT)  /*!< inverse source address filtering result */
+#define ENET_SRC_FILTER_DISABLE                   ((uint32_t)0x00000000U)                       /*!< source address function in filter disable */
+#define ENET_SRC_FILTER                           ENET_MAC_FRMF_SAFLT                           /*!< filter source address function */
+#define ENET_SRC_FILTER_INVERSE                   ENET_MAC_FRMF_SAIFLT                          /*!< inverse source address filtering result function */
+
+#define ENET_BROADCASTFRAMES_ENABLE               ((uint32_t)0x00000000U)                       /*!< the address filters pass all received broadcast frames */
+#define ENET_BROADCASTFRAMES_DISABLE              ENET_MAC_FRMF_BFRMD                           /*!< the address filters filter all incoming broadcast frames */
+ 
+#define ENET_DEST_FILTER_INVERSE_ENABLE           ENET_MAC_FRMF_DAIFLT                          /*!< inverse DA filtering result */
+#define ENET_DEST_FILTER_INVERSE_DISABLE          ((uint32_t)0x00000000U)                       /*!< not inverse DA filtering result */
+#define ENET_DEST_FILTER_INVERSE                  ENET_MAC_FRMF_DAIFLT                          /*!< inverse DA filtering result function */
+
+#define ENET_PROMISCUOUS_ENABLE                   ENET_MAC_FRMF_PM                              /*!< promiscuous mode enabled */
+#define ENET_PROMISCUOUS_DISABLE                  ((uint32_t)0x00000000U)                       /*!< promiscuous mode disabled */
+          
+#define ENET_MULTICAST_FILTER_HASH_OR_PERFECT     (ENET_MAC_FRMF_HMF | ENET_MAC_FRMF_HPFLT)     /*!< pass multicast frames that match either the perfect or the hash filtering */
+#define ENET_MULTICAST_FILTER_HASH                ENET_MAC_FRMF_HMF                             /*!< pass multicast frames that match the hash filtering */
+#define ENET_MULTICAST_FILTER_PERFECT             ((uint32_t)0x00000000U)                       /*!< pass multicast frames that match the perfect filtering */
+#define ENET_MULTICAST_FILTER_NONE                ENET_MAC_FRMF_MFD                             /*!< all multicast frames are passed */
+#define ENET_MULTICAST_FILTER_PASS                ENET_MAC_FRMF_MFD                             /*!< pass all multicast frames function */
+#define ENET_MULTICAST_FILTER_HASH_MODE           ENET_MAC_FRMF_HMF                             /*!< HASH multicast filter function */
+#define ENET_FILTER_MODE_EITHER                   ENET_MAC_FRMF_HPFLT                           /*!< HASH or perfect filter function */
+
+#define ENET_UNICAST_FILTER_EITHER                (ENET_MAC_FRMF_HUF | ENET_MAC_FRMF_HPFLT)     /*!< pass unicast frames that match either the perfect or the hash filtering */
+#define ENET_UNICAST_FILTER_HASH                  ENET_MAC_FRMF_HUF                             /*!< pass unicast frames that match the hash filtering */
+#define ENET_UNICAST_FILTER_PERFECT               ((uint32_t)0x00000000U)                       /*!< pass unicast frames that match the perfect filtering */
+#define ENET_UNICAST_FILTER_HASH_MODE             ENET_MAC_FRMF_HUF                             /*!< HASH unicast filter function */
+
+/* mac_phy_ctl register value */
+#define MAC_PHY_CTL_CLR(regval)                   (BITS(2,4) & ((uint32_t)(regval) << 2))       /*!< write value to ENET_MAC_PHY_CTL_CLR bit field */
+#define ENET_MDC_HCLK_DIV42                       MAC_PHY_CTL_CLR(0)                            /*!< HCLK:60-100 MHz; MDC clock= HCLK/42 */
+#define ENET_MDC_HCLK_DIV62                       MAC_PHY_CTL_CLR(1)                            /*!< HCLK:100-150 MHz; MDC clock= HCLK/62 */
+#define ENET_MDC_HCLK_DIV16                       MAC_PHY_CTL_CLR(2)                            /*!< HCLK:20-35 MHz; MDC clock= HCLK/16 */
+#define ENET_MDC_HCLK_DIV26                       MAC_PHY_CTL_CLR(3)                            /*!< HCLK:35-60 MHz; MDC clock= HCLK/26 */
+#define ENET_MDC_HCLK_DIV102                      MAC_PHY_CTL_CLR(4)                            /*!< HCLK:150-240 MHz; MDC clock= HCLK/102 */
+
+#define MAC_PHY_CTL_PR(regval)                    (BITS(6,10) & ((uint32_t)(regval) << 6))      /*!< write value to ENET_MAC_PHY_CTL_PR bit field */
+
+#define MAC_PHY_CTL_PA(regval)                    (BITS(11,15) & ((uint32_t)(regval) << 11))    /*!< write value to ENET_MAC_PHY_CTL_PA bit field */
+
+/* mac_phy_data register value */
+#define MAC_PHY_DATA_PD(regval)                   (BITS(0,15) & ((uint32_t)(regval) << 0))      /*!< write value to ENET_MAC_PHY_DATA_PD bit field */
+
+/* mac_fctl register value */
+#define MAC_FCTL_PLTS(regval)                     (BITS(4,5) & ((uint32_t)(regval) << 4))       /*!< write value to ENET_MAC_FCTL_PLTS bit field */
+#define ENET_PAUSETIME_MINUS4                     MAC_FCTL_PLTS(0)                              /*!< pause time minus 4 slot times */
+#define ENET_PAUSETIME_MINUS28                    MAC_FCTL_PLTS(1)                              /*!< pause time minus 28 slot times */
+#define ENET_PAUSETIME_MINUS144                   MAC_FCTL_PLTS(2)                              /*!< pause time minus 144 slot times */
+#define ENET_PAUSETIME_MINUS256                   MAC_FCTL_PLTS(3)                              /*!< pause time minus 256 slot times */ 
+
+#define ENET_ZERO_QUANTA_PAUSE_ENABLE             ((uint32_t)0x00000000U)                       /*!< enable the automatic zero-quanta generation function */
+#define ENET_ZERO_QUANTA_PAUSE_DISABLE            ENET_MAC_FCTL_DZQP                            /*!< disable the automatic zero-quanta generation function */
+#define ENET_ZERO_QUANTA_PAUSE                    ENET_MAC_FCTL_DZQP                            /*!< the automatic zero-quanta generation function */
+
+#define ENET_MAC0_AND_UNIQUE_ADDRESS_PAUSEDETECT  ENET_MAC_FCTL_UPFDT                           /*!< besides the unique multicast address, MAC also use the MAC0 address to detect pause frame */
+#define ENET_UNIQUE_PAUSEDETECT                   ((uint32_t)0x00000000U)                       /*!< only the unique multicast address for pause frame which is specified in IEEE802.3 can be detected */
+ 
+#define ENET_RX_FLOWCONTROL_ENABLE                ENET_MAC_FCTL_RFCEN                           /*!< enable decoding function for the received pause frame and process it */
+#define ENET_RX_FLOWCONTROL_DISABLE               ((uint32_t)0x00000000U)                       /*!< decode function for pause frame is disabled */
+#define ENET_RX_FLOWCONTROL                       ENET_MAC_FCTL_RFCEN                           /*!< decoding function for the received pause frame and process it */
+
+#define ENET_TX_FLOWCONTROL_ENABLE                ENET_MAC_FCTL_TFCEN                           /*!< enable the flow control operation in the MAC */
+#define ENET_TX_FLOWCONTROL_DISABLE               ((uint32_t)0x00000000U)                       /*!< disable the flow control operation in the MAC */
+#define ENET_TX_FLOWCONTROL                       ENET_MAC_FCTL_TFCEN                           /*!< the flow control operation in the MAC */
+
+#define ENET_BACK_PRESSURE_ENABLE                 ENET_MAC_FCTL_FLCBBKPA                        /*!< enable the back pressure operation in the MAC */
+#define ENET_BACK_PRESSURE_DISABLE                ((uint32_t)0x00000000U)                       /*!< disable the back pressure operation in the MAC */
+#define ENET_BACK_PRESSURE                        ENET_MAC_FCTL_FLCBBKPA                        /*!< the back pressure operation in the MAC */
+                                                                                      
+#define MAC_FCTL_PTM(regval)                      (BITS(16,31) & ((uint32_t)(regval) << 16))    /*!< write value to ENET_MAC_FCTL_PTM bit field */
+/* mac_vlt register value */
+#define MAC_VLT_VLTI(regval)                      (BITS(0,15) & ((uint32_t)(regval) << 0))      /*!< write value to ENET_MAC_VLT_VLTI bit field */
+ 
+#define ENET_VLANTAGCOMPARISON_12BIT              ENET_MAC_VLT_VLTC                             /*!< only low 12 bits of the VLAN tag are used for comparison */
+#define ENET_VLANTAGCOMPARISON_16BIT              ((uint32_t)0x00000000U)                       /*!< all 16 bits of the VLAN tag are used for comparison */
+
+/* mac_wum register value */ 
+#define ENET_WUM_FLAG_WUFFRPR                     ENET_MAC_WUM_WUFFRPR                          /*!< wakeup frame filter register poniter reset */
+#define ENET_WUM_FLAG_WUFR                        ENET_MAC_WUM_WUFR                             /*!< wakeup frame received */
+#define ENET_WUM_FLAG_MPKR                        ENET_MAC_WUM_MPKR                             /*!< magic packet received */
+#define ENET_WUM_POWER_DOWN                       ENET_MAC_WUM_PWD                              /*!< power down mode */    
+#define ENET_WUM_MAGIC_PACKET_FRAME               ENET_MAC_WUM_MPEN                             /*!< enable a wakeup event due to magic packet reception */   
+#define ENET_WUM_WAKE_UP_FRAME                    ENET_MAC_WUM_WFEN                             /*!< enable a wakeup event due to wakeup frame reception */     
+#define ENET_WUM_GLOBAL_UNICAST                   ENET_MAC_WUM_GU                               /*!< any received unicast frame passed filter is considered to be a wakeup frame */
+
+/* mac_dbg register value */
+#define ENET_MAC_RECEIVER_NOT_IDLE                ENET_MAC_DBG_MRNI                             /*!< MAC receiver is not in idle state */
+#define ENET_RX_ASYNCHRONOUS_FIFO_STATE           ENET_MAC_DBG_RXAFS                            /*!< Rx asynchronous FIFO status */
+#define ENET_RXFIFO_WRITING                       ENET_MAC_DBG_RXFW                             /*!< RxFIFO is doing write operation */
+#define ENET_RXFIFO_READ_STATUS                   ENET_MAC_DBG_RXFRS                            /*!< RxFIFO read operation status */
+#define ENET_RXFIFO_STATE                         ENET_MAC_DBG_RXFS                             /*!< RxFIFO state */
+#define ENET_MAC_TRANSMITTER_NOT_IDLE             ENET_MAC_DBG_MTNI                             /*!< MAC transmitter is not in idle state */
+#define ENET_MAC_TRANSMITTER_STATUS               ENET_MAC_DBG_SOMT                             /*!< status of MAC transmitter */
+#define ENET_PAUSE_CONDITION_STATUS               ENET_MAC_DBG_PCS                              /*!< pause condition status */
+#define ENET_TXFIFO_READ_STATUS                   ENET_MAC_DBG_TXFRS                            /*!< TxFIFO read operation status */
+#define ENET_TXFIFO_WRITING                       ENET_MAC_DBG_TXFW                             /*!< TxFIFO is doing write operation */
+#define ENET_TXFIFO_NOT_EMPTY                     ENET_MAC_DBG_TXFNE                            /*!< TxFIFO is not empty */
+#define ENET_TXFIFO_FULL                          ENET_MAC_DBG_TXFF                             /*!< TxFIFO is full */
+
+#define GET_MAC_DBG_RXAFS(regval)                 GET_BITS((regval),1,2)                        /*!< get value of ENET_MAC_DBG_RXAFS bit field */
+
+#define GET_MAC_DBG_RXFRS(regval)                 GET_BITS((regval),5,6)                        /*!< get value of ENET_MAC_DBG_RXFRS bit field */
+
+#define GET_MAC_DBG_RXFS(regval)                  GET_BITS((regval),8,9)                        /*!< get value of ENET_MAC_DBG_RXFS bit field */
+
+#define GET_MAC_DBG_SOMT(regval)                  GET_BITS((regval),17,18)                      /*!< get value of ENET_MAC_DBG_SOMT bit field */
+
+#define GET_MAC_DBG_TXFRS(regval)                 GET_BITS((regval),20,21)                      /*!< get value of ENET_MAC_DBG_TXFRS bit field */
+
+/* mac_addr0h register value */
+#define MAC_ADDR0H_ADDR0H(regval)                 (BITS(0,15) & ((uint32_t)(regval) << 0))      /*!< write value to ENET_MAC_ADDR0H_ADDR0H bit field */
+
+/* mac_addrxh register value, x = 1,2,3 */
+#define MAC_ADDR123H_ADDR123H(regval)             (BITS(0,15) & ((uint32_t)(regval) << 0))      /*!< write value to ENET_MAC_ADDRxH_ADDRxH(x=1,2,3) bit field */
+
+#define ENET_ADDRESS_MASK_BYTE0                   BIT(24)                                       /*!< low register bits [7:0] */
+#define ENET_ADDRESS_MASK_BYTE1                   BIT(25)                                       /*!< low register bits [15:8] */
+#define ENET_ADDRESS_MASK_BYTE2                   BIT(26)                                       /*!< low register bits [23:16] */
+#define ENET_ADDRESS_MASK_BYTE3                   BIT(27)                                       /*!< low register bits [31:24] */
+#define ENET_ADDRESS_MASK_BYTE4                   BIT(28)                                       /*!< high register bits [7:0] */
+#define ENET_ADDRESS_MASK_BYTE5                   BIT(29)                                       /*!< high register bits [15:8] */
+
+#define ENET_ADDRESS_FILTER_SA                    BIT(30)                                       /*!< use MAC address[47:0] is to compare with the SA fields of the received frame */
+#define ENET_ADDRESS_FILTER_DA                    ((uint32_t)0x00000000)                        /*!< use MAC address[47:0] is to compare with the DA fields of the received frame */
+ 
+/* mac_fcth register value */
+#define MAC_FCTH_RFA(regval)                      ((BITS(0,2) & ((uint32_t)(regval) << 0)) << 8)  /*!< write value to ENET_MAC_FCTH_RFA bit field */
+#define ENET_ACTIVE_THRESHOLD_256BYTES            MAC_FCTH_RFA(0)                               /*!< threshold level is 256 bytes */
+#define ENET_ACTIVE_THRESHOLD_512BYTES            MAC_FCTH_RFA(1)                               /*!< threshold level is 512 bytes */
+#define ENET_ACTIVE_THRESHOLD_768BYTES            MAC_FCTH_RFA(2)                               /*!< threshold level is 768 bytes */
+#define ENET_ACTIVE_THRESHOLD_1024BYTES           MAC_FCTH_RFA(3)                               /*!< threshold level is 1024 bytes */
+#define ENET_ACTIVE_THRESHOLD_1280BYTES           MAC_FCTH_RFA(4)                               /*!< threshold level is 1280 bytes */
+#define ENET_ACTIVE_THRESHOLD_1536BYTES           MAC_FCTH_RFA(5)                               /*!< threshold level is 1536 bytes */
+#define ENET_ACTIVE_THRESHOLD_1792BYTES           MAC_FCTH_RFA(6)                               /*!< threshold level is 1792 bytes */
+
+#define MAC_FCTH_RFD(regval)                      ((BITS(4,6) & ((uint32_t)(regval) << 4)) << 8)  /*!< write value to ENET_MAC_FCTH_RFD bit field */
+#define ENET_DEACTIVE_THRESHOLD_256BYTES          MAC_FCTH_RFD(0)                               /*!< threshold level is 256 bytes */
+#define ENET_DEACTIVE_THRESHOLD_512BYTES          MAC_FCTH_RFD(1)                               /*!< threshold level is 512 bytes */
+#define ENET_DEACTIVE_THRESHOLD_768BYTES          MAC_FCTH_RFD(2)                               /*!< threshold level is 768 bytes */
+#define ENET_DEACTIVE_THRESHOLD_1024BYTES         MAC_FCTH_RFD(3)                               /*!< threshold level is 1024 bytes */
+#define ENET_DEACTIVE_THRESHOLD_1280BYTES         MAC_FCTH_RFD(4)                               /*!< threshold level is 1280 bytes */
+#define ENET_DEACTIVE_THRESHOLD_1536BYTES         MAC_FCTH_RFD(5)                               /*!< threshold level is 1536 bytes */
+#define ENET_DEACTIVE_THRESHOLD_1792BYTES         MAC_FCTH_RFD(6)                               /*!< threshold level is 1792 bytes */
+
+/* msc_ctl register value */
+#define ENET_MSC_COUNTER_STOP_ROLLOVER            ENET_MSC_CTL_CTSR                             /*!< counter stop rollover */
+#define ENET_MSC_RESET_ON_READ                    ENET_MSC_CTL_RTOR                             /*!< reset on read */
+#define ENET_MSC_COUNTERS_FREEZE                  ENET_MSC_CTL_MCFZ                             /*!< MSC counter freeze */
+
+/* ptp_tsctl register value */
+#define ENET_RXTX_TIMESTAMP                       ENET_PTP_TSCTL_TMSEN                          /*!< enable timestamp function for transmit and receive frames */
+#define ENET_PTP_TIMESTAMP_INT                    ENET_PTP_TSCTL_TMSITEN                        /*!< timestamp interrupt trigger enable */
+#define ENET_ALL_RX_TIMESTAMP                     ENET_PTP_TSCTL_ARFSEN                         /*!< all received frames are taken snapshot */
+#define ENET_NONTYPE_FRAME_SNAPSHOT               ENET_PTP_TSCTL_ESEN                           /*!< take snapshot when received non type frame */
+#define ENET_IPV6_FRAME_SNAPSHOT                  ENET_PTP_TSCTL_IP6SEN                         /*!< take snapshot for IPv6 frame */
+#define ENET_IPV4_FRAME_SNAPSHOT                  ENET_PTP_TSCTL_IP4SEN                         /*!< take snapshot for IPv4 frame */
+#define ENET_PTP_FRAME_USE_MACADDRESS_FILTER      ENET_PTP_TSCTL_MAFEN                          /*!< enable MAC address1-3 to filter the PTP frame */
+
+/* ptp_ssinc register value */
+#define PTP_SSINC_STMSSI(regval)                  (BITS(0,7) & ((uint32_t)(regval) << 0))       /*!< write value to ENET_PTP_SSINC_STMSSI bit field */
+
+/* ptp_tsl register value */
+#define GET_PTP_TSL_STMSS(regval)                 GET_BITS((uint32_t)(regval),0,30)             /*!< get value of ENET_PTP_TSL_STMSS bit field */
+ 
+#define ENET_PTP_TIME_POSITIVE                    ((uint32_t)0x00000000)                        /*!< time value is positive */
+#define ENET_PTP_TIME_NEGATIVE                    ENET_PTP_TSL_STS                              /*!< time value is negative */
+
+#define GET_PTP_TSL_STS(regval)                   (((regval) & BIT(31)) >> (31U))               /*!< get value of ENET_PTP_TSL_STS bit field */
+
+/* ptp_tsul register value */
+#define PTP_TSUL_TMSUSS(regval)                   (BITS(0,30) & ((uint32_t)(regval) << 0))      /*!< write value to ENET_PTP_TSUL_TMSUSS bit field */
+
+#define ENET_PTP_ADD_TO_TIME                      ((uint32_t)0x00000000)                        /*!< timestamp update value is added to system time */
+#define ENET_PTP_SUBSTRACT_FROM_TIME              ENET_PTP_TSUL_TMSUPNS                         /*!< timestamp update value is subtracted from system time */
+
+/* ptp_ppsctl register value */
+#define PTP_PPSCTL_PPSOFC(regval)                 (BITS(0,3) & ((uint32_t)(regval) << 0))       /*!< write value to ENET_PTP_PPSCTL_PPSOFC bit field */
+#define ENET_PPSOFC_1HZ                           PTP_PPSCTL_PPSOFC(0)                          /*!< PPS output 1Hz frequency */
+#define ENET_PPSOFC_2HZ                           PTP_PPSCTL_PPSOFC(1)                          /*!< PPS output 2Hz frequency */
+#define ENET_PPSOFC_4HZ                           PTP_PPSCTL_PPSOFC(2)                          /*!< PPS output 4Hz frequency */
+#define ENET_PPSOFC_8HZ                           PTP_PPSCTL_PPSOFC(3)                          /*!< PPS output 8Hz frequency */
+#define ENET_PPSOFC_16HZ                          PTP_PPSCTL_PPSOFC(4)                          /*!< PPS output 16Hz frequency */
+#define ENET_PPSOFC_32HZ                          PTP_PPSCTL_PPSOFC(5)                          /*!< PPS output 32Hz frequency */
+#define ENET_PPSOFC_64HZ                          PTP_PPSCTL_PPSOFC(6)                          /*!< PPS output 64Hz frequency */
+#define ENET_PPSOFC_128HZ                         PTP_PPSCTL_PPSOFC(7)                          /*!< PPS output 128Hz frequency */
+#define ENET_PPSOFC_256HZ                         PTP_PPSCTL_PPSOFC(8)                          /*!< PPS output 256Hz frequency */
+#define ENET_PPSOFC_512HZ                         PTP_PPSCTL_PPSOFC(9)                          /*!< PPS output 512Hz frequency */
+#define ENET_PPSOFC_1024HZ                        PTP_PPSCTL_PPSOFC(10)                         /*!< PPS output 1024Hz frequency */
+#define ENET_PPSOFC_2048HZ                        PTP_PPSCTL_PPSOFC(11)                         /*!< PPS output 2048Hz frequency */
+#define ENET_PPSOFC_4096HZ                        PTP_PPSCTL_PPSOFC(12)                         /*!< PPS output 4096Hz frequency */
+#define ENET_PPSOFC_8192HZ                        PTP_PPSCTL_PPSOFC(13)                         /*!< PPS output 8192Hz frequency */
+#define ENET_PPSOFC_16384HZ                       PTP_PPSCTL_PPSOFC(14)                         /*!< PPS output 16384Hz frequency */
+#define ENET_PPSOFC_32768HZ                       PTP_PPSCTL_PPSOFC(15)                         /*!< PPS output 32768Hz frequency */
+
+/* dma_bctl register value */
+#define DMA_BCTL_DPSL(regval)                     (BITS(2,6) & ((uint32_t)(regval) << 2))       /*!< write value to ENET_DMA_BCTL_DPSL bit field */
+#define GET_DMA_BCTL_DPSL(regval)                 GET_BITS((regval),2,6)                        /*!< get value of ENET_DMA_BCTL_DPSL bit field */
+
+#define ENET_ENHANCED_DESCRIPTOR                  ENET_DMA_BCTL_DFM                             /*!< enhanced mode descriptor */
+#define ENET_NORMAL_DESCRIPTOR                    ((uint32_t)0x00000000)                        /*!< normal mode descriptor */
+
+#define DMA_BCTL_PGBL(regval)                     (BITS(8,13) & ((uint32_t)(regval) << 8))      /*!< write value to ENET_DMA_BCTL_PGBL bit field */
+#define ENET_PGBL_1BEAT                           DMA_BCTL_PGBL(1)                              /*!< maximum number of beats is 1 */
+#define ENET_PGBL_2BEAT                           DMA_BCTL_PGBL(2)                              /*!< maximum number of beats is 2 */
+#define ENET_PGBL_4BEAT                           DMA_BCTL_PGBL(4)                              /*!< maximum number of beats is 4 */
+#define ENET_PGBL_8BEAT                           DMA_BCTL_PGBL(8)                              /*!< maximum number of beats is 8 */
+#define ENET_PGBL_16BEAT                          DMA_BCTL_PGBL(16)                             /*!< maximum number of beats is 16 */
+#define ENET_PGBL_32BEAT                          DMA_BCTL_PGBL(32)                             /*!< maximum number of beats is 32 */                
+#define ENET_PGBL_4xPGBL_4BEAT                    (DMA_BCTL_PGBL(1)|ENET_DMA_BCTL_FPBL)         /*!< maximum number of beats is 4 */
+#define ENET_PGBL_4xPGBL_8BEAT                    (DMA_BCTL_PGBL(2)|ENET_DMA_BCTL_FPBL)         /*!< maximum number of beats is 8 */
+#define ENET_PGBL_4xPGBL_16BEAT                   (DMA_BCTL_PGBL(4)|ENET_DMA_BCTL_FPBL)         /*!< maximum number of beats is 16 */
+#define ENET_PGBL_4xPGBL_32BEAT                   (DMA_BCTL_PGBL(8)|ENET_DMA_BCTL_FPBL)         /*!< maximum number of beats is 32 */
+#define ENET_PGBL_4xPGBL_64BEAT                   (DMA_BCTL_PGBL(16)|ENET_DMA_BCTL_FPBL)        /*!< maximum number of beats is 64 */
+#define ENET_PGBL_4xPGBL_128BEAT                  (DMA_BCTL_PGBL(32)|ENET_DMA_BCTL_FPBL)        /*!< maximum number of beats is 128 */
+
+#define DMA_BCTL_RTPR(regval)                     (BITS(14,15) & ((uint32_t)(regval) << 14))    /*!< write value to ENET_DMA_BCTL_RTPR bit field */
+#define ENET_ARBITRATION_RXTX_1_1                 DMA_BCTL_RTPR(0)                              /*!< receive and transmit priority ratio is 1:1*/
+#define ENET_ARBITRATION_RXTX_2_1                 DMA_BCTL_RTPR(1)                              /*!< receive and transmit priority ratio is 2:1*/
+#define ENET_ARBITRATION_RXTX_3_1                 DMA_BCTL_RTPR(2)                              /*!< receive and transmit priority ratio is 3:1 */
+#define ENET_ARBITRATION_RXTX_4_1                 DMA_BCTL_RTPR(3)                              /*!< receive and transmit priority ratio is 4:1 */  
+#define ENET_ARBITRATION_RXPRIORTX                ENET_DMA_BCTL_DAB                             /*!< RxDMA has higher priority than TxDMA */
+
+#define ENET_FIXED_BURST_ENABLE                   ENET_DMA_BCTL_FB                              /*!< AHB can only use SINGLE/INCR4/INCR8/INCR16 during start of normal burst transfers */
+#define ENET_FIXED_BURST_DISABLE                  ((uint32_t)0x00000000)                        /*!< AHB can use SINGLE/INCR burst transfer operations */
+
+#define DMA_BCTL_RXDP(regval)                     (BITS(17,22) & ((uint32_t)(regval) << 17))    /*!< write value to ENET_DMA_BCTL_RXDP bit field */
+#define ENET_RXDP_1BEAT                           DMA_BCTL_RXDP(1)                              /*!< maximum number of beats 1 */
+#define ENET_RXDP_2BEAT                           DMA_BCTL_RXDP(2)                              /*!< maximum number of beats 2 */
+#define ENET_RXDP_4BEAT                           DMA_BCTL_RXDP(4)                              /*!< maximum number of beats 4 */
+#define ENET_RXDP_8BEAT                           DMA_BCTL_RXDP(8)                              /*!< maximum number of beats 8 */
+#define ENET_RXDP_16BEAT                          DMA_BCTL_RXDP(16)                             /*!< maximum number of beats 16 */
+#define ENET_RXDP_32BEAT                          DMA_BCTL_RXDP(32)                             /*!< maximum number of beats 32 */                
+#define ENET_RXDP_4xPGBL_4BEAT                    (DMA_BCTL_RXDP(1)|ENET_DMA_BCTL_FPBL)         /*!< maximum number of beats 4 */
+#define ENET_RXDP_4xPGBL_8BEAT                    (DMA_BCTL_RXDP(2)|ENET_DMA_BCTL_FPBL)         /*!< maximum number of beats 8 */
+#define ENET_RXDP_4xPGBL_16BEAT                   (DMA_BCTL_RXDP(4)|ENET_DMA_BCTL_FPBL)         /*!< maximum number of beats 16 */
+#define ENET_RXDP_4xPGBL_32BEAT                   (DMA_BCTL_RXDP(8)|ENET_DMA_BCTL_FPBL)         /*!< maximum number of beats 32 */
+#define ENET_RXDP_4xPGBL_64BEAT                   (DMA_BCTL_RXDP(16)|ENET_DMA_BCTL_FPBL)        /*!< maximum number of beats 64 */
+#define ENET_RXDP_4xPGBL_128BEAT                  (DMA_BCTL_RXDP(32)|ENET_DMA_BCTL_FPBL)        /*!< maximum number of beats 128 */  
+
+#define ENET_RXTX_DIFFERENT_PGBL                  ENET_DMA_BCTL_UIP                             /*!< RxDMA uses the RXDP[5:0], while TxDMA uses the PGBL[5:0] */
+#define ENET_RXTX_SAME_PGBL                       ((uint32_t)0x00000000)                        /*!< RxDMA/TxDMA uses PGBL[5:0] */
+
+#define ENET_ADDRESS_ALIGN_ENABLE                 ENET_DMA_BCTL_AA                              /*!< enabled address-aligned */
+#define ENET_ADDRESS_ALIGN_DISABLE                ((uint32_t)0x00000000)                        /*!< disable address-aligned */
+
+#define ENET_MIXED_BURST_ENABLE                   ENET_DMA_BCTL_MB                              /*!< AHB master interface transfer burst length greater than 16 with INCR */
+#define ENET_MIXED_BURST_DISABLE                  ((uint32_t)0x00000000)                        /*!< AHB master interface only transfer fixed burst length with 16 and below */
+
+/* dma_stat register value */
+#define GET_DMA_STAT_RP(regval)                   GET_BITS((uint32_t)(regval),17,19)            /*!< get value of ENET_DMA_STAT_RP bit field */
+#define ENET_RX_STATE_STOPPED                     ((uint32_t)0x00000000)                        /*!< reset or stop rx command issued */
+#define ENET_RX_STATE_FETCHING                    BIT(17)                                       /*!< fetching the Rx descriptor */
+#define ENET_RX_STATE_WAITING                     (BIT(17)|BIT(18))                             /*!< waiting for receive packet */
+#define ENET_RX_STATE_SUSPENDED                   BIT(19)                                       /*!< Rx descriptor unavailable */
+#define ENET_RX_STATE_CLOSING                     (BIT(17)|BIT(19))                             /*!< closing receive descriptor */
+#define ENET_RX_STATE_QUEUING                     ENET_DMA_STAT_RP                              /*!< transferring the receive packet data from recevie buffer to host memory */
+
+#define GET_DMA_STAT_TP(regval)                   GET_BITS((uint32_t)(regval),20,22)            /*!< get value of ENET_DMA_STAT_TP bit field */
+#define ENET_TX_STATE_STOPPED                     ((uint32_t)0x00000000)                        /*!< reset or stop Tx Command issued  */
+#define ENET_TX_STATE_FETCHING                    BIT(20)                                       /*!< fetching the Tx descriptor */
+#define ENET_TX_STATE_WAITING                     BIT(21)                                       /*!< waiting for status */
+#define ENET_TX_STATE_READING                     (BIT(20)|BIT(21))                             /*!< reading the data from host memory buffer and queuing it to transmit buffer */
+#define ENET_TX_STATE_SUSPENDED                   (BIT(21)|BIT(22))                             /*!< Tx descriptor unavailabe or transmit buffer underflow */
+#define ENET_TX_STATE_CLOSING                     ENET_DMA_STAT_TP                              /*!< closing Tx descriptor */
+
+#define GET_DMA_STAT_EB(regval)                   GET_BITS((uint32_t)(regval),23,25)            /*!< get value of ENET_DMA_STAT_EB bit field */
+#define ENET_ERROR_TXDATA_TRANSFER                BIT(23)                                       /*!< error during data transfer by TxDMA or RxDMA */
+#define ENET_ERROR_READ_TRANSFER                  BIT(24)                                       /*!< error during write transfer or read transfer */
+#define ENET_ERROR_DESC_ACCESS                    BIT(25)                                       /*!< error during descriptor or buffer access */
+
+/* dma_ctl register value */
+#define DMA_CTL_RTHC(regval)                      (BITS(3,4) & ((uint32_t)(regval) << 3))       /*!< write value to ENET_DMA_CTL_RTHC bit field */
+#define ENET_RX_THRESHOLD_64BYTES                 DMA_CTL_RTHC(0)                               /*!< threshold level is 64 Bytes */
+#define ENET_RX_THRESHOLD_32BYTES                 DMA_CTL_RTHC(1)                               /*!< threshold level is 32 Bytes */
+#define ENET_RX_THRESHOLD_96BYTES                 DMA_CTL_RTHC(2)                               /*!< threshold level is 96 Bytes */
+#define ENET_RX_THRESHOLD_128BYTES                DMA_CTL_RTHC(3)                               /*!< threshold level is 128 Bytes */
+
+#define DMA_CTL_TTHC(regval)                      (BITS(14,16) & ((uint32_t)(regval) << 14))    /*!< write value to ENET_DMA_CTL_TTHC bit field */
+#define ENET_TX_THRESHOLD_64BYTES                 DMA_CTL_TTHC(0)                               /*!< threshold level is 64 Bytes */
+#define ENET_TX_THRESHOLD_128BYTES                DMA_CTL_TTHC(1)                               /*!< threshold level is 128 Bytes */
+#define ENET_TX_THRESHOLD_192BYTES                DMA_CTL_TTHC(2)                               /*!< threshold level is 192 Bytes */
+#define ENET_TX_THRESHOLD_256BYTES                DMA_CTL_TTHC(3)                               /*!< threshold level is 256 Bytes */
+#define ENET_TX_THRESHOLD_40BYTES                 DMA_CTL_TTHC(4)                               /*!< threshold level is 40 Bytes */
+#define ENET_TX_THRESHOLD_32BYTES                 DMA_CTL_TTHC(5)                               /*!< threshold level is 32 Bytes */
+#define ENET_TX_THRESHOLD_24BYTES                 DMA_CTL_TTHC(6)                               /*!< threshold level is 24 Bytes */
+#define ENET_TX_THRESHOLD_16BYTES                 DMA_CTL_TTHC(7)                               /*!< threshold level is 16 Bytes */
+
+#define ENET_TCPIP_CKSUMERROR_ACCEPT              ENET_DMA_CTL_DTCERFD                          /*!< Rx frame with only payload error but no other errors will not be dropped */
+#define ENET_TCPIP_CKSUMERROR_DROP                ((uint32_t)0x00000000)                        /*!< all error frames will be dropped when FERF = 0 */
+
+#define ENET_RX_MODE_STOREFORWARD                 ENET_DMA_CTL_RSFD                             /*!< RxFIFO operates in store-and-forward mode */
+#define ENET_RX_MODE_CUTTHROUGH                   ((uint32_t)0x00000000)                        /*!< RxFIFO operates in cut-through mode */
+
+#define ENET_FLUSH_RXFRAME_ENABLE                 ((uint32_t)0x00000000)                        /*!< RxDMA flushes all frames */
+#define ENET_FLUSH_RXFRAME_DISABLE                ENET_DMA_CTL_DAFRF                            /*!< RxDMA does not flush any frames */
+#define ENET_NO_FLUSH_RXFRAME                     ENET_DMA_CTL_DAFRF                            /*!< RxDMA flushes frames function */
+
+#define ENET_TX_MODE_STOREFORWARD                 ENET_DMA_CTL_TSFD                             /*!< TxFIFO operates in store-and-forward mode */
+#define ENET_TX_MODE_CUTTHROUGH                   ((uint32_t)0x00000000)                        /*!< TxFIFO operates in cut-through mode */
+
+#define ENET_FORWARD_ERRFRAMES_ENABLE             (ENET_DMA_CTL_FERF << 2)                      /*!< all frame received with error except runt error are forwarded to memory */
+#define ENET_FORWARD_ERRFRAMES_DISABLE            ((uint32_t)0x00000000)                        /*!< RxFIFO drop error frame */
+#define ENET_FORWARD_ERRFRAMES                    (ENET_DMA_CTL_FERF << 2)                      /*!< the function that all frame received with error except runt error are forwarded to memory */
+
+#define ENET_FORWARD_UNDERSZ_GOODFRAMES_ENABLE    (ENET_DMA_CTL_FUF << 2)                       /*!< forward undersized good frames */
+#define ENET_FORWARD_UNDERSZ_GOODFRAMES_DISABLE   ((uint32_t)0x00000000)                        /*!< RxFIFO drops all frames whose length is less than 64 bytes */  
+#define ENET_FORWARD_UNDERSZ_GOODFRAMES           (ENET_DMA_CTL_FUF << 2)                       /*!< the function that forwarding undersized good frames */
+
+#define ENET_SECONDFRAME_OPT_ENABLE               ENET_DMA_CTL_OSF                              /*!< TxDMA controller operate on second frame mode enable*/
+#define ENET_SECONDFRAME_OPT_DISABLE              ((uint32_t)0x00000000)                        /*!< TxDMA controller operate on second frame mode disable */
+#define ENET_SECONDFRAME_OPT                      ENET_DMA_CTL_OSF                              /*!< TxDMA controller operate on second frame function */
+/* dma_mfbocnt register value */
+#define GET_DMA_MFBOCNT_MSFC(regval)              GET_BITS((regval),0,15)                       /*!< get value of ENET_DMA_MFBOCNT_MSFC bit field */
+
+#define GET_DMA_MFBOCNT_MSFA(regval)              GET_BITS((regval),17,27)                      /*!< get value of ENET_DMA_MFBOCNT_MSFA bit field */
+
+/* dma_rswdc register value */
+#define DMA_RSWDC_WDCFRS(regval)                  (BITS(0,7) & ((uint32_t)(regval) << 0))       /*!< write value to ENET_DMA_RSWDC_WDCFRS bit field */
+
+/* dma tx descriptor tdes0 register value */
+#define TDES0_CONT(regval)                        (BITS(3,6) & ((uint32_t)(regval) << 3))       /*!< write value to ENET DMA TDES0 CONT bit field */
+#define GET_TDES0_COCNT(regval)                   GET_BITS((regval),3,6)                        /*!< get value of ENET DMA TDES0 CONT bit field */
+
+#define TDES0_CM(regval)                          (BITS(22,23) & ((uint32_t)(regval) << 22))    /*!< write value to ENET DMA TDES0 CM bit field */
+#define ENET_CHECKSUM_DISABLE                     TDES0_CM(0)                                   /*!< checksum insertion disabled */ 
+#define ENET_CHECKSUM_IPV4HEADER                  TDES0_CM(1)                                   /*!< only IP header checksum calculation and insertion are enabled */ 
+#define ENET_CHECKSUM_TCPUDPICMP_SEGMENT          TDES0_CM(2)                                   /*!< TCP/UDP/ICMP checksum insertion calculated but pseudo-header  */ 
+#define ENET_CHECKSUM_TCPUDPICMP_FULL             TDES0_CM(3)                                   /*!< TCP/UDP/ICMP checksum insertion fully calculated */ 
+
+/* dma tx descriptor tdes1 register value */
+#define TDES1_TB1S(regval)                        (BITS(0,12) & ((uint32_t)(regval) << 0))      /*!< write value to ENET DMA TDES1 TB1S bit field */
+
+#define TDES1_TB2S(regval)                        (BITS(16,28) & ((uint32_t)(regval) << 16))    /*!< write value to ENET DMA TDES1 TB2S bit field */
+
+/* dma rx descriptor rdes0 register value */
+#define RDES0_FRML(regval)                        (BITS(16,29) & ((uint32_t)(regval) << 16))    /*!< write value to ENET DMA RDES0 FRML bit field */
+#define GET_RDES0_FRML(regval)                    GET_BITS((regval),16,29)                      /*!< get value of ENET DMA RDES0 FRML bit field */
+
+/* dma rx descriptor rdes1 register value */
+#define ENET_RECEIVE_COMPLETE_INT_ENABLE          ((uint32_t)0x00000000U)                       /*!< RS bit immediately set after Rx completed */
+#define ENET_RECEIVE_COMPLETE_INT_DISABLE         ENET_RDES1_DINTC                              /*!< RS bit not immediately set after Rx completed */
+
+#define GET_RDES1_RB1S(regval)                    GET_BITS((regval),0,12)                       /*!< get value of ENET DMA RDES1 RB1S bit field */
+
+#define GET_RDES1_RB2S(regval)                    GET_BITS((regval),16,28)                      /*!< get value of ENET DMA RDES1 RB2S bit field */
+
+/* dma rx descriptor rdes4 register value */
+#define RDES4_IPPLDT(regval)                      (BITS(0,2) & ((uint32_t)(regval) << 0))       /*!< write value to ENET DMA RDES4 IPPLDT bit field */
+#define GET_RDES4_IPPLDT(regval)                  GET_BITS((regval),0,2)                        /*!< get value of ENET DMA RDES4 IPPLDT bit field */
+
+#define RDES4_PTPMT(regval)                       (BITS(8,11) & ((uint32_t)(regval) << 8))      /*!< write value to ENET DMA RDES4 PTPMT bit field */
+#define GET_RDES4_PTPMT(regval)                   GET_BITS((regval),8,11)                       /*!< get value of ENET DMA RDES4 PTPMT bit field */
+
+/* ENET register mask value */
+#define MAC_CFG_MASK                              ((uint32_t)0xFD30810FU)                       /*!< ENET_MAC_CFG register mask */
+#define MAC_FCTL_MASK                             ((uint32_t)0x0000FF41U)                       /*!< ENET_MAC_FCTL register mask */
+#define DMA_CTL_MASK                              ((uint32_t)0xF8DE3F23U)                       /*!< ENET_DMA_CTL register mask */
+#define DMA_BCTL_MASK                             ((uint32_t)0xF800007DU)                       /*!< ENET_DMA_BCTL register mask */
+#define ENET_MSC_PRESET_MASK                      (~(ENET_MSC_CTL_PMC | ENET_MSC_CTL_AFHPM))    /*!< ENET_MSC_CTL preset mask */
+
+#ifdef SELECT_DESCRIPTORS_ENHANCED_MODE
+#define ETH_DMATXDESC_SIZE                        ((uint32_t)0x00000020U)                       /*!< TxDMA enhanced descriptor size */
+#define ETH_DMARXDESC_SIZE                        ((uint32_t)0x00000020U)                       /*!< RxDMA enhanced descriptor size */
+#else
+#define ETH_DMATXDESC_SIZE                        ((uint32_t)0x00000010U)                       /*!< TxDMA descriptor size */
+#define ETH_DMARXDESC_SIZE                        ((uint32_t)0x00000010U)                       /*!< RxDMA descriptor size */
+#endif /* SELECT_DESCRIPTORS_ENHANCED_MODE */ 
+
+/* ENET remote wake-up frame register length */
+#define ETH_WAKEUP_REGISTER_LENGTH                8U                                            /*!< remote wake-up frame register length */
+
+/* ENET frame size */ 
+#define ENET_MAX_FRAME_SIZE                       1524U                                         /*!< header + frame_extra + payload + CRC */    
+
+/* ENET delay timeout */
+#define ENET_DELAY_TO                             ((uint32_t)0x0004FFFFU)                       /*!< ENET delay timeout */
+#define ENET_RESET_TO                             ((uint32_t)0x000004FFU)                       /*!< ENET reset timeout */
+
+
+
+/* function declarations */
+/* main function */
+/* deinitialize the ENET, and reset structure parameters for ENET initialization */
+void enet_deinit(void);
+/* configure the parameters which are usually less cared for initialization */
+void enet_initpara_config(enet_option_enum option, uint32_t para);
+/* initialize ENET peripheral with generally concerned parameters and the less cared parameters */
+ErrStatus enet_init(enet_mediamode_enum mediamode, enet_chksumconf_enum checksum, enet_frmrecept_enum recept);
+/* reset all core internal registers located in CLK_TX and CLK_RX */
+ErrStatus enet_software_reset(void);
+/* check receive frame valid and return frame size */
+uint32_t enet_rxframe_size_get(void);
+/* initialize the dma tx/rx descriptors's parameters in chain mode */
+void enet_descriptors_chain_init(enet_dmadirection_enum direction);
+/* initialize the dma tx/rx descriptors's parameters in ring mode */
+void enet_descriptors_ring_init(enet_dmadirection_enum direction);
+/* handle current received frame data to application buffer */
+ErrStatus enet_frame_receive(uint8_t *buffer, uint32_t bufsize);
+/* handle current received frame but without data copy to application buffer */
+#define ENET_NOCOPY_FRAME_RECEIVE()         enet_frame_receive(NULL, 0U)
+/* handle application buffer data to transmit it */
+ErrStatus enet_frame_transmit(uint8_t *buffer, uint32_t length);
+/* handle current transmit frame but without data copy from application buffer */
+#define ENET_NOCOPY_FRAME_TRANSMIT(len)     enet_frame_transmit(NULL, (len))
+/* configure the transmit IP frame checksum offload calculation and insertion */
+void enet_transmit_checksum_config(enet_descriptors_struct *desc, uint32_t checksum);
+/* ENET Tx and Rx function enable (include MAC and DMA module) */
+void enet_enable(void);   
+/* ENET Tx and Rx function disable (include MAC and DMA module) */
+void enet_disable(void);
+/* configure MAC address */
+void enet_mac_address_set(enet_macaddress_enum mac_addr, uint8_t paddr[]);
+/* get MAC address */   
+void enet_mac_address_get(enet_macaddress_enum mac_addr, uint8_t paddr[]);
+
+/* get the ENET MAC/MSC/PTP/DMA status flag */
+FlagStatus enet_flag_get(enet_flag_enum enet_flag);
+/* clear the ENET DMA status flag */
+void enet_flag_clear(enet_flag_clear_enum enet_flag);
+/* enable ENET MAC/MSC/DMA interrupt */
+void enet_interrupt_enable(enet_int_enum enet_int);
+/* disable ENET MAC/MSC/DMA interrupt */
+void enet_interrupt_disable(enet_int_enum enet_int);
+/* get ENET MAC/MSC/DMA interrupt flag */
+FlagStatus enet_interrupt_flag_get(enet_int_flag_enum int_flag);
+/* clear ENET DMA interrupt flag */
+void enet_interrupt_flag_clear(enet_int_flag_clear_enum int_flag_clear);
+
+/* MAC function */
+/* ENET Tx function enable (include MAC and DMA module) */
+void enet_tx_enable(void);
+/* ENET Tx function disable (include MAC and DMA module) */
+void enet_tx_disable(void);
+/* ENET Rx function enable (include MAC and DMA module) */
+void enet_rx_enable(void);
+/* ENET Rx function disable (include MAC and DMA module) */
+void enet_rx_disable(void);
+/* put registers value into the application buffer */
+void enet_registers_get(enet_registers_type_enum type, uint32_t *preg, uint32_t num);
+/* get the enet debug status from the debug register */
+uint32_t enet_debug_status_get(uint32_t mac_debug);
+/* enable the MAC address filter */
+void enet_address_filter_enable(enet_macaddress_enum mac_addr);
+/* disable the MAC address filter */
+void enet_address_filter_disable(enet_macaddress_enum mac_addr);
+/* configure the MAC address filter */
+void enet_address_filter_config(enet_macaddress_enum mac_addr, uint32_t addr_mask, uint32_t filter_type);
+/* PHY interface configuration (configure SMI clock and reset PHY chip) */
+ErrStatus enet_phy_config(void);
+/* write to/read from a PHY register */
+ErrStatus enet_phy_write_read(enet_phydirection_enum direction, uint16_t phy_address, uint16_t phy_reg, uint16_t *pvalue);
+/* enable the loopback function of phy chip */
+ErrStatus enet_phyloopback_enable(void);
+/* disable the loopback function of phy chip */
+ErrStatus enet_phyloopback_disable(void);
+/* enable ENET forward feature */
+void enet_forward_feature_enable(uint32_t feature);
+/* disable ENET forward feature */
+void enet_forward_feature_disable(uint32_t feature);
+/* enable ENET fliter feature */
+void enet_fliter_feature_enable(uint32_t feature);
+/* disable ENET fliter feature */
+void enet_fliter_feature_disable(uint32_t feature);
+
+/* flow control function */
+/* generate the pause frame, ENET will send pause frame after enable transmit flow control */
+ErrStatus enet_pauseframe_generate(void);
+/* configure the pause frame detect type */
+void enet_pauseframe_detect_config(uint32_t detect);
+/* configure the pause frame parameters */
+void enet_pauseframe_config(uint32_t pausetime, uint32_t pause_threshold);
+/* configure the threshold of the flow control(deactive and active threshold) */
+void enet_flowcontrol_threshold_config(uint32_t deactive, uint32_t active);
+/* enable ENET flow control feature */
+void enet_flowcontrol_feature_enable(uint32_t feature);
+/* disable ENET flow control feature */
+void enet_flowcontrol_feature_disable(uint32_t feature);
+
+/* DMA function */
+/* get the dma transmit/receive process state */
+uint32_t enet_dmaprocess_state_get(enet_dmadirection_enum direction); 
+/* poll the dma transmission/reception enable */
+void enet_dmaprocess_resume(enet_dmadirection_enum direction);
+/* check and recover the Rx process */
+void enet_rxprocess_check_recovery(void);
+/* flush the ENET transmit fifo, and wait until the flush operation completes */
+ErrStatus enet_txfifo_flush(void);
+/* get the transmit/receive address of current descriptor, or current buffer, or descriptor table */
+uint32_t enet_current_desc_address_get(enet_desc_reg_enum addr_get);
+/* get the Tx or Rx descriptor information */
+uint32_t enet_desc_information_get(enet_descriptors_struct *desc, enet_descstate_enum info_get);
+/* get the number of missed frames during receiving */
+void enet_missed_frame_counter_get(uint32_t *rxfifo_drop, uint32_t *rxdma_drop);
+
+/* descriptor function */
+/* get the bit flag of ENET dma descriptor */
+FlagStatus enet_desc_flag_get(enet_descriptors_struct *desc, uint32_t desc_flag);
+/* set the bit flag of ENET dma tx descriptor */
+void enet_desc_flag_set(enet_descriptors_struct *desc, uint32_t desc_flag);
+/* clear the bit flag of ENET dma tx descriptor */
+void enet_desc_flag_clear(enet_descriptors_struct *desc, uint32_t desc_flag); 
+/* when receiving the completed, set RS bit in ENET_DMA_STAT register will immediately set */
+void enet_rx_desc_immediate_receive_complete_interrupt(enet_descriptors_struct *desc);
+/* when receiving the completed, set RS bit in ENET_DMA_STAT register will is set after a configurable delay time */
+void enet_rx_desc_delay_receive_complete_interrupt(enet_descriptors_struct *desc, uint32_t delay_time);
+/* drop current receive frame */
+void enet_rxframe_drop(void);
+/* enable DMA feature */
+void enet_dma_feature_enable(uint32_t feature);
+/* disable DMA feature */
+void enet_dma_feature_disable(uint32_t feature);
+
+
+/* special enhanced mode function */
+#ifdef SELECT_DESCRIPTORS_ENHANCED_MODE
+/* get the bit of extended status flag in ENET DMA descriptor */
+uint32_t enet_rx_desc_enhanced_status_get(enet_descriptors_struct *desc, uint32_t desc_status);
+/* configure descriptor to work in enhanced mode */
+void enet_desc_select_enhanced_mode(void);
+/* initialize the dma Tx/Rx descriptors's parameters in enhanced chain mode with ptp function */
+void enet_ptp_enhanced_descriptors_chain_init(enet_dmadirection_enum direction);
+/* initialize the dma Tx/Rx descriptors's parameters in enhanced ring mode with ptp function */
+void enet_ptp_enhanced_descriptors_ring_init(enet_dmadirection_enum direction);
+/* receive a packet data with timestamp values to application buffer, when the DMA is in enhanced mode */
+ErrStatus enet_ptpframe_receive_enhanced_mode(uint8_t *buffer, uint32_t bufsize, uint32_t timestamp[]);
+/* handle current received frame but without data copy to application buffer in PTP enhanced mode */
+#define ENET_NOCOPY_PTPFRAME_RECEIVE_ENHANCED_MODE(ptr)           enet_ptpframe_receive_enhanced_mode(NULL, 0U, (ptr))
+/* send data with timestamp values in application buffer as a transmit packet, when the DMA is in enhanced mode */
+ErrStatus enet_ptpframe_transmit_enhanced_mode(uint8_t *buffer, uint32_t length, uint32_t timestamp[]);
+/* handle current transmit frame but without data copy from application buffer in PTP enhanced mode */
+#define ENET_NOCOPY_PTPFRAME_TRANSMIT_ENHANCED_MODE(len, ptr)     enet_ptpframe_transmit_enhanced_mode(NULL, (len), (ptr))
+
+#else
+
+/* configure descriptor to work in normal mode */
+void enet_desc_select_normal_mode(void);
+/* initialize the dma Tx/Rx descriptors's parameters in normal chain mode with ptp function */
+void enet_ptp_normal_descriptors_chain_init(enet_dmadirection_enum direction, enet_descriptors_struct *desc_ptptab);
+/* initialize the dma Tx/Rx descriptors's parameters in normal ring mode with ptp function */
+void enet_ptp_normal_descriptors_ring_init(enet_dmadirection_enum direction, enet_descriptors_struct *desc_ptptab);
+/* receive a packet data with timestamp values to application buffer, when the DMA is in normal mode */
+ErrStatus enet_ptpframe_receive_normal_mode(uint8_t *buffer, uint32_t bufsize, uint32_t timestamp[]);
+/* handle current received frame but without data copy to application buffer in PTP normal mode */
+#define ENET_NOCOPY_PTPFRAME_RECEIVE_NORMAL_MODE(ptr)             enet_ptpframe_receive_normal_mode(NULL, 0U, (ptr))
+/* send data with timestamp values in application buffer as a transmit packet, when the DMA is in normal mode */
+ErrStatus enet_ptpframe_transmit_normal_mode(uint8_t *buffer, uint32_t length, uint32_t timestamp[]);
+/* handle current transmit frame but without data copy from application buffer in PTP normal mode */
+#define ENET_NOCOPY_PTPFRAME_TRANSMIT_NORMAL_MODE(len, ptr)       enet_ptpframe_transmit_normal_mode(NULL, (len), (ptr))
+
+#endif /* SELECT_DESCRIPTORS_ENHANCED_MODE */
+
+/* WUM function */
+/* wakeup frame filter register pointer reset */
+void enet_wum_filter_register_pointer_reset(void);
+/* set the remote wakeup frame registers */
+void enet_wum_filter_config(uint32_t pdata[]);
+/* enable wakeup management features */
+void enet_wum_feature_enable(uint32_t feature);
+/* disable wakeup management features */
+void enet_wum_feature_disable(uint32_t feature);
+
+/* MSC function */
+/* reset the MAC statistics counters */
+void enet_msc_counters_reset(void);
+/* enable the MAC statistics counter features */ 
+void enet_msc_feature_enable(uint32_t feature);
+/* disable the MAC statistics counter features */ 
+void enet_msc_feature_disable(uint32_t feature);
+/* configure MAC statistics counters preset mode */
+void enet_msc_counters_preset_config(enet_msc_preset_enum mode);
+/* get MAC statistics counter */                   
+uint32_t enet_msc_counters_get(enet_msc_counter_enum counter);
+
+/* PTP function */
+/* enable the PTP features */
+void enet_ptp_feature_enable(uint32_t feature);
+/* disable the PTP features */
+void enet_ptp_feature_disable(uint32_t feature);
+/* configure the PTP timestamp function */
+ErrStatus enet_ptp_timestamp_function_config(enet_ptp_function_enum func);
+/* configure the PTP system time subsecond increment value */
+void enet_ptp_subsecond_increment_config(uint32_t subsecond);
+/* adjusting the PTP clock frequency only in fine update mode */
+void enet_ptp_timestamp_addend_config(uint32_t add);
+/* initializing or adding/subtracting to second of the PTP system time */
+void enet_ptp_timestamp_update_config(uint32_t sign, uint32_t second, uint32_t subsecond);
+/* configure the PTP expected target time */
+void enet_ptp_expected_time_config(uint32_t second, uint32_t nanosecond);
+/* get the PTP current system time */
+void enet_ptp_system_time_get(enet_ptp_systime_struct *systime_struct);
+/* configure the PPS output frequency */
+void enet_ptp_pps_output_frequency_config(uint32_t freq);
+
+
+/* internal function */
+/* reset the ENET initpara struct, call it before using enet_initpara_config() */
+void enet_initpara_reset(void);
+
+
+#endif /* GD32F4XX_ENET_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_exmc.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_exmc.h
@@ -1,0 +1,814 @@
+/*!
+    \file    gd32f4xx_exmc.h
+    \brief   definitions for the EXMC
+    
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+    \version 2022-06-08, V3.0.1, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_EXMC_H
+#define GD32F4XX_EXMC_H
+
+#include "gd32f4xx.h"
+
+/* EXMC definitions */
+#define EXMC                                (EXMC_BASE)                   /*!< EXMC register base address */
+#define EXMC_NOR_PSRAM                      (EXMC_BASE - 0x40000000)      /*!< EXMC NOR/PSRAM base address */
+#define EXMC_NAND                           (EXMC_BASE - 0x30000000)      /*!< EXMC NAND base address */
+#define EXMC_PCCARD                         (EXMC_BASE - 0x10000000)      /*!< EXMC PC card base address */
+#define EXMC_SDRAM                          (EXMC_BASE + 0x20000000)      /*!< EXMC SDRAM base address */
+
+/* registers definitions */
+/* NOR/PSRAM */
+#define EXMC_SNCTL0                         REG32(EXMC + 0x00U)           /*!< EXMC SRAM/NOR flash control register for region0 */
+#define EXMC_SNTCFG0                        REG32(EXMC + 0x04U)           /*!< EXMC SRAM/NOR flash timing configuration register for region0 */
+#define EXMC_SNWTCFG0                       REG32(EXMC + 0x104U)          /*!< EXMC SRAM/NOR flash write timing configuration register for region0 */
+
+#define EXMC_SNCTL1                         REG32(EXMC + 0x08U)           /*!< EXMC SRAM/NOR flash control register for region1 */
+#define EXMC_SNTCFG1                        REG32(EXMC + 0x0CU)           /*!< EXMC SRAM/NOR flash timing configuration register for region1 */
+#define EXMC_SNWTCFG1                       REG32(EXMC + 0x10CU)          /*!< EXMC SRAM/NOR flash write timing configuration register for region1 */
+
+#define EXMC_SNCTL2                         REG32(EXMC + 0x10U)           /*!< EXMC SRAM/NOR flash control register for region2 */
+#define EXMC_SNTCFG2                        REG32(EXMC + 0x14U)           /*!< EXMC SRAM/NOR flash timing configuration register for region2 */
+#define EXMC_SNWTCFG2                       REG32(EXMC + 0x114U)          /*!< EXMC SRAM/NOR flash write timing configuration register for region2 */
+
+#define EXMC_SNCTL3                         REG32(EXMC + 0x18U)           /*!< EXMC SRAM/NOR flash control register for region3 */
+#define EXMC_SNTCFG3                        REG32(EXMC + 0x1CU)           /*!< EXMC SRAM/NOR flash timing configuration register for region3 */
+#define EXMC_SNWTCFG3                       REG32(EXMC + 0x11CU)          /*!< EXMC SRAM/NOR flash write timing configuration register for region3 */
+
+/* NAND/PC card */
+#define EXMC_NPCTL1                         REG32(EXMC + 0x60U)           /*!< EXMC NAND/PC card control register for bank1 */
+#define EXMC_NPINTEN1                       REG32(EXMC + 0x64U)           /*!< EXMC NAND/PC card interrupt enable register for bank1 */
+#define EXMC_NPCTCFG1                       REG32(EXMC + 0x68U)           /*!< EXMC NAND/PC card common space timing configuration register for bank1 */
+#define EXMC_NPATCFG1                       REG32(EXMC + 0x6CU)           /*!< EXMC NAND/PC card attribute space timing configuration register for bank1 */
+#define EXMC_NECC1                          REG32(EXMC + 0x74U)           /*!< EXMC NAND ECC register */
+
+#define EXMC_NPCTL2                         REG32(EXMC + 0x80U)           /*!< EXMC NAND/PC card control register for bank2 */
+#define EXMC_NPINTEN2                       REG32(EXMC + 0x84U)           /*!< EXMC NAND/PC card interrupt enable register for bank2 */
+#define EXMC_NPCTCFG2                       REG32(EXMC + 0x88U)           /*!< EXMC NAND/PC card common space timing configuration register for bank2 */
+#define EXMC_NPATCFG2                       REG32(EXMC + 0x8CU)           /*!< EXMC NAND/PC card attribute space timing configuration register for bank2 */
+#define EXMC_NECC2                          REG32(EXMC + 0x94U)           /*!< EXMC NAND ECC register */
+
+#define EXMC_NPCTL3                         REG32(EXMC + 0xA0U)           /*!< EXMC NAND/PC card control register for bank3 */
+#define EXMC_NPINTEN3                       REG32(EXMC + 0xA4U)           /*!< EXMC NAND/PC card interrupt enable register for bank3 */
+#define EXMC_NPCTCFG3                       REG32(EXMC + 0xA8U)           /*!< EXMC NAND/PC card common space timing configuration register for bank3 */
+#define EXMC_NPATCFG3                       REG32(EXMC + 0xACU)           /*!< EXMC NAND/PC card attribute space timing configuration register for bank3 */
+#define EXMC_PIOTCFG3                       REG32(EXMC + 0xB0U)           /*!< EXMC PC card I/O space timing configuration register for bank3 */
+
+/* SDRAM */
+#define EXMC_SDCTL0                         REG32(EXMC + 0x140U)          /*!< EXMC SDRAM control register for device0 */
+#define EXMC_SDTCFG0                        REG32(EXMC + 0x148U)          /*!< EXMC SDRAM timing configuration register register for device0 */
+
+#define EXMC_SDCTL1                         REG32(EXMC + 0x144U)          /*!< EXMC SDRAM control register for device1 */
+#define EXMC_SDTCFG1                        REG32(EXMC + 0x14CU)          /*!< EXMC SDRAM timing configuration register register for device1 */
+
+#define EXMC_SDCMD                          REG32(EXMC + 0x150U)          /*!< EXMC SDRAM command register */
+#define EXMC_SDARI                          REG32(EXMC + 0x154U)          /*!< EXMC SDRAM auto-refresh interval register */
+#define EXMC_SDSTAT                         REG32(EXMC + 0x158U)          /*!< EXMC SDRAM status register */
+#define EXMC_SDRSCTL                        REG32(EXMC + 0x180U)          /*!< EXMC SDRAM read sample control register */
+
+/* SQPI PSRAM */
+#define EXMC_SINIT                          REG32(EXMC + 0x310U)          /*!< EXMC SPI initialization register */
+#define EXMC_SRCMD                          REG32(EXMC + 0x320U)          /*!< EXMC SPI read command register */
+#define EXMC_SWCMD                          REG32(EXMC + 0x330U)          /*!< EXMC SPI write command register */
+#define EXMC_SIDL                           REG32(EXMC + 0x340U)          /*!< EXMC SPI ID low register */
+#define EXMC_SIDH                           REG32(EXMC + 0x350U)          /*!< EXMC SPI ID high register */
+
+/* bits definitions */
+/* EXMC_SNCTLx,x=0..3 */
+#define EXMC_SNCTL_NRBKEN                   BIT(0)                        /*!< NOR bank enable */
+#define EXMC_SNCTL_NRMUX                    BIT(1)                        /*!< NOR bank memory address/data multiplexing enable */
+#define EXMC_SNCTL_NRTP                     BITS(2,3)                     /*!< NOR bank memory type */
+#define EXMC_SNCTL_NRW                      BITS(4,5)                     /*!< NOR bank memory data bus width */
+#define EXMC_SNCTL_NREN                     BIT(6)                        /*!< NOR flash access enable */
+#define EXMC_SNCTL_SBRSTEN                  BIT(8)                        /*!< synchronous burst enable */
+#define EXMC_SNCTL_NRWTPOL                  BIT(9)                        /*!< NWAIT signal polarity */
+#define EXMC_SNCTL_WRAPEN                   BIT(10)                       /*!< wrapped burst mode enable */
+#define EXMC_SNCTL_NRWTCFG                  BIT(11)                       /*!< NWAIT signal configuration, only work in synchronous mode */
+#define EXMC_SNCTL_WEN                      BIT(12)                       /*!< write enable */
+#define EXMC_SNCTL_NRWTEN                   BIT(13)                       /*!< NWAIT signal enable */
+#define EXMC_SNCTL_EXMODEN                  BIT(14)                       /*!< extended mode enable */
+#define EXMC_SNCTL_ASYNCWTEN                BIT(15)                       /*!< asynchronous wait enable */
+#define EXMC_SNCTL_CPS                      BITS(16,18)                   /*!< CRAM page size */
+#define EXMC_SNCTL_SYNCWR                   BIT(19)                       /*!< synchronous write configuration */
+#define EXMC_SNCTL_CCK                      BIT(20)                       /*!< consecutive clock configuration */
+
+/* EXMC_SNTCFGx,x=0..3 */
+#define EXMC_SNTCFG_ASET                    BITS(0,3)                     /*!< asynchronous address setup time */
+#define EXMC_SNTCFG_AHLD                    BITS(4,7)                     /*!< asynchronous address hold time */
+#define EXMC_SNTCFG_DSET                    BITS(8,15)                    /*!< asynchronous data setup time */
+#define EXMC_SNTCFG_BUSLAT                  BITS(16,19)                   /*!< bus latency */
+#define EXMC_SNTCFG_CKDIV                   BITS(20,23)                   /*!< synchronous clock divide ratio */
+#define EXMC_SNTCFG_DLAT                    BITS(24,27)                   /*!< synchronous data latency for NOR flash */
+#define EXMC_SNTCFG_ASYNCMOD                BITS(28,29)                   /*!< asynchronous access mode */
+
+/* EXMC_SNWTCFGx,x=0..3 */
+#define EXMC_SNWTCFG_WASET                  BITS(0,3)                     /*!< asynchronous address setup time */
+#define EXMC_SNWTCFG_WAHLD                  BITS(4,7)                     /*!< asynchronous address hold time */
+#define EXMC_SNWTCFG_WDSET                  BITS(8,15)                    /*!< asynchronous data setup time */
+#define EXMC_SNWTCFG_WBUSLAT                BITS(16,19)                   /*!< bus latency */
+#define EXMC_SNWTCFG_WASYNCMOD              BITS(28,29)                   /*!< asynchronous access mode */
+
+/* EXMC_NPCTLx,x=1..3 */
+#define EXMC_NPCTL_NDWTEN                   BIT(1)                        /*!< wait feature enable */
+#define EXMC_NPCTL_NDBKEN                   BIT(2)                        /*!< NAND bank enable */
+#define EXMC_NPCTL_NDTP                     BIT(3)                        /*!< NAND bank memory type */
+#define EXMC_NPCTL_NDW                      BITS(4,5)                     /*!< NAND bank memory data bus width */
+#define EXMC_NPCTL_ECCEN                    BIT(6)                        /*!< ECC enable */
+#define EXMC_NPCTL_CTR                      BITS(9,12)                    /*!< CLE to RE delay */
+#define EXMC_NPCTL_ATR                      BITS(13,16)                   /*!< ALE to RE delay */
+#define EXMC_NPCTL_ECCSZ                    BITS(17,19)                   /*!< ECC size */
+
+/* EXMC_NPINTENx,x=1..3 */
+#define EXMC_NPINTEN_INTRS                  BIT(0)                        /*!< interrupt rising edge status */
+#define EXMC_NPINTEN_INTHS                  BIT(1)                        /*!< interrupt high-level status */
+#define EXMC_NPINTEN_INTFS                  BIT(2)                        /*!< interrupt falling edge status */
+#define EXMC_NPINTEN_INTREN                 BIT(3)                        /*!< interrupt rising edge detection enable */
+#define EXMC_NPINTEN_INTHEN                 BIT(4)                        /*!< interrupt high-level detection enable */
+#define EXMC_NPINTEN_INTFEN                 BIT(5)                        /*!< interrupt falling edge detection enable */
+#define EXMC_NPINTEN_FFEPT                  BIT(6)                        /*!< FIFO empty flag */
+
+/* EXMC_NPCTCFGx,x=1..3 */
+#define EXMC_NPCTCFG_COMSET                 BITS(0,7)                     /*!< common memory setup time */
+#define EXMC_NPCTCFG_COMWAIT                BITS(8,15)                    /*!< common memory wait time */
+#define EXMC_NPCTCFG_COMHLD                 BITS(16,23)                   /*!< common memory hold time */
+#define EXMC_NPCTCFG_COMHIZ                 BITS(24,31)                   /*!< common memory data bus HiZ time */
+
+/* EXMC_NPATCFGx,x=1..3 */
+#define EXMC_NPATCFG_ATTSET                 BITS(0,7)                     /*!< attribute memory setup time */
+#define EXMC_NPATCFG_ATTWAIT                BITS(8,15)                    /*!< attribute memory wait time */
+#define EXMC_NPATCFG_ATTHLD                 BITS(16,23)                   /*!< attribute memory hold time */
+#define EXMC_NPATCFG_ATTHIZ                 BITS(24,31)                   /*!< attribute memory data bus HiZ time */
+
+/* EXMC_PIOTCFG3 */
+#define EXMC_PIOTCFG3_IOSET                 BITS(0,7)                     /*!< IO space setup time */
+#define EXMC_PIOTCFG3_IOWAIT                BITS(8,15)                    /*!< IO space wait time */
+#define EXMC_PIOTCFG3_IOHLD                 BITS(16,23)                   /*!< IO space hold time */
+#define EXMC_PIOTCFG3_IOHIZ                 BITS(24,31)                   /*!< IO space data bus HiZ time */
+
+/* EXMC_NECCx,x=1..2 */
+#define EXMC_NECC_ECC                       BITS(0,31)                    /*!< ECC result */
+
+/* EXMC_SDCTLx,x=0..1 */
+#define EXMC_SDCTL_CAW                      BITS(0,1)                     /*!< column address bit width */
+#define EXMC_SDCTL_RAW                      BITS(2,3)                     /*!< row address bit width */
+#define EXMC_SDCTL_SDW                      BITS(4,5)                     /*!< SDRAM data bus width */
+#define EXMC_SDCTL_NBK                      BIT(6)                        /*!< number of banks */
+#define EXMC_SDCTL_CL                       BIT(7,8)                      /*!< CAS Latency */
+#define EXMC_SDCTL_WPEN                     BIT(9)                        /*!< write protection enable */
+#define EXMC_SDCTL_SDCLK                    BITS(10,11)                   /*!< SDRAM clock configuration */
+#define EXMC_SDCTL_BRSTRD                   BIT(12)                       /*!< burst read enable */
+#define EXMC_SDCTL_PIPED                    BITS(13,14)                   /*!< pipeline delay */
+
+/* EXMC_SDTCFGx,x=0..1 */
+#define EXMC_SDTCFG_LMRD                    BITS(0,3)                     /*!< load mode register delay */
+#define EXMC_SDTCFG_XSRD                    BITS(4,7)                     /*!< exit self-refresh delay */
+#define EXMC_SDTCFG_RASD                    BITS(8,11)                    /*!< row address select delay */
+#define EXMC_SDTCFG_ARFD                    BITS(12,15)                   /*!< auto refresh delay */
+#define EXMC_SDTCFG_WRD                     BITS(16,19)                   /*!< write recovery delay */
+#define EXMC_SDTCFG_RPD                     BITS(20,23)                   /*!< row precharge delay */
+#define EXMC_SDTCFG_RCD                     BITS(24,27)                   /*!< row to column delay */
+
+/* EXMC_SDCMD */
+#define EXMC_SDCMD_CMD                      BITS(0,2)                     /*!< command */
+#define EXMC_SDCMD_DS1                      BIT(3)                        /*!< select device1 */
+#define EXMC_SDCMD_DS0                      BIT(4)                        /*!< select device0 */
+#define EXMC_SDCMD_NARF                     BITS(5,8)                     /*!< number of successive auto-refresh */
+#define EXMC_SDCMD_MRC                      BITS(9,21)                    /*!< mode register content */
+
+/* EXMC_SDARI */
+#define EXMC_SDARI_REC                      BIT(0)                        /*!< refresh error flag clear */
+#define EXMC_SDARI_ARINTV                   BITS(1,13)                    /*!< auto-refresh interval */
+#define EXMC_SDARI_REIE                     BIT(14)                       /*!< refresh error interrupt enable */
+
+/* EXMC_SDSTAT */
+#define EXMC_SDSDAT_REIF                    BIT(0)                        /*!< refresh error interrupt flag */
+#define EXMC_SDSDAT_STA0                    BITS(1,2)                     /*!< device0 status */
+#define EXMC_SDSDAT_STA1                    BITS(3,4)                     /*!< device1 status */
+#define EXMC_SDSDAT_NRDY                    BIT(5)                        /*!< not ready status */
+
+/* EXMC_SDRSCTL */
+#define EXMC_SDRSCTL_RSEN                   BIT(0)                        /*!< read sample enable */
+#define EXMC_SDRSCTL_SSCR                   BIT(1)                        /*!< select sample cycle of read data */
+#define EXMC_SDRSCTL_SDSC                   BITS(4,7)                     /*!< select the delayed sample clock of read data */
+
+/* EXMC_SINIT */
+#define EXMC_SINIT_CMDBIT                   BITS(16,17)                   /*!< bit number of SPI PSRAM command phase */
+#define EXMC_SINIT_ARDBIT                   BITS(24,28)                   /*!< bit number of SPI PSRAM address phase */
+#define EXMC_SINIT_IDL                      BITS(29,30)                   /*!< SPI PSRAM ID length */
+#define EXMC_SINIT_POL                      BIT(31)                       /*!< read data sample polarity */
+
+/* EXMC_SRCMD */
+#define EXMC_SRCMD_RCMD                     BITS(0,15)                    /*!< SPI read command for AHB read transfer */
+#define EXMC_SRCMD_RWAITCYCLE               BITS(16,19)                   /*!< SPI read wait cycle number after address phase */
+#define EXMC_SRCMD_RMODE                    BITS(20,21)                   /*!< SPI PSRAM read command mode */
+#define EXMC_SRCMD_RDID                     BIT(31)                       /*!< send SPI read ID command */
+
+/* EXMC_SWCMD */
+#define EXMC_SWCMD_WCMD                     BITS(0,15)                    /*!< SPI write command for AHB write transfer */
+#define EXMC_SWCMD_WWAITCYCLE               BITS(16,19)                   /*!< SPI write wait cycle number after address phase */
+#define EXMC_SWCMD_WMODE                    BITS(20,21)                   /*!< SPI PSRAM write command mode */
+#define EXMC_SWCMD_SC                       BIT(31)                       /*!< send SPI special command */
+
+/* EXMC_SIDL */
+#define EXMC_SIDL_SIDL                      BITS(0,31)                    /*!< ID low data saved for SPI read ID command */
+
+/* EXMC_SIDH */
+#define EXMC_SIDL_SIDH                      BITS(0,31)                    /*!< ID high Data saved for SPI read ID command */
+
+/* constants definitions */
+/* EXMC NOR/SRAM timing initialize structure */
+typedef struct
+{
+    uint32_t asyn_access_mode;                                          /*!< asynchronous access mode */
+    uint32_t syn_data_latency;                                          /*!< configure the data latency */
+    uint32_t syn_clk_division;                                          /*!< configure the clock divide ratio */
+    uint32_t bus_latency;                                               /*!< configure the bus latency */
+    uint32_t asyn_data_setuptime;                                       /*!< configure the data setup time, asynchronous access mode valid */
+    uint32_t asyn_address_holdtime;                                     /*!< configure the address hold time, asynchronous access mode valid */
+    uint32_t asyn_address_setuptime;                                    /*!< configure the address setup time, asynchronous access mode valid */
+}exmc_norsram_timing_parameter_struct;
+
+/* EXMC NOR/SRAM initialize structure */
+typedef struct
+{
+    uint32_t norsram_region;                                            /*!< select the region of EXMC NOR/SRAM bank */
+    uint32_t write_mode;                                                /*!< the write mode, synchronous mode or asynchronous mode */
+    uint32_t extended_mode;                                             /*!< enable or disable the extended mode */
+    uint32_t asyn_wait;                                                 /*!< enable or disable the asynchronous wait function */
+    uint32_t nwait_signal;                                              /*!< enable or disable the NWAIT signal while in synchronous bust mode */
+    uint32_t memory_write;                                              /*!< enable or disable the write operation */
+    uint32_t nwait_config;                                              /*!< NWAIT signal configuration */
+    uint32_t wrap_burst_mode;                                           /*!< enable or disable the wrap burst mode */
+    uint32_t nwait_polarity;                                            /*!< specifies the polarity of NWAIT signal from memory */
+    uint32_t burst_mode;                                                /*!< enable or disable the burst mode */
+    uint32_t databus_width;                                             /*!< specifies the databus width of external memory */
+    uint32_t memory_type;                                               /*!< specifies the type of external memory */
+    uint32_t address_data_mux;                                          /*!< specifies whether the data bus and address bus are multiplexed */
+    exmc_norsram_timing_parameter_struct* read_write_timing;            /*!< timing parameters for read and write if the extendedmode is not used or the timing 
+                                                                             parameters for read if the extendedmode is used. */
+    exmc_norsram_timing_parameter_struct* write_timing;                 /*!< timing parameters for write when the extendedmode is used. */
+}exmc_norsram_parameter_struct;
+
+/* EXMC NAND/PC card timing initialize structure */
+typedef struct
+{
+    uint32_t databus_hiztime;                                           /*!< configure the dadtabus HiZ time for write operation */
+    uint32_t holdtime;                                                  /*!< configure the address hold time(or the data hold time for write operation) */
+    uint32_t waittime;                                                  /*!< configure the minimum wait time */
+    uint32_t setuptime;                                                 /*!< configure the address setup time */
+}exmc_nand_pccard_timing_parameter_struct;
+
+/* EXMC NAND initialize structure */
+typedef struct
+{
+    uint32_t nand_bank;                                                 /*!< select the bank of NAND */ 
+    uint32_t ecc_size;                                                  /*!< the page size for the ECC calculation */
+    uint32_t atr_latency;                                               /*!< configure the latency of ALE low to RB low */
+    uint32_t ctr_latency;                                               /*!< configure the latency of CLE low to RB low */
+    uint32_t ecc_logic;                                                 /*!< enable or disable the ECC calculation logic */
+    uint32_t databus_width;                                             /*!< the NAND flash databus width */
+    uint32_t wait_feature;                                              /*!< enable or disable the wait feature */
+    exmc_nand_pccard_timing_parameter_struct* common_space_timing;      /*!< the timing parameters for NAND flash common space */
+    exmc_nand_pccard_timing_parameter_struct* attribute_space_timing;   /*!< the timing parameters for NAND flash attribute space */
+}exmc_nand_parameter_struct;
+
+/* EXMC PC card initialize structure */
+typedef struct
+{
+    uint32_t atr_latency;                                               /*!< configure the latency of ALE low to RB low */
+    uint32_t ctr_latency;                                               /*!< configure the latency of CLE low to RB low */
+    uint32_t wait_feature;                                              /*!< enable or disable the wait feature */
+    exmc_nand_pccard_timing_parameter_struct*  common_space_timing;     /*!< the timing parameters for PC card common space */
+    exmc_nand_pccard_timing_parameter_struct*  attribute_space_timing;  /*!< the timing parameters for PC card attribute space */
+    exmc_nand_pccard_timing_parameter_struct*  io_space_timing;         /*!< the timing parameters for PC card IO space */
+}exmc_pccard_parameter_struct;
+
+/* EXMC SDRAM timing initialize structure */
+typedef struct
+{
+    uint32_t row_to_column_delay;                                       /*!< configure the row to column delay */
+    uint32_t row_precharge_delay;                                       /*!< configure the row precharge delay */
+    uint32_t write_recovery_delay;                                      /*!< configure the write recovery delay */
+    uint32_t auto_refresh_delay;                                        /*!< configure the auto refresh delay */
+    uint32_t row_address_select_delay;                                  /*!< configure the row address select delay */
+    uint32_t exit_selfrefresh_delay;                                    /*!< configure the exit self-refresh delay */
+    uint32_t load_mode_register_delay;                                  /*!< configure the load mode register delay */
+}exmc_sdram_timing_parameter_struct;
+
+/* EXMC SDRAM initialize structure */
+typedef struct
+{
+    uint32_t sdram_device;                                              /*!< device of SDRAM */
+    uint32_t pipeline_read_delay;                                       /*!< the delay for reading data after CAS latency in HCLK clock cycles */
+    uint32_t burst_read_switch;                                         /*!< enable or disable the burst read */
+    uint32_t sdclock_config;                                            /*!< the SDCLK memory clock for both SDRAM banks */
+    uint32_t write_protection;                                          /*!< enable or disable SDRAM bank write protection function */
+    uint32_t cas_latency;                                               /*!< configure the SDRAM CAS latency */
+    uint32_t internal_bank_number;                                      /*!< the number of internal bank */
+    uint32_t data_width;                                                /*!< the databus width of SDRAM memory */
+    uint32_t row_address_width;                                         /*!< the bit width of a row address */
+    uint32_t column_address_width;                                      /*!< the bit width of a column address */
+    exmc_sdram_timing_parameter_struct* timing;                         /*!< the timing parameters for write and read SDRAM */
+}exmc_sdram_parameter_struct;
+
+/* EXMC SDRAM command initialize structure */
+typedef struct
+{
+    uint32_t mode_register_content;                                     /*!< the SDRAM mode register content */
+    uint32_t auto_refresh_number;                                       /*!< the number of successive auto-refresh cycles will be send when CMD = 011 */
+    uint32_t bank_select;                                               /*!< the bank which command will be sent to */
+    uint32_t command;                                                   /*!< the commands that will be sent to SDRAM */
+}exmc_sdram_command_parameter_struct;
+
+/* EXMC SQPISRAM initialize structure */
+typedef struct{
+    uint32_t sample_polarity;                                           /*!< read data sample polarity */
+    uint32_t id_length;                                                 /*!< SPI PSRAM ID length */
+    uint32_t address_bits;                                              /*!< bit number of SPI PSRAM address phase */
+    uint32_t command_bits;                                              /*!< bit number of SPI PSRAM command phase */
+}exmc_sqpipsram_parameter_struct;
+
+/* EXMC register address */
+#define EXMC_SNCTL(region)                    REG32(EXMC + 0x08U*((uint32_t)(region)))                      /*!< EXMC SRAM/NOR flash control registers, region = 0,1,2,3 */
+#define EXMC_SNTCFG(region)                   REG32(EXMC + 0x04U + 0x08U*((uint32_t)(region)))              /*!< EXMC SRAM/NOR flash timing configuration registers, region = 0,1,2,3 */
+#define EXMC_SNWTCFG(region)                  REG32(EXMC + 0x104U + 0x08U*((uint32_t)(region)))             /*!< EXMC SRAM/NOR flash write timing configuration registers, region = 0,1,2,3 */
+
+#define EXMC_NPCTL(bank)                      REG32(EXMC + 0x40U + 0x20U*((uint32_t)(bank)))                /*!< EXMC NAND/PC card control registers, bank = 1,2,3 */
+#define EXMC_NPINTEN(bank)                    REG32(EXMC + 0x44U + 0x20U*((uint32_t)(bank)))                /*!< EXMC NAND/PC card interrupt enable registers, bank = 1,2,3 */
+#define EXMC_NPCTCFG(bank)                    REG32(EXMC + 0x48U + 0x20U*((uint32_t)(bank)))                /*!< EXMC NAND/PC card common space timing configuration registers, bank = 1,2,3 */
+#define EXMC_NPATCFG(bank)                    REG32(EXMC + 0x4CU + 0x20U*((uint32_t)(bank)))                /*!< EXMC NAND/PC card attribute space timing configuration registers, bank = 1,2,3 */
+#define EXMC_NECC(bank)                       REG32(EXMC + 0x54U + 0x20U*((uint32_t)(bank)))                /*!< EXMC NAND ECC registers, bank = 1,2 */
+
+#define EXMC_SDCTL(device)                    REG32(EXMC + 0x140U + 0x4U*(((uint32_t)(device)) - 0x4U))     /*!< EXMC SDRAM control registers,device = 0,1 */
+#define EXMC_SDTCFG(device)                   REG32(EXMC + 0x148U + 0x4U*(((uint32_t)(device)) - 0x4U))     /*!< EXMC SDRAM timing configuration registers,device = 0,1 */
+
+/* CRAM page size */
+#define SNCTL_CPS(regval)                   (BITS(16,18) & ((uint32_t)(regval) << 16))
+#define EXMC_CRAM_AUTO_SPLIT                SNCTL_CPS(0)                  /*!< automatic burst split on page boundary crossing */
+#define EXMC_CRAM_PAGE_SIZE_128_BYTES       SNCTL_CPS(1)                  /*!< page size is 128 bytes */
+#define EXMC_CRAM_PAGE_SIZE_256_BYTES       SNCTL_CPS(2)                  /*!< page size is 256 bytes */
+#define EXMC_CRAM_PAGE_SIZE_512_BYTES       SNCTL_CPS(3)                  /*!< page size is 512 bytes */
+#define EXMC_CRAM_PAGE_SIZE_1024_BYTES      SNCTL_CPS(4)                  /*!< page size is 1024 bytes */
+
+/* NOR bank memory data bus width */
+#define SNCTL_NRW(regval)                   (BITS(4,5) & ((uint32_t)(regval) << 4))
+#define EXMC_NOR_DATABUS_WIDTH_8B           SNCTL_NRW(0)                  /*!< NOR data width is 8 bits */
+#define EXMC_NOR_DATABUS_WIDTH_16B          SNCTL_NRW(1)                  /*!< NOR data width is 16 bits */
+
+/* NOR bank memory type */
+#define SNCTL_NRTP(regval)                  (BITS(2,3) & ((uint32_t)(regval) << 2))
+#define EXMC_MEMORY_TYPE_SRAM               SNCTL_NRTP(0)                 /*!< SRAM,ROM */
+#define EXMC_MEMORY_TYPE_PSRAM              SNCTL_NRTP(1)                 /*!< PSRAM,CRAM */
+#define EXMC_MEMORY_TYPE_NOR                SNCTL_NRTP(2)                 /*!< NOR flash */
+
+/* asynchronous access mode */
+#define SNTCFG_ASYNCMOD(regval)             (BITS(28,29) & ((uint32_t)(regval) << 28))
+#define EXMC_ACCESS_MODE_A                  SNTCFG_ASYNCMOD(0)            /*!< mode A access */
+#define EXMC_ACCESS_MODE_B                  SNTCFG_ASYNCMOD(1)            /*!< mode B access */
+#define EXMC_ACCESS_MODE_C                  SNTCFG_ASYNCMOD(2)            /*!< mode C access */
+#define EXMC_ACCESS_MODE_D                  SNTCFG_ASYNCMOD(3)            /*!< mode D access */
+
+/* data latency for NOR flash */
+#define SNTCFG_DLAT(regval)                 (BITS(24,27) & ((uint32_t)(regval) << 24))
+#define EXMC_DATALAT_2_CLK                  SNTCFG_DLAT(0)                /*!< data latency of first burst access is 2 EXMC_CLK */
+#define EXMC_DATALAT_3_CLK                  SNTCFG_DLAT(1)                /*!< data latency of first burst access is 3 EXMC_CLK */
+#define EXMC_DATALAT_4_CLK                  SNTCFG_DLAT(2)                /*!< data latency of first burst access is 4 EXMC_CLK */
+#define EXMC_DATALAT_5_CLK                  SNTCFG_DLAT(3)                /*!< data latency of first burst access is 5 EXMC_CLK */
+#define EXMC_DATALAT_6_CLK                  SNTCFG_DLAT(4)                /*!< data latency of first burst access is 6 EXMC_CLK */
+#define EXMC_DATALAT_7_CLK                  SNTCFG_DLAT(5)                /*!< data latency of first burst access is 7 EXMC_CLK */
+#define EXMC_DATALAT_8_CLK                  SNTCFG_DLAT(6)                /*!< data latency of first burst access is 8 EXMC_CLK */
+#define EXMC_DATALAT_9_CLK                  SNTCFG_DLAT(7)                /*!< data latency of first burst access is 9 EXMC_CLK */
+#define EXMC_DATALAT_10_CLK                 SNTCFG_DLAT(8)                /*!< data latency of first burst access is 10 EXMC_CLK */
+#define EXMC_DATALAT_11_CLK                 SNTCFG_DLAT(9)                /*!< data latency of first burst access is 11 EXMC_CLK */
+#define EXMC_DATALAT_12_CLK                 SNTCFG_DLAT(10)               /*!< data latency of first burst access is 12 EXMC_CLK */
+#define EXMC_DATALAT_13_CLK                 SNTCFG_DLAT(11)               /*!< data latency of first burst access is 13 EXMC_CLK */
+#define EXMC_DATALAT_14_CLK                 SNTCFG_DLAT(12)               /*!< data latency of first burst access is 14 EXMC_CLK */
+#define EXMC_DATALAT_15_CLK                 SNTCFG_DLAT(13)               /*!< data latency of first burst access is 15 EXMC_CLK */
+#define EXMC_DATALAT_16_CLK                 SNTCFG_DLAT(14)               /*!< data latency of first burst access is 16 EXMC_CLK */
+#define EXMC_DATALAT_17_CLK                 SNTCFG_DLAT(15)               /*!< data latency of first burst access is 17 EXMC_CLK */
+
+/* synchronous clock divide ratio */
+#define SNTCFG_CKDIV(regval)                (BITS(20,23) & ((uint32_t)(regval) << 20))
+#define EXMC_SYN_CLOCK_RATIO_DISABLE        SNTCFG_CKDIV(0)               /*!< EXMC_CLK disable */
+#define EXMC_SYN_CLOCK_RATIO_2_CLK          SNTCFG_CKDIV(1)               /*!< EXMC_CLK = 2*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_3_CLK          SNTCFG_CKDIV(2)               /*!< EXMC_CLK = 3*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_4_CLK          SNTCFG_CKDIV(3)               /*!< EXMC_CLK = 4*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_5_CLK          SNTCFG_CKDIV(4)               /*!< EXMC_CLK = 5*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_6_CLK          SNTCFG_CKDIV(5)               /*!< EXMC_CLK = 6*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_7_CLK          SNTCFG_CKDIV(6)               /*!< EXMC_CLK = 7*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_8_CLK          SNTCFG_CKDIV(7)               /*!< EXMC_CLK = 8*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_9_CLK          SNTCFG_CKDIV(8)               /*!< EXMC_CLK = 9*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_10_CLK         SNTCFG_CKDIV(9)               /*!< EXMC_CLK = 10*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_11_CLK         SNTCFG_CKDIV(10)              /*!< EXMC_CLK = 11*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_12_CLK         SNTCFG_CKDIV(11)              /*!< EXMC_CLK = 12*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_13_CLK         SNTCFG_CKDIV(12)              /*!< EXMC_CLK = 13*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_14_CLK         SNTCFG_CKDIV(13)              /*!< EXMC_CLK = 14*HCLK*/
+#define EXMC_SYN_CLOCK_RATIO_15_CLK         SNTCFG_CKDIV(14)              /*!< EXMC_CLK = 15*HCLK */
+#define EXMC_SYN_CLOCK_RATIO_16_CLK         SNTCFG_CKDIV(15)              /*!< EXMC_CLK = 16*HCLK */
+
+/* ECC size */
+#define NPCTL_ECCSZ(regval)                 (BITS(17,19) & ((uint32_t)(regval) << 17))
+#define EXMC_ECC_SIZE_256BYTES              NPCTL_ECCSZ(0)                /* ECC size is 256 bytes */
+#define EXMC_ECC_SIZE_512BYTES              NPCTL_ECCSZ(1)                /* ECC size is 512 bytes */
+#define EXMC_ECC_SIZE_1024BYTES             NPCTL_ECCSZ(2)                /* ECC size is 1024 bytes */
+#define EXMC_ECC_SIZE_2048BYTES             NPCTL_ECCSZ(3)                /* ECC size is 2048 bytes */
+#define EXMC_ECC_SIZE_4096BYTES             NPCTL_ECCSZ(4)                /* ECC size is 4096 bytes */
+#define EXMC_ECC_SIZE_8192BYTES             NPCTL_ECCSZ(5)                /* ECC size is 8192 bytes */
+
+/* ALE to RE delay */
+#define NPCTL_ATR(regval)                   (BITS(13,16) & ((uint32_t)(regval) << 13))
+#define EXMC_ALE_RE_DELAY_1_HCLK            NPCTL_ATR(0)                  /* ALE to RE delay = 1*HCLK */
+#define EXMC_ALE_RE_DELAY_2_HCLK            NPCTL_ATR(1)                  /* ALE to RE delay = 2*HCLK */
+#define EXMC_ALE_RE_DELAY_3_HCLK            NPCTL_ATR(2)                  /* ALE to RE delay = 3*HCLK */
+#define EXMC_ALE_RE_DELAY_4_HCLK            NPCTL_ATR(3)                  /* ALE to RE delay = 4*HCLK */
+#define EXMC_ALE_RE_DELAY_5_HCLK            NPCTL_ATR(4)                  /* ALE to RE delay = 5*HCLK */
+#define EXMC_ALE_RE_DELAY_6_HCLK            NPCTL_ATR(5)                  /* ALE to RE delay = 6*HCLK */
+#define EXMC_ALE_RE_DELAY_7_HCLK            NPCTL_ATR(6)                  /* ALE to RE delay = 7*HCLK */
+#define EXMC_ALE_RE_DELAY_8_HCLK            NPCTL_ATR(7)                  /* ALE to RE delay = 8*HCLK */
+#define EXMC_ALE_RE_DELAY_9_HCLK            NPCTL_ATR(8)                  /* ALE to RE delay = 9*HCLK */
+#define EXMC_ALE_RE_DELAY_10_HCLK           NPCTL_ATR(9)                  /* ALE to RE delay = 10*HCLK */
+#define EXMC_ALE_RE_DELAY_11_HCLK           NPCTL_ATR(10)                 /* ALE to RE delay = 11*HCLK */
+#define EXMC_ALE_RE_DELAY_12_HCLK           NPCTL_ATR(11)                 /* ALE to RE delay = 12*HCLK */
+#define EXMC_ALE_RE_DELAY_13_HCLK           NPCTL_ATR(12)                 /* ALE to RE delay = 13*HCLK */
+#define EXMC_ALE_RE_DELAY_14_HCLK           NPCTL_ATR(13)                 /* ALE to RE delay = 14*HCLK */
+#define EXMC_ALE_RE_DELAY_15_HCLK           NPCTL_ATR(14)                 /* ALE to RE delay = 15*HCLK */
+#define EXMC_ALE_RE_DELAY_16_HCLK           NPCTL_ATR(15)                 /* ALE to RE delay = 16*HCLK */
+
+/* CLE to RE delay */
+#define NPCTL_CTR(regval)                   (BITS(9,12) & ((uint32_t)(regval) << 9))
+#define EXMC_CLE_RE_DELAY_1_HCLK            NPCTL_CTR(0)                  /* CLE to RE delay = 1*HCLK */
+#define EXMC_CLE_RE_DELAY_2_HCLK            NPCTL_CTR(1)                  /* CLE to RE delay = 2*HCLK */
+#define EXMC_CLE_RE_DELAY_3_HCLK            NPCTL_CTR(2)                  /* CLE to RE delay = 3*HCLK */
+#define EXMC_CLE_RE_DELAY_4_HCLK            NPCTL_CTR(3)                  /* CLE to RE delay = 4*HCLK */
+#define EXMC_CLE_RE_DELAY_5_HCLK            NPCTL_CTR(4)                  /* CLE to RE delay = 5*HCLK */
+#define EXMC_CLE_RE_DELAY_6_HCLK            NPCTL_CTR(5)                  /* CLE to RE delay = 6*HCLK */
+#define EXMC_CLE_RE_DELAY_7_HCLK            NPCTL_CTR(6)                  /* CLE to RE delay = 7*HCLK */
+#define EXMC_CLE_RE_DELAY_8_HCLK            NPCTL_CTR(7)                  /* CLE to RE delay = 8*HCLK */
+#define EXMC_CLE_RE_DELAY_9_HCLK            NPCTL_CTR(8)                  /* CLE to RE delay = 9*HCLK */
+#define EXMC_CLE_RE_DELAY_10_HCLK           NPCTL_CTR(9)                  /* CLE to RE delay = 10*HCLK */
+#define EXMC_CLE_RE_DELAY_11_HCLK           NPCTL_CTR(10)                 /* CLE to RE delay = 11*HCLK */
+#define EXMC_CLE_RE_DELAY_12_HCLK           NPCTL_CTR(11)                 /* CLE to RE delay = 12*HCLK */
+#define EXMC_CLE_RE_DELAY_13_HCLK           NPCTL_CTR(12)                 /* CLE to RE delay = 13*HCLK */
+#define EXMC_CLE_RE_DELAY_14_HCLK           NPCTL_CTR(13)                 /* CLE to RE delay = 14*HCLK */
+#define EXMC_CLE_RE_DELAY_15_HCLK           NPCTL_CTR(14)                 /* CLE to RE delay = 15*HCLK */
+#define EXMC_CLE_RE_DELAY_16_HCLK           NPCTL_CTR(15)                 /* CLE to RE delay = 16*HCLK */
+
+/* NAND bank memory data bus width */
+#define NPCTL_NDW(regval)                   (BITS(4,5) & ((uint32_t)(regval) << 4))
+#define EXMC_NAND_DATABUS_WIDTH_8B          NPCTL_NDW(0)                  /*!< NAND data width is 8 bits */
+#define EXMC_NAND_DATABUS_WIDTH_16B         NPCTL_NDW(1)                  /*!< NAND data width is 16 bits */
+
+/* SDRAM pipeline delay */
+#define SDCTL_PIPED(regval)                 (BITS(13,14) & ((uint32_t)(regval) << 13))
+#define EXMC_PIPELINE_DELAY_0_HCLK          SDCTL_PIPED(0)                /*!< 0 HCLK clock cycle delay */
+#define EXMC_PIPELINE_DELAY_1_HCLK          SDCTL_PIPED(1)                /*!< 1 HCLK clock cycle delay */
+#define EXMC_PIPELINE_DELAY_2_HCLK          SDCTL_PIPED(2)                /*!< 2 HCLK clock cycle delay */
+
+/* SDRAM clock configuration */
+#define SDCTL_SDCLK(regval)                 (BITS(10,11) & ((uint32_t)(regval) << 10))
+#define EXMC_SDCLK_DISABLE                  SDCTL_SDCLK(0)                /*!< SDCLK memory clock disabled */
+#define EXMC_SDCLK_PERIODS_2_HCLK           SDCTL_SDCLK(2)                /*!< SDCLK memory period = 2*HCLK */
+#define EXMC_SDCLK_PERIODS_3_HCLK           SDCTL_SDCLK(3)                /*!< SDCLK memory period = 3*HCLK */
+
+/* CAS latency */
+#define SDCTL_CL(regval)                    (BITS(7,8) & ((uint32_t)(regval) << 7))
+#define EXMC_CAS_LATENCY_1_SDCLK            SDCTL_CL(1)                   /*!< CAS latency is 1 memory clock cycle */
+#define EXMC_CAS_LATENCY_2_SDCLK            SDCTL_CL(2)                   /*!< CAS latency is 2 memory clock cycle */
+#define EXMC_CAS_LATENCY_3_SDCLK            SDCTL_CL(3)                   /*!< CAS latency is 3 memory clock cycle */
+
+/* SDRAM data bus width */
+#define SDCTL_SDW(regval)                   (BITS(4,5) & ((uint32_t)(regval) << 4))
+#define EXMC_SDRAM_DATABUS_WIDTH_8B         SDCTL_SDW(0)                  /*!< SDRAM data width 8 bits */
+#define EXMC_SDRAM_DATABUS_WIDTH_16B        SDCTL_SDW(1)                  /*!< SDRAM data width 16 bits */
+#define EXMC_SDRAM_DATABUS_WIDTH_32B        SDCTL_SDW(2)                  /*!< SDRAM data width 32 bits */
+
+/* SDRAM row address bit width */
+#define SDCTL_RAW(regval)                   (BITS(2,3) & ((uint32_t)(regval) << 2))
+#define EXMC_SDRAM_ROW_ADDRESS_11           SDCTL_RAW(0)                  /*!< row address bit width is 11 bits */
+#define EXMC_SDRAM_ROW_ADDRESS_12           SDCTL_RAW(1)                  /*!< row address bit width is 12 bits */
+#define EXMC_SDRAM_ROW_ADDRESS_13           SDCTL_RAW(2)                  /*!< row address bit width is 13 bits */
+
+/* SDRAM column address bit width */
+#define SDCTL_CAW(regval)                   (BITS(0,1) & ((uint32_t)(regval) << 0))
+#define EXMC_SDRAM_COW_ADDRESS_8            SDCTL_CAW(0)                  /*!< column address bit width is 8 bits */
+#define EXMC_SDRAM_COW_ADDRESS_9            SDCTL_CAW(1)                  /*!< column address bit width is 9 bits */
+#define EXMC_SDRAM_COW_ADDRESS_10           SDCTL_CAW(2)                  /*!< column address bit width is 10 bits */
+#define EXMC_SDRAM_COW_ADDRESS_11           SDCTL_CAW(3)                  /*!< column address bit width is 11 bits */
+
+/* SDRAM number of successive auto-refresh */
+#define SDCMD_NARF(regval)                  (BITS(5,8) & ((uint32_t)(regval) << 5))
+#define EXMC_SDRAM_AUTO_REFLESH_1_SDCLK     SDCMD_NARF(0)                 /*!< 1 auto-refresh cycle */
+#define EXMC_SDRAM_AUTO_REFLESH_2_SDCLK     SDCMD_NARF(1)                 /*!< 2 auto-refresh cycles */
+#define EXMC_SDRAM_AUTO_REFLESH_3_SDCLK     SDCMD_NARF(2)                 /*!< 3 auto-refresh cycles */
+#define EXMC_SDRAM_AUTO_REFLESH_4_SDCLK     SDCMD_NARF(3)                 /*!< 4 auto-refresh cycles */
+#define EXMC_SDRAM_AUTO_REFLESH_5_SDCLK     SDCMD_NARF(4)                 /*!< 5 auto-refresh cycles */
+#define EXMC_SDRAM_AUTO_REFLESH_6_SDCLK     SDCMD_NARF(5)                 /*!< 6 auto-refresh cycles */
+#define EXMC_SDRAM_AUTO_REFLESH_7_SDCLK     SDCMD_NARF(6)                 /*!< 7 auto-refresh cycles */
+#define EXMC_SDRAM_AUTO_REFLESH_8_SDCLK     SDCMD_NARF(7)                 /*!< 8 auto-refresh cycles */
+#define EXMC_SDRAM_AUTO_REFLESH_9_SDCLK     SDCMD_NARF(8)                 /*!< 9 auto-refresh cycles */
+#define EXMC_SDRAM_AUTO_REFLESH_10_SDCLK    SDCMD_NARF(9)                 /*!< 10 auto-refresh cycles */
+#define EXMC_SDRAM_AUTO_REFLESH_11_SDCLK    SDCMD_NARF(10)                /*!< 11 auto-refresh cycles */
+#define EXMC_SDRAM_AUTO_REFLESH_12_SDCLK    SDCMD_NARF(11)                /*!< 12 auto-refresh cycles */
+#define EXMC_SDRAM_AUTO_REFLESH_13_SDCLK    SDCMD_NARF(12)                /*!< 13 auto-refresh cycles */
+#define EXMC_SDRAM_AUTO_REFLESH_14_SDCLK    SDCMD_NARF(13)                /*!< 14 auto-refresh cycles */
+#define EXMC_SDRAM_AUTO_REFLESH_15_SDCLK    SDCMD_NARF(14)                /*!< 15 auto-refresh cycles */
+
+/* SDRAM command selection */
+#define SDCMD_CMD(regval)                   (BITS(0,2) & ((uint32_t)(regval) << 0))
+#define EXMC_SDRAM_NORMAL_OPERATION         SDCMD_CMD(0)                  /*!< normal operation command */
+#define EXMC_SDRAM_CLOCK_ENABLE             SDCMD_CMD(1)                  /*!< clock enable command */
+#define EXMC_SDRAM_PRECHARGE_ALL            SDCMD_CMD(2)                  /*!< precharge all command */
+#define EXMC_SDRAM_AUTO_REFRESH             SDCMD_CMD(3)                  /*!< auto-refresh command */
+#define EXMC_SDRAM_LOAD_MODE_REGISTER       SDCMD_CMD(4)                  /*!< load mode register command */
+#define EXMC_SDRAM_SELF_REFRESH             SDCMD_CMD(5)                  /*!< self-refresh command */
+#define EXMC_SDRAM_POWERDOWN_ENTRY          SDCMD_CMD(6)                  /*!< power-down entry command */
+
+/* SDRAM the delayed sample clock of read data */
+#define SDRSCTL_SDSC(regval)                (BITS(4,7) & ((uint32_t)(regval) << 4))
+#define EXMC_SDRAM_0_DELAY_CELL             SDRSCTL_SDSC(0)               /*!< select the clock after 0 delay cell */
+#define EXMC_SDRAM_1_DELAY_CELL             SDRSCTL_SDSC(1)               /*!< select the clock after 1 delay cell */
+#define EXMC_SDRAM_2_DELAY_CELL             SDRSCTL_SDSC(2)               /*!< select the clock after 2 delay cell */
+#define EXMC_SDRAM_3_DELAY_CELL             SDRSCTL_SDSC(3)               /*!< select the clock after 3 delay cell */
+#define EXMC_SDRAM_4_DELAY_CELL             SDRSCTL_SDSC(4)               /*!< select the clock after 4 delay cell */
+#define EXMC_SDRAM_5_DELAY_CELL             SDRSCTL_SDSC(5)               /*!< select the clock after 5 delay cell */
+#define EXMC_SDRAM_6_DELAY_CELL             SDRSCTL_SDSC(6)               /*!< select the clock after 6 delay cell */
+#define EXMC_SDRAM_7_DELAY_CELL             SDRSCTL_SDSC(7)               /*!< select the clock after 7 delay cell */
+#define EXMC_SDRAM_8_DELAY_CELL             SDRSCTL_SDSC(8)               /*!< select the clock after 8 delay cell */
+#define EXMC_SDRAM_9_DELAY_CELL             SDRSCTL_SDSC(9)               /*!< select the clock after 9 delay cell */
+#define EXMC_SDRAM_10_DELAY_CELL            SDRSCTL_SDSC(10)              /*!< select the clock after 10 delay cell */
+#define EXMC_SDRAM_11_DELAY_CELL            SDRSCTL_SDSC(11)              /*!< select the clock after 11 delay cell */
+#define EXMC_SDRAM_12_DELAY_CELL            SDRSCTL_SDSC(12)              /*!< select the clock after 12 delay cell */
+#define EXMC_SDRAM_13_DELAY_CELL            SDRSCTL_SDSC(13)              /*!< select the clock after 13 delay cell */
+#define EXMC_SDRAM_14_DELAY_CELL            SDRSCTL_SDSC(14)              /*!< select the clock after 14 delay cell */
+#define EXMC_SDRAM_15_DELAY_CELL            SDRSCTL_SDSC(15)              /*!< select the clock after 15 delay cell */
+
+/* SPI PSRAM ID length */
+#define SINIT_IDL(regval)                   (BITS(29,30) & ((uint32_t)(regval) << 29))
+#define EXMC_SQPIPSRAM_ID_LENGTH_64B        SINIT_IDL(0)                  /*!< SPI PSRAM ID length is 64 bits */
+#define EXMC_SQPIPSRAM_ID_LENGTH_32B        SINIT_IDL(1)                  /*!< SPI PSRAM ID length is 32 bits */
+#define EXMC_SQPIPSRAM_ID_LENGTH_16B        SINIT_IDL(2)                  /*!< SPI PSRAM ID length is 16 bits */
+#define EXMC_SQPIPSRAM_ID_LENGTH_8B         SINIT_IDL(3)                  /*!< SPI PSRAM ID length is 8 bits */
+
+/* SPI PSRAM bit number of address phase */
+#define SINIT_ADRBIT(regval)                (BITS(24,28) & ((uint32_t)(regval) << 24))
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_1B       SINIT_ADRBIT(1)               /*!< SPI PSRAM address is 1 bit */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_2B       SINIT_ADRBIT(2)               /*!< SPI PSRAM address is 2 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_3B       SINIT_ADRBIT(3)               /*!< SPI PSRAM address is 3 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_4B       SINIT_ADRBIT(4)               /*!< SPI PSRAM address is 4 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_5B       SINIT_ADRBIT(5)               /*!< SPI PSRAM address is 5 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_6B       SINIT_ADRBIT(6)               /*!< SPI PSRAM address is 6 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_7B       SINIT_ADRBIT(7)               /*!< SPI PSRAM address is 7 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_8B       SINIT_ADRBIT(8)               /*!< SPI PSRAM address is 8 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_9B       SINIT_ADRBIT(9)               /*!< SPI PSRAM address is 9 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_10B      SINIT_ADRBIT(10)              /*!< SPI PSRAM address is 10 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_11B      SINIT_ADRBIT(11)              /*!< SPI PSRAM address is 11 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_12B      SINIT_ADRBIT(12)              /*!< SPI PSRAM address is 12 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_13B      SINIT_ADRBIT(13)              /*!< SPI PSRAM address is 13 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_14B      SINIT_ADRBIT(14)              /*!< SPI PSRAM address is 14 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_15B      SINIT_ADRBIT(15)              /*!< SPI PSRAM address is 15 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_16B      SINIT_ADRBIT(16)              /*!< SPI PSRAM address is 16 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_17B      SINIT_ADRBIT(17)              /*!< SPI PSRAM address is 17 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_18B      SINIT_ADRBIT(18)              /*!< SPI PSRAM address is 18 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_19B      SINIT_ADRBIT(19)              /*!< SPI PSRAM address is 19 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_20B      SINIT_ADRBIT(20)              /*!< SPI PSRAM address is 20 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_21B      SINIT_ADRBIT(21)              /*!< SPI PSRAM address is 21 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_22B      SINIT_ADRBIT(22)              /*!< SPI PSRAM address is 22 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_23B      SINIT_ADRBIT(23)              /*!< SPI PSRAM address is 23 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_24B      SINIT_ADRBIT(24)              /*!< SPI PSRAM address is 24 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_25B      SINIT_ADRBIT(25)              /*!< SPI PSRAM address is 25 bits */
+#define EXMC_SQPIPSRAM_ADDR_LENGTH_26B      SINIT_ADRBIT(26)              /*!< SPI PSRAM address is 26 bits */
+
+/* SPI PSRAM bit number of command phase */
+#define SINIT_CMDBIT(regval)                (BITS(16,17) & ((uint32_t)(regval) << 16))
+#define EXMC_SQPIPSRAM_COMMAND_LENGTH_4B    SINIT_CMDBIT(0)               /*!< SPI PSRAM command is 4 bits */
+#define EXMC_SQPIPSRAM_COMMAND_LENGTH_8B    SINIT_CMDBIT(1)               /*!< SPI PSRAM command is 8 bits */
+#define EXMC_SQPIPSRAM_COMMAND_LENGTH_16B   SINIT_CMDBIT(2)               /*!< SPI PSRAM command is 16 bits */
+
+/* SPI PSRAM read command mode */
+#define SRCMD_RMODE(regval)                 (BITS(20,21) & ((uint32_t)(regval) << 20))
+#define EXMC_SQPIPSRAM_READ_MODE_DISABLE    SRCMD_RMODE(0)                /*!< not SPI mode */
+#define EXMC_SQPIPSRAM_READ_MODE_SPI        SRCMD_RMODE(1)                /*!< SPI mode */
+#define EXMC_SQPIPSRAM_READ_MODE_SQPI       SRCMD_RMODE(2)                /*!< SQPI mode */
+#define EXMC_SQPIPSRAM_READ_MODE_QPI        SRCMD_RMODE(3)                /*!< QPI mode */
+
+/* SPI PSRAM write command mode */
+#define SRCMD_WMODE(regval)                 (BITS(20,21) & ((uint32_t)(regval) << 20))
+#define EXMC_SQPIPSRAM_WRITE_MODE_DISABLE   SRCMD_WMODE(0)                /*!< not SPI mode */
+#define EXMC_SQPIPSRAM_WRITE_MODE_SPI       SRCMD_WMODE(1)                /*!< SPI mode */
+#define EXMC_SQPIPSRAM_WRITE_MODE_SQPI      SRCMD_WMODE(2)                /*!< SQPI mode */
+#define EXMC_SQPIPSRAM_WRITE_MODE_QPI       SRCMD_WMODE(3)                /*!< QPI mode */
+
+/* EXMC NOR/SRAM bank region definition */
+#define EXMC_BANK0_NORSRAM_REGION0          ((uint32_t)0x00000000U)       /*!< bank0 NOR/SRAM region0 */
+#define EXMC_BANK0_NORSRAM_REGION1          ((uint32_t)0x00000001U)       /*!< bank0 NOR/SRAM region1 */
+#define EXMC_BANK0_NORSRAM_REGION2          ((uint32_t)0x00000002U)       /*!< bank0 NOR/SRAM region2 */
+#define EXMC_BANK0_NORSRAM_REGION3          ((uint32_t)0x00000003U)       /*!< bank0 NOR/SRAM region3 */
+
+/* EXMC consecutive clock */
+#define EXMC_CLOCK_SYN_MODE                 ((uint32_t)0x00000000U)       /*!< EXMC_CLK is generated only during synchronous access */
+#define EXMC_CLOCK_UNCONDITIONALLY          EXMC_SNCTL_CCK                /*!< EXMC_CLK is generated unconditionally */
+
+/* EXMC NOR/SRAM write mode */
+#define EXMC_ASYN_WRITE                     ((uint32_t)0x00000000U)       /*!< asynchronous write mode */
+#define EXMC_SYN_WRITE                      EXMC_SNCTL_SYNCWR             /*!< synchronous write mode */
+
+/* EXMC NWAIT signal configuration */
+#define EXMC_NWAIT_CONFIG_BEFORE            ((uint32_t)0x00000000U)       /*!< NWAIT signal is active one data cycle before wait state */
+#define EXMC_NWAIT_CONFIG_DURING            EXMC_SNCTL_NRWTCFG            /*!< NWAIT signal is active during wait state */
+
+/* EXMC NWAIT signal polarity configuration */
+#define EXMC_NWAIT_POLARITY_LOW             ((uint32_t)0x00000000U)       /*!< low level is active of NWAIT */
+#define EXMC_NWAIT_POLARITY_HIGH            EXMC_SNCTL_NRWTPOL            /*!< high level is active of NWAIT */
+
+/* EXMC NAND/PC card bank definition */
+#define EXMC_BANK1_NAND                     ((uint32_t)0x00000001U)       /*!< NAND flash bank1 */
+#define EXMC_BANK2_NAND                     ((uint32_t)0x00000002U)       /*!< NAND flash bank2 */
+#define EXMC_BANK3_PCCARD                   ((uint32_t)0x00000003U)       /*!< PC card bank3 */
+
+/* EXMC SDRAM bank definition */
+#define EXMC_SDRAM_DEVICE0                  ((uint32_t)0x00000004U)       /*!< SDRAM device0 */
+#define EXMC_SDRAM_DEVICE1                  ((uint32_t)0x00000005U)       /*!< SDRAM device1 */
+
+/* EXMC SDRAM internal banks */
+#define EXMC_SDRAM_2_INTER_BANK             ((uint32_t)0x00000000U)       /*!< 2 internal banks */
+#define EXMC_SDRAM_4_INTER_BANK             EXMC_SDCTL_NBK                /*!< 4 internal banks */
+
+/* SDRAM device0 selection */
+#define EXMC_SDRAM_DEVICE0_UNSELECT         ((uint32_t)0x00000000U)       /*!< unselect SDRAM device0 */
+#define EXMC_SDRAM_DEVICE0_SELECT           EXMC_SDCMD_DS0                /*!< select SDRAM device0 */
+
+/* SDRAM device1 selection */
+#define EXMC_SDRAM_DEVICE1_UNSELECT         ((uint32_t)0x00000000U)       /*!< unselect SDRAM device1 */
+#define EXMC_SDRAM_DEVICE1_SELECT           EXMC_SDCMD_DS1                /*!< select SDRAM device1 */
+
+/* SDRAM device status */
+#define EXMC_SDRAM_DEVICE_NORMAL            ((uint32_t)0x00000000U)       /*!< normal status */
+#define EXMC_SDRAM_DEVICE_SELF_REFRESH      ((uint32_t)0x00000001U)       /*!< self refresh status */
+#define EXMC_SDRAM_DEVICE_POWER_DOWN        ((uint32_t)0x00000002U)       /*!< power down status */
+
+/* sample cycle of read data */
+#define EXMC_SDRAM_READSAMPLE_0_EXTRAHCLK   ((uint32_t)0x00000000U)       /*!< add 0 extra HCLK cycle to the read data sample clock besides the delay chain */
+#define EXMC_SDRAM_READSAMPLE_1_EXTRAHCLK   EXMC_SDRSCTL_SSCR             /*!< add 1 extra HCLK cycle to the read data sample clock besides the delay chain */
+
+/* read data sample polarity */
+#define EXMC_SQPIPSRAM_SAMPLE_RISING_EDGE   ((uint32_t)0x00000000U)       /*!< sample data at rising edge */
+#define EXMC_SQPIPSRAM_SAMPLE_FALLING_EDGE  EXMC_SINIT_POL                /*!< sample data at falling edge */
+
+/* SQPI SRAM command flag */
+#define EXMC_SEND_COMMAND_FLAG_RDID         EXMC_SRCMD_RDID               /*!< EXMC_SRCMD_RDID flag bit */
+#define EXMC_SEND_COMMAND_FLAG_SC           EXMC_SWCMD_SC                 /*!< EXMC_SWCMD_SC flag bit */
+
+/* EXMC flag bits */
+#define EXMC_NAND_PCCARD_FLAG_RISE          EXMC_NPINTEN_INTRS            /*!< interrupt rising edge status */
+#define EXMC_NAND_PCCARD_FLAG_LEVEL         EXMC_NPINTEN_INTHS            /*!< interrupt high-level status */
+#define EXMC_NAND_PCCARD_FLAG_FALL          EXMC_NPINTEN_INTFS            /*!< interrupt falling edge status */
+#define EXMC_NAND_PCCARD_FLAG_FIFOE         EXMC_NPINTEN_FFEPT            /*!< FIFO empty flag */
+#define EXMC_SDRAM_FLAG_REFRESH             EXMC_SDSDAT_REIF              /*!< refresh error interrupt flag */
+#define EXMC_SDRAM_FLAG_NREADY              EXMC_SDSDAT_NRDY              /*!< not ready status  */
+
+/* EXMC interrupt flag bits */
+#define EXMC_NAND_PCCARD_INT_FLAG_RISE      EXMC_NPINTEN_INTREN           /*!< rising edge interrupt and flag */
+#define EXMC_NAND_PCCARD_INT_FLAG_LEVEL     EXMC_NPINTEN_INTHEN           /*!< high-level interrupt and flag  */
+#define EXMC_NAND_PCCARD_INT_FLAG_FALL      EXMC_NPINTEN_INTFEN           /*!< falling edge interrupt and flag */
+#define EXMC_SDRAM_INT_FLAG_REFRESH         EXMC_SDARI_REIE               /*!< refresh error interrupt and flag  */
+
+/* function declarations */
+/* initialization functions */
+/* NOR/SRAM */
+/* deinitialize EXMC NOR/SRAM region */
+void exmc_norsram_deinit(uint32_t exmc_norsram_region);
+/* initialize exmc_norsram_parameter_struct with the default values */
+void exmc_norsram_struct_para_init(exmc_norsram_parameter_struct* exmc_norsram_init_struct);
+/* initialize EXMC NOR/SRAM region */
+void exmc_norsram_init(exmc_norsram_parameter_struct* exmc_norsram_init_struct);
+/* enable EXMC NOR/SRAM region */
+void exmc_norsram_enable(uint32_t exmc_norsram_region);
+/* disable EXMC NOR/SRAM region */
+void exmc_norsram_disable(uint32_t exmc_norsram_region);
+/* NAND */
+/* deinitialize EXMC NAND bank */
+void exmc_nand_deinit(uint32_t exmc_nand_bank);
+/* initialize exmc_nand_parameter_struct with the default values */
+void exmc_nand_struct_para_init(exmc_nand_parameter_struct* exmc_nand_init_struct);
+/* initialize EXMC NAND bank */
+void exmc_nand_init(exmc_nand_parameter_struct* exmc_nand_init_struct);
+/* enable EXMC NAND bank */
+void exmc_nand_enable(uint32_t exmc_nand_bank);
+/* disable EXMC NAND bank */
+void exmc_nand_disable(uint32_t exmc_nand_bank);
+/* PC card */
+/* deinitialize EXMC PC card bank */
+void exmc_pccard_deinit(void);
+/* initialize exmc_pccard_parameter_struct with the default values */
+void exmc_pccard_struct_para_init(exmc_pccard_parameter_struct* exmc_pccard_init_struct);
+/* initialize EXMC PC card bank */
+void exmc_pccard_init(exmc_pccard_parameter_struct* exmc_pccard_init_struct);
+/* enable EXMC PC card bank */
+void exmc_pccard_enable(void);
+/* disable EXMC PC card bank */
+void exmc_pccard_disable(void);
+/* SDRAM */
+/* deinitialize EXMC SDRAM device */
+void exmc_sdram_deinit(uint32_t exmc_sdram_device);
+/* initialize exmc_sdram_parameter_struct with the default values */
+void exmc_sdram_struct_para_init(exmc_sdram_parameter_struct* exmc_sdram_init_struct);
+/* initialize EXMC SDRAM device */
+void exmc_sdram_init(exmc_sdram_parameter_struct* exmc_sdram_init_struct);
+/* initialize exmc_sdram_command_parameter_struct with the default values */
+void exmc_sdram_struct_command_para_init(exmc_sdram_command_parameter_struct *exmc_sdram_command_init_struct);
+/* SQPIPSRAM */
+/* deinitialize EXMC SQPIPSRAM */
+void exmc_sqpipsram_deinit(void);
+/* initialize exmc_sqpipsram_parameter_struct with the default values */
+void exmc_sqpipsram_struct_para_init(exmc_sqpipsram_parameter_struct* exmc_sqpipsram_init_struct);
+/* initialize EXMC SQPIPSRAM */
+void exmc_sqpipsram_init(exmc_sqpipsram_parameter_struct* exmc_sqpipsram_init_struct);
+
+/* function configuration */
+/* NOR/SRAM */
+/* configure consecutive clock */
+void exmc_norsram_consecutive_clock_config(uint32_t clock_mode);
+/* configure CRAM page size */
+void exmc_norsram_page_size_config(uint32_t exmc_norsram_region, uint32_t page_size);
+/* NAND */
+/* enable or disable the EXMC NAND ECC function */
+void exmc_nand_ecc_config(uint32_t exmc_nand_bank, ControlStatus newvalue);
+/* get the EXMC ECC value */
+uint32_t exmc_ecc_get(uint32_t exmc_nand_bank);
+/* SDRAM */
+/* enable or disable read sample */
+void exmc_sdram_readsample_enable(ControlStatus newvalue);
+/* configure the delayed sample clock of read data */
+void exmc_sdram_readsample_config(uint32_t delay_cell, uint32_t extra_hclk);
+/* configure the SDRAM memory command */
+void exmc_sdram_command_config(exmc_sdram_command_parameter_struct* exmc_sdram_command_init_struct);
+/* set auto-refresh interval */
+void exmc_sdram_refresh_count_set(uint32_t exmc_count);
+/* set the number of successive auto-refresh command */
+void exmc_sdram_autorefresh_number_set(uint32_t exmc_number);
+/* configure the write protection function */
+void exmc_sdram_write_protection_config(uint32_t exmc_sdram_device, ControlStatus newvalue);
+/* get the status of SDRAM device0 or device1 */
+uint32_t exmc_sdram_bankstatus_get(uint32_t exmc_sdram_device);
+/* SQPIPSRAM */
+/* set the read command */
+void exmc_sqpipsram_read_command_set(uint32_t read_command_mode,uint32_t read_wait_cycle,uint32_t read_command_code);
+/* set the write command */
+void exmc_sqpipsram_write_command_set(uint32_t write_command_mode,uint32_t write_wait_cycle,uint32_t write_command_code);
+/* send SPI read ID command */
+void exmc_sqpipsram_read_id_command_send(void);
+/* send SPI special command which does not have address and data phase */
+void exmc_sqpipsram_write_cmd_send(void);
+/* get the EXMC SPI ID low data */
+uint32_t exmc_sqpipsram_low_id_get(void);
+/* get the EXMC SPI ID high data */
+uint32_t exmc_sqpipsram_high_id_get(void);
+/* get the bit value of EXMC send write command bit or read ID command */
+FlagStatus exmc_sqpipsram_send_command_state_get(uint32_t send_command_flag);
+
+/* interrupt & flag functions */
+/* enable EXMC interrupt */
+void exmc_interrupt_enable(uint32_t exmc_bank,uint32_t interrupt);
+/* disable EXMC interrupt */
+void exmc_interrupt_disable(uint32_t exmc_bank,uint32_t interrupt);
+/* get EXMC flag status */
+FlagStatus exmc_flag_get(uint32_t exmc_bank,uint32_t flag);
+/* clear EXMC flag status */
+void exmc_flag_clear(uint32_t exmc_bank,uint32_t flag);
+/* get EXMC interrupt flag */
+FlagStatus exmc_interrupt_flag_get(uint32_t exmc_bank,uint32_t interrupt);
+/* clear EXMC interrupt flag */
+void exmc_interrupt_flag_clear(uint32_t exmc_bank,uint32_t interrupt);
+
+#endif /* GD32F4XX_EXMC_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_exti.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_exti.h
@@ -1,0 +1,277 @@
+/*!
+    \file    gd32f4xx_exti.h
+    \brief   definitions for the EXTI
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_EXTI_H
+#define GD32F4XX_EXTI_H
+
+#include "gd32f4xx.h"
+
+/* EXTI definitions */
+#define EXTI                         EXTI_BASE
+
+/* registers definitions */
+#define EXTI_INTEN                   REG32(EXTI + 0x00U)      /*!< interrupt enable register */
+#define EXTI_EVEN                    REG32(EXTI + 0x04U)      /*!< event enable register */
+#define EXTI_RTEN                    REG32(EXTI + 0x08U)      /*!< rising edge trigger enable register */
+#define EXTI_FTEN                    REG32(EXTI + 0x0CU)      /*!< falling trigger enable register */
+#define EXTI_SWIEV                   REG32(EXTI + 0x10U)      /*!< software interrupt event register */
+#define EXTI_PD                      REG32(EXTI + 0x14U)      /*!< pending register */
+
+/* bits definitions */
+/* EXTI_INTEN */
+#define EXTI_INTEN_INTEN0            BIT(0)                   /*!< interrupt from line 0 */
+#define EXTI_INTEN_INTEN1            BIT(1)                   /*!< interrupt from line 1 */
+#define EXTI_INTEN_INTEN2            BIT(2)                   /*!< interrupt from line 2 */
+#define EXTI_INTEN_INTEN3            BIT(3)                   /*!< interrupt from line 3 */
+#define EXTI_INTEN_INTEN4            BIT(4)                   /*!< interrupt from line 4 */
+#define EXTI_INTEN_INTEN5            BIT(5)                   /*!< interrupt from line 5 */
+#define EXTI_INTEN_INTEN6            BIT(6)                   /*!< interrupt from line 6 */
+#define EXTI_INTEN_INTEN7            BIT(7)                   /*!< interrupt from line 7 */
+#define EXTI_INTEN_INTEN8            BIT(8)                   /*!< interrupt from line 8 */
+#define EXTI_INTEN_INTEN9            BIT(9)                   /*!< interrupt from line 9 */
+#define EXTI_INTEN_INTEN10           BIT(10)                  /*!< interrupt from line 10 */
+#define EXTI_INTEN_INTEN11           BIT(11)                  /*!< interrupt from line 11 */
+#define EXTI_INTEN_INTEN12           BIT(12)                  /*!< interrupt from line 12 */
+#define EXTI_INTEN_INTEN13           BIT(13)                  /*!< interrupt from line 13 */
+#define EXTI_INTEN_INTEN14           BIT(14)                  /*!< interrupt from line 14 */
+#define EXTI_INTEN_INTEN15           BIT(15)                  /*!< interrupt from line 15 */
+#define EXTI_INTEN_INTEN16           BIT(16)                  /*!< interrupt from line 16 */
+#define EXTI_INTEN_INTEN17           BIT(17)                  /*!< interrupt from line 17 */
+#define EXTI_INTEN_INTEN18           BIT(18)                  /*!< interrupt from line 18 */
+#define EXTI_INTEN_INTEN19           BIT(19)                  /*!< interrupt from line 19 */
+#define EXTI_INTEN_INTEN20           BIT(20)                  /*!< interrupt from line 20 */
+#define EXTI_INTEN_INTEN21           BIT(21)                  /*!< interrupt from line 21 */
+#define EXTI_INTEN_INTEN22           BIT(22)                  /*!< interrupt from line 22 */
+
+/* EXTI_EVEN */
+#define EXTI_EVEN_EVEN0              BIT(0)                   /*!< event from line 0 */
+#define EXTI_EVEN_EVEN1              BIT(1)                   /*!< event from line 1 */
+#define EXTI_EVEN_EVEN2              BIT(2)                   /*!< event from line 2 */
+#define EXTI_EVEN_EVEN3              BIT(3)                   /*!< event from line 3 */
+#define EXTI_EVEN_EVEN4              BIT(4)                   /*!< event from line 4 */
+#define EXTI_EVEN_EVEN5              BIT(5)                   /*!< event from line 5 */
+#define EXTI_EVEN_EVEN6              BIT(6)                   /*!< event from line 6 */
+#define EXTI_EVEN_EVEN7              BIT(7)                   /*!< event from line 7 */
+#define EXTI_EVEN_EVEN8              BIT(8)                   /*!< event from line 8 */
+#define EXTI_EVEN_EVEN9              BIT(9)                   /*!< event from line 9 */
+#define EXTI_EVEN_EVEN10             BIT(10)                  /*!< event from line 10 */
+#define EXTI_EVEN_EVEN11             BIT(11)                  /*!< event from line 11 */
+#define EXTI_EVEN_EVEN12             BIT(12)                  /*!< event from line 12 */
+#define EXTI_EVEN_EVEN13             BIT(13)                  /*!< event from line 13 */
+#define EXTI_EVEN_EVEN14             BIT(14)                  /*!< event from line 14 */
+#define EXTI_EVEN_EVEN15             BIT(15)                  /*!< event from line 15 */
+#define EXTI_EVEN_EVEN16             BIT(16)                  /*!< event from line 16 */
+#define EXTI_EVEN_EVEN17             BIT(17)                  /*!< event from line 17 */
+#define EXTI_EVEN_EVEN18             BIT(18)                  /*!< event from line 18 */
+#define EXTI_EVEN_EVEN19             BIT(19)                  /*!< event from line 19 */
+#define EXTI_EVEN_EVEN20             BIT(20)                  /*!< event from line 20 */
+#define EXTI_EVEN_EVEN21             BIT(21)                  /*!< event from line 21 */
+#define EXTI_EVEN_EVEN22             BIT(22)                  /*!< event from line 22 */
+
+/* EXTI_RTEN */
+#define EXTI_RTEN_RTEN0              BIT(0)                   /*!< rising edge from line 0 */
+#define EXTI_RTEN_RTEN1              BIT(1)                   /*!< rising edge from line 1 */
+#define EXTI_RTEN_RTEN2              BIT(2)                   /*!< rising edge from line 2 */
+#define EXTI_RTEN_RTEN3              BIT(3)                   /*!< rising edge from line 3 */
+#define EXTI_RTEN_RTEN4              BIT(4)                   /*!< rising edge from line 4 */
+#define EXTI_RTEN_RTEN5              BIT(5)                   /*!< rising edge from line 5 */
+#define EXTI_RTEN_RTEN6              BIT(6)                   /*!< rising edge from line 6 */
+#define EXTI_RTEN_RTEN7              BIT(7)                   /*!< rising edge from line 7 */
+#define EXTI_RTEN_RTEN8              BIT(8)                   /*!< rising edge from line 8 */
+#define EXTI_RTEN_RTEN9              BIT(9)                   /*!< rising edge from line 9 */
+#define EXTI_RTEN_RTEN10             BIT(10)                  /*!< rising edge from line 10 */
+#define EXTI_RTEN_RTEN11             BIT(11)                  /*!< rising edge from line 11 */
+#define EXTI_RTEN_RTEN12             BIT(12)                  /*!< rising edge from line 12 */
+#define EXTI_RTEN_RTEN13             BIT(13)                  /*!< rising edge from line 13 */
+#define EXTI_RTEN_RTEN14             BIT(14)                  /*!< rising edge from line 14 */
+#define EXTI_RTEN_RTEN15             BIT(15)                  /*!< rising edge from line 15 */
+#define EXTI_RTEN_RTEN16             BIT(16)                  /*!< rising edge from line 16 */
+#define EXTI_RTEN_RTEN17             BIT(17)                  /*!< rising edge from line 17 */
+#define EXTI_RTEN_RTEN18             BIT(18)                  /*!< rising edge from line 18 */
+#define EXTI_RTEN_RTEN19             BIT(19)                  /*!< rising edge from line 19 */
+#define EXTI_RTEN_RTEN20             BIT(20)                  /*!< rising edge from line 20 */
+#define EXTI_RTEN_RTEN21             BIT(21)                  /*!< rising edge from line 21 */
+#define EXTI_RTEN_RTEN22             BIT(22)                  /*!< rising edge from line 22 */
+
+/* EXTI_FTEN */
+#define EXTI_FTEN_FTEN0              BIT(0)                   /*!< falling edge from line 0 */
+#define EXTI_FTEN_FTEN1              BIT(1)                   /*!< falling edge from line 1 */
+#define EXTI_FTEN_FTEN2              BIT(2)                   /*!< falling edge from line 2 */
+#define EXTI_FTEN_FTEN3              BIT(3)                   /*!< falling edge from line 3 */
+#define EXTI_FTEN_FTEN4              BIT(4)                   /*!< falling edge from line 4 */
+#define EXTI_FTEN_FTEN5              BIT(5)                   /*!< falling edge from line 5 */
+#define EXTI_FTEN_FTEN6              BIT(6)                   /*!< falling edge from line 6 */
+#define EXTI_FTEN_FTEN7              BIT(7)                   /*!< falling edge from line 7 */
+#define EXTI_FTEN_FTEN8              BIT(8)                   /*!< falling edge from line 8 */
+#define EXTI_FTEN_FTEN9              BIT(9)                   /*!< falling edge from line 9 */
+#define EXTI_FTEN_FTEN10             BIT(10)                  /*!< falling edge from line 10 */
+#define EXTI_FTEN_FTEN11             BIT(11)                  /*!< falling edge from line 11 */
+#define EXTI_FTEN_FTEN12             BIT(12)                  /*!< falling edge from line 12 */
+#define EXTI_FTEN_FTEN13             BIT(13)                  /*!< falling edge from line 13 */
+#define EXTI_FTEN_FTEN14             BIT(14)                  /*!< falling edge from line 14 */
+#define EXTI_FTEN_FTEN15             BIT(15)                  /*!< falling edge from line 15 */
+#define EXTI_FTEN_FTEN16             BIT(16)                  /*!< falling edge from line 16 */
+#define EXTI_FTEN_FTEN17             BIT(17)                  /*!< falling edge from line 17 */
+#define EXTI_FTEN_FTEN18             BIT(18)                  /*!< falling edge from line 18 */
+#define EXTI_FTEN_FTEN19             BIT(19)                  /*!< falling edge from line 19 */
+#define EXTI_FTEN_FTEN20             BIT(20)                  /*!< falling edge from line 20 */
+#define EXTI_FTEN_FTEN21             BIT(21)                  /*!< falling edge from line 21 */
+#define EXTI_FTEN_FTEN22             BIT(22)                  /*!< falling edge from line 22 */
+
+/* EXTI_SWIEV */
+#define EXTI_SWIEV_SWIEV0            BIT(0)                   /*!< software interrupt/event request from line 0 */
+#define EXTI_SWIEV_SWIEV1            BIT(1)                   /*!< software interrupt/event request from line 1 */
+#define EXTI_SWIEV_SWIEV2            BIT(2)                   /*!< software interrupt/event request from line 2 */
+#define EXTI_SWIEV_SWIEV3            BIT(3)                   /*!< software interrupt/event request from line 3 */
+#define EXTI_SWIEV_SWIEV4            BIT(4)                   /*!< software interrupt/event request from line 4 */
+#define EXTI_SWIEV_SWIEV5            BIT(5)                   /*!< software interrupt/event request from line 5 */
+#define EXTI_SWIEV_SWIEV6            BIT(6)                   /*!< software interrupt/event request from line 6 */
+#define EXTI_SWIEV_SWIEV7            BIT(7)                   /*!< software interrupt/event request from line 7 */
+#define EXTI_SWIEV_SWIEV8            BIT(8)                   /*!< software interrupt/event request from line 8 */
+#define EXTI_SWIEV_SWIEV9            BIT(9)                   /*!< software interrupt/event request from line 9 */
+#define EXTI_SWIEV_SWIEV10           BIT(10)                  /*!< software interrupt/event request from line 10 */
+#define EXTI_SWIEV_SWIEV11           BIT(11)                  /*!< software interrupt/event request from line 11 */
+#define EXTI_SWIEV_SWIEV12           BIT(12)                  /*!< software interrupt/event request from line 12 */
+#define EXTI_SWIEV_SWIEV13           BIT(13)                  /*!< software interrupt/event request from line 13 */
+#define EXTI_SWIEV_SWIEV14           BIT(14)                  /*!< software interrupt/event request from line 14 */
+#define EXTI_SWIEV_SWIEV15           BIT(15)                  /*!< software interrupt/event request from line 15 */
+#define EXTI_SWIEV_SWIEV16           BIT(16)                  /*!< software interrupt/event request from line 16 */
+#define EXTI_SWIEV_SWIEV17           BIT(17)                  /*!< software interrupt/event request from line 17 */
+#define EXTI_SWIEV_SWIEV18           BIT(18)                  /*!< software interrupt/event request from line 18 */
+#define EXTI_SWIEV_SWIEV19           BIT(19)                  /*!< software interrupt/event request from line 19 */
+#define EXTI_SWIEV_SWIEV20           BIT(20)                  /*!< software interrupt/event request from line 20 */
+#define EXTI_SWIEV_SWIEV21           BIT(21)                  /*!< software interrupt/event request from line 21 */
+#define EXTI_SWIEV_SWIEV22           BIT(22)                  /*!< software interrupt/event request from line 22 */
+
+/* EXTI_PD */
+#define EXTI_PD_PD0                  BIT(0)                   /*!< interrupt/event pending status from line 0 */
+#define EXTI_PD_PD1                  BIT(1)                   /*!< interrupt/event pending status from line 1 */
+#define EXTI_PD_PD2                  BIT(2)                   /*!< interrupt/event pending status from line 2 */
+#define EXTI_PD_PD3                  BIT(3)                   /*!< interrupt/event pending status from line 3 */
+#define EXTI_PD_PD4                  BIT(4)                   /*!< interrupt/event pending status from line 4 */
+#define EXTI_PD_PD5                  BIT(5)                   /*!< interrupt/event pending status from line 5 */
+#define EXTI_PD_PD6                  BIT(6)                   /*!< interrupt/event pending status from line 6 */
+#define EXTI_PD_PD7                  BIT(7)                   /*!< interrupt/event pending status from line 7 */
+#define EXTI_PD_PD8                  BIT(8)                   /*!< interrupt/event pending status from line 8 */
+#define EXTI_PD_PD9                  BIT(9)                   /*!< interrupt/event pending status from line 9 */
+#define EXTI_PD_PD10                 BIT(10)                  /*!< interrupt/event pending status from line 10 */
+#define EXTI_PD_PD11                 BIT(11)                  /*!< interrupt/event pending status from line 11 */
+#define EXTI_PD_PD12                 BIT(12)                  /*!< interrupt/event pending status from line 12 */
+#define EXTI_PD_PD13                 BIT(13)                  /*!< interrupt/event pending status from line 13 */
+#define EXTI_PD_PD14                 BIT(14)                  /*!< interrupt/event pending status from line 14 */
+#define EXTI_PD_PD15                 BIT(15)                  /*!< interrupt/event pending status from line 15 */
+#define EXTI_PD_PD16                 BIT(16)                  /*!< interrupt/event pending status from line 16 */
+#define EXTI_PD_PD17                 BIT(17)                  /*!< interrupt/event pending status from line 17 */
+#define EXTI_PD_PD18                 BIT(18)                  /*!< interrupt/event pending status from line 18 */
+#define EXTI_PD_PD19                 BIT(19)                  /*!< interrupt/event pending status from line 19 */
+#define EXTI_PD_PD20                 BIT(20)                  /*!< interrupt/event pending status from line 20 */
+#define EXTI_PD_PD21                 BIT(21)                  /*!< interrupt/event pending status from line 21 */
+#define EXTI_PD_PD22                 BIT(22)                  /*!< interrupt/event pending status from line 22 */
+
+/* constants definitions */
+/* EXTI line number */
+typedef enum
+{ 
+    EXTI_0      = BIT(0),                                     /*!< EXTI line 0 */
+    EXTI_1      = BIT(1),                                     /*!< EXTI line 1 */
+    EXTI_2      = BIT(2),                                     /*!< EXTI line 2 */
+    EXTI_3      = BIT(3),                                     /*!< EXTI line 3 */
+    EXTI_4      = BIT(4),                                     /*!< EXTI line 4 */
+    EXTI_5      = BIT(5),                                     /*!< EXTI line 5 */
+    EXTI_6      = BIT(6),                                     /*!< EXTI line 6 */
+    EXTI_7      = BIT(7),                                     /*!< EXTI line 7 */
+    EXTI_8      = BIT(8),                                     /*!< EXTI line 8 */
+    EXTI_9      = BIT(9),                                     /*!< EXTI line 9 */
+    EXTI_10     = BIT(10),                                    /*!< EXTI line 10 */
+    EXTI_11     = BIT(11),                                    /*!< EXTI line 11 */
+    EXTI_12     = BIT(12),                                    /*!< EXTI line 12 */
+    EXTI_13     = BIT(13),                                    /*!< EXTI line 13 */
+    EXTI_14     = BIT(14),                                    /*!< EXTI line 14 */
+    EXTI_15     = BIT(15),                                    /*!< EXTI line 15 */
+    EXTI_16     = BIT(16),                                    /*!< EXTI line 16 */
+    EXTI_17     = BIT(17),                                    /*!< EXTI line 17 */
+    EXTI_18     = BIT(18),                                    /*!< EXTI line 18 */
+    EXTI_19     = BIT(19),                                    /*!< EXTI line 19 */
+    EXTI_20     = BIT(20),                                    /*!< EXTI line 20 */    
+    EXTI_21     = BIT(21),                                    /*!< EXTI line 21 */
+    EXTI_22     = BIT(22),                                    /*!< EXTI line 22 */
+}exti_line_enum;
+
+/* external interrupt and event  */
+typedef enum
+{
+    EXTI_INTERRUPT   = 0,                                     /*!< EXTI interrupt mode */
+    EXTI_EVENT                                                /*!< EXTI event mode */
+}exti_mode_enum;
+
+/* interrupt trigger mode */
+typedef enum
+{ 
+    EXTI_TRIG_RISING = 0,                                     /*!< EXTI rising edge trigger */
+    EXTI_TRIG_FALLING,                                        /*!< EXTI falling edge trigger */
+    EXTI_TRIG_BOTH,                                           /*!< EXTI rising and falling edge trigger */
+    EXTI_TRIG_NONE                                            /*!< none EXTI edge trigger */
+}exti_trig_type_enum;
+
+/* function declarations */
+/* deinitialize the EXTI */
+void exti_deinit(void);
+/* enable the configuration of EXTI initialize */
+void exti_init(exti_line_enum linex, exti_mode_enum mode, exti_trig_type_enum trig_type);
+/* enable the interrupts from EXTI line x */
+void exti_interrupt_enable(exti_line_enum linex);
+/* disable the interrupts from EXTI line x */
+void exti_interrupt_disable(exti_line_enum linex);
+/* enable the events from EXTI line x */
+void exti_event_enable(exti_line_enum linex);
+/* disable the events from EXTI line x */
+void exti_event_disable(exti_line_enum linex);
+/* EXTI software interrupt event enable */
+void exti_software_interrupt_enable(exti_line_enum linex);
+/* EXTI software interrupt event disable */
+void exti_software_interrupt_disable(exti_line_enum linex);
+
+/* interrupt & flag functions */
+/* get EXTI lines pending flag */
+FlagStatus exti_flag_get(exti_line_enum linex);
+/* clear EXTI lines pending flag */
+void exti_flag_clear(exti_line_enum linex);
+/* get EXTI lines flag when the interrupt flag is set */
+FlagStatus exti_interrupt_flag_get(exti_line_enum linex);
+/* clear EXTI lines pending flag */
+void exti_interrupt_flag_clear(exti_line_enum linex);
+
+#endif /* GD32F4XX_EXTI_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_fmc.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_fmc.h
@@ -1,0 +1,415 @@
+/*!
+    \file    gd32f4xx_fmc.h
+    \brief   definitions for the FMC
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2020-12-20, V2.1.1, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+
+#ifndef GD32F4XX_FMC_H
+#define GD32F4XX_FMC_H
+
+#include "gd32f4xx.h"
+
+/* FMC and option byte definition */
+#define FMC                        FMC_BASE                       /*!< FMC register base address */
+#define OB                         OB_BASE                        /*!< option byte base address */
+
+/* registers definitions */
+#define FMC_WS                     REG32((FMC) + 0x00000000U)     /*!< FMC wait state register */
+#define FMC_KEY                    REG32((FMC) + 0x00000004U)     /*!< FMC unlock key register */
+#define FMC_OBKEY                  REG32((FMC) + 0x00000008U)     /*!< FMC option byte unlock key register */
+#define FMC_STAT                   REG32((FMC) + 0x0000000CU)     /*!< FMC status register */
+#define FMC_CTL                    REG32((FMC) + 0x00000010U)     /*!< FMC control register */
+#define FMC_OBCTL0                 REG32((FMC) + 0x00000014U)     /*!< FMC option byte control register 0 */
+#define FMC_OBCTL1                 REG32((FMC) + 0x00000018U)     /*!< FMC option byte control register 1 */
+#define FMC_PECFG                  REG32((FMC) + 0x00000020U)     /*!< FMC page erase configuration register */
+#define FMC_PEKEY                  REG32((FMC) + 0x00000024U)     /*!< FMC unlock page erase key register */
+#define FMC_WSEN                   REG32((FMC) + 0x000000FCU)     /*!< FMC wait state enable register */
+#define FMC_PID                    REG32((FMC) + 0x00000100U)     /*!< FMC product ID register */
+
+#define OB_WP1                     REG32((OB) + 0x00000008U)      /*!< option byte write protection 1 */
+#define OB_USER                    REG32((OB) + 0x00010000U)      /*!< option byte user value*/
+#define OB_SPC                     REG32((OB) + 0x00010001U)      /*!< option byte security protection value */
+#define OB_WP0                     REG32((OB) + 0x00010008U)      /*!< option byte write protection 0 */
+
+/* bits definitions */
+/* FMC_WS */
+#define FMC_WC_WSCNT               BITS(0,3)                      /*!< wait state counter */
+
+/* FMC_KEY */
+#define FMC_KEY_KEY                BITS(0,31)                     /*!< FMC main flash key bits */
+
+/* FMC_OBKEY */
+#define FMC_OBKEY_OBKEY            BITS(0,31)                     /*!< option byte key bits */
+
+/* FMC_STAT */
+#define FMC_STAT_END               BIT(0)                         /*!< end of operation flag bit */
+#define FMC_STAT_OPERR             BIT(1)                         /*!< flash operation error flag bit */
+#define FMC_STAT_WPERR             BIT(4)                         /*!< erase/Program protection error flag bit */
+#define FMC_STAT_PGMERR            BIT(6)                         /*!< program size not match error flag bit */
+#define FMC_STAT_PGSERR            BIT(7)                         /*!< program sequence error flag bit */
+#define FMC_STAT_RDDERR            BIT(8)                         /*!< read D-bus protection error flag bit */
+#define FMC_STAT_BUSY              BIT(16)                        /*!< flash busy flag bit */
+
+/* FMC_CTL */
+#define FMC_CTL_PG                 BIT(0)                         /*!< main flash program command bit */
+#define FMC_CTL_SER                BIT(1)                         /*!< main flash sector erase command bit */
+#define FMC_CTL_MER0               BIT(2)                         /*!< main flash mass erase for bank0 command bit */
+#define FMC_CTL_SN                 BITS(3,7)                      /*!< select which sector number to be erased */
+#define FMC_CTL_PSZ                BITS(8,9)                      /*!< program size bit */
+#define FMC_CTL_MER1               BIT(15)                        /*!< main flash mass erase for bank1 command bit */
+#define FMC_CTL_START              BIT(16)                        /*!< send erase command to FMC bit */
+#define FMC_CTL_ENDIE              BIT(24)                        /*!< end of operation interrupt enable bit */
+#define FMC_CTL_ERRIE              BIT(25)                        /*!< error interrupt enable bit */
+#define FMC_CTL_LK                 BIT(31)                        /*!< FMC_CTL lock bit */
+
+/* FMC_OBCTL0 */
+#define FMC_OBCTL0_OB_LK           BIT(0)                         /*!< FMC_OBCTL0 lock bit */
+#define FMC_OBCTL0_OB_START        BIT(1)                         /*!< send option byte change command to FMC bit */
+#define FMC_OBCTL0_BOR_TH          BITS(2,3)                      /*!< option byte BOR threshold value */
+#define FMC_OBCTL0_BB              BIT(4)                         /*!< option byte boot bank value */
+#define FMC_OBCTL0_NWDG_HW         BIT(5)                         /*!< option byte watchdog value */
+#define FMC_OBCTL0_NRST_DPSLP      BIT(6)                         /*!< option byte deepsleep reset value */
+#define FMC_OBCTL0_NRST_STDBY      BIT(7)                         /*!< option byte standby reset value */
+#define FMC_OBCTL0_SPC             BITS(8,15)                     /*!< option byte Security Protection code */
+#define FMC_OBCTL0_WP0             BITS(16,27)                    /*!< erase/program protection of each sector when DRP is 0 */
+#define FMC_OBCTL0_DBS             BIT(30)                        /*!< double banks or single bank selection when flash size is 1M bytes */
+#define FMC_OBCTL0_DRP             BIT(31)                        /*!< D-bus read protection bit */
+
+/* FMC_OBCTL1 */
+#define FMC_OBCTL1_WP1             BITS(16,27)                    /*!< erase/program protection of each sector when DRP is 0 */
+
+/* FMC_PECFG */
+#define FMC_PE_EN                  BIT(31)                        /*!< the enable bit of page erase function */
+#define FMC_PE_ADDR                BITS(0,28)                     /*!< page erase address */
+
+/* FMC_PEKEY */
+#define FMC_PE_KEY                 BITS(0,31)                     /*!< FMC_PECFG unlock key value */
+
+/* FMC_WSEN */
+#define FMC_WSEN_WSEN              BIT(0)                         /*!< FMC wait state enable bit */
+
+/* FMC_PID */
+#define FMC_PID_PID                BITS(0,31)                     /*!< product ID bits */
+
+/* constants definitions */
+/* fmc state */
+typedef enum {
+    FMC_READY = 0,                                                /*!< the operation has been completed */
+    FMC_BUSY,                                                     /*!< the operation is in progress */
+    FMC_RDDERR,                                                   /*!< read D-bus protection error */
+    FMC_PGSERR,                                                   /*!< program sequence error */
+    FMC_PGMERR,                                                   /*!< program size not match error */
+    FMC_WPERR,                                                    /*!< erase/program protection error */
+    FMC_OPERR,                                                    /*!< operation error */
+    FMC_TOERR                                                     /*!< timeout error */
+} fmc_state_enum;
+
+/* unlock key */
+#define UNLOCK_KEY0                ((uint32_t)0x45670123U)        /*!< unlock key 0 */
+#define UNLOCK_KEY1                ((uint32_t)0xCDEF89ABU)        /*!< unlock key 1 */
+#define UNLOCK_PE_KEY              ((uint32_t)0xA9B8C7D6U)        /*!< unlock page erase function key */
+
+#define OB_UNLOCK_KEY0             ((uint32_t)0x08192A3BU)        /*!< ob unlock key 0 */
+#define OB_UNLOCK_KEY1             ((uint32_t)0x4C5D6E7FU)        /*!< ob unlock key 1 */
+
+/* option byte write protection */
+#define OB_LWP                     ((uint32_t)0x000000FFU)        /*!< write protection low bits */
+#define OB_HWP                     ((uint32_t)0x0000FF00U)        /*!< write protection high bits */
+
+/* FMC wait state counter */
+#define WC_WSCNT(regval)           (BITS(0,3) & ((uint32_t)(regval)))
+#define WS_WSCNT_0                 WC_WSCNT(0)                    /*!< FMC 0 wait */
+#define WS_WSCNT_1                 WC_WSCNT(1)                    /*!< FMC 1 wait */
+#define WS_WSCNT_2                 WC_WSCNT(2)                    /*!< FMC 2 wait */
+#define WS_WSCNT_3                 WC_WSCNT(3)                    /*!< FMC 3 wait */
+#define WS_WSCNT_4                 WC_WSCNT(4)                    /*!< FMC 4 wait */
+#define WS_WSCNT_5                 WC_WSCNT(5)                    /*!< FMC 5 wait */
+#define WS_WSCNT_6                 WC_WSCNT(6)                    /*!< FMC 6 wait */
+#define WS_WSCNT_7                 WC_WSCNT(7)                    /*!< FMC 7 wait */
+#define WS_WSCNT_8                 WC_WSCNT(8)                    /*!< FMC 8 wait */
+#define WS_WSCNT_9                 WC_WSCNT(9)                    /*!< FMC 9 wait */
+#define WS_WSCNT_10                WC_WSCNT(10)                   /*!< FMC 10 wait */
+#define WS_WSCNT_11                WC_WSCNT(11)                   /*!< FMC 11 wait */
+#define WS_WSCNT_12                WC_WSCNT(12)                   /*!< FMC 12 wait */
+#define WS_WSCNT_13                WC_WSCNT(13)                   /*!< FMC 13 wait */
+#define WS_WSCNT_14                WC_WSCNT(14)                   /*!< FMC 14 wait */
+#define WS_WSCNT_15                WC_WSCNT(15)                   /*!< FMC 15 wait */
+
+/* option byte BOR threshold value */
+#define OBCTL0_BOR_TH(regval)      (BITS(2,3) & ((uint32_t)(regval))<< 2)
+#define OB_BOR_TH_VALUE3           OBCTL0_BOR_TH(0)               /*!< BOR threshold value 3 */
+#define OB_BOR_TH_VALUE2           OBCTL0_BOR_TH(1)               /*!< BOR threshold value 2 */
+#define OB_BOR_TH_VALUE1           OBCTL0_BOR_TH(2)               /*!< BOR threshold value 1 */
+#define OB_BOR_TH_OFF              OBCTL0_BOR_TH(3)               /*!< no BOR function */
+
+/* option byte boot bank value */
+#define OBCTL0_BB(regval)          (BIT(4) & ((uint32_t)(regval)<<4))
+#define OB_BB_DISABLE              OBCTL0_BB(0)                   /*!< boot from bank0 */
+#define OB_BB_ENABLE               OBCTL0_BB(1)                   /*!< boot from bank1 or bank0 if bank1 is void */
+
+/* option byte software/hardware free watch dog timer */
+#define OBCTL0_NWDG_HW(regval)     (BIT(5) & ((uint32_t)(regval))<< 5)
+#define OB_FWDGT_SW                OBCTL0_NWDG_HW(1)              /*!< software free watchdog */
+#define OB_FWDGT_HW                OBCTL0_NWDG_HW(0)              /*!< hardware free watchdog */
+
+/* option byte reset or not entering deep sleep mode */
+#define OBCTL0_NRST_DPSLP(regval)  (BIT(6) & ((uint32_t)(regval))<< 6)
+#define OB_DEEPSLEEP_NRST          OBCTL0_NRST_DPSLP(1)           /*!< no reset when entering deepsleep mode */
+#define OB_DEEPSLEEP_RST           OBCTL0_NRST_DPSLP(0)           /*!< generate a reset instead of entering deepsleep mode */
+
+/* option byte reset or not entering standby mode */
+#define OBCTL0_NRST_STDBY(regval)  (BIT(7) & ((uint32_t)(regval))<< 7)
+#define OB_STDBY_NRST              OBCTL0_NRST_STDBY(1)           /*!< no reset when entering deepsleep mode */
+#define OB_STDBY_RST               OBCTL0_NRST_STDBY(0)           /*!< generate a reset instead of entering standby mode */
+
+/* read protect configure */
+#define FMC_NSPC                   ((uint8_t)0xAAU)               /*!< no security protection */
+#define FMC_LSPC                   ((uint8_t)0xABU)               /*!< low security protection */
+#define FMC_HSPC                   ((uint8_t)0xCCU)               /*!< high security protection */
+
+/* option bytes write protection */
+#define OB_WP_0                    ((uint32_t)0x00000001U)        /*!< erase/program protection of sector 0  */
+#define OB_WP_1                    ((uint32_t)0x00000002U)        /*!< erase/program protection of sector 1  */
+#define OB_WP_2                    ((uint32_t)0x00000004U)        /*!< erase/program protection of sector 2  */
+#define OB_WP_3                    ((uint32_t)0x00000008U)        /*!< erase/program protection of sector 3  */
+#define OB_WP_4                    ((uint32_t)0x00000010U)        /*!< erase/program protection of sector 4  */
+#define OB_WP_5                    ((uint32_t)0x00000020U)        /*!< erase/program protection of sector 5  */
+#define OB_WP_6                    ((uint32_t)0x00000040U)        /*!< erase/program protection of sector 6  */
+#define OB_WP_7                    ((uint32_t)0x00000080U)        /*!< erase/program protection of sector 7  */
+#define OB_WP_8                    ((uint32_t)0x00000100U)        /*!< erase/program protection of sector 8  */
+#define OB_WP_9                    ((uint32_t)0x00000200U)        /*!< erase/program protection of sector 9  */
+#define OB_WP_10                   ((uint32_t)0x00000400U)        /*!< erase/program protection of sector 10 */
+#define OB_WP_11                   ((uint32_t)0x00000800U)        /*!< erase/program protection of sector 11 */
+#define OB_WP_12                   ((uint32_t)0x00010000U)        /*!< erase/program protection of sector 12 */
+#define OB_WP_13                   ((uint32_t)0x00020000U)        /*!< erase/program protection of sector 13 */
+#define OB_WP_14                   ((uint32_t)0x00040000U)        /*!< erase/program protection of sector 14 */
+#define OB_WP_15                   ((uint32_t)0x00080000U)        /*!< erase/program protection of sector 15 */
+#define OB_WP_16                   ((uint32_t)0x00100000U)        /*!< erase/program protection of sector 16 */
+#define OB_WP_17                   ((uint32_t)0x00200000U)        /*!< erase/program protection of sector 17 */
+#define OB_WP_18                   ((uint32_t)0x00400000U)        /*!< erase/program protection of sector 18 */
+#define OB_WP_19                   ((uint32_t)0x00800000U)        /*!< erase/program protection of sector 19 */
+#define OB_WP_20                   ((uint32_t)0x01000000U)        /*!< erase/program protection of sector 20 */
+#define OB_WP_21                   ((uint32_t)0x02000000U)        /*!< erase/program protection of sector 21 */
+#define OB_WP_22                   ((uint32_t)0x04000000U)        /*!< erase/program protection of sector 22 */
+#define OB_WP_23_27                ((uint32_t)0x08000000U)        /*!< erase/program protection of sector 23~27 */
+#define OB_WP_ALL                  ((uint32_t)0x0FFF0FFFU)        /*!< erase/program protection of all sectors */
+
+/* option bytes D-bus read protection */
+#define OB_DRP_0                   ((uint32_t)0x00000001U)        /*!< D-bus read protection protection of sector 0  */
+#define OB_DRP_1                   ((uint32_t)0x00000002U)        /*!< D-bus read protection protection of sector 1  */
+#define OB_DRP_2                   ((uint32_t)0x00000004U)        /*!< D-bus read protection protection of sector 2  */
+#define OB_DRP_3                   ((uint32_t)0x00000008U)        /*!< D-bus read protection protection of sector 3  */
+#define OB_DRP_4                   ((uint32_t)0x00000010U)        /*!< D-bus read protection protection of sector 4  */
+#define OB_DRP_5                   ((uint32_t)0x00000020U)        /*!< D-bus read protection protection of sector 5  */
+#define OB_DRP_6                   ((uint32_t)0x00000040U)        /*!< D-bus read protection protection of sector 6  */
+#define OB_DRP_7                   ((uint32_t)0x00000080U)        /*!< D-bus read protection protection of sector 7  */
+#define OB_DRP_8                   ((uint32_t)0x00000100U)        /*!< D-bus read protection protection of sector 8  */
+#define OB_DRP_9                   ((uint32_t)0x00000200U)        /*!< D-bus read protection protection of sector 9  */
+#define OB_DRP_10                  ((uint32_t)0x00000400U)        /*!< D-bus read protection protection of sector 10 */
+#define OB_DRP_11                  ((uint32_t)0x00000800U)        /*!< D-bus read protection protection of sector 11 */
+#define OB_DRP_12                  ((uint32_t)0x00010000U)        /*!< D-bus read protection protection of sector 12 */
+#define OB_DRP_13                  ((uint32_t)0x00020000U)        /*!< D-bus read protection protection of sector 13 */
+#define OB_DRP_14                  ((uint32_t)0x00040000U)        /*!< D-bus read protection protection of sector 14 */
+#define OB_DRP_15                  ((uint32_t)0x00080000U)        /*!< D-bus read protection protection of sector 15 */
+#define OB_DRP_16                  ((uint32_t)0x00100000U)        /*!< D-bus read protection protection of sector 16 */
+#define OB_DRP_17                  ((uint32_t)0x00200000U)        /*!< D-bus read protection protection of sector 17 */
+#define OB_DRP_18                  ((uint32_t)0x00400000U)        /*!< D-bus read protection protection of sector 18 */
+#define OB_DRP_19                  ((uint32_t)0x00800000U)        /*!< D-bus read protection protection of sector 19 */
+#define OB_DRP_20                  ((uint32_t)0x01000000U)        /*!< D-bus read protection protection of sector 20 */
+#define OB_DRP_21                  ((uint32_t)0x02000000U)        /*!< D-bus read protection protection of sector 21 */
+#define OB_DRP_22                  ((uint32_t)0x04000000U)        /*!< D-bus read protection protection of sector 22 */
+#define OB_DRP_23_27               ((uint32_t)0x08000000U)        /*!< D-bus read protection protection of sector 23~27 */
+#define OB_DRP_ALL                 ((uint32_t)0x0FFF0FFFU)        /*!< D-bus read protection protection of all sectors */
+
+/* double banks or single bank selection when flash size is 1M bytes */
+#define OBCTL0_DBS(regval)         (BIT(30) & ((uint32_t)(regval) << 30U))
+#define OB_DBS_DISABLE             OBCTL0_DBS(0)                  /*!< single bank when flash size is 1M bytes */
+#define OB_DBS_ENABLE              OBCTL0_DBS(1)                  /*!< double bank when flash size is 1M bytes */
+
+/* option bytes D-bus read protection mode */
+#define OBCTL0_DRP(regval)         (BIT(31) & ((uint32_t)(regval) << 31U))
+#define OB_DRP_DISABLE             OBCTL0_DRP(0)                  /*!< the WPx bits used as erase/program protection of each sector */
+#define OB_DRP_ENABLE              OBCTL0_DRP(1)                  /*!< the WPx bits used as erase/program protection and D-bus read protection of each sector */
+
+/* FMC sectors */
+#define CTL_SN(regval)             (BITS(3,7) & ((uint32_t)(regval))<< 3)
+#define CTL_SECTOR_NUMBER_0        CTL_SN(0)                      /*!< sector 0   */
+#define CTL_SECTOR_NUMBER_1        CTL_SN(1)                      /*!< sector 1   */
+#define CTL_SECTOR_NUMBER_2        CTL_SN(2)                      /*!< sector 2   */
+#define CTL_SECTOR_NUMBER_3        CTL_SN(3)                      /*!< sector 3   */
+#define CTL_SECTOR_NUMBER_4        CTL_SN(4)                      /*!< sector 4   */
+#define CTL_SECTOR_NUMBER_5        CTL_SN(5)                      /*!< sector 5   */
+#define CTL_SECTOR_NUMBER_6        CTL_SN(6)                      /*!< sector 6   */
+#define CTL_SECTOR_NUMBER_7        CTL_SN(7)                      /*!< sector 7   */
+#define CTL_SECTOR_NUMBER_8        CTL_SN(8)                      /*!< sector 8   */
+#define CTL_SECTOR_NUMBER_9        CTL_SN(9)                      /*!< sector 9   */
+#define CTL_SECTOR_NUMBER_10       CTL_SN(10)                     /*!< sector 10  */
+#define CTL_SECTOR_NUMBER_11       CTL_SN(11)                     /*!< sector 11  */
+#define CTL_SECTOR_NUMBER_24       CTL_SN(12)                     /*!< sector 24  */
+#define CTL_SECTOR_NUMBER_25       CTL_SN(13)                     /*!< sector 25  */
+#define CTL_SECTOR_NUMBER_26       CTL_SN(14)                     /*!< sector 26  */
+#define CTL_SECTOR_NUMBER_27       CTL_SN(15)                     /*!< sector 27  */
+#define CTL_SECTOR_NUMBER_12       CTL_SN(16)                     /*!< sector 12  */
+#define CTL_SECTOR_NUMBER_13       CTL_SN(17)                     /*!< sector 13  */
+#define CTL_SECTOR_NUMBER_14       CTL_SN(18)                     /*!< sector 14  */
+#define CTL_SECTOR_NUMBER_15       CTL_SN(19)                     /*!< sector 15  */
+#define CTL_SECTOR_NUMBER_16       CTL_SN(20)                     /*!< sector 16  */
+#define CTL_SECTOR_NUMBER_17       CTL_SN(21)                     /*!< sector 17  */
+#define CTL_SECTOR_NUMBER_18       CTL_SN(22)                     /*!< sector 18  */
+#define CTL_SECTOR_NUMBER_19       CTL_SN(23)                     /*!< sector 19  */
+#define CTL_SECTOR_NUMBER_20       CTL_SN(24)                     /*!< sector 20  */
+#define CTL_SECTOR_NUMBER_21       CTL_SN(25)                     /*!< sector 21  */
+#define CTL_SECTOR_NUMBER_22       CTL_SN(26)                     /*!< sector 22  */
+#define CTL_SECTOR_NUMBER_23       CTL_SN(27)                     /*!< sector 23  */
+
+
+/* FMC program size */
+#define CTL_PSZ(regval)            (BITS(8,9) & ((uint32_t)(regval))<< 8U)
+#define CTL_PSZ_BYTE               CTL_PSZ(0)                     /*!< FMC program by byte access */
+#define CTL_PSZ_HALF_WORD          CTL_PSZ(1)                     /*!< FMC program by half-word access */
+#define CTL_PSZ_WORD               CTL_PSZ(2)                     /*!< FMC program by word access */
+
+/* FMC interrupt enable */
+#define FMC_INT_END                ((uint32_t)0x01000000U)        /*!< enable FMC end of program interrupt */
+#define FMC_INT_ERR                ((uint32_t)0x02000000U)        /*!< enable FMC error interrupt */
+
+/* FMC flags */
+#define FMC_FLAG_END               FMC_STAT_END                   /*!< FMC end of operation flag bit */
+#define FMC_FLAG_OPERR             FMC_STAT_OPERR                 /*!< FMC operation error flag bit */
+#define FMC_FLAG_WPERR             FMC_STAT_WPERR                 /*!< FMC erase/program protection error flag bit */
+#define FMC_FLAG_PGMERR            FMC_STAT_PGMERR                /*!< FMC program size not match error flag bit */
+#define FMC_FLAG_PGSERR            FMC_STAT_PGSERR                /*!< FMC program sequence error flag bit */
+#define FMC_FLAG_RDDERR            FMC_STAT_RDDERR                /*!< FMC read D-bus protection error flag bit */
+#define FMC_FLAG_BUSY              FMC_STAT_BUSY                  /*!< FMC busy flag */
+
+/* FMC interrupt flags */
+#define FMC_INT_FLAG_END           FMC_STAT_END                   /*!< FMC end of operation interrupt flag */
+#define FMC_INT_FLAG_OPERR         FMC_STAT_OPERR                 /*!< FMC operation error interrupt flag */
+#define FMC_INT_FLAG_WPERR         FMC_STAT_WPERR                 /*!< FMC erase/program protection error interrupt flag */
+#define FMC_INT_FLAG_PGMERR        FMC_STAT_PGMERR                /*!< FMC program size not match error interrupt flag */
+#define FMC_INT_FLAG_PGSERR        FMC_STAT_PGSERR                /*!< FMC program sequence error interrupt flag */
+#define FMC_INT_FLAG_RDDERR        FMC_STAT_RDDERR                /*!< FMC read D-bus protection error interrupt flag */
+
+
+/* FMC time out */
+#define FMC_TIMEOUT_COUNT          ((uint32_t)0x4FFFFFFFU)        /*!< count to judge of FMC timeout */
+
+/* function declarations */
+/* FMC main memory programming functions */
+/* set the FMC wait state counter */
+void fmc_wscnt_set(uint32_t wscnt);
+/* unlock the main FMC operation */
+void fmc_unlock(void);
+/* lock the main FMC operation */
+void fmc_lock(void);
+#if defined (GD32F425) || defined (GD32F427) || defined (GD32F470)
+/* FMC erase page */
+fmc_state_enum fmc_page_erase(uint32_t page_addr);
+#endif
+/* FMC erase sector */
+fmc_state_enum fmc_sector_erase(uint32_t fmc_sector);
+/* FMC erase whole chip */
+fmc_state_enum fmc_mass_erase(void);
+/* FMC erase whole bank0 */
+fmc_state_enum fmc_bank0_erase(void);
+/* FMC erase whole bank1 */
+fmc_state_enum fmc_bank1_erase(void);
+/* FMC program a word at the corresponding address */
+fmc_state_enum fmc_word_program(uint32_t address, uint32_t data);
+/* FMC program a half word at the corresponding address */
+fmc_state_enum fmc_halfword_program(uint32_t address, uint16_t data);
+/* FMC program a byte at the corresponding address */
+fmc_state_enum fmc_byte_program(uint32_t address, uint8_t data);
+
+/* FMC option bytes programming functions */
+/* unlock the option byte operation */
+void ob_unlock(void);
+/* lock the option byte operation */
+void ob_lock(void);
+/* send option byte change command */
+void ob_start(void);
+/* erase option byte */
+void ob_erase(void);
+/* enable write protect */
+ErrStatus ob_write_protection_enable(uint32_t ob_wp);
+/* disable write protect */
+ErrStatus ob_write_protection_disable(uint32_t ob_wp);
+/* enable erase/program protection and D-bus read protection */
+void ob_drp_enable(uint32_t ob_drp);
+/* disable erase/program protection and D-bus read protection */
+void ob_drp_disable(void);
+/* configure security protection level */
+void ob_security_protection_config(uint8_t ob_spc);
+/* program the FMC user option byte */
+void ob_user_write(uint32_t ob_fwdgt, uint32_t ob_deepsleep, uint32_t ob_stdby);
+/* program the option byte BOR threshold value */
+void ob_user_bor_threshold(uint32_t ob_bor_th);
+/* configure the boot mode */
+void ob_boot_mode_config(uint32_t boot_mode);
+/* get the FMC user option byte */
+uint8_t ob_user_get(void);
+/* get the FMC option byte write protection */
+uint16_t ob_write_protection0_get(void);
+/* get the FMC option byte write protection */
+uint16_t ob_write_protection1_get(void);
+/* get the FMC erase/program protection and D-bus read protection option bytes value */
+uint16_t ob_drp0_get(void);
+/* get the FMC erase/program protection and D-bus read protection option bytes value */
+uint16_t ob_drp1_get(void);
+/* get option byte security protection code value */
+FlagStatus ob_spc_get(void);
+/* get the FMC option byte BOR threshold value */
+uint8_t ob_user_bor_threshold_get(void);
+
+/* FMC interrupts and flags management functions */
+/* get flag set or reset */
+FlagStatus fmc_flag_get(uint32_t fmc_flag);
+/* clear the FMC pending flag */
+void fmc_flag_clear(uint32_t fmc_flag);
+/* enable FMC interrupt */
+void fmc_interrupt_enable(uint32_t fmc_int);
+/* disable FMC interrupt */
+void fmc_interrupt_disable(uint32_t fmc_int);
+/* get FMC interrupt flag set or reset */
+FlagStatus fmc_interrupt_flag_get(uint32_t fmc_int_flag);
+/* clear the FMC interrupt flag */
+void fmc_interrupt_flag_clear(uint32_t fmc_int_flag);
+/* get the FMC state */
+fmc_state_enum fmc_state_get(void);
+/* check whether FMC is ready or not */
+fmc_state_enum fmc_ready_wait(uint32_t timeout);
+
+#endif /* GD32F4XX_FMC_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_fwdgt.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_fwdgt.h
@@ -1,0 +1,114 @@
+/*!
+    \file    gd32f4xx_fwdgt.h
+    \brief   definitions for the FWDGT
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_FWDGT_H
+#define GD32F4XX_FWDGT_H
+
+#include "gd32f4xx.h"
+
+/* FWDGT definitions */
+#define FWDGT                       FWDGT_BASE                      /*!< FWDGT base address */
+
+/* registers definitions */
+#define FWDGT_CTL                   REG32((FWDGT) + 0x00U)          /*!< FWDGT control register */
+#define FWDGT_PSC                   REG32((FWDGT) + 0x04U)          /*!< FWDGT prescaler register */
+#define FWDGT_RLD                   REG32((FWDGT) + 0x08U)          /*!< FWDGT reload register */
+#define FWDGT_STAT                  REG32((FWDGT) + 0x0CU)          /*!< FWDGT status register */
+
+/* bits definitions */
+/* FWDGT_CTL */
+#define FWDGT_CTL_CMD               BITS(0,15)                      /*!< FWDGT command value */
+
+/* FWDGT_PSC */
+#define FWDGT_PSC_PSC               BITS(0,2)                       /*!< FWDGT prescaler divider value */
+
+/* FWDGT_RLD */
+#define FWDGT_RLD_RLD               BITS(0,11)                      /*!< FWDGT counter reload value */
+
+/* FWDGT_STAT */
+#define FWDGT_STAT_PUD              BIT(0)                          /*!< FWDGT prescaler divider value update */
+#define FWDGT_STAT_RUD              BIT(1)                          /*!< FWDGT counter reload value update */
+
+/* constants definitions */
+/* psc register value */
+#define PSC_PSC(regval)             (BITS(0,2) & ((uint32_t)(regval) << 0))
+#define FWDGT_PSC_DIV4              ((uint8_t)PSC_PSC(0))           /*!< FWDGT prescaler set to 4 */
+#define FWDGT_PSC_DIV8              ((uint8_t)PSC_PSC(1))           /*!< FWDGT prescaler set to 8 */
+#define FWDGT_PSC_DIV16             ((uint8_t)PSC_PSC(2))           /*!< FWDGT prescaler set to 16 */
+#define FWDGT_PSC_DIV32             ((uint8_t)PSC_PSC(3))           /*!< FWDGT prescaler set to 32 */
+#define FWDGT_PSC_DIV64             ((uint8_t)PSC_PSC(4))           /*!< FWDGT prescaler set to 64 */
+#define FWDGT_PSC_DIV128            ((uint8_t)PSC_PSC(5))           /*!< FWDGT prescaler set to 128 */
+#define FWDGT_PSC_DIV256            ((uint8_t)PSC_PSC(6))           /*!< FWDGT prescaler set to 256 */
+
+/* control value */
+#define FWDGT_WRITEACCESS_ENABLE    ((uint16_t)0x5555U)             /*!< FWDGT_CTL bits write access enable value */
+#define FWDGT_WRITEACCESS_DISABLE   ((uint16_t)0x0000U)             /*!< FWDGT_CTL bits write access disable value */
+#define FWDGT_KEY_RELOAD            ((uint16_t)0xAAAAU)             /*!< FWDGT_CTL bits fwdgt counter reload value */
+#define FWDGT_KEY_ENABLE            ((uint16_t)0xCCCCU)             /*!< FWDGT_CTL bits fwdgt counter enable value */
+
+/* FWDGT timeout value */
+#define FWDGT_PSC_TIMEOUT           ((uint32_t)0x000FFFFFU)         /*!< FWDGT_PSC register write operation state flag timeout */
+#define FWDGT_RLD_TIMEOUT           ((uint32_t)0x000FFFFFU)         /*!< FWDGT_RLD register write operation state flag timeout */
+
+/* FWDGT flag definitions */
+#define FWDGT_FLAG_PUD              FWDGT_STAT_PUD                  /*!< FWDGT prescaler divider value update flag */
+#define FWDGT_FLAG_RUD              FWDGT_STAT_RUD                  /*!< FWDGT counter reload value update flag */
+
+/* write value to FWDGT_RLD_RLD bit field */
+#define RLD_RLD(regval)             (BITS(0,11) & ((uint32_t)(regval) << 0))
+
+/* function declarations */
+/* enable write access to FWDGT_PSC and FWDGT_RLD */
+void fwdgt_write_enable(void);
+/* disable write access to FWDGT_PSC and FWDGT_RLD */
+void fwdgt_write_disable(void);
+/* start the free watchdog timer counter */
+void fwdgt_enable(void);
+
+/* configure the free watchdog timer counter prescaler value */
+ErrStatus fwdgt_prescaler_value_config(uint16_t prescaler_value);
+/* configure the free watchdog timer counter reload value */
+ErrStatus fwdgt_reload_value_config(uint16_t reload_value);
+/* reload the counter of FWDGT */
+void fwdgt_counter_reload(void);
+/* configure counter reload value, and prescaler divider value */
+ErrStatus fwdgt_config(uint16_t reload_value, uint8_t prescaler_div);
+
+/* get flag state of FWDGT */
+FlagStatus fwdgt_flag_get(uint16_t flag);
+
+#endif /* GD32F4XX_FWDGT_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_gpio.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_gpio.h
@@ -1,0 +1,409 @@
+/*!
+    \file    gd32f4xx_gpio.h
+    \brief   definitions for the GPIO
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_GPIO_H
+#define GD32F4XX_GPIO_H
+
+#include "gd32f4xx.h"
+
+/* GPIOx(x=A,B,C,D,E,F,G,H,I) definitions */
+#define GPIOA                      (GPIO_BASE + 0x00000000U)
+#define GPIOB                      (GPIO_BASE + 0x00000400U)
+#define GPIOC                      (GPIO_BASE + 0x00000800U)
+#define GPIOD                      (GPIO_BASE + 0x00000C00U)
+#define GPIOE                      (GPIO_BASE + 0x00001000U)
+#define GPIOF                      (GPIO_BASE + 0x00001400U)
+#define GPIOG                      (GPIO_BASE + 0x00001800U)
+#define GPIOH                      (GPIO_BASE + 0x00001C00U)
+#define GPIOI                      (GPIO_BASE + 0x00002000U)
+
+/* registers definitions */
+#define GPIO_CTL(gpiox)            REG32((gpiox) + 0x00U)    /*!< GPIO port control register */
+#define GPIO_OMODE(gpiox)          REG32((gpiox) + 0x04U)    /*!< GPIO port output mode register */
+#define GPIO_OSPD(gpiox)           REG32((gpiox) + 0x08U)    /*!< GPIO port output speed register */
+#define GPIO_PUD(gpiox)            REG32((gpiox) + 0x0CU)    /*!< GPIO port pull-up/pull-down register */
+#define GPIO_ISTAT(gpiox)          REG32((gpiox) + 0x10U)    /*!< GPIO port input status register */
+#define GPIO_OCTL(gpiox)           REG32((gpiox) + 0x14U)    /*!< GPIO port output control register */
+#define GPIO_BOP(gpiox)            REG32((gpiox) + 0x18U)    /*!< GPIO port bit operate register */
+#define GPIO_LOCK(gpiox)           REG32((gpiox) + 0x1CU)    /*!< GPIO port configuration lock register */
+#define GPIO_AFSEL0(gpiox)         REG32((gpiox) + 0x20U)    /*!< GPIO alternate function selected register 0 */
+#define GPIO_AFSEL1(gpiox)         REG32((gpiox) + 0x24U)    /*!< GPIO alternate function selected register 1 */
+#define GPIO_BC(gpiox)             REG32((gpiox) + 0x28U)    /*!< GPIO bit clear register */
+#define GPIO_TG(gpiox)             REG32((gpiox) + 0x2CU)    /*!< GPIO port bit toggle register */
+
+/* bits definitions */
+/* GPIO_CTL */
+#define GPIO_CTL_CTL0              BITS(0,1)                 /*!< pin 0 configuration bits */ 
+#define GPIO_CTL_CTL1              BITS(2,3)                 /*!< pin 1 configuration bits */
+#define GPIO_CTL_CTL2              BITS(4,5)                 /*!< pin 2 configuration bits */
+#define GPIO_CTL_CTL3              BITS(6,7)                 /*!< pin 3 configuration bits */
+#define GPIO_CTL_CTL4              BITS(8,9)                 /*!< pin 4 configuration bits */
+#define GPIO_CTL_CTL5              BITS(10,11)               /*!< pin 5 configuration bits */
+#define GPIO_CTL_CTL6              BITS(12,13)               /*!< pin 6 configuration bits */
+#define GPIO_CTL_CTL7              BITS(14,15)               /*!< pin 7 configuration bits */
+#define GPIO_CTL_CTL8              BITS(16,17)               /*!< pin 8 configuration bits */
+#define GPIO_CTL_CTL9              BITS(18,19)               /*!< pin 9 configuration bits */
+#define GPIO_CTL_CTL10             BITS(20,21)               /*!< pin 10 configuration bits */
+#define GPIO_CTL_CTL11             BITS(22,23)               /*!< pin 11 configuration bits */
+#define GPIO_CTL_CTL12             BITS(24,25)               /*!< pin 12 configuration bits */
+#define GPIO_CTL_CTL13             BITS(26,27)               /*!< pin 13 configuration bits */
+#define GPIO_CTL_CTL14             BITS(28,29)               /*!< pin 14 configuration bits */
+#define GPIO_CTL_CTL15             BITS(30,31)               /*!< pin 15 configuration bits */
+
+/* GPIO_OMODE */
+#define GPIO_OMODE_OM0             BIT(0)                    /*!< pin 0 output mode bit */
+#define GPIO_OMODE_OM1             BIT(1)                    /*!< pin 1 output mode bit */
+#define GPIO_OMODE_OM2             BIT(2)                    /*!< pin 2 output mode bit */
+#define GPIO_OMODE_OM3             BIT(3)                    /*!< pin 3 output mode bit */
+#define GPIO_OMODE_OM4             BIT(4)                    /*!< pin 4 output mode bit */
+#define GPIO_OMODE_OM5             BIT(5)                    /*!< pin 5 output mode bit */
+#define GPIO_OMODE_OM6             BIT(6)                    /*!< pin 6 output mode bit */
+#define GPIO_OMODE_OM7             BIT(7)                    /*!< pin 7 output mode bit */
+#define GPIO_OMODE_OM8             BIT(8)                    /*!< pin 8 output mode bit */
+#define GPIO_OMODE_OM9             BIT(9)                    /*!< pin 9 output mode bit */
+#define GPIO_OMODE_OM10            BIT(10)                   /*!< pin 10 output mode bit */
+#define GPIO_OMODE_OM11            BIT(11)                   /*!< pin 11 output mode bit */
+#define GPIO_OMODE_OM12            BIT(12)                   /*!< pin 12 output mode bit */
+#define GPIO_OMODE_OM13            BIT(13)                   /*!< pin 13 output mode bit */
+#define GPIO_OMODE_OM14            BIT(14)                   /*!< pin 14 output mode bit */
+#define GPIO_OMODE_OM15            BIT(15)                   /*!< pin 15 output mode bit */
+
+/* GPIO_OSPD */
+#define GPIO_OSPD_OSPD0            BITS(0,1)                 /*!< pin 0 output max speed bits */
+#define GPIO_OSPD_OSPD1            BITS(2,3)                 /*!< pin 1 output max speed bits */
+#define GPIO_OSPD_OSPD2            BITS(4,5)                 /*!< pin 2 output max speed bits */
+#define GPIO_OSPD_OSPD3            BITS(6,7)                 /*!< pin 3 output max speed bits */
+#define GPIO_OSPD_OSPD4            BITS(8,9)                 /*!< pin 4 output max speed bits */
+#define GPIO_OSPD_OSPD5            BITS(10,11)               /*!< pin 5 output max speed bits */
+#define GPIO_OSPD_OSPD6            BITS(12,13)               /*!< pin 6 output max speed bits */
+#define GPIO_OSPD_OSPD7            BITS(14,15)               /*!< pin 7 output max speed bits */
+#define GPIO_OSPD_OSPD8            BITS(16,17)               /*!< pin 8 output max speed bits */
+#define GPIO_OSPD_OSPD9            BITS(18,19)               /*!< pin 9 output max speed bits */
+#define GPIO_OSPD_OSPD10           BITS(20,21)               /*!< pin 10 output max speed bits */
+#define GPIO_OSPD_OSPD11           BITS(22,23)               /*!< pin 11 output max speed bits */
+#define GPIO_OSPD_OSPD12           BITS(24,25)               /*!< pin 12 output max speed bits */
+#define GPIO_OSPD_OSPD13           BITS(26,27)               /*!< pin 13 output max speed bits */
+#define GPIO_OSPD_OSPD14           BITS(28,29)               /*!< pin 14 output max speed bits */
+#define GPIO_OSPD_OSPD15           BITS(30,31)               /*!< pin 15 output max speed bits */
+
+/* GPIO_PUD */
+#define GPIO_PUD_PUD0              BITS(0,1)                 /*!< pin 0 pull-up or pull-down bits */
+#define GPIO_PUD_PUD1              BITS(2,3)                 /*!< pin 1 pull-up or pull-down bits */
+#define GPIO_PUD_PUD2              BITS(4,5)                 /*!< pin 2 pull-up or pull-down bits */
+#define GPIO_PUD_PUD3              BITS(6,7)                 /*!< pin 3 pull-up or pull-down bits */
+#define GPIO_PUD_PUD4              BITS(8,9)                 /*!< pin 4 pull-up or pull-down bits */
+#define GPIO_PUD_PUD5              BITS(10,11)               /*!< pin 5 pull-up or pull-down bits */
+#define GPIO_PUD_PUD6              BITS(12,13)               /*!< pin 6 pull-up or pull-down bits */
+#define GPIO_PUD_PUD7              BITS(14,15)               /*!< pin 7 pull-up or pull-down bits */
+#define GPIO_PUD_PUD8              BITS(16,17)               /*!< pin 8 pull-up or pull-down bits */
+#define GPIO_PUD_PUD9              BITS(18,19)               /*!< pin 9 pull-up or pull-down bits */
+#define GPIO_PUD_PUD10             BITS(20,21)               /*!< pin 10 pull-up or pull-down bits */
+#define GPIO_PUD_PUD11             BITS(22,23)               /*!< pin 11 pull-up or pull-down bits */
+#define GPIO_PUD_PUD12             BITS(24,25)               /*!< pin 12 pull-up or pull-down bits */
+#define GPIO_PUD_PUD13             BITS(26,27)               /*!< pin 13 pull-up or pull-down bits */
+#define GPIO_PUD_PUD14             BITS(28,29)               /*!< pin 14 pull-up or pull-down bits */
+#define GPIO_PUD_PUD15             BITS(30,31)               /*!< pin 15 pull-up or pull-down bits */
+
+/* GPIO_ISTAT */
+#define GPIO_ISTAT_ISTAT0          BIT(0)                    /*!< pin 0 input status */
+#define GPIO_ISTAT_ISTAT1          BIT(1)                    /*!< pin 1 input status */
+#define GPIO_ISTAT_ISTAT2          BIT(2)                    /*!< pin 2 input status */
+#define GPIO_ISTAT_ISTAT3          BIT(3)                    /*!< pin 3 input status */
+#define GPIO_ISTAT_ISTAT4          BIT(4)                    /*!< pin 4 input status */
+#define GPIO_ISTAT_ISTAT5          BIT(5)                    /*!< pin 5 input status */
+#define GPIO_ISTAT_ISTAT6          BIT(6)                    /*!< pin 6 input status */
+#define GPIO_ISTAT_ISTAT7          BIT(7)                    /*!< pin 7 input status */
+#define GPIO_ISTAT_ISTAT8          BIT(8)                    /*!< pin 8 input status */
+#define GPIO_ISTAT_ISTAT9          BIT(9)                    /*!< pin 9 input status */
+#define GPIO_ISTAT_ISTAT10         BIT(10)                   /*!< pin 10 input status */
+#define GPIO_ISTAT_ISTAT11         BIT(11)                   /*!< pin 11 input status */
+#define GPIO_ISTAT_ISTAT12         BIT(12)                   /*!< pin 12 input status */
+#define GPIO_ISTAT_ISTAT13         BIT(13)                   /*!< pin 13 input status */
+#define GPIO_ISTAT_ISTAT14         BIT(14)                   /*!< pin 14 input status */
+#define GPIO_ISTAT_ISTAT15         BIT(15)                   /*!< pin 15 input status */
+
+/* GPIO_OCTL */
+#define GPIO_OCTL_OCTL0            BIT(0)                    /*!< pin 0 output control bit */
+#define GPIO_OCTL_OCTL1            BIT(1)                    /*!< pin 1 output control bit */
+#define GPIO_OCTL_OCTL2            BIT(2)                    /*!< pin 2 output control bit */
+#define GPIO_OCTL_OCTL3            BIT(3)                    /*!< pin 3 output control bit */
+#define GPIO_OCTL_OCTL4            BIT(4)                    /*!< pin 4 output control bit */
+#define GPIO_OCTL_OCTL5            BIT(5)                    /*!< pin 5 output control bit */
+#define GPIO_OCTL_OCTL6            BIT(6)                    /*!< pin 6 output control bit */
+#define GPIO_OCTL_OCTL7            BIT(7)                    /*!< pin 7 output control bit */
+#define GPIO_OCTL_OCTL8            BIT(8)                    /*!< pin 8 output control bit */
+#define GPIO_OCTL_OCTL9            BIT(9)                    /*!< pin 9 output control bit */
+#define GPIO_OCTL_OCTL10           BIT(10)                   /*!< pin 10 output control bit */
+#define GPIO_OCTL_OCTL11           BIT(11)                   /*!< pin 11 output control bit */
+#define GPIO_OCTL_OCTL12           BIT(12)                   /*!< pin 12 output control bit */
+#define GPIO_OCTL_OCTL13           BIT(13)                   /*!< pin 13 output control bit */
+#define GPIO_OCTL_OCTL14           BIT(14)                   /*!< pin 14 output control bit */
+#define GPIO_OCTL_OCTL15           BIT(15)                   /*!< pin 15 output control bit */
+
+/* GPIO_BOP */
+#define GPIO_BOP_BOP0              BIT(0)                    /*!< pin 0 set bit */
+#define GPIO_BOP_BOP1              BIT(1)                    /*!< pin 1 set bit */
+#define GPIO_BOP_BOP2              BIT(2)                    /*!< pin 2 set bit */
+#define GPIO_BOP_BOP3              BIT(3)                    /*!< pin 3 set bit */
+#define GPIO_BOP_BOP4              BIT(4)                    /*!< pin 4 set bit */
+#define GPIO_BOP_BOP5              BIT(5)                    /*!< pin 5 set bit */
+#define GPIO_BOP_BOP6              BIT(6)                    /*!< pin 6 set bit */
+#define GPIO_BOP_BOP7              BIT(7)                    /*!< pin 7 set bit */
+#define GPIO_BOP_BOP8              BIT(8)                    /*!< pin 8 set bit */
+#define GPIO_BOP_BOP9              BIT(9)                    /*!< pin 9 set bit */
+#define GPIO_BOP_BOP10             BIT(10)                   /*!< pin 10 set bit */
+#define GPIO_BOP_BOP11             BIT(11)                   /*!< pin 11 set bit */
+#define GPIO_BOP_BOP12             BIT(12)                   /*!< pin 12 set bit */
+#define GPIO_BOP_BOP13             BIT(13)                   /*!< pin 13 set bit */
+#define GPIO_BOP_BOP14             BIT(14)                   /*!< pin 14 set bit */
+#define GPIO_BOP_BOP15             BIT(15)                   /*!< pin 15 set bit */
+#define GPIO_BOP_CR0               BIT(16)                   /*!< pin 0 clear bit */
+#define GPIO_BOP_CR1               BIT(17)                   /*!< pin 1 clear bit */
+#define GPIO_BOP_CR2               BIT(18)                   /*!< pin 2 clear bit */
+#define GPIO_BOP_CR3               BIT(19)                   /*!< pin 3 clear bit */
+#define GPIO_BOP_CR4               BIT(20)                   /*!< pin 4 clear bit */
+#define GPIO_BOP_CR5               BIT(21)                   /*!< pin 5 clear bit */
+#define GPIO_BOP_CR6               BIT(22)                   /*!< pin 6 clear bit */
+#define GPIO_BOP_CR7               BIT(23)                   /*!< pin 7 clear bit */
+#define GPIO_BOP_CR8               BIT(24)                   /*!< pin 8 clear bit */
+#define GPIO_BOP_CR9               BIT(25)                   /*!< pin 9 clear bit */
+#define GPIO_BOP_CR10              BIT(26)                   /*!< pin 10 clear bit */
+#define GPIO_BOP_CR11              BIT(27)                   /*!< pin 11 clear bit */
+#define GPIO_BOP_CR12              BIT(28)                   /*!< pin 12 clear bit */
+#define GPIO_BOP_CR13              BIT(29)                   /*!< pin 13 clear bit */
+#define GPIO_BOP_CR14              BIT(30)                   /*!< pin 14 clear bit */
+#define GPIO_BOP_CR15              BIT(31)                   /*!< pin 15 clear bit */
+
+/* GPIO_LOCK */
+#define GPIO_LOCK_LK0              BIT(0)                    /*!< pin 0 lock bit */
+#define GPIO_LOCK_LK1              BIT(1)                    /*!< pin 1 lock bit */
+#define GPIO_LOCK_LK2              BIT(2)                    /*!< pin 2 lock bit */
+#define GPIO_LOCK_LK3              BIT(3)                    /*!< pin 3 lock bit */
+#define GPIO_LOCK_LK4              BIT(4)                    /*!< pin 4 lock bit */
+#define GPIO_LOCK_LK5              BIT(5)                    /*!< pin 5 lock bit */
+#define GPIO_LOCK_LK6              BIT(6)                    /*!< pin 6 lock bit */
+#define GPIO_LOCK_LK7              BIT(7)                    /*!< pin 7 lock bit */
+#define GPIO_LOCK_LK8              BIT(8)                    /*!< pin 8 lock bit */
+#define GPIO_LOCK_LK9              BIT(9)                    /*!< pin 9 lock bit */
+#define GPIO_LOCK_LK10             BIT(10)                   /*!< pin 10 lock bit */
+#define GPIO_LOCK_LK11             BIT(11)                   /*!< pin 11 lock bit */
+#define GPIO_LOCK_LK12             BIT(12)                   /*!< pin 12 lock bit */
+#define GPIO_LOCK_LK13             BIT(13)                   /*!< pin 13 lock bit */
+#define GPIO_LOCK_LK14             BIT(14)                   /*!< pin 14 lock bit */
+#define GPIO_LOCK_LK15             BIT(15)                   /*!< pin 15 lock bit */
+#define GPIO_LOCK_LKK              BIT(16)                   /*!< pin lock sequence key */
+
+/* GPIO_AFSEL0 */
+#define GPIO_AFSEL0_SEL0           BITS(0,3)                 /*!< pin 0 alternate function selected */
+#define GPIO_AFSEL0_SEL1           BITS(4,7)                 /*!< pin 1 alternate function selected */
+#define GPIO_AFSEL0_SEL2           BITS(8,11)                /*!< pin 2 alternate function selected */
+#define GPIO_AFSEL0_SEL3           BITS(12,15)               /*!< pin 3 alternate function selected */
+#define GPIO_AFSEL0_SEL4           BITS(16,19)               /*!< pin 4 alternate function selected */
+#define GPIO_AFSEL0_SEL5           BITS(20,23)               /*!< pin 5 alternate function selected */
+#define GPIO_AFSEL0_SEL6           BITS(24,27)               /*!< pin 6 alternate function selected */
+#define GPIO_AFSEL0_SEL7           BITS(28,31)               /*!< pin 7 alternate function selected */
+
+/* GPIO_AFSEL1 */
+#define GPIO_AFSEL1_SEL8           BITS(0,3)                 /*!< pin 8 alternate function selected */
+#define GPIO_AFSEL1_SEL9           BITS(4,7)                 /*!< pin 9 alternate function selected */
+#define GPIO_AFSEL1_SEL10          BITS(8,11)                /*!< pin 10 alternate function selected */
+#define GPIO_AFSEL1_SEL11          BITS(12,15)               /*!< pin 11 alternate function selected */
+#define GPIO_AFSEL1_SEL12          BITS(16,19)               /*!< pin 12 alternate function selected */
+#define GPIO_AFSEL1_SEL13          BITS(20,23)               /*!< pin 13 alternate function selected */
+#define GPIO_AFSEL1_SEL14          BITS(24,27)               /*!< pin 14 alternate function selected */
+#define GPIO_AFSEL1_SEL15          BITS(28,31)               /*!< pin 15 alternate function selected */
+
+/* GPIO_BC */
+#define GPIO_BC_CR0                BIT(0)                    /*!< pin 0 clear bit */
+#define GPIO_BC_CR1                BIT(1)                    /*!< pin 1 clear bit */
+#define GPIO_BC_CR2                BIT(2)                    /*!< pin 2 clear bit */
+#define GPIO_BC_CR3                BIT(3)                    /*!< pin 3 clear bit */
+#define GPIO_BC_CR4                BIT(4)                    /*!< pin 4 clear bit */
+#define GPIO_BC_CR5                BIT(5)                    /*!< pin 5 clear bit */
+#define GPIO_BC_CR6                BIT(6)                    /*!< pin 6 clear bit */
+#define GPIO_BC_CR7                BIT(7)                    /*!< pin 7 clear bit */
+#define GPIO_BC_CR8                BIT(8)                    /*!< pin 8 clear bit */
+#define GPIO_BC_CR9                BIT(9)                    /*!< pin 9 clear bit */
+#define GPIO_BC_CR10               BIT(10)                   /*!< pin 10 clear bit */
+#define GPIO_BC_CR11               BIT(11)                   /*!< pin 11 clear bit */
+#define GPIO_BC_CR12               BIT(12)                   /*!< pin 12 clear bit */
+#define GPIO_BC_CR13               BIT(13)                   /*!< pin 13 clear bit */
+#define GPIO_BC_CR14               BIT(14)                   /*!< pin 14 clear bit */
+#define GPIO_BC_CR15               BIT(15)                   /*!< pin 15 clear bit */
+
+/* GPIO_TG */
+#define GPIO_TG_TG0                BIT(0)                    /*!< pin 0 toggle bit */
+#define GPIO_TG_TG1                BIT(1)                    /*!< pin 1 toggle bit */
+#define GPIO_TG_TG2                BIT(2)                    /*!< pin 2 toggle bit */
+#define GPIO_TG_TG3                BIT(3)                    /*!< pin 3 toggle bit */
+#define GPIO_TG_TG4                BIT(4)                    /*!< pin 4 toggle bit */
+#define GPIO_TG_TG5                BIT(5)                    /*!< pin 5 toggle bit */
+#define GPIO_TG_TG6                BIT(6)                    /*!< pin 6 toggle bit */
+#define GPIO_TG_TG7                BIT(7)                    /*!< pin 7 toggle bit */
+#define GPIO_TG_TG8                BIT(8)                    /*!< pin 8 toggle bit */
+#define GPIO_TG_TG9                BIT(9)                    /*!< pin 9 toggle bit */
+#define GPIO_TG_TG10               BIT(10)                   /*!< pin 10 toggle bit */
+#define GPIO_TG_TG11               BIT(11)                   /*!< pin 11 toggle bit */
+#define GPIO_TG_TG12               BIT(12)                   /*!< pin 12 toggle bit */
+#define GPIO_TG_TG13               BIT(13)                   /*!< pin 13 toggle bit */
+#define GPIO_TG_TG14               BIT(14)                   /*!< pin 14 toggle bit */
+#define GPIO_TG_TG15               BIT(15)                   /*!< pin 15 toggle bit */
+
+/* constants definitions */
+typedef FlagStatus bit_status;
+
+/* output mode definitions */
+#define CTL_CLTR(regval)           (BITS(0,1) & ((uint32_t)(regval) << 0))
+#define GPIO_MODE_INPUT            CTL_CLTR(0)               /*!< input mode */
+#define GPIO_MODE_OUTPUT           CTL_CLTR(1)               /*!< output mode */
+#define GPIO_MODE_AF               CTL_CLTR(2)               /*!< alternate function mode */
+#define GPIO_MODE_ANALOG           CTL_CLTR(3)               /*!< analog mode */
+
+/* pull-up/ pull-down definitions */
+#define PUD_PUPD(regval)           (BITS(0,1) & ((uint32_t)(regval) << 0))
+#define GPIO_PUPD_NONE             PUD_PUPD(0)               /*!< floating mode, no pull-up and pull-down resistors */
+#define GPIO_PUPD_PULLUP           PUD_PUPD(1)               /*!< with pull-up resistor */
+#define GPIO_PUPD_PULLDOWN         PUD_PUPD(2)               /*!< with pull-down resistor */
+
+/* GPIO pin definitions */
+#define GPIO_PIN_0                 BIT(0)                    /*!< GPIO pin 0 */
+#define GPIO_PIN_1                 BIT(1)                    /*!< GPIO pin 1 */
+#define GPIO_PIN_2                 BIT(2)                    /*!< GPIO pin 2 */
+#define GPIO_PIN_3                 BIT(3)                    /*!< GPIO pin 3 */
+#define GPIO_PIN_4                 BIT(4)                    /*!< GPIO pin 4 */
+#define GPIO_PIN_5                 BIT(5)                    /*!< GPIO pin 5 */
+#define GPIO_PIN_6                 BIT(6)                    /*!< GPIO pin 6 */
+#define GPIO_PIN_7                 BIT(7)                    /*!< GPIO pin 7 */
+#define GPIO_PIN_8                 BIT(8)                    /*!< GPIO pin 8 */
+#define GPIO_PIN_9                 BIT(9)                    /*!< GPIO pin 9 */
+#define GPIO_PIN_10                BIT(10)                   /*!< GPIO pin 10 */
+#define GPIO_PIN_11                BIT(11)                   /*!< GPIO pin 11 */
+#define GPIO_PIN_12                BIT(12)                   /*!< GPIO pin 12 */
+#define GPIO_PIN_13                BIT(13)                   /*!< GPIO pin 13 */
+#define GPIO_PIN_14                BIT(14)                   /*!< GPIO pin 14 */
+#define GPIO_PIN_15                BIT(15)                   /*!< GPIO pin 15 */
+#define GPIO_PIN_ALL               BITS(0,15)                /*!< GPIO pin all */
+
+/* GPIO mode configuration values */
+#define GPIO_MODE_SET(n, mode)     ((uint32_t)((uint32_t)(mode) << (2U * (n))))
+#define GPIO_MODE_MASK(n)          (0x3U << (2U * (n)))
+
+/* GPIO pull-up/ pull-down values */
+#define GPIO_PUPD_SET(n, pupd)     ((uint32_t)((uint32_t)(pupd) << (2U * (n))))
+#define GPIO_PUPD_MASK(n)          (0x3U << (2U * (n)))
+
+/* GPIO output speed values */
+#define GPIO_OSPEED_SET(n, speed)  ((uint32_t)((uint32_t)(speed) << (2U * (n))))
+#define GPIO_OSPEED_MASK(n)        (0x3U << (2U * (n)))
+
+/* GPIO output type */
+#define GPIO_OTYPE_PP              ((uint8_t)(0x00U))        /*!< push pull mode */
+#define GPIO_OTYPE_OD              ((uint8_t)(0x01U))        /*!< open drain mode */
+
+/* GPIO output max speed level */
+#define OSPD_OSPD(regval)          (BITS(0,1) & ((uint32_t)(regval) << 0))
+#define GPIO_OSPEED_LEVEL0         OSPD_OSPD(0)              /*!< output max speed level 0 */
+#define GPIO_OSPEED_LEVEL1         OSPD_OSPD(1)              /*!< output max speed level 1 */
+#define GPIO_OSPEED_LEVEL2         OSPD_OSPD(2)              /*!< output max speed level 2 */
+#define GPIO_OSPEED_LEVEL3         OSPD_OSPD(3)              /*!< output max speed level 3 */
+
+/* GPIO output max speed value */
+#define GPIO_OSPEED_2MHZ           GPIO_OSPEED_LEVEL0        /*!< output max speed 2MHz */
+#define GPIO_OSPEED_25MHZ          GPIO_OSPEED_LEVEL1        /*!< output max speed 25MHz */
+#define GPIO_OSPEED_50MHZ          GPIO_OSPEED_LEVEL2        /*!< output max speed 50MHz */
+#define GPIO_OSPEED_MAX            GPIO_OSPEED_LEVEL3        /*!< GPIO very high output speed, max speed more than 50MHz */
+
+/* GPIO alternate function values */
+#define GPIO_AFR_SET(n, af)        ((uint32_t)((uint32_t)(af) << (4U * (n))))
+#define GPIO_AFR_MASK(n)           (0xFU << (4U * (n)))
+ 
+/* GPIO alternate function */
+#define AF(regval)                 (BITS(0,3) & ((uint32_t)(regval) << 0)) 
+#define GPIO_AF_0                   AF(0)                    /*!< alternate function 0 selected */
+#define GPIO_AF_1                   AF(1)                    /*!< alternate function 1 selected */
+#define GPIO_AF_2                   AF(2)                    /*!< alternate function 2 selected */
+#define GPIO_AF_3                   AF(3)                    /*!< alternate function 3 selected */
+#define GPIO_AF_4                   AF(4)                    /*!< alternate function 4 selected */
+#define GPIO_AF_5                   AF(5)                    /*!< alternate function 5 selected */
+#define GPIO_AF_6                   AF(6)                    /*!< alternate function 6 selected */
+#define GPIO_AF_7                   AF(7)                    /*!< alternate function 7 selected */
+#define GPIO_AF_8                   AF(8)                    /*!< alternate function 8 selected */
+#define GPIO_AF_9                   AF(9)                    /*!< alternate function 9 selected */
+#define GPIO_AF_10                  AF(10)                   /*!< alternate function 10 selected */
+#define GPIO_AF_11                  AF(11)                   /*!< alternate function 11 selected */
+#define GPIO_AF_12                  AF(12)                   /*!< alternate function 12 selected */
+#define GPIO_AF_13                  AF(13)                   /*!< alternate function 13 selected */
+#define GPIO_AF_14                  AF(14)                   /*!< alternate function 14 selected */
+#define GPIO_AF_15                  AF(15)                   /*!< alternate function 15 selected */
+
+/* function declarations */
+/* reset GPIO port */
+void gpio_deinit(uint32_t gpio_periph);
+/* set GPIO mode */
+void gpio_mode_set(uint32_t gpio_periph, uint32_t mode, uint32_t pull_up_down, uint32_t pin);
+/* set GPIO output type and speed */
+void gpio_output_options_set(uint32_t gpio_periph, uint8_t otype, uint32_t speed, uint32_t pin);
+
+/* set GPIO pin bit */
+void gpio_bit_set(uint32_t gpio_periph, uint32_t pin);
+/* reset GPIO pin bit */
+void gpio_bit_reset(uint32_t gpio_periph, uint32_t pin);
+/* write data to the specified GPIO pin */
+void gpio_bit_write(uint32_t gpio_periph, uint32_t pin, bit_status bit_value);
+/* write data to the specified GPIO port */
+void gpio_port_write(uint32_t gpio_periph, uint16_t data);
+
+/* get GPIO pin input status */
+FlagStatus gpio_input_bit_get(uint32_t gpio_periph, uint32_t pin);
+/* get GPIO port input status */
+uint16_t gpio_input_port_get(uint32_t gpio_periph);
+/* get GPIO pin output status */
+FlagStatus gpio_output_bit_get(uint32_t gpio_periph, uint32_t pin);
+/* get GPIO port output status */
+uint16_t gpio_output_port_get(uint32_t gpio_periph);
+
+/* set GPIO alternate function */
+void gpio_af_set(uint32_t gpio_periph, uint32_t alt_func_num, uint32_t pin);
+/* lock GPIO pin bit */
+void gpio_pin_lock(uint32_t gpio_periph, uint32_t pin);
+
+/* toggle GPIO pin status */
+void gpio_bit_toggle(uint32_t gpio_periph, uint32_t pin);
+/* toggle GPIO port status */
+void gpio_port_toggle(uint32_t gpio_periph);
+
+#endif /* GD32F4XX_GPIO_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_i2c.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_i2c.h
@@ -1,0 +1,413 @@
+/*!
+    \file    gd32f4xx_i2c.h
+    \brief   definitions for the I2C
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2019-04-16, V2.0.1, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_I2C_H
+#define GD32F4XX_I2C_H
+
+#include "gd32f4xx.h"
+
+/* I2Cx(x=0,1,2) definitions */
+#define I2C0                          I2C_BASE                          /*!< I2C0 base address */
+#define I2C1                          (I2C_BASE + 0x00000400U)          /*!< I2C1 base address */
+#define I2C2                          (I2C_BASE + 0x00000800U)          /*!< I2C2 base address */
+
+/* registers definitions */
+#define I2C_CTL0(i2cx)                REG32((i2cx) + 0x00000000U)       /*!< I2C control register 0 */
+#define I2C_CTL1(i2cx)                REG32((i2cx) + 0x00000004U)       /*!< I2C control register 1 */
+#define I2C_SADDR0(i2cx)              REG32((i2cx) + 0x00000008U)       /*!< I2C slave address register 0 */
+#define I2C_SADDR1(i2cx)              REG32((i2cx) + 0x0000000CU)       /*!< I2C slave address register 1 */
+#define I2C_DATA(i2cx)                REG32((i2cx) + 0x00000010U)       /*!< I2C transfer buffer register */
+#define I2C_STAT0(i2cx)               REG32((i2cx) + 0x00000014U)       /*!< I2C transfer status register 0 */
+#define I2C_STAT1(i2cx)               REG32((i2cx) + 0x00000018U)       /*!< I2C transfer status register */
+#define I2C_CKCFG(i2cx)               REG32((i2cx) + 0x0000001CU)       /*!< I2C clock configure register */
+#define I2C_RT(i2cx)                  REG32((i2cx) + 0x00000020U)       /*!< I2C rise time register */
+#define I2C_FCTL(i2cx)                REG32((i2cx) + 0x00000024U)       /*!< I2C filter control register */
+#define I2C_SAMCS(i2cx)               REG32((i2cx) + 0x00000080U)       /*!< I2C SAM control and status register */
+
+/* bits definitions */
+/* I2Cx_CTL0 */
+#define I2C_CTL0_I2CEN                BIT(0)                            /*!< peripheral enable */
+#define I2C_CTL0_SMBEN                BIT(1)                            /*!< SMBus mode */
+#define I2C_CTL0_SMBSEL               BIT(3)                            /*!< SMBus type */
+#define I2C_CTL0_ARPEN                BIT(4)                            /*!< ARP enable */
+#define I2C_CTL0_PECEN                BIT(5)                            /*!< PEC enable */
+#define I2C_CTL0_GCEN                 BIT(6)                            /*!< general call enable */
+#define I2C_CTL0_SS                   BIT(7)                            /*!< clock stretching disable (slave mode) */
+#define I2C_CTL0_START                BIT(8)                            /*!< start generation */
+#define I2C_CTL0_STOP                 BIT(9)                            /*!< stop generation */
+#define I2C_CTL0_ACKEN                BIT(10)                           /*!< acknowledge enable */
+#define I2C_CTL0_POAP                 BIT(11)                           /*!< acknowledge/PEC position (for data reception) */
+#define I2C_CTL0_PECTRANS             BIT(12)                           /*!< packet error checking */
+#define I2C_CTL0_SALT                 BIT(13)                           /*!< SMBus alert */
+#define I2C_CTL0_SRESET               BIT(15)                           /*!< software reset */
+
+/* I2Cx_CTL1 */
+#define I2C_CTL1_I2CCLK               BITS(0,5)                         /*!< I2CCLK[5:0] bits (peripheral clock frequency) */
+#define I2C_CTL1_ERRIE                BIT(8)                            /*!< error interrupt enable */
+#define I2C_CTL1_EVIE                 BIT(9)                            /*!< event interrupt enable */
+#define I2C_CTL1_BUFIE                BIT(10)                           /*!< buffer interrupt enable */
+#define I2C_CTL1_DMAON                BIT(11)                           /*!< DMA requests enable */
+#define I2C_CTL1_DMALST               BIT(12)                           /*!< DMA last transfer */
+
+/* I2Cx_SADDR0 */
+#define I2C_SADDR0_ADDRESS0           BIT(0)                            /*!< bit 0 of a 10-bit address */
+#define I2C_SADDR0_ADDRESS            BITS(1,7)                         /*!< 7-bit address or bits 7:1 of a 10-bit address */
+#define I2C_SADDR0_ADDRESS_H          BITS(8,9)                         /*!< highest two bits of a 10-bit address */
+#define I2C_SADDR0_ADDFORMAT          BIT(15)                           /*!< address mode for the I2C slave */
+
+/* I2Cx_SADDR1 */
+#define I2C_SADDR1_DUADEN             BIT(0)                            /*!< aual-address mode switch */
+#define I2C_SADDR1_ADDRESS2           BITS(1,7)                         /*!< second I2C address for the slave in dual-address mode */
+
+/* I2Cx_DATA */
+#define I2C_DATA_TRB                  BITS(0,7)                         /*!< 8-bit data register */
+
+/* I2Cx_STAT0 */
+#define I2C_STAT0_SBSEND              BIT(0)                            /*!< start bit (master mode) */
+#define I2C_STAT0_ADDSEND             BIT(1)                            /*!< address sent (master mode)/matched (slave mode) */
+#define I2C_STAT0_BTC                 BIT(2)                            /*!< byte transfer finished */
+#define I2C_STAT0_ADD10SEND           BIT(3)                            /*!< 10-bit header sent (master mode) */
+#define I2C_STAT0_STPDET              BIT(4)                            /*!< stop detection (slave mode) */
+#define I2C_STAT0_RBNE                BIT(6)                            /*!< data register not empty (receivers) */
+#define I2C_STAT0_TBE                 BIT(7)                            /*!< data register empty (transmitters) */
+#define I2C_STAT0_BERR                BIT(8)                            /*!< bus error */
+#define I2C_STAT0_LOSTARB             BIT(9)                            /*!< arbitration lost (master mode) */
+#define I2C_STAT0_AERR                BIT(10)                           /*!< acknowledge failure */
+#define I2C_STAT0_OUERR               BIT(11)                           /*!< overrun/underrun */
+#define I2C_STAT0_PECERR              BIT(12)                           /*!< PEC error in reception */
+#define I2C_STAT0_SMBTO               BIT(14)                           /*!< timeout signal in SMBus mode */
+#define I2C_STAT0_SMBALT              BIT(15)                           /*!< SMBus alert status */
+
+/* I2Cx_STAT1 */
+#define I2C_STAT1_MASTER              BIT(0)                            /*!< master/slave */
+#define I2C_STAT1_I2CBSY              BIT(1)                            /*!< bus busy */
+#define I2C_STAT1_TR                  BIT(2)                            /*!< transmitter/receiver */
+#define I2C_STAT1_RXGC                BIT(4)                            /*!< general call address (slave mode) */
+#define I2C_STAT1_DEFSMB              BIT(5)                            /*!< SMBus device default address (slave mode) */
+#define I2C_STAT1_HSTSMB              BIT(6)                            /*!< SMBus host header (slave mode) */
+#define I2C_STAT1_DUMODF              BIT(7)                            /*!< dual flag (slave mode) */
+#define I2C_STAT1_PECV                BITS(8,15)                        /*!< packet error checking value */
+
+/* I2Cx_CKCFG */
+#define I2C_CKCFG_CLKC                BITS(0,11)                        /*!< clock control register in fast/standard mode (master mode) */
+#define I2C_CKCFG_DTCY                BIT(14)                           /*!< fast mode duty cycle */
+#define I2C_CKCFG_FAST                BIT(15)                           /*!< I2C speed selection in master mode */
+
+/* I2Cx_RT */
+#define I2C_RT_RISETIME               BITS(0,5)                         /*!< maximum rise time in fast/standard mode (Master mode) */
+
+/* I2Cx_FCTL */
+#define I2C_FCTL_DF                   BITS(0,3)                         /*!< digital noise filter */
+#define I2C_FCTL_AFD                  BIT(4)                            /*!< analog noise filter disable */
+
+/* I2Cx_SAMCS */
+#define I2C_SAMCS_SAMEN               BIT(0)                            /*!< SAM_V interface enable */
+#define I2C_SAMCS_STOEN               BIT(1)                            /*!< SAM_V interface timeout detect enable */
+#define I2C_SAMCS_TFFIE               BIT(4)                            /*!< txframe fall interrupt enable */
+#define I2C_SAMCS_TFRIE               BIT(5)                            /*!< txframe rise interrupt enable */
+#define I2C_SAMCS_RFFIE               BIT(6)                            /*!< rxframe fall interrupt enable */
+#define I2C_SAMCS_RFRIE               BIT(7)                            /*!< rxframe rise interrupt enable */
+#define I2C_SAMCS_TXF                 BIT(8)                            /*!< level of txframe signal */
+#define I2C_SAMCS_RXF                 BIT(9)                            /*!< level of rxframe signal */
+#define I2C_SAMCS_TFF                 BIT(12)                           /*!< txframe fall flag */
+#define I2C_SAMCS_TFR                 BIT(13)                           /*!< txframe rise flag */
+#define I2C_SAMCS_RFF                 BIT(14)                           /*!< rxframe fall flag */
+#define I2C_SAMCS_RFR                 BIT(15)                           /*!< rxframe rise flag */
+
+/* constants definitions */
+/* define the I2C bit position and its register index offset */
+#define I2C_REGIDX_BIT(regidx, bitpos)  (((uint32_t)(regidx) << 6) | (uint32_t)(bitpos))
+#define I2C_REG_VAL(i2cx, offset)       (REG32((i2cx) + (((uint32_t)(offset) & 0x0000FFFFU) >> 6)))
+#define I2C_BIT_POS(val)                ((uint32_t)(val) & 0x0000001FU)
+#define I2C_REGIDX_BIT2(regidx, bitpos, regidx2, bitpos2)   (((uint32_t)(regidx2) << 22) | (uint32_t)((bitpos2) << 16)\
+                                                            | (((uint32_t)(regidx) << 6) | (uint32_t)(bitpos)))
+#define I2C_REG_VAL2(i2cx, offset)      (REG32((i2cx) + ((uint32_t)(offset) >> 22)))
+#define I2C_BIT_POS2(val)               (((uint32_t)(val) & 0x001F0000U) >> 16)
+
+/* register offset */
+#define I2C_CTL1_REG_OFFSET           ((uint32_t)0x00000004U)           /*!< CTL1 register offset */
+#define I2C_STAT0_REG_OFFSET          ((uint32_t)0x00000014U)           /*!< STAT0 register offset */
+#define I2C_STAT1_REG_OFFSET          ((uint32_t)0x00000018U)           /*!< STAT1 register offset */
+#define I2C_SAMCS_REG_OFFSET          ((uint32_t)0x00000080U)           /*!< SAMCS register offset */
+
+/* I2C flags */
+typedef enum {
+    /* flags in STAT0 register */
+    I2C_FLAG_SBSEND = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 0U),         /*!< start condition sent out in master mode */
+    I2C_FLAG_ADDSEND = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 1U),        /*!< address is sent in master mode or received and matches in slave mode */
+    I2C_FLAG_BTC = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 2U),            /*!< byte transmission finishes */
+    I2C_FLAG_ADD10SEND = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 3U),      /*!< header of 10-bit address is sent in master mode */
+    I2C_FLAG_STPDET = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 4U),         /*!< stop condition detected in slave mode */
+    I2C_FLAG_RBNE = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 6U),           /*!< I2C_DATA is not empty during receiving */
+    I2C_FLAG_TBE = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 7U),            /*!< I2C_DATA is empty during transmitting */
+    I2C_FLAG_BERR = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 8U),           /*!< a bus error occurs indication a unexpected start or stop condition on I2C bus */
+    I2C_FLAG_LOSTARB = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 9U),        /*!< arbitration lost in master mode */
+    I2C_FLAG_AERR = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 10U),          /*!< acknowledge error */
+    I2C_FLAG_OUERR = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 11U),         /*!< over-run or under-run situation occurs in slave mode */
+    I2C_FLAG_PECERR = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 12U),        /*!< PEC error when receiving data */
+    I2C_FLAG_SMBTO = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 14U),         /*!< timeout signal in SMBus mode */
+    I2C_FLAG_SMBALT = I2C_REGIDX_BIT(I2C_STAT0_REG_OFFSET, 15U),        /*!< SMBus alert status */
+    /* flags in STAT1 register */
+    I2C_FLAG_MASTER = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 0U),         /*!< a flag indicating whether I2C block is in master or slave mode */
+    I2C_FLAG_I2CBSY = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 1U),         /*!< busy flag */
+    I2C_FLAG_TR = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 2U),             /*!< whether the I2C is a transmitter or a receiver */
+    I2C_FLAG_RXGC = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 4U),           /*!< general call address (00h) received */
+    I2C_FLAG_DEFSMB = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 5U),         /*!< default address of SMBus device */
+    I2C_FLAG_HSTSMB = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 6U),         /*!< SMBus host header detected in slave mode */
+    I2C_FLAG_DUMOD = I2C_REGIDX_BIT(I2C_STAT1_REG_OFFSET, 7U),          /*!< dual flag in slave mode indicating which address is matched in dual-address mode */
+    /* flags in SAMCS register */
+    I2C_FLAG_TFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 12U),           /*!< txframe fall flag */
+    I2C_FLAG_TFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 13U),           /*!< txframe rise flag */
+    I2C_FLAG_RFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 14U),           /*!< rxframe fall flag */
+    I2C_FLAG_RFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 15U)            /*!< rxframe rise flag */
+} i2c_flag_enum;
+
+/* I2C interrupt flags */
+typedef enum {
+    /* interrupt flags in CTL1 register */
+    I2C_INT_FLAG_SBSEND = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 0U),        /*!< start condition sent out in master mode interrupt flag */
+    I2C_INT_FLAG_ADDSEND = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 1U),       /*!< address is sent in master mode or received and matches in slave mode interrupt flag */
+    I2C_INT_FLAG_BTC =  I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 2U),          /*!< byte transmission finishes interrupt flag */
+    I2C_INT_FLAG_ADD10SEND =  I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 3U),    /*!< header of 10-bit address is sent in master mode interrupt flag */
+    I2C_INT_FLAG_STPDET = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 4U),        /*!< stop condition detected in slave mode interrupt flag */
+    I2C_INT_FLAG_RBNE = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 6U),          /*!< I2C_DATA is not Empty during receiving interrupt flag */
+    I2C_INT_FLAG_TBE = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 9U, I2C_STAT0_REG_OFFSET, 7U),           /*!< I2C_DATA is empty during transmitting interrupt flag */
+    I2C_INT_FLAG_BERR = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 8U),          /*!< a bus error occurs indication a unexpected start or stop condition on I2C bus interrupt flag */
+    I2C_INT_FLAG_LOSTARB = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 9U),       /*!< arbitration lost in master mode interrupt flag */
+    I2C_INT_FLAG_AERR = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 10U),         /*!< acknowledge error interrupt flag */
+    I2C_INT_FLAG_OUERR = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 11U),        /*!< over-run or under-run situation occurs in slave mode interrupt flag */
+    I2C_INT_FLAG_PECERR = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 12U),       /*!< PEC error when receiving data interrupt flag */
+    I2C_INT_FLAG_SMBTO = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 14U),        /*!< timeout signal in SMBus mode interrupt flag */
+    I2C_INT_FLAG_SMBALT = I2C_REGIDX_BIT2(I2C_CTL1_REG_OFFSET, 8U, I2C_STAT0_REG_OFFSET, 15U),       /*!< SMBus alert status interrupt flag */
+    /* interrupt flags in SAMCS register */
+    I2C_INT_FLAG_TFF = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 4U, I2C_SAMCS_REG_OFFSET, 12U),         /*!< txframe fall interrupt flag */
+    I2C_INT_FLAG_TFR = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 5U, I2C_SAMCS_REG_OFFSET, 13U),         /*!< txframe rise interrupt flag */
+    I2C_INT_FLAG_RFF = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 6U, I2C_SAMCS_REG_OFFSET, 14U),         /*!< rxframe fall interrupt flag */
+    I2C_INT_FLAG_RFR = I2C_REGIDX_BIT2(I2C_SAMCS_REG_OFFSET, 7U, I2C_SAMCS_REG_OFFSET, 15U)          /*!< rxframe rise interrupt flag */
+} i2c_interrupt_flag_enum;
+
+/* I2C interrupt */
+typedef enum {
+    /* interrupt in CTL1 register */
+    I2C_INT_ERR = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 8U),              /*!< error interrupt */
+    I2C_INT_EV = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 9U),               /*!< event interrupt */
+    I2C_INT_BUF = I2C_REGIDX_BIT(I2C_CTL1_REG_OFFSET, 10U),             /*!< buffer interrupt */
+    /* interrupt in SAMCS register */
+    I2C_INT_TFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 4U),             /*!< txframe fall interrupt */
+    I2C_INT_TFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 5U),             /*!< txframe rise interrupt */
+    I2C_INT_RFF = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 6U),             /*!< rxframe fall interrupt */
+    I2C_INT_RFR = I2C_REGIDX_BIT(I2C_SAMCS_REG_OFFSET, 7U)              /*!< rxframe rise interrupt */
+} i2c_interrupt_enum;
+
+/* the digital noise filter can filter spikes's length */
+typedef enum {
+    I2C_DF_DISABLE = 0,                                                 /*!< disable digital noise filter */
+    I2C_DF_1PCLK,                                                       /*!< enable digital noise filter and the maximum filtered spiker's length 1 PCLK1 */
+    I2C_DF_2PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 2 PCLK1 */
+    I2C_DF_3PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 3 PCLK1 */
+    I2C_DF_4PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 4 PCLK1 */
+    I2C_DF_5PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 5 PCLK1 */
+    I2C_DF_6PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 6 PCLK1 */
+    I2C_DF_7PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 7 PCLK1 */
+    I2C_DF_8PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 8 PCLK1 */
+    I2C_DF_9PCLKS,                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 9 PCLK1 */
+    I2C_DF_10PCLKS,                                                     /*!< enable digital noise filter and the maximum filtered spiker's length 10 PCLK1 */
+    I2C_DF_11PCLKS,                                                     /*!< enable digital noise filter and the maximum filtered spiker's length 11 PCLK1 */
+    I2C_DF_12PCLKS,                                                     /*!< enable digital noise filter and the maximum filtered spiker's length 12 PCLK1 */
+    I2C_DF_13PCLKS,                                                     /*!< enable digital noise filter and the maximum filtered spiker's length 13 PCLK1 */
+    I2C_DF_14PCLKS,                                                     /*!< enable digital noise filter and the maximum filtered spiker's length 14 PCLK1 */
+    I2C_DF_15PCLKS                                                      /*!< enable digital noise filter and the maximum filtered spiker's length 15 PCLK1 */
+} i2c_digital_filter_enum;
+
+/* SMBus/I2C mode switch and SMBus type selection */
+#define I2C_I2CMODE_ENABLE            ((uint32_t)0x00000000U)           /*!< I2C mode */
+#define I2C_SMBUSMODE_ENABLE          I2C_CTL0_SMBEN                    /*!< SMBus mode */
+
+/* SMBus/I2C mode switch and SMBus type selection */
+#define I2C_SMBUS_DEVICE              ((uint32_t)0x00000000U)           /*!< SMBus mode device type */
+#define I2C_SMBUS_HOST                I2C_CTL0_SMBSEL                   /*!< SMBus mode host type */
+
+/* I2C transfer direction */
+#define I2C_RECEIVER                  ((uint32_t)0x00000001U)           /*!< receiver */
+#define I2C_TRANSMITTER               ((uint32_t)0xFFFFFFFEU)           /*!< transmitter */
+
+/* whether or not to send an ACK */
+#define I2C_ACK_DISABLE               ((uint32_t)0x00000000U)           /*!< ACK will be not sent */
+#define I2C_ACK_ENABLE                I2C_CTL0_ACKEN                    /*!< ACK will be sent */
+
+/* I2C POAP position*/
+#define I2C_ACKPOS_CURRENT            ((uint32_t)0x00000000U)           /*!< ACKEN bit decides whether or not to send ACK or not for the current byte */
+#define I2C_ACKPOS_NEXT               I2C_CTL0_POAP                     /*!< ACKEN bit decides whether or not to send ACK for the next byte */
+
+/* whether or not to stretch SCL low */
+#define I2C_SCLSTRETCH_ENABLE         ((uint32_t)0x00000000U)           /*!< enable SCL stretching */
+#define I2C_SCLSTRETCH_DISABLE        I2C_CTL0_SS                       /*!< disable SCL stretching */
+
+/* whether or not to response to a general call */
+#define I2C_GCEN_ENABLE               I2C_CTL0_GCEN                     /*!< slave will response to a general call */
+#define I2C_GCEN_DISABLE              ((uint32_t)0x00000000U)           /*!< slave will not response to a general call */
+
+/* software reset I2C */
+#define I2C_SRESET_RESET              ((uint32_t)0x00000000U)           /*!< I2C is not under reset */
+#define I2C_SRESET_SET                I2C_CTL0_SRESET                   /*!< I2C is under reset */
+
+/* I2C DMA mode configure */
+/* DMA mode switch */
+#define I2C_DMA_OFF                   ((uint32_t)0x00000000U)           /*!< disable DMA mode */
+#define I2C_DMA_ON                    I2C_CTL1_DMAON                    /*!< enable DMA mode */
+
+/* flag indicating DMA last transfer */
+#define I2C_DMALST_OFF                ((uint32_t)0x00000000U)           /*!< next DMA EOT is not the last transfer */
+#define I2C_DMALST_ON                 I2C_CTL1_DMALST                   /*!< next DMA EOT is the last transfer */
+
+/* I2C PEC configure */
+/* PEC enable */
+#define I2C_PEC_DISABLE              ((uint32_t)0x00000000U)            /*!< PEC calculation off */
+#define I2C_PEC_ENABLE                I2C_CTL0_PECEN                    /*!< PEC calculation on */
+
+/* PEC transfer */
+#define I2C_PECTRANS_DISABLE          ((uint32_t)0x00000000U)           /*!< not transfer PEC value */
+#define I2C_PECTRANS_ENABLE           I2C_CTL0_PECTRANS                 /*!< transfer PEC value */
+
+/* I2C SMBus configure */
+/* issue or not alert through SMBA pin */
+#define I2C_SALTSEND_DISABLE          ((uint32_t)0x00000000U)           /*!< not issue alert through SMBA */
+#define I2C_SALTSEND_ENABLE           I2C_CTL0_SALT                     /*!< issue alert through SMBA pin */
+
+/* ARP protocol in SMBus switch */
+#define I2C_ARP_DISABLE               ((uint32_t)0x00000000U)           /*!< disable ARP */
+#define I2C_ARP_ENABLE                I2C_CTL0_ARPEN                    /*!< enable ARP */
+
+/* transmit I2C data */
+#define DATA_TRANS(regval)            (BITS(0,7) & ((uint32_t)(regval) << 0))
+
+/* receive I2C data */
+#define DATA_RECV(regval)             GET_BITS((uint32_t)(regval), 0, 7)
+
+/* I2C duty cycle in fast mode */
+#define I2C_DTCY_2                    ((uint32_t)0x00000000U)           /*!< T_low/T_high = 2 in fast mode */
+#define I2C_DTCY_16_9                 I2C_CKCFG_DTCY                    /*!< T_low/T_high = 16/9 in fast mode */
+
+/* address mode for the I2C slave */
+#define I2C_ADDFORMAT_7BITS           ((uint32_t)0x00000000U)           /*!< address format is 7 bits */
+#define I2C_ADDFORMAT_10BITS          I2C_SADDR0_ADDFORMAT              /*!< address format is 10 bits */
+
+/* function declarations */
+/* initialization functions */
+/* reset I2C */
+void i2c_deinit(uint32_t i2c_periph);
+/* configure I2C clock */
+void i2c_clock_config(uint32_t i2c_periph, uint32_t clkspeed, uint32_t dutycyc);
+/* configure I2C address */
+void i2c_mode_addr_config(uint32_t i2c_periph, uint32_t mode, uint32_t addformat, uint32_t addr);
+
+/* application function declarations */
+/* select SMBus type */
+void i2c_smbus_type_config(uint32_t i2c_periph, uint32_t type);
+/* whether or not to send an ACK */
+void i2c_ack_config(uint32_t i2c_periph, uint32_t ack);
+/* configure I2C POAP position */
+void i2c_ackpos_config(uint32_t i2c_periph, uint32_t pos);
+/* master sends slave address */
+void i2c_master_addressing(uint32_t i2c_periph, uint32_t addr, uint32_t trandirection);
+/* enable dual-address mode */
+void i2c_dualaddr_enable(uint32_t i2c_periph, uint32_t addr);
+/* disable dual-address mode */
+void i2c_dualaddr_disable(uint32_t i2c_periph);
+/* enable I2C */
+void i2c_enable(uint32_t i2c_periph);
+/* disable I2C */
+void i2c_disable(uint32_t i2c_periph);
+/* generate a START condition on I2C bus */
+void i2c_start_on_bus(uint32_t i2c_periph);
+/* generate a STOP condition on I2C bus */
+void i2c_stop_on_bus(uint32_t i2c_periph);
+/* I2C transmit data function */
+void i2c_data_transmit(uint32_t i2c_periph, uint8_t data);
+/* I2C receive data function */
+uint8_t i2c_data_receive(uint32_t i2c_periph);
+/* configure I2C DMA mode */
+void i2c_dma_config(uint32_t i2c_periph, uint32_t dmastate);
+/* configure whether next DMA EOT is DMA last transfer or not */
+void i2c_dma_last_transfer_config(uint32_t i2c_periph, uint32_t dmalast);
+/* whether to stretch SCL low when data is not ready in slave mode */
+void i2c_stretch_scl_low_config(uint32_t i2c_periph, uint32_t stretchpara);
+/* whether or not to response to a general call */
+void i2c_slave_response_to_gcall_config(uint32_t i2c_periph, uint32_t gcallpara);
+/* configure software reset of I2C */
+void i2c_software_reset_config(uint32_t i2c_periph, uint32_t sreset);
+/* configure I2C PEC calculation */
+void i2c_pec_config(uint32_t i2c_periph, uint32_t pecstate);
+/* configure whether to transfer PEC value */
+void i2c_pec_transfer_config(uint32_t i2c_periph, uint32_t pecpara);
+/* get packet error checking value */
+uint8_t i2c_pec_value_get(uint32_t i2c_periph);
+/* configure I2C alert through SMBA pin */
+void i2c_smbus_alert_config(uint32_t i2c_periph, uint32_t smbuspara);
+/* configure I2C ARP protocol in SMBus */
+void i2c_smbus_arp_config(uint32_t i2c_periph, uint32_t arpstate);
+/* disable analog noise filter */
+void i2c_analog_noise_filter_disable(uint32_t i2c_periph);
+/* enable analog noise filter */
+void i2c_analog_noise_filter_enable(uint32_t i2c_periph);
+/* configure digital noise filter */
+void i2c_digital_noise_filter_config(uint32_t i2c_periph, i2c_digital_filter_enum dfilterpara);
+/* enable SAM_V interface */
+void i2c_sam_enable(uint32_t i2c_periph);
+/* disable SAM_V interface */
+void i2c_sam_disable(uint32_t i2c_periph);
+/* enable SAM_V interface timeout detect */
+void i2c_sam_timeout_enable(uint32_t i2c_periph);
+/* disable SAM_V interface timeout detect */
+void i2c_sam_timeout_disable(uint32_t i2c_periph);
+
+/* interrupt & flag functions */
+/* get I2C flag status */
+FlagStatus i2c_flag_get(uint32_t i2c_periph, i2c_flag_enum flag);
+/* clear I2C flag status */
+void i2c_flag_clear(uint32_t i2c_periph, i2c_flag_enum flag);
+/* enable I2C interrupt */
+void i2c_interrupt_enable(uint32_t i2c_periph, i2c_interrupt_enum interrupt);
+/* disable I2C interrupt */
+void i2c_interrupt_disable(uint32_t i2c_periph, i2c_interrupt_enum interrupt);
+/* get I2C interrupt flag status */
+FlagStatus i2c_interrupt_flag_get(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag);
+/* clear I2C interrupt flag status */
+void i2c_interrupt_flag_clear(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag);
+
+#endif /* GD32F4XX_I2C_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_ipa.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_ipa.h
@@ -1,0 +1,381 @@
+/*!
+    \file    gd32f4xx_ipa.h
+    \brief   definitions for the IPA
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_IPA_H
+#define GD32F4XX_IPA_H
+
+#include "gd32f4xx.h"
+
+/* TLI definitions */
+#define IPA                               IPA_BASE                     /*!< IPA base address */
+
+/* bits definitions */
+/* registers definitions */
+#define IPA_CTL                           REG32(IPA + 0x00000000U)     /*!< IPA control register */
+#define IPA_INTF                          REG32(IPA + 0x00000004U)     /*!< IPA interrupt flag register */
+#define IPA_INTC                          REG32(IPA + 0x00000008U)     /*!< IPA interrupt flag clear register */
+#define IPA_FMADDR                        REG32(IPA + 0x0000000CU)     /*!< IPA foreground memory base address register */
+#define IPA_FLOFF                         REG32(IPA + 0x00000010U)     /*!< IPA foreground line offset register */
+#define IPA_BMADDR                        REG32(IPA + 0x00000014U)     /*!< IPA background memory base address register */
+#define IPA_BLOFF                         REG32(IPA + 0x00000018U)     /*!< IPA background line offset register */
+#define IPA_FPCTL                         REG32(IPA + 0x0000001CU)     /*!< IPA foreground pixel control register */
+#define IPA_FPV                           REG32(IPA + 0x00000020U)     /*!< IPA foreground pixel value register */
+#define IPA_BPCTL                         REG32(IPA + 0x00000024U)     /*!< IPA background pixel control register */
+#define IPA_BPV                           REG32(IPA + 0x00000028U)     /*!< IPA background pixel value register */
+#define IPA_FLMADDR                       REG32(IPA + 0x0000002CU)     /*!< IPA foreground LUT memory base address register */
+#define IPA_BLMADDR                       REG32(IPA + 0x00000030U)     /*!< IPA background LUT memory base address register */
+#define IPA_DPCTL                         REG32(IPA + 0x00000034U)     /*!< IPA destination pixel control register */
+#define IPA_DPV                           REG32(IPA + 0x00000038U)     /*!< IPA destination pixel value register */
+#define IPA_DMADDR                        REG32(IPA + 0x0000003CU)     /*!< IPA destination memory base address register */
+#define IPA_DLOFF                         REG32(IPA + 0x00000040U)     /*!< IPA destination line offset register */
+#define IPA_IMS                           REG32(IPA + 0x00000044U)     /*!< IPA image size register */
+#define IPA_LM                            REG32(IPA + 0x00000048U)     /*!< IPA line mark register */
+#define IPA_ITCTL                         REG32(IPA + 0x0000004CU)     /*!< IPA inter-timer control register */
+
+/* IPA_CTL */
+#define IPA_CTL_TEN                       BIT(0)           /*!< transfer enable */
+#define IPA_CTL_THU                       BIT(1)           /*!< transfer hang up */
+#define IPA_CTL_TST                       BIT(2)           /*!< transfer stop */
+#define IPA_CTL_TAEIE                     BIT(8)           /*!< enable bit for transfer access error interrupt */
+#define IPA_CTL_FTFIE                     BIT(9)           /*!< enable bit for full transfer finish interrup */
+#define IPA_CTL_TLMIE                     BIT(10)          /*!< enable bit for transfer line mark interrupt */
+#define IPA_CTL_LACIE                     BIT(11)          /*!< enable bit for LUT access conflict interrupt */
+#define IPA_CTL_LLFIE                     BIT(12)          /*!< enable bit for LUT loading finish interrupt */
+#define IPA_CTL_WCFIE                     BIT(13)          /*!< enable bit for wrong configuration interrupt */
+#define IPA_CTL_PFCM                      BITS(16,17)      /*!< pixel format convert mode */
+
+/* IPA_INTF */
+#define IPA_INTF_TAEIF                    BIT(0)           /*!< transfer access error interrupt flag */
+#define IPA_INTF_FTFIF                    BIT(1)           /*!< full transfer finish interrupt flag */
+#define IPA_INTF_TLMIF                    BIT(2)           /*!< transfer line mark interrupt flag */
+#define IPA_INTF_LACIF                    BIT(3)           /*!< LUT access conflict interrupt flag */
+#define IPA_INTF_LLFIF                    BIT(4)           /*!< LUT loading finish interrupt flag */
+#define IPA_INTF_WCFIF                    BIT(5)           /*!< wrong configuration interrupt flag */
+
+/* IPA_INTC */
+#define IPA_INTC_TAEIFC                   BIT(0)           /*!< clear bit for transfer access error interrupt flag */
+#define IPA_INTC_FTFIFC                   BIT(1)           /*!< clear bit for full transfer finish interrupt flag */
+#define IPA_INTC_TLMIFC                   BIT(2)           /*!< clear bit for transfer line mark interrupt flag */
+#define IPA_INTC_LACIFC                   BIT(3)           /*!< clear bit for LUT access conflict interrupt flag */
+#define IPA_INTC_LLFIFC                   BIT(4)           /*!< clear bit for LUT loading finish interrupt flag */
+#define IPA_INTC_WCFIFC                   BIT(5)           /*!< clear bit for wrong configuration interrupt flag */
+
+/* IPA_FMADDR */
+#define IPA_FMADDR_FMADDR                 BITS(0,31)       /*!< foreground memory base address */
+
+/* IPA_FLOFF */
+#define IPA_FLOFF_FLOFF                   BITS(0,13)       /*!< foreground line offset */
+
+/* IPA_BMADDR */
+#define IPA_BMADDR_BMADDR                 BITS(0,31)       /*!< background memory base address */
+
+/* IPA_BLOFF */
+#define IPA_BLOFF_BLOFF                   BITS(0,13)       /*!< background line offset */
+
+/* IPA_FPCTL */
+#define IPA_FPCTL_FPF                     BITS(0,3)        /*!< foreground pixel format */
+#define IPA_FPCTL_FLPF                    BIT(4)           /*!< foreground LUT pixel format */
+#define IPA_FPCTL_FLLEN                   BIT(5)           /*!< foreground LUT loading enable */
+#define IPA_FPCTL_FCNP                    BITS(8,15)       /*!< foreground LUT number of pixel */
+#define IPA_FPCTL_FAVCA                   BITS(16,17)      /*!< foreground alpha value calculation algorithm */
+#define IPA_FPCTL_FPDAV                   BITS(24,31)      /*!< foreground pre- defined alpha value */
+
+/* IPA_FPV */
+#define IPA_FPV_FPDBV                     BITS(0,7)        /*!< foreground pre-defined red value */
+#define IPA_FPV_FPDGV                     BITS(8,15)       /*!< foreground pre-defined green value */
+#define IPA_FPV_FPDRV                     BITS(16,23)      /*!< foreground pre-defined red value */
+
+/* IPA_BPCTL */
+#define IPA_BPCTL_BPF                     BITS(0,3)        /*!< background pixel format */
+#define IPA_BPCTL_BLPF                    BIT(4)           /*!< background LUT pixel format */
+#define IPA_BPCTL_BLLEN                   BIT(5)           /*!< background LUT loading enable */
+#define IPA_BPCTL_BCNP                    BITS(8,15)       /*!< background LUT number of pixel */
+#define IPA_BPCTL_BAVCA                   BITS(16,17)      /*!< background alpha value calculation algorithm */
+#define IPA_BPCTL_BPDAV                   BITS(24,31)      /*!< background pre- defined alpha value */
+
+/* IPA_BPV */
+#define IPA_BPV_BPDBV                     BITS(0,7)        /*!< background pre-defined blue value */
+#define IPA_BPV_BPDGV                     BITS(8,15)       /*!< background pre-defined green value */
+#define IPA_BPV_BPDRV                     BITS(16,23)      /*!< background pre-defined red value */
+
+/* IPA_FLMADDR */
+#define IPA_FLMADDR_FLMADDR               BITS(0,31)       /*!< foreground LUT memory base address */
+
+/* IPA_BLMADDR */
+#define IPA_BLMADDR_BLMADDR               BITS(0,31)       /*!< background LUT memory base address */
+
+/* IPA_DPCTL */
+#define IPA_DPCTL_DPF                     BITS(0,2)        /*!< destination pixel control register */
+
+/* IPA_DPV */
+/* destination pixel format ARGB8888 */
+#define IPA_DPV_DPDBV_0                   BITS(0,7)        /*!< destination pre-defined blue value */
+#define IPA_DPV_DPDGV_0                   BITS(8,15)       /*!< destination pre-defined green value */
+#define IPA_DPV_DPDRV_0                   BITS(16,23)      /*!< destination pre-defined red value */
+#define IPA_DPV_DPDAV_0                   BITS(24,31)      /*!< destination pre-defined alpha value */
+
+/* destination pixel format RGB8888 */
+#define IPA_DPV_DPDBV_1                   BITS(0,7)        /*!< destination pre-defined blue value */
+#define IPA_DPV_DPDGV_1                   BITS(8,15)       /*!< destination pre-defined green value */
+#define IPA_DPV_DPDRV_1                   BITS(16,23)      /*!< destination pre-defined red value */
+
+/* destination pixel format RGB565 */
+#define IPA_DPV_DPDBV_2                   BITS(0,4)        /*!< destination pre-defined blue value */
+#define IPA_DPV_DPDGV_2                   BITS(5,10)       /*!< destination pre-defined green value */
+#define IPA_DPV_DPDRV_2                   BITS(11,15)      /*!< destination pre-defined red value */
+
+/* destination pixel format ARGB1555 */
+#define IPA_DPV_DPDBV_3                   BITS(0,4)        /*!< destination pre-defined blue value */
+#define IPA_DPV_DPDGV_3                   BITS(5,9)        /*!< destination pre-defined green value */
+#define IPA_DPV_DPDRV_3                   BITS(10,14)      /*!< destination pre-defined red value */
+#define IPA_DPV_DPDAV_3                   BIT(15)          /*!< destination pre-defined alpha value */
+
+/* destination pixel format ARGB4444 */
+#define IPA_DPV_DPDBV_4                   BITS(0,3)        /*!< destination pre-defined blue value */
+#define IPA_DPV_DPDGV_4                   BITS(4,7)        /*!< destination pre-defined green value */
+#define IPA_DPV_DPDRV_4                   BITS(8,11)       /*!< destination pre-defined red value */
+#define IPA_DPV_DPDAV_4                   BITS(12,15)      /*!< destination pre-defined alpha value */
+
+/* IPA_DMADDR */
+#define IPA_DMADDR_DMADDR                 BITS(0,31)       /*!< destination memory base address */
+
+/* IPA_DLOFF */
+#define IPA_DLOFF_DLOFF                   BITS(0,13)       /*!< destination line offset */
+
+/* IPA_IMS */
+#define IPA_IMS_HEIGHT                    BITS(0,15)       /*!< height of the image to be processed */
+#define IPA_IMS_WIDTH                     BITS(16,29)      /*!< width of the image to be processed */
+
+/* IPA_LM */
+#define IPA_LM_LM                         BITS(0,15)       /*!< line mark */
+
+/* IPA_ITCTL */
+#define IPA_ITCTL_ITEN                    BIT(0)           /*!< inter-timer enable */
+#define IPA_ITCTL_NCCI                    BITS(8,15)       /*!< number of clock cycles interval */
+
+
+/* constants definitions */
+/* IPA foreground parameter struct definitions */
+typedef struct {
+    uint32_t foreground_memaddr;                          /*!< foreground memory base address */
+    uint32_t foreground_lineoff;                          /*!< foreground line offset */
+    uint32_t foreground_prealpha;                         /*!< foreground pre-defined alpha value */
+    uint32_t foreground_alpha_algorithm;                  /*!< foreground alpha value calculation algorithm */
+    uint32_t foreground_pf;                               /*!< foreground pixel format */
+    uint32_t foreground_prered;                           /*!< foreground pre-defined red value */
+    uint32_t foreground_pregreen;                         /*!< foreground pre-defined green value */
+    uint32_t foreground_preblue;                          /*!< foreground pre-defined blue value */
+} ipa_foreground_parameter_struct;
+
+/* IPA background parameter struct definitions */
+typedef struct {
+    uint32_t background_memaddr;                          /*!< background memory base address */
+    uint32_t background_lineoff;                          /*!< background line offset */
+    uint32_t background_prealpha;                         /*!< background pre-defined alpha value */
+    uint32_t background_alpha_algorithm;                  /*!< background alpha value calculation algorithm */
+    uint32_t background_pf;                               /*!< background pixel format */
+    uint32_t background_prered;                           /*!< background pre-defined red value */
+    uint32_t background_pregreen;                         /*!< background pre-defined green value */
+    uint32_t background_preblue;                          /*!< background pre-defined blue value */
+} ipa_background_parameter_struct;
+
+/* IPA destination parameter struct definitions */
+typedef struct {
+    uint32_t destination_memaddr;                         /*!< destination memory base address */
+    uint32_t destination_lineoff;                         /*!< destination line offset */
+    uint32_t destination_prealpha;                        /*!< destination pre-defined alpha value */
+    uint32_t destination_pf;                              /*!< destination pixel format */
+    uint32_t destination_prered;                          /*!< destination pre-defined red value */
+    uint32_t destination_pregreen;                        /*!< destination pre-defined green value */
+    uint32_t destination_preblue;                         /*!< destination pre-defined blue value */
+    uint32_t image_width;                                 /*!< width of the image to be processed */
+    uint32_t image_height;                                /*!< height of the image to be processed */
+} ipa_destination_parameter_struct;
+
+/* destination pixel format */
+typedef enum {
+    IPA_DPF_ARGB8888,                                     /*!< destination pixel format ARGB8888 */
+    IPA_DPF_RGB888,                                       /*!< destination pixel format RGB888 */
+    IPA_DPF_RGB565,                                       /*!< destination pixel format RGB565 */
+    IPA_DPF_ARGB1555,                                     /*!< destination pixel format ARGB1555 */
+    IPA_DPF_ARGB4444                                      /*!< destination pixel format ARGB4444 */
+} ipa_dpf_enum;
+
+/* LUT pixel format */
+#define IPA_LUT_PF_ARGB8888             ((uint8_t)0x00U)                 /*!< LUT pixel format ARGB8888 */
+#define IPA_LUT_PF_RGB888               ((uint8_t)0x01U)                 /*!< LUT pixel format RGB888 */
+
+/* Inter-timer */
+#define IPA_INTER_TIMER_DISABLE         ((uint8_t)0x00U)                 /*!< inter-timer disable */
+#define IPA_INTER_TIMER_ENABLE          ((uint8_t)0x01U)                 /*!< inter-timer enable */
+
+/* IPA pixel format convert mode */
+#define CTL_PFCM(regval)                (BITS(16,17) & ((uint32_t)(regval) << 16))
+#define IPA_FGTODE                      CTL_PFCM(0)                      /*!< foreground memory to destination memory without pixel format convert */
+#define IPA_FGTODE_PF_CONVERT           CTL_PFCM(1)                      /*!< foreground memory to destination memory with pixel format convert */
+#define IPA_FGBGTODE                    CTL_PFCM(2)                      /*!< blending foreground and background memory to destination memory */
+#define IPA_FILL_UP_DE                  CTL_PFCM(3)                      /*!< fill up destination memory with specific color */
+
+/* foreground alpha value calculation algorithm */
+#define FPCTL_FAVCA(regval)             (BITS(16,17) & ((uint32_t)(regval) << 16))
+#define IPA_FG_ALPHA_MODE_0             FPCTL_FAVCA(0)                   /*!< no effect */
+#define IPA_FG_ALPHA_MODE_1             FPCTL_FAVCA(1)                   /*!< FPDAV[7:0] is selected as the foreground alpha value */
+#define IPA_FG_ALPHA_MODE_2             FPCTL_FAVCA(2)                   /*!< FPDAV[7:0] multiplied by read alpha value */
+
+/* background alpha value calculation algorithm */
+#define BPCTL_BAVCA(regval)             (BITS(16,17) & ((uint32_t)(regval) << 16))
+#define IPA_BG_ALPHA_MODE_0             BPCTL_BAVCA(0)                   /*!< no effect */
+#define IPA_BG_ALPHA_MODE_1             BPCTL_BAVCA(1)                   /*!< BPDAV[7:0] is selected as the background alpha value */
+#define IPA_BG_ALPHA_MODE_2             BPCTL_BAVCA(2)                   /*!< BPDAV[7:0] multiplied by read alpha value */
+
+/* foreground pixel format */
+#define FPCTL_PPF(regval)               (BITS(0,3) & ((uint32_t)(regval)))
+#define FOREGROUND_PPF_ARGB8888         FPCTL_PPF(0)                     /*!< foreground pixel format ARGB8888 */
+#define FOREGROUND_PPF_RGB888           FPCTL_PPF(1)                     /*!< foreground pixel format RGB888 */
+#define FOREGROUND_PPF_RGB565           FPCTL_PPF(2)                     /*!< foreground pixel format RGB565 */
+#define FOREGROUND_PPF_ARG1555          FPCTL_PPF(3)                     /*!< foreground pixel format ARGB1555 */
+#define FOREGROUND_PPF_ARGB4444         FPCTL_PPF(4)                     /*!< foreground pixel format ARGB4444 */
+#define FOREGROUND_PPF_L8               FPCTL_PPF(5)                     /*!< foreground pixel format L8 */
+#define FOREGROUND_PPF_AL44             FPCTL_PPF(6)                     /*!< foreground pixel format AL44 */
+#define FOREGROUND_PPF_AL88             FPCTL_PPF(7)                     /*!< foreground pixel format AL88 */
+#define FOREGROUND_PPF_L4               FPCTL_PPF(8)                     /*!< foreground pixel format L4 */
+#define FOREGROUND_PPF_A8               FPCTL_PPF(9)                     /*!< foreground pixel format A8 */
+#define FOREGROUND_PPF_A4               FPCTL_PPF(10)                    /*!< foreground pixel format A4 */
+
+/* background pixel format */
+#define BPCTL_PPF(regval)               (BITS(0,3) & ((uint32_t)(regval)))
+#define BACKGROUND_PPF_ARGB8888         BPCTL_PPF(0)                     /*!< background pixel format ARGB8888 */
+#define BACKGROUND_PPF_RGB888           BPCTL_PPF(1)                     /*!< background pixel format RGB888 */
+#define BACKGROUND_PPF_RGB565           BPCTL_PPF(2)                     /*!< background pixel format RGB565 */
+#define BACKGROUND_PPF_ARG1555          BPCTL_PPF(3)                     /*!< background pixel format ARGB1555 */
+#define BACKGROUND_PPF_ARGB4444         BPCTL_PPF(4)                     /*!< background pixel format ARGB4444 */
+#define BACKGROUND_PPF_L8               BPCTL_PPF(5)                     /*!< background pixel format L8 */
+#define BACKGROUND_PPF_AL44             BPCTL_PPF(6)                     /*!< background pixel format AL44 */
+#define BACKGROUND_PPF_AL88             BPCTL_PPF(7)                     /*!< background pixel format AL88 */
+#define BACKGROUND_PPF_L4               BPCTL_PPF(8)                     /*!< background pixel format L4 */
+#define BACKGROUND_PPF_A8               BPCTL_PPF(9)                     /*!< background pixel format A8 */
+#define BACKGROUND_PPF_A4               BPCTL_PPF(10)                    /*!< background pixel format A4 */
+
+/* IPA flags */
+#define IPA_FLAG_TAE                    IPA_INTF_TAEIF                   /*!< transfer access error interrupt flag */
+#define IPA_FLAG_FTF                    IPA_INTF_FTFIF                   /*!< full transfer finish interrupt flag */
+#define IPA_FLAG_TLM                    IPA_INTF_TLMIF                   /*!< transfer line mark interrupt flag */
+#define IPA_FLAG_LAC                    IPA_INTF_LACIF                   /*!< LUT access conflict interrupt flag */
+#define IPA_FLAG_LLF                    IPA_INTF_LLFIF                   /*!< LUT loading finish interrupt flag */
+#define IPA_FLAG_WCF                    IPA_INTF_WCFIF                   /*!< wrong configuration interrupt flag */
+
+/* IPA interrupt enable or disable */
+#define IPA_INT_TAE                     IPA_CTL_TAEIE                    /*!< transfer access error interrupt */
+#define IPA_INT_FTF                     IPA_CTL_FTFIE                    /*!< full transfer finish interrupt */
+#define IPA_INT_TLM                     IPA_CTL_TLMIE                    /*!< transfer line mark interrupt */
+#define IPA_INT_LAC                     IPA_CTL_LACIE                    /*!< LUT access conflict interrupt */
+#define IPA_INT_LLF                     IPA_CTL_LLFIE                    /*!< LUT loading finish interrupt */
+#define IPA_INT_WCF                     IPA_CTL_WCFIE                    /*!< wrong configuration interrupt */
+
+/* IPA interrupt flags */
+#define IPA_INT_FLAG_TAE                IPA_INTF_TAEIF                   /*!< transfer access error interrupt flag */
+#define IPA_INT_FLAG_FTF                IPA_INTF_FTFIF                   /*!< full transfer finish interrupt flag */
+#define IPA_INT_FLAG_TLM                IPA_INTF_TLMIF                   /*!< transfer line mark interrupt flag */
+#define IPA_INT_FLAG_LAC                IPA_INTF_LACIF                   /*!< LUT access conflict interrupt flag */
+#define IPA_INT_FLAG_LLF                IPA_INTF_LLFIF                   /*!< LUT loading finish interrupt flag */
+#define IPA_INT_FLAG_WCF                IPA_INTF_WCFIF                   /*!< wrong configuration interrupt flag */
+
+/* function declarations */
+/* functions enable or disable, pixel format convert mode set */
+/* deinitialize IPA */
+void ipa_deinit(void);
+/* enable IPA transfer */
+void ipa_transfer_enable(void);
+/* enable IPA transfer hang up */
+void ipa_transfer_hangup_enable(void);
+/* disable IPA transfer hang up */
+void ipa_transfer_hangup_disable(void);
+/* enable IPA transfer stop */
+void ipa_transfer_stop_enable(void);
+/* disable IPA transfer stop */
+void ipa_transfer_stop_disable(void);
+/* enable IPA foreground LUT loading */
+void ipa_foreground_lut_loading_enable(void);
+/* enable IPA background LUT loading */
+void ipa_background_lut_loading_enable(void);
+/* set pixel format convert mode, the function is invalid when the IPA transfer is enabled */
+void ipa_pixel_format_convert_mode_set(uint32_t pfcm);
+
+/* structure initialization, foreground, background, destination and LUT initialization */
+/* initialize the structure of IPA foreground parameter struct with the default values, it is
+  suggested that call this function after an ipa_foreground_parameter_struct structure is defined */
+void ipa_foreground_struct_para_init(ipa_foreground_parameter_struct *foreground_struct);
+/* initialize foreground parameters */
+void ipa_foreground_init(ipa_foreground_parameter_struct *foreground_struct);
+/* initialize the structure of IPA background parameter struct with the default values, it is
+  suggested that call this function after an ipa_background_parameter_struct structure is defined */
+void ipa_background_struct_para_init(ipa_background_parameter_struct *background_struct);
+/* initialize background parameters */
+void ipa_background_init(ipa_background_parameter_struct *background_struct);
+/* initialize the structure of IPA destination parameter struct with the default values, it is
+  suggested that call this function after an ipa_destination_parameter_struct structure is defined */
+void ipa_destination_struct_para_init(ipa_destination_parameter_struct *destination_struct);
+/* initialize destination parameters */
+void ipa_destination_init(ipa_destination_parameter_struct *destination_struct);
+/* initialize IPA foreground LUT parameters */
+void ipa_foreground_lut_init(uint8_t fg_lut_num, uint8_t fg_lut_pf, uint32_t fg_lut_addr);
+/* initialize IPA background LUT parameters */
+void ipa_background_lut_init(uint8_t bg_lut_num, uint8_t bg_lut_pf, uint32_t bg_lut_addr);
+
+/* configuration functions */
+/* configure IPA line mark */
+void ipa_line_mark_config(uint16_t line_num);
+/* inter-timer enable or disable */
+void ipa_inter_timer_config(uint8_t timer_cfg);
+/* configure the number of clock cycles interval */
+void ipa_interval_clock_num_config(uint8_t clk_num);
+
+/* flag and interrupt functions */
+/* get IPA flag status in IPA_INTF register */
+FlagStatus ipa_flag_get(uint32_t flag);
+/* clear IPA flag in IPA_INTF register */
+void ipa_flag_clear(uint32_t flag);
+/* enable IPA interrupt */
+void ipa_interrupt_enable(uint32_t int_flag);
+/* disable IPA interrupt */
+void ipa_interrupt_disable(uint32_t int_flag);
+/* get IPA interrupt flag */
+FlagStatus ipa_interrupt_flag_get(uint32_t int_flag);
+/* clear IPA interrupt flag */
+void ipa_interrupt_flag_clear(uint32_t int_flag);
+
+#endif /* GD32F4XX_IPA_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_iref.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_iref.h
@@ -1,0 +1,187 @@
+/*!
+    \file    gd32f4xx_iref.h
+    \brief   definitions for the IREF
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_IREF_H
+#define GD32F4XX_IREF_H
+
+#include "gd32f4xx.h"
+
+/* IREF definitions */
+#define IREF                            IREF_BASE              /*!< IREF base address */
+
+/* registers definitions */
+#define IREF_CTL                        REG32(IREF + 0x300U)   /*!< IREF control register */
+
+/* bits definitions */
+/* IREF_CTL */
+#define IREF_CTL_CSDT                   BITS(0,5)              /*!< current step data */
+#define IREF_CTL_SCMOD                  BIT(7)                 /*!< sink current mode */
+#define IREF_CTL_CPT                    BITS(8,12)             /*!< current precision trim */
+#define IREF_CTL_SSEL                   BIT(14)                /*!< step selection */ 
+#define IREF_CTL_CREN                   BIT(15)                /*!< current reference enable */
+
+/* constants definitions */
+/* IREF current precision trim */
+#define CTL_CPT(regval)                 (BITS(8,12) & ((uint32_t)(regval) << 8))
+#define IREF_CUR_PRECISION_TRIM_0       CTL_CPT(0)             /*!< IREF current precision trim 0 */
+#define IREF_CUR_PRECISION_TRIM_1       CTL_CPT(1)             /*!< IREF current precision trim 1 */
+#define IREF_CUR_PRECISION_TRIM_2       CTL_CPT(2)             /*!< IREF current precision trim 2 */
+#define IREF_CUR_PRECISION_TRIM_3       CTL_CPT(3)             /*!< IREF current precision trim 3 */
+#define IREF_CUR_PRECISION_TRIM_4       CTL_CPT(4)             /*!< IREF current precision trim 4 */
+#define IREF_CUR_PRECISION_TRIM_5       CTL_CPT(5)             /*!< IREF current precision trim 5 */
+#define IREF_CUR_PRECISION_TRIM_6       CTL_CPT(6)             /*!< IREF current precision trim 6 */
+#define IREF_CUR_PRECISION_TRIM_7       CTL_CPT(7)             /*!< IREF current precision trim 7 */
+#define IREF_CUR_PRECISION_TRIM_8       CTL_CPT(8)             /*!< IREF current precision trim 8 */
+#define IREF_CUR_PRECISION_TRIM_9       CTL_CPT(9)             /*!< IREF current precision trim 9 */
+#define IREF_CUR_PRECISION_TRIM_10      CTL_CPT(10)            /*!< IREF current precision trim 10 */
+#define IREF_CUR_PRECISION_TRIM_11      CTL_CPT(11)            /*!< IREF current precision trim 11 */
+#define IREF_CUR_PRECISION_TRIM_12      CTL_CPT(12)            /*!< IREF current precision trim 12 */
+#define IREF_CUR_PRECISION_TRIM_13      CTL_CPT(13)            /*!< IREF current precision trim 13 */
+#define IREF_CUR_PRECISION_TRIM_14      CTL_CPT(14)            /*!< IREF current precision trim 14 */
+#define IREF_CUR_PRECISION_TRIM_15      CTL_CPT(15)            /*!< IREF current precision trim 15 */
+#define IREF_CUR_PRECISION_TRIM_16      CTL_CPT(16)            /*!< IREF current precision trim 16 */
+#define IREF_CUR_PRECISION_TRIM_17      CTL_CPT(17)            /*!< IREF current precision trim 17 */
+#define IREF_CUR_PRECISION_TRIM_18      CTL_CPT(18)            /*!< IREF current precision trim 18 */
+#define IREF_CUR_PRECISION_TRIM_19      CTL_CPT(19)            /*!< IREF current precision trim 19 */
+#define IREF_CUR_PRECISION_TRIM_20      CTL_CPT(20)            /*!< IREF current precision trim 20 */
+#define IREF_CUR_PRECISION_TRIM_21      CTL_CPT(21)            /*!< IREF current precision trim 21 */
+#define IREF_CUR_PRECISION_TRIM_22      CTL_CPT(22)            /*!< IREF current precision trim 22 */
+#define IREF_CUR_PRECISION_TRIM_23      CTL_CPT(23)            /*!< IREF current precision trim 23 */
+#define IREF_CUR_PRECISION_TRIM_24      CTL_CPT(24)            /*!< IREF current precision trim 24 */
+#define IREF_CUR_PRECISION_TRIM_25      CTL_CPT(25)            /*!< IREF current precision trim 25 */
+#define IREF_CUR_PRECISION_TRIM_26      CTL_CPT(26)            /*!< IREF current precision trim 26 */
+#define IREF_CUR_PRECISION_TRIM_27      CTL_CPT(27)            /*!< IREF current precision trim 27 */
+#define IREF_CUR_PRECISION_TRIM_28      CTL_CPT(28)            /*!< IREF current precision trim 28 */
+#define IREF_CUR_PRECISION_TRIM_29      CTL_CPT(29)            /*!< IREF current precision trim 29 */
+#define IREF_CUR_PRECISION_TRIM_30      CTL_CPT(30)            /*!< IREF current precision trim 30 */
+#define IREF_CUR_PRECISION_TRIM_31      CTL_CPT(31)            /*!< IREF current precision trim 31 */
+
+/* IREF current step */
+#define CTL_CSDT(regval)                (BITS(0,5) & ((uint32_t)(regval) << 0))
+#define IREF_CUR_STEP_DATA_0            CTL_CSDT(0)            /*!< IREF current step data 0 */
+#define IREF_CUR_STEP_DATA_1            CTL_CSDT(1)            /*!< IREF current step data 1 */
+#define IREF_CUR_STEP_DATA_2            CTL_CSDT(2)            /*!< IREF current step data 2 */
+#define IREF_CUR_STEP_DATA_3            CTL_CSDT(3)            /*!< IREF current step data 3 */
+#define IREF_CUR_STEP_DATA_4            CTL_CSDT(4)            /*!< IREF current step data 4 */
+#define IREF_CUR_STEP_DATA_5            CTL_CSDT(5)            /*!< IREF current step data 5 */
+#define IREF_CUR_STEP_DATA_6            CTL_CSDT(6)            /*!< IREF current step data 6 */
+#define IREF_CUR_STEP_DATA_7            CTL_CSDT(7)            /*!< IREF current step data 7 */
+#define IREF_CUR_STEP_DATA_8            CTL_CSDT(8)            /*!< IREF current step data 8 */
+#define IREF_CUR_STEP_DATA_9            CTL_CSDT(9)            /*!< IREF current step data 9 */
+#define IREF_CUR_STEP_DATA_10           CTL_CSDT(10)           /*!< IREF current step data 10 */
+#define IREF_CUR_STEP_DATA_11           CTL_CSDT(11)           /*!< IREF current step data 11 */
+#define IREF_CUR_STEP_DATA_12           CTL_CSDT(12)           /*!< IREF current step data 12 */
+#define IREF_CUR_STEP_DATA_13           CTL_CSDT(13)           /*!< IREF current step data 13 */
+#define IREF_CUR_STEP_DATA_14           CTL_CSDT(14)           /*!< IREF current step data 14 */
+#define IREF_CUR_STEP_DATA_15           CTL_CSDT(15)           /*!< IREF current step data 15 */
+#define IREF_CUR_STEP_DATA_16           CTL_CSDT(16)           /*!< IREF current step data 16 */
+#define IREF_CUR_STEP_DATA_17           CTL_CSDT(17)           /*!< IREF current step data 17 */
+#define IREF_CUR_STEP_DATA_18           CTL_CSDT(18)           /*!< IREF current step data 18 */
+#define IREF_CUR_STEP_DATA_19           CTL_CSDT(19)           /*!< IREF current step data 19 */
+#define IREF_CUR_STEP_DATA_20           CTL_CSDT(20)           /*!< IREF current step data 20 */
+#define IREF_CUR_STEP_DATA_21           CTL_CSDT(21)           /*!< IREF current step data 21 */
+#define IREF_CUR_STEP_DATA_22           CTL_CSDT(22)           /*!< IREF current step data 22 */
+#define IREF_CUR_STEP_DATA_23           CTL_CSDT(23)           /*!< IREF current step data 23 */
+#define IREF_CUR_STEP_DATA_24           CTL_CSDT(24)           /*!< IREF current step data 24 */
+#define IREF_CUR_STEP_DATA_25           CTL_CSDT(25)           /*!< IREF current step data 25 */
+#define IREF_CUR_STEP_DATA_26           CTL_CSDT(26)           /*!< IREF current step data 26 */
+#define IREF_CUR_STEP_DATA_27           CTL_CSDT(27)           /*!< IREF current step data 27 */
+#define IREF_CUR_STEP_DATA_28           CTL_CSDT(28)           /*!< IREF current step data 28 */
+#define IREF_CUR_STEP_DATA_29           CTL_CSDT(29)           /*!< IREF current step data 29 */
+#define IREF_CUR_STEP_DATA_30           CTL_CSDT(30)           /*!< IREF current step data 30 */
+#define IREF_CUR_STEP_DATA_31           CTL_CSDT(31)           /*!< IREF current step data 31 */
+#define IREF_CUR_STEP_DATA_32           CTL_CSDT(32)           /*!< IREF current step data 32 */
+#define IREF_CUR_STEP_DATA_33           CTL_CSDT(33)           /*!< IREF current step data 33 */
+#define IREF_CUR_STEP_DATA_34           CTL_CSDT(34)           /*!< IREF current step data 34 */
+#define IREF_CUR_STEP_DATA_35           CTL_CSDT(35)           /*!< IREF current step data 35 */
+#define IREF_CUR_STEP_DATA_36           CTL_CSDT(36)           /*!< IREF current step data 36 */
+#define IREF_CUR_STEP_DATA_37           CTL_CSDT(37)           /*!< IREF current step data 37 */
+#define IREF_CUR_STEP_DATA_38           CTL_CSDT(38)           /*!< IREF current step data 38 */
+#define IREF_CUR_STEP_DATA_39           CTL_CSDT(39)           /*!< IREF current step data 39 */
+#define IREF_CUR_STEP_DATA_40           CTL_CSDT(40)           /*!< IREF current step data 40 */
+#define IREF_CUR_STEP_DATA_41           CTL_CSDT(41)           /*!< IREF current step data 41 */
+#define IREF_CUR_STEP_DATA_42           CTL_CSDT(42)           /*!< IREF current step data 42 */
+#define IREF_CUR_STEP_DATA_43           CTL_CSDT(43)           /*!< IREF current step data 43 */
+#define IREF_CUR_STEP_DATA_44           CTL_CSDT(44)           /*!< IREF current step data 44 */
+#define IREF_CUR_STEP_DATA_45           CTL_CSDT(45)           /*!< IREF current step data 45 */
+#define IREF_CUR_STEP_DATA_46           CTL_CSDT(46)           /*!< IREF current step data 46 */
+#define IREF_CUR_STEP_DATA_47           CTL_CSDT(47)           /*!< IREF current step data 47 */
+#define IREF_CUR_STEP_DATA_48           CTL_CSDT(48)           /*!< IREF current step data 48 */
+#define IREF_CUR_STEP_DATA_49           CTL_CSDT(49)           /*!< IREF current step data 49 */
+#define IREF_CUR_STEP_DATA_50           CTL_CSDT(50)           /*!< IREF current step data 50 */
+#define IREF_CUR_STEP_DATA_51           CTL_CSDT(51)           /*!< IREF current step data 51 */
+#define IREF_CUR_STEP_DATA_52           CTL_CSDT(52)           /*!< IREF current step data 52 */
+#define IREF_CUR_STEP_DATA_53           CTL_CSDT(53)           /*!< IREF current step data 53 */
+#define IREF_CUR_STEP_DATA_54           CTL_CSDT(54)           /*!< IREF current step data 54 */
+#define IREF_CUR_STEP_DATA_55           CTL_CSDT(55)           /*!< IREF current step data 54 */
+#define IREF_CUR_STEP_DATA_56           CTL_CSDT(56)           /*!< IREF current step data 54 */
+#define IREF_CUR_STEP_DATA_57           CTL_CSDT(57)           /*!< IREF current step data 57 */
+#define IREF_CUR_STEP_DATA_58           CTL_CSDT(58)           /*!< IREF current step data 58 */
+#define IREF_CUR_STEP_DATA_59           CTL_CSDT(59)           /*!< IREF current step data 59 */
+#define IREF_CUR_STEP_DATA_60           CTL_CSDT(60)           /*!< IREF current step data 60 */
+#define IREF_CUR_STEP_DATA_61           CTL_CSDT(61)           /*!< IREF current step data 61 */
+#define IREF_CUR_STEP_DATA_62           CTL_CSDT(62)           /*!< IREF current step data 62 */
+#define IREF_CUR_STEP_DATA_63           CTL_CSDT(63)           /*!< IREF current step data 63 */
+ 
+/* IREF mode selection */
+#define IREF_STEP(regval)               (BIT(14) & ((uint32_t)(regval) << 14))
+#define IREF_MODE_LOW_POWER             IREF_STEP(0)           /*!< low power, 1uA step */
+#define IREF_MODE_HIGH_CURRENT          IREF_STEP(1)           /*!< high current, 8uA step */
+ 
+/* IREF sink current mode*/ 
+#define IREF_CURRENT(regval)            (BIT(7) & ((uint32_t)(regval) << 7))
+#define IREF_SOURCE_CURRENT             IREF_CURRENT(0)        /*!< IREF source current */
+#define IREF_SINK_CURRENT               IREF_CURRENT(1)        /*!< IREF sink current */
+
+/* function declarations */
+/* deinitialize IREF */
+void iref_deinit(void);
+/* enable IREF */
+void iref_enable(void);
+/* disable IREF */
+void iref_disable(void);
+
+/* set IREF mode*/
+void iref_mode_set(uint32_t step);
+/* set IREF sink current mode*/
+void iref_sink_set(uint32_t sinkmode);
+/* set IREF current precision trim value */
+void iref_precision_trim_value_set(uint32_t precisiontrim);
+/* set IREF step data*/
+void iref_step_data_config(uint32_t stepdata);
+
+#endif /* GD32F4XX_IREF_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_libopt.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_libopt.h
@@ -1,0 +1,81 @@
+/*!
+    \file    gd32f4xx_libopt.h
+    \brief   library optional for gd32f4xx
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_LIBOPT_H
+#define GD32F4XX_LIBOPT_H
+
+#if defined (GD32F450) || defined (GD32F405) || defined (GD32F407) || defined (GD32F470) || defined (GD32F425) || defined (GD32F427)
+#include "gd32f4xx_rcu.h"
+#include "gd32f4xx_adc.h"
+#include "gd32f4xx_can.h"
+#include "gd32f4xx_crc.h"
+#include "gd32f4xx_ctc.h"
+#include "gd32f4xx_dac.h"
+#include "gd32f4xx_dbg.h"
+#include "gd32f4xx_dci.h"
+#include "gd32f4xx_dma.h"
+#include "gd32f4xx_exti.h"
+#include "gd32f4xx_fmc.h"
+#include "gd32f4xx_fwdgt.h"
+#include "gd32f4xx_gpio.h"
+#include "gd32f4xx_syscfg.h"
+#include "gd32f4xx_i2c.h"
+#include "gd32f4xx_iref.h"
+#include "gd32f4xx_pmu.h"
+#include "gd32f4xx_rtc.h"
+#include "gd32f4xx_sdio.h"
+#include "gd32f4xx_spi.h"
+#include "gd32f4xx_timer.h"
+#include "gd32f4xx_trng.h"
+#include "gd32f4xx_usart.h"
+#include "gd32f4xx_wwdgt.h"
+#include "gd32f4xx_misc.h"
+#endif
+
+#if defined (GD32F450) || defined (GD32F470)
+#include "gd32f4xx_enet.h"
+#include "gd32f4xx_exmc.h"
+#include "gd32f4xx_ipa.h"
+#include "gd32f4xx_tli.h"
+#endif
+
+#if defined (GD32F407) || defined (GD32F427)
+#include "gd32f4xx_enet.h"
+#include "gd32f4xx_exmc.h"
+#endif
+
+#endif /* GD32F4XX_LIBOPT_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_misc.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_misc.h
@@ -1,0 +1,93 @@
+/*!
+    \file    gd32f4xx_misc.h
+    \brief   definitions for the MISC
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_MISC_H
+#define GD32F4XX_MISC_H
+
+#include "gd32f4xx.h"
+
+/* constants definitions */
+/* set the RAM and FLASH base address */
+#define NVIC_VECTTAB_RAM            ((uint32_t)0x20000000) /*!< RAM base address */
+#define NVIC_VECTTAB_FLASH          ((uint32_t)0x08000000) /*!< Flash base address */
+
+/* set the NVIC vector table offset mask */
+#define NVIC_VECTTAB_OFFSET_MASK    ((uint32_t)0x1FFFFF80)
+
+/* the register key mask, if you want to do the write operation, you should write 0x5FA to VECTKEY bits */
+#define NVIC_AIRCR_VECTKEY_MASK     ((uint32_t)0x05FA0000)
+
+/* priority group - define the pre-emption priority and the subpriority */
+#define NVIC_PRIGROUP_PRE0_SUB4     ((uint32_t)0x700) /*!< 0 bits for pre-emption priority 4 bits for subpriority */
+#define NVIC_PRIGROUP_PRE1_SUB3     ((uint32_t)0x600) /*!< 1 bits for pre-emption priority 3 bits for subpriority */
+#define NVIC_PRIGROUP_PRE2_SUB2     ((uint32_t)0x500) /*!< 2 bits for pre-emption priority 2 bits for subpriority */
+#define NVIC_PRIGROUP_PRE3_SUB1     ((uint32_t)0x400) /*!< 3 bits for pre-emption priority 1 bits for subpriority */
+#define NVIC_PRIGROUP_PRE4_SUB0     ((uint32_t)0x300) /*!< 4 bits for pre-emption priority 0 bits for subpriority */
+
+/* choose the method to enter or exit the lowpower mode */
+#define SCB_SCR_SLEEPONEXIT         ((uint8_t)0x02) /*!< choose the the system whether enter low power mode by exiting from ISR */
+#define SCB_SCR_SLEEPDEEP           ((uint8_t)0x04) /*!< choose the the system enter the DEEPSLEEP mode or SLEEP mode */
+#define SCB_SCR_SEVONPEND           ((uint8_t)0x10) /*!< choose the interrupt source that can wake up the lowpower mode */
+
+#define SCB_LPM_SLEEP_EXIT_ISR      SCB_SCR_SLEEPONEXIT
+#define SCB_LPM_DEEPSLEEP           SCB_SCR_SLEEPDEEP
+#define SCB_LPM_WAKE_BY_ALL_INT     SCB_SCR_SEVONPEND
+
+/* choose the systick clock source */
+#define SYSTICK_CLKSOURCE_HCLK_DIV8 ((uint32_t)0xFFFFFFFBU) /*!< systick clock source is from HCLK/8 */
+#define SYSTICK_CLKSOURCE_HCLK      ((uint32_t)0x00000004U) /*!< systick clock source is from HCLK */
+
+/* function declarations */
+/* set the priority group */
+void nvic_priority_group_set(uint32_t nvic_prigroup);
+
+/* enable NVIC request */
+void nvic_irq_enable(uint8_t nvic_irq, uint8_t nvic_irq_pre_priority, uint8_t nvic_irq_sub_priority);
+/* disable NVIC request */
+void nvic_irq_disable(uint8_t nvic_irq);
+
+/* set the NVIC vector table base address */
+void nvic_vector_table_set(uint32_t nvic_vict_tab, uint32_t offset);
+
+/* set the state of the low power mode */
+void system_lowpower_set(uint8_t lowpower_mode);
+/* reset the state of the low power mode */
+void system_lowpower_reset(uint8_t lowpower_mode);
+
+/* set the systick clock source */
+void systick_clksource_set(uint32_t systick_clksource);
+
+#endif /* GD32F4XX_MISC_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_pmu.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_pmu.h
@@ -1,0 +1,206 @@
+/*!
+    \file    gd32f4xx_pmu.h
+    \brief   definitions for the PMU
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+
+#ifndef GD32F4XX_PMU_H
+#define GD32F4XX_PMU_H
+
+#include "gd32f4xx.h"
+
+/* PMU definitions */
+#define PMU                           PMU_BASE                          /*!< PMU base address */
+
+/* registers definitions */
+#define PMU_CTL                       REG32((PMU) + 0x00000000U)        /*!< PMU control register */
+#define PMU_CS                        REG32((PMU) + 0x00000004U)        /*!< PMU control and status register */
+
+/* bits definitions */
+/* PMU_CTL */
+#define PMU_CTL_LDOLP                 BIT(0)                            /*!< LDO low power mode */
+#define PMU_CTL_STBMOD                BIT(1)                            /*!< standby mode */
+#define PMU_CTL_WURST                 BIT(2)                            /*!< wakeup flag reset */
+#define PMU_CTL_STBRST                BIT(3)                            /*!< standby flag reset */
+#define PMU_CTL_LVDEN                 BIT(4)                            /*!< low voltage detector enable */
+#define PMU_CTL_LVDT                  BITS(5,7)                         /*!< low voltage detector threshold */
+#define PMU_CTL_BKPWEN                BIT(8)                            /*!< backup domain write enable */
+#define PMU_CTL_LDLP                  BIT(10)                           /*!< low-driver mode when use low power LDO */
+#define PMU_CTL_LDNP                  BIT(11)                           /*!< low-driver mode when use normal power LDO */
+#define PMU_CTL_LDOVS                 BITS(14,15)                       /*!< LDO output voltage select */
+#define PMU_CTL_HDEN                  BIT(16)                           /*!< high-driver mode enable */
+#define PMU_CTL_HDS                   BIT(17)                           /*!< high-driver mode switch */
+#define PMU_CTL_LDEN                  BITS(18,19)                       /*!< low-driver mode enable in deep-sleep mode */
+
+/* PMU_CS */
+#define PMU_CS_WUF                    BIT(0)                            /*!< wakeup flag */
+#define PMU_CS_STBF                   BIT(1)                            /*!< standby flag */
+#define PMU_CS_LVDF                   BIT(2)                            /*!< low voltage detector status flag */
+#define PMU_CS_BLDORF                 BIT(3)                            /*!< backup SRAM LDO ready flag */
+#define PMU_CS_WUPEN                  BIT(8)                            /*!< wakeup pin enable */
+#define PMU_CS_BLDOON                 BIT(9)                            /*!< backup SRAM LDO on */
+#define PMU_CS_LDOVSRF                BIT(14)                           /*!< LDO voltage select ready flag */
+#define PMU_CS_HDRF                   BIT(16)                           /*!< high-driver ready flag */
+#define PMU_CS_HDSRF                  BIT(17)                           /*!< high-driver switch ready flag */
+#define PMU_CS_LDRF                   BITS(18,19)                       /*!< low-driver mode ready flag */
+
+/* constants definitions */
+/* PMU ldo definitions */
+#define PMU_LDO_NORMAL                ((uint32_t)0x00000000U)           /*!< LDO normal work when PMU enter deep-sleep mode */
+#define PMU_LDO_LOWPOWER              PMU_CTL_LDOLP                     /*!< LDO work at low power status when PMU enter deep-sleep mode */
+
+/* PMU low voltage detector threshold definitions */
+#define CTL_LVDT(regval)              (BITS(5,7)&((uint32_t)(regval)<<5))
+#define PMU_LVDT_0                    CTL_LVDT(0)                       /*!< voltage threshold is 2.1V */
+#define PMU_LVDT_1                    CTL_LVDT(1)                       /*!< voltage threshold is 2.3V */
+#define PMU_LVDT_2                    CTL_LVDT(2)                       /*!< voltage threshold is 2.4V */
+#define PMU_LVDT_3                    CTL_LVDT(3)                       /*!< voltage threshold is 2.6V */
+#define PMU_LVDT_4                    CTL_LVDT(4)                       /*!< voltage threshold is 2.7V */
+#define PMU_LVDT_5                    CTL_LVDT(5)                       /*!< voltage threshold is 2.9V */
+#define PMU_LVDT_6                    CTL_LVDT(6)                       /*!< voltage threshold is 3.0V */
+#define PMU_LVDT_7                    CTL_LVDT(7)                       /*!< voltage threshold is 3.1V */
+
+/* PMU low-driver mode when use low power LDO */
+#define CTL_LDLP(regval)              (BIT(10)&((uint32_t)(regval)<<10))
+#define PMU_NORMALDR_LOWPWR           CTL_LDLP(0)                       /*!< normal driver when use low power LDO */
+#define PMU_LOWDR_LOWPWR              CTL_LDLP(1)                       /*!< low-driver mode enabled when LDEN is 11 and use low power LDO */
+
+/* PMU low-driver mode when use normal power LDO */
+#define CTL_LDNP(regval)              (BIT(11)&((uint32_t)(regval)<<11))
+#define PMU_NORMALDR_NORMALPWR        CTL_LDNP(0)                       /*!< normal driver when use normal power LDO */
+#define PMU_LOWDR_NORMALPWR           CTL_LDNP(1)                       /*!< low-driver mode enabled when LDEN is 11 and use normal power LDO */
+
+/* PMU LDO output voltage select definitions */
+#define CTL_LDOVS(regval)             (BITS(14,15)&((uint32_t)(regval)<<14))
+#define PMU_LDOVS_LOW                 CTL_LDOVS(1)                      /*!< LDO output voltage low mode */
+#define PMU_LDOVS_MID                 CTL_LDOVS(2)                      /*!< LDO output voltage mid mode */
+#define PMU_LDOVS_HIGH                CTL_LDOVS(3)                      /*!< LDO output voltage high mode */
+
+
+/* PMU high-driver mode switch */
+#define CTL_HDS(regval)               (BIT(17)&((uint32_t)(regval)<<17))
+#define PMU_HIGHDR_SWITCH_NONE        CTL_HDS(0)                        /*!< no high-driver mode switch */
+#define PMU_HIGHDR_SWITCH_EN          CTL_HDS(1)                        /*!< high-driver mode switch */
+
+/* PMU low-driver mode enable in deep-sleep mode */
+#define CTL_LDEN(regval)              (BITS(18,19)&((uint32_t)(regval)<<18))
+#define PMU_LOWDRIVER_DISABLE         CTL_LDEN(0)                       /*!< low-driver mode disable in deep-sleep mode */
+#define PMU_LOWDRIVER_ENABLE          CTL_LDEN(3)                       /*!< low-driver mode enable in deep-sleep mode */
+
+/* PMU backup SRAM LDO on or off */
+#define CS_BLDOON(regval)             (BIT(9)&((uint32_t)(regval)<<9))
+#define PMU_BLDOON_OFF                CS_BLDOON(0)                      /*!< backup SRAM LDO off */
+#define PMU_BLDOON_ON                 CS_BLDOON(1)                      /*!< the backup SRAM LDO on */
+
+/* PMU low power mode ready flag definitions */
+#define CS_LDRF(regval)               (BITS(18,19)&((uint32_t)(regval)<<18))
+#define PMU_LDRF_NORMAL               CS_LDRF(0)                        /*!< normal driver in deep-sleep mode */
+#define PMU_LDRF_LOWDRIVER            CS_LDRF(3)                        /*!< low-driver mode in deep-sleep mode */
+
+/* PMU flag definitions */
+#define PMU_FLAG_WAKEUP               PMU_CS_WUF                        /*!< wakeup flag status */
+#define PMU_FLAG_STANDBY              PMU_CS_STBF                       /*!< standby flag status */
+#define PMU_FLAG_LVD                  PMU_CS_LVDF                       /*!< lvd flag status */
+#define PMU_FLAG_BLDORF               PMU_CS_BLDORF                     /*!< backup SRAM LDO ready flag */
+#define PMU_FLAG_LDOVSRF              PMU_CS_LDOVSRF                    /*!< LDO voltage select ready flag */
+#define PMU_FLAG_HDRF                 PMU_CS_HDRF                       /*!< high-driver ready flag */
+#define PMU_FLAG_HDSRF                PMU_CS_HDSRF                      /*!< high-driver switch ready flag */
+#define PMU_FLAG_LDRF                 PMU_CS_LDRF                       /*!< low-driver mode ready flag */
+
+/* PMU flag reset definitions */
+#define PMU_FLAG_RESET_WAKEUP         ((uint8_t)0x00U)                  /*!< wakeup flag reset */
+#define PMU_FLAG_RESET_STANDBY        ((uint8_t)0x01U)                  /*!< standby flag reset */
+
+/* PMU command constants definitions */
+#define WFI_CMD                       ((uint8_t)0x00U)                  /*!< use WFI command */
+#define WFE_CMD                       ((uint8_t)0x01U)                  /*!< use WFE command */
+
+/* function declarations */
+/* reset PMU registers */
+void pmu_deinit(void);
+
+/* LVD functions */
+/* select low voltage detector threshold */
+void pmu_lvd_select(uint32_t lvdt_n);
+/* disable PMU lvd */
+void pmu_lvd_disable(void);
+
+/* LDO functions */
+/* select LDO output voltage */
+void pmu_ldo_output_select(uint32_t ldo_output);
+
+/* functions of low-driver mode and high-driver mode */
+/* enable high-driver mode */
+void pmu_highdriver_mode_enable(void);
+/* disable high-driver mode */
+void pmu_highdriver_mode_disable(void);
+/* switch high-driver mode */
+void pmu_highdriver_switch_select(uint32_t highdr_switch);
+/* enable low-driver mode in deep-sleep */
+void pmu_lowdriver_mode_enable(void);
+/* disable low-driver mode in deep-sleep */
+void pmu_lowdriver_mode_disable(void);
+/* in deep-sleep mode, driver mode when use low power LDO */
+void pmu_lowpower_driver_config(uint32_t mode);
+/* in deep-sleep mode, driver mode when use normal power LDO */
+void pmu_normalpower_driver_config(uint32_t mode);
+
+/* set PMU mode */
+/* PMU work in sleep mode */
+void pmu_to_sleepmode(uint8_t sleepmodecmd);
+/* PMU work in deepsleep mode */
+void pmu_to_deepsleepmode(uint32_t ldo, uint32_t lowdrive, uint8_t deepsleepmodecmd);
+/* PMU work in standby mode */
+void pmu_to_standbymode(void);
+/* enable PMU wakeup pin */
+void pmu_wakeup_pin_enable(void);
+/* disable PMU wakeup pin */
+void pmu_wakeup_pin_disable(void);
+
+/* backup related functions */
+/* backup SRAM LDO on */
+void pmu_backup_ldo_config(uint32_t bkp_ldo);
+/* enable write access to the registers in backup domain */
+void pmu_backup_write_enable(void);
+/* disable write access to the registers in backup domain */
+void pmu_backup_write_disable(void);
+
+/* flag functions */
+/* get flag state */
+FlagStatus pmu_flag_get(uint32_t flag);
+/* clear flag bit */
+void pmu_flag_clear(uint32_t flag);
+
+#endif /* GD32F4XX_PMU_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_rcu.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_rcu.h
@@ -1,0 +1,1183 @@
+/*!
+    \file    gd32f4xx_rcu.h
+    \brief   definitions for the RCU
+    
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_RCU_H
+#define GD32F4XX_RCU_H
+
+#include "gd32f4xx.h"
+
+/* RCU definitions */
+#define RCU                             RCU_BASE
+
+/* registers definitions */
+#define RCU_CTL                         REG32(RCU + 0x00U)        /*!< control register */
+#define RCU_PLL                         REG32(RCU + 0x04U)        /*!< PLL register */
+#define RCU_CFG0                        REG32(RCU + 0x08U)        /*!< clock configuration register 0 */
+#define RCU_INT                         REG32(RCU + 0x0CU)        /*!< clock interrupt register */
+#define RCU_AHB1RST                     REG32(RCU + 0x10U)        /*!< AHB1 reset register */
+#define RCU_AHB2RST                     REG32(RCU + 0x14U)        /*!< AHB2 reset register */
+#define RCU_AHB3RST                     REG32(RCU + 0x18U)        /*!< AHB3 reset register */
+#define RCU_APB1RST                     REG32(RCU + 0x20U)        /*!< APB1 reset register */
+#define RCU_APB2RST                     REG32(RCU + 0x24U)        /*!< APB2 reset register */
+#define RCU_AHB1EN                      REG32(RCU + 0x30U)        /*!< AHB1 enable register */
+#define RCU_AHB2EN                      REG32(RCU + 0x34U)        /*!< AHB2 enable register */
+#define RCU_AHB3EN                      REG32(RCU + 0x38U)        /*!< AHB3 enable register */
+#define RCU_APB1EN                      REG32(RCU + 0x40U)        /*!< APB1 enable register */
+#define RCU_APB2EN                      REG32(RCU + 0x44U)        /*!< APB2 enable register */
+#define RCU_AHB1SPEN                    REG32(RCU + 0x50U)        /*!< AHB1 sleep mode enable register */
+#define RCU_AHB2SPEN                    REG32(RCU + 0x54U)        /*!< AHB2 sleep mode enable register */
+#define RCU_AHB3SPEN                    REG32(RCU + 0x58U)        /*!< AHB3 sleep mode enable register */ 
+#define RCU_APB1SPEN                    REG32(RCU + 0x60U)        /*!< APB1 sleep mode enable register */
+#define RCU_APB2SPEN                    REG32(RCU + 0x64U)        /*!< APB2 sleep mode enable register */
+#define RCU_BDCTL                       REG32(RCU + 0x70U)        /*!< backup domain control register */
+#define RCU_RSTSCK                      REG32(RCU + 0x74U)        /*!< reset source / clock register */
+#define RCU_PLLSSCTL                    REG32(RCU + 0x80U)        /*!< PLL clock spread spectrum control register */
+#define RCU_PLLI2S                      REG32(RCU + 0x84U)        /*!< PLLI2S register */ 
+#define RCU_PLLSAI                      REG32(RCU + 0x88U)        /*!< PLLSAI register */ 
+#define RCU_CFG1                        REG32(RCU + 0x8CU)        /*!< clock configuration register 1 */
+#define RCU_ADDCTL                      REG32(RCU + 0xC0U)        /*!< Additional clock control register */
+#define RCU_ADDINT                      REG32(RCU + 0xCCU)        /*!< Additional clock interrupt register */
+#define RCU_ADDAPB1RST                  REG32(RCU + 0xE0U)        /*!< APB1 additional reset register */
+#define RCU_ADDAPB1EN                   REG32(RCU + 0xE4U)        /*!< APB1 additional enable register */
+#define RCU_ADDAPB1SPEN                 REG32(RCU + 0xE8U)        /*!< APB1 additional sleep mode enable register */
+#define RCU_VKEY                        REG32(RCU + 0x100U)       /*!< voltage key register */
+#define RCU_DSV                         REG32(RCU + 0x134U)       /*!< deep-sleep mode voltage register */
+
+/* bits definitions */
+/* RCU_CTL */
+#define RCU_CTL_IRC16MEN                BIT(0)                    /*!< internal high speed oscillator enable */
+#define RCU_CTL_IRC16MSTB               BIT(1)                    /*!< IRC16M high speed internal oscillator stabilization flag */
+#define RCU_CTL_IRC16MADJ               BITS(3,7)                 /*!< high speed internal oscillator clock trim adjust value */
+#define RCU_CTL_IRC16MCALIB             BITS(8,15)                /*!< high speed internal oscillator calibration value register */
+#define RCU_CTL_HXTALEN                 BIT(16)                   /*!< external high speed oscillator enable */
+#define RCU_CTL_HXTALSTB                BIT(17)                   /*!< external crystal oscillator clock stabilization flag */
+#define RCU_CTL_HXTALBPS                BIT(18)                   /*!< external crystal oscillator clock bypass mode enable */
+#define RCU_CTL_CKMEN                   BIT(19)                   /*!< HXTAL clock monitor enable */
+#define RCU_CTL_PLLEN                   BIT(24)                   /*!< PLL enable */
+#define RCU_CTL_PLLSTB                  BIT(25)                   /*!< PLL Clock Stabilization Flag */
+#define RCU_CTL_PLLI2SEN                BIT(26)                   /*!< PLLI2S enable */
+#define RCU_CTL_PLLI2SSTB               BIT(27)                   /*!< PLLI2S Clock Stabilization Flag */
+#define RCU_CTL_PLLSAIEN                BIT(28)                   /*!< PLLSAI enable */
+#define RCU_CTL_PLLSAISTB               BIT(29)                   /*!< PLLSAI Clock Stabilization Flag */
+
+/* RCU_PLL */
+#define RCU_PLL_PLLPSC                  BITS(0,5)                 /*!< The PLL VCO source clock prescaler */
+#define RCU_PLL_PLLN                    BITS(6,14)                /*!< The PLL VCO clock multi factor */
+#define RCU_PLL_PLLP                    BITS(16,17)               /*!< The PLLP output frequency division factor from PLL VCO clock */
+#define RCU_PLL_PLLSEL                  BIT(22)                   /*!< PLL Clock Source Selection */
+#define RCU_PLL_PLLQ                    BITS(24,27)               /*!< The PLL Q output frequency division factor from PLL VCO clock */
+
+/* RCU_CFG0 */
+#define RCU_CFG0_SCS                    BITS(0,1)                 /*!< system clock switch */
+#define RCU_CFG0_SCSS                   BITS(2,3)                 /*!< system clock switch status */
+#define RCU_CFG0_AHBPSC                 BITS(4,7)                 /*!< AHB prescaler selection */
+#define RCU_CFG0_APB1PSC                BITS(10,12)               /*!< APB1 prescaler selection */
+#define RCU_CFG0_APB2PSC                BITS(13,15)               /*!< APB2 prescaler selection */
+#define RCU_CFG0_RTCDIV                 BITS(16,20)               /*!< RTC clock divider factor */
+#define RCU_CFG0_CKOUT0SEL              BITS(21,22)               /*!< CKOUT0 Clock Source Selection */
+#define RCU_CFG0_I2SSEL                 BIT(23)                   /*!< I2S Clock Source Selection */
+#define RCU_CFG0_CKOUT0DIV              BITS(24,26)               /*!< The CK_OUT0 divider which the CK_OUT0 frequency can be reduced */
+#define RCU_CFG0_CKOUT1DIV              BITS(27,29)               /*!< The CK_OUT1 divider which the CK_OUT1 frequency can be reduced */
+#define RCU_CFG0_CKOUT1SEL              BITS(30,31)               /*!< CKOUT1 Clock Source Selection */
+
+/* RCU_INT */
+#define RCU_INT_IRC32KSTBIF             BIT(0)                    /*!< IRC32K stabilization interrupt flag */
+#define RCU_INT_LXTALSTBIF              BIT(1)                    /*!< LXTAL stabilization interrupt flag */
+#define RCU_INT_IRC16MSTBIF             BIT(2)                    /*!< IRC16M stabilization interrupt flag */
+#define RCU_INT_HXTALSTBIF              BIT(3)                    /*!< HXTAL stabilization interrupt flag */
+#define RCU_INT_PLLSTBIF                BIT(4)                    /*!< PLL stabilization interrupt flag */
+#define RCU_INT_PLLI2SSTBIF             BIT(5)                    /*!< PLLI2S stabilization interrupt flag */
+#define RCU_INT_PLLSAISTBIF             BIT(6)                    /*!< PLLSAI stabilization interrupt flag */
+#define RCU_INT_CKMIF                   BIT(7)                    /*!< HXTAL clock stuck interrupt flag */
+#define RCU_INT_IRC32KSTBIE             BIT(8)                    /*!< IRC32K stabilization interrupt enable */
+#define RCU_INT_LXTALSTBIE              BIT(9)                    /*!< LXTAL stabilization interrupt enable */
+#define RCU_INT_IRC16MSTBIE             BIT(10)                   /*!< IRC16M stabilization interrupt enable */
+#define RCU_INT_HXTALSTBIE              BIT(11)                   /*!< HXTAL stabilization interrupt enable */
+#define RCU_INT_PLLSTBIE                BIT(12)                   /*!< PLL stabilization interrupt enable */
+#define RCU_INT_PLLI2SSTBIE             BIT(13)                   /*!< PLLI2S Stabilization Interrupt Enable */
+#define RCU_INT_PLLSAISTBIE             BIT(14)                   /*!< PLLSAI Stabilization Interrupt Enable */
+#define RCU_INT_IRC32KSTBIC             BIT(16)                   /*!< IRC32K Stabilization Interrupt Clear */
+#define RCU_INT_LXTALSTBIC              BIT(17)                   /*!< LXTAL Stabilization Interrupt Clear */
+#define RCU_INT_IRC16MSTBIC             BIT(18)                   /*!< IRC16M Stabilization Interrupt Clear */
+#define RCU_INT_HXTALSTBIC              BIT(19)                   /*!< HXTAL Stabilization Interrupt Clear */
+#define RCU_INT_PLLSTBIC                BIT(20)                   /*!< PLL stabilization Interrupt Clear */
+#define RCU_INT_PLLI2SSTBIC             BIT(21)                   /*!< PLLI2S stabilization Interrupt Clear */
+#define RCU_INT_PLLSAISTBIC             BIT(22)                   /*!< PLLSAI stabilization Interrupt Clear */
+#define RCU_INT_CKMIC                   BIT(23)                   /*!< HXTAL Clock Stuck Interrupt Clear */
+
+/* RCU_AHB1RST */
+#define RCU_AHB1RST_PARST               BIT(0)                    /*!< GPIO port A reset */
+#define RCU_AHB1RST_PBRST               BIT(1)                    /*!< GPIO port B reset */
+#define RCU_AHB1RST_PCRST               BIT(2)                    /*!< GPIO port C reset */
+#define RCU_AHB1RST_PDRST               BIT(3)                    /*!< GPIO port D reset */
+#define RCU_AHB1RST_PERST               BIT(4)                    /*!< GPIO port E reset */
+#define RCU_AHB1RST_PFRST               BIT(5)                    /*!< GPIO port F reset */
+#define RCU_AHB1RST_PGRST               BIT(6)                    /*!< GPIO port G reset */
+#define RCU_AHB1RST_PHRST               BIT(7)                    /*!< GPIO port H reset */
+#define RCU_AHB1RST_PIRST               BIT(8)                    /*!< GPIO port I reset */
+#define RCU_AHB1RST_CRCRST              BIT(12)                   /*!< CRC reset */ 
+#define RCU_AHB1RST_DMA0RST             BIT(21)                   /*!< DMA0 reset */
+#define RCU_AHB1RST_DMA1RST             BIT(22)                   /*!< DMA1 reset */
+#define RCU_AHB1RST_IPARST              BIT(23)                   /*!< IPA reset */
+#define RCU_AHB1RST_ENETRST             BIT(25)                   /*!< ENET reset */
+#define RCU_AHB1RST_USBHSRST            BIT(29)                   /*!< USBHS reset */
+
+/* RCU_AHB2RST */
+#define RCU_AHB2RST_DCIRST              BIT(0)                    /*!< DCI reset */
+#define RCU_AHB2RST_TRNGRST             BIT(6)                    /*!< TRNG reset */
+#define RCU_AHB2RST_USBFSRST            BIT(7)                    /*!< USBFS reset */
+                                    
+/* RCU_AHB3RST */
+#define RCU_AHB3RST_EXMCRST             BIT(0)                    /*!< EXMC reset */
+
+/* RCU_APB1RST */
+#define RCU_APB1RST_TIMER1RST           BIT(0)                    /*!< TIMER1 reset */
+#define RCU_APB1RST_TIMER2RST           BIT(1)                    /*!< TIMER2 reset */
+#define RCU_APB1RST_TIMER3RST           BIT(2)                    /*!< TIMER3 reset */
+#define RCU_APB1RST_TIMER4RST           BIT(3)                    /*!< TIMER4 reset */
+#define RCU_APB1RST_TIMER5RST           BIT(4)                    /*!< TIMER5 reset */
+#define RCU_APB1RST_TIMER6RST           BIT(5)                    /*!< TIMER6 reset */
+#define RCU_APB1RST_TIMER11RST          BIT(6)                    /*!< TIMER11 reset */
+#define RCU_APB1RST_TIMER12RST          BIT(7)                    /*!< TIMER12 reset */
+#define RCU_APB1RST_TIMER13RST          BIT(8)                    /*!< TIMER13 reset */
+#define RCU_APB1RST_WWDGTRST            BIT(11)                   /*!< WWDGT reset */
+#define RCU_APB1RST_SPI1RST             BIT(14)                   /*!< SPI1 reset */
+#define RCU_APB1RST_SPI2RST             BIT(15)                   /*!< SPI2 reset */
+#define RCU_APB1RST_USART1RST           BIT(17)                   /*!< USART1 reset */
+#define RCU_APB1RST_USART2RST           BIT(18)                   /*!< USART2 reset */
+#define RCU_APB1RST_UART3RST            BIT(19)                   /*!< UART3 reset */
+#define RCU_APB1RST_UART4RST            BIT(20)                   /*!< UART4 reset */
+#define RCU_APB1RST_I2C0RST             BIT(21)                   /*!< I2C0 reset */
+#define RCU_APB1RST_I2C1RST             BIT(22)                   /*!< I2C1 reset */
+#define RCU_APB1RST_I2C2RST             BIT(23)                   /*!< I2C2 reset */
+#define RCU_APB1RST_CAN0RST             BIT(25)                   /*!< CAN0 reset */
+#define RCU_APB1RST_CAN1RST             BIT(26)                   /*!< CAN1 reset */
+#define RCU_APB1RST_PMURST              BIT(28)                   /*!< PMU reset */
+#define RCU_APB1RST_DACRST              BIT(29)                   /*!< DAC reset */
+#define RCU_APB1RST_UART6RST            BIT(30)                   /*!< UART6 reset */
+#define RCU_APB1RST_UART7RST            BIT(31)                   /*!< UART7 reset */
+
+/* RCU_APB2RST */
+#define RCU_APB2RST_TIMER0RST           BIT(0)                    /*!< TIMER0 reset */
+#define RCU_APB2RST_TIMER7RST           BIT(1)                    /*!< TIMER7 reset */
+#define RCU_APB2RST_USART0RST           BIT(4)                    /*!< USART0 reset */
+#define RCU_APB2RST_USART5RST           BIT(5)                    /*!< USART5 reset */
+#define RCU_APB2RST_ADCRST              BIT(8)                    /*!< ADC reset */
+#define RCU_APB2RST_SDIORST             BIT(11)                   /*!< SDIO reset */
+#define RCU_APB2RST_SPI0RST             BIT(12)                   /*!< SPI0 reset */
+#define RCU_APB2RST_SPI3RST             BIT(13)                   /*!< SPI3 reset */
+#define RCU_APB2RST_SYSCFGRST           BIT(14)                   /*!< SYSCFG reset */
+#define RCU_APB2RST_TIMER8RST           BIT(16)                   /*!< TIMER8 reset */
+#define RCU_APB2RST_TIMER9RST           BIT(17)                   /*!< TIMER9 reset */
+#define RCU_APB2RST_TIMER10RST          BIT(18)                   /*!< TIMER10 reset */
+#define RCU_APB2RST_SPI4RST             BIT(20)                   /*!< SPI4 reset */
+#define RCU_APB2RST_SPI5RST             BIT(21)                   /*!< SPI5 reset */
+#define RCU_APB2RST_TLIRST              BIT(26)                   /*!< TLI reset */
+
+/* RCU_AHB1EN */
+#define RCU_AHB1EN_PAEN                 BIT(0)                    /*!< GPIO port A clock enable */
+#define RCU_AHB1EN_PBEN                 BIT(1)                    /*!< GPIO port B clock enable */
+#define RCU_AHB1EN_PCEN                 BIT(2)                    /*!< GPIO port C clock enable */
+#define RCU_AHB1EN_PDEN                 BIT(3)                    /*!< GPIO port D clock enable */
+#define RCU_AHB1EN_PEEN                 BIT(4)                    /*!< GPIO port E clock enable */
+#define RCU_AHB1EN_PFEN                 BIT(5)                    /*!< GPIO port F clock enable */
+#define RCU_AHB1EN_PGEN                 BIT(6)                    /*!< GPIO port G clock enable */
+#define RCU_AHB1EN_PHEN                 BIT(7)                    /*!< GPIO port H clock enable */
+#define RCU_AHB1EN_PIEN                 BIT(8)                    /*!< GPIO port I clock enable */
+#define RCU_AHB1EN_CRCEN                BIT(12)                   /*!< CRC clock enable */
+#define RCU_AHB1EN_BKPSRAMEN            BIT(18)                   /*!< BKPSRAM clock enable */
+#define RCU_AHB1EN_TCMSRAMEN            BIT(20)                   /*!< TCMSRAM clock enable */
+#define RCU_AHB1EN_DMA0EN               BIT(21)                   /*!< DMA0 clock enable */
+#define RCU_AHB1EN_DMA1EN               BIT(22)                   /*!< DMA1 clock enable */
+#define RCU_AHB1EN_IPAEN                BIT(23)                   /*!< IPA clock enable */
+#define RCU_AHB1EN_ENETEN               BIT(25)                   /*!< ENET clock enable */
+#define RCU_AHB1EN_ENETTXEN             BIT(26)                   /*!< Ethernet TX clock enable */
+#define RCU_AHB1EN_ENETRXEN             BIT(27)                   /*!< Ethernet RX clock enable */
+#define RCU_AHB1EN_ENETPTPEN            BIT(28)                   /*!< Ethernet PTP clock enable */
+#define RCU_AHB1EN_USBHSEN              BIT(29)                   /*!< USBHS clock enable */
+#define RCU_AHB1EN_USBHSULPIEN          BIT(30)                   /*!< USBHS ULPI clock enable */
+
+/* RCU_AHB2EN */
+#define RCU_AHB2EN_DCIEN                BIT(0)                    /*!< DCI clock enable */
+#define RCU_AHB2EN_TRNGEN               BIT(6)                    /*!< TRNG clock enable */
+#define RCU_AHB2EN_USBFSEN              BIT(7)                    /*!< USBFS clock enable */
+
+/* RCU_AHB3EN */
+#define RCU_AHB3EN_EXMCEN               BIT(0)                    /*!< EXMC clock enable */
+
+/* RCU_APB1EN */
+#define RCU_APB1EN_TIMER1EN             BIT(0)                    /*!< TIMER1 clock enable */
+#define RCU_APB1EN_TIMER2EN             BIT(1)                    /*!< TIMER2 clock enable */
+#define RCU_APB1EN_TIMER3EN             BIT(2)                    /*!< TIMER3 clock enable */
+#define RCU_APB1EN_TIMER4EN             BIT(3)                    /*!< TIMER4 clock enable */
+#define RCU_APB1EN_TIMER5EN             BIT(4)                    /*!< TIMER5 clock enable */
+#define RCU_APB1EN_TIMER6EN             BIT(5)                    /*!< TIMER6 clock enable */
+#define RCU_APB1EN_TIMER11EN            BIT(6)                    /*!< TIMER11 clock enable */
+#define RCU_APB1EN_TIMER12EN            BIT(7)                    /*!< TIMER12 clock enable */
+#define RCU_APB1EN_TIMER13EN            BIT(8)                    /*!< TIMER13 clock enable */
+#define RCU_APB1EN_WWDGTEN              BIT(11)                   /*!< WWDGT clock enable */
+#define RCU_APB1EN_SPI1EN               BIT(14)                   /*!< SPI1 clock enable */
+#define RCU_APB1EN_SPI2EN               BIT(15)                   /*!< SPI2 clock enable */
+#define RCU_APB1EN_USART1EN             BIT(17)                   /*!< USART1 clock enable */
+#define RCU_APB1EN_USART2EN             BIT(18)                   /*!< USART2 clock enable */
+#define RCU_APB1EN_UART3EN              BIT(19)                   /*!< UART3 clock enable */
+#define RCU_APB1EN_UART4EN              BIT(20)                   /*!< UART4 clock enable */
+#define RCU_APB1EN_I2C0EN               BIT(21)                   /*!< I2C0 clock enable */
+#define RCU_APB1EN_I2C1EN               BIT(22)                   /*!< I2C1 clock enable */
+#define RCU_APB1EN_I2C2EN               BIT(23)                   /*!< I2C2 clock enable */
+#define RCU_APB1EN_CAN0EN               BIT(25)                   /*!< CAN0 clock enable */
+#define RCU_APB1EN_CAN1EN               BIT(26)                   /*!< CAN1 clock enable */
+#define RCU_APB1EN_PMUEN                BIT(28)                   /*!< PMU clock enable */
+#define RCU_APB1EN_DACEN                BIT(29)                   /*!< DAC clock enable */
+#define RCU_APB1EN_UART6EN              BIT(30)                   /*!< UART6 clock enable */
+#define RCU_APB1EN_UART7EN              BIT(31)                   /*!< UART7 clock enable */
+
+/* RCU_APB2EN */
+#define RCU_APB2EN_TIMER0EN             BIT(0)                    /*!< TIMER0 clock enable */
+#define RCU_APB2EN_TIMER7EN             BIT(1)                    /*!< TIMER7 clock enable */
+#define RCU_APB2EN_USART0EN             BIT(4)                    /*!< USART0 clock enable */
+#define RCU_APB2EN_USART5EN             BIT(5)                    /*!< USART5 clock enable */
+#define RCU_APB2EN_ADC0EN               BIT(8)                    /*!< ADC0 clock enable */
+#define RCU_APB2EN_ADC1EN               BIT(9)                    /*!< ADC1 clock enable */
+#define RCU_APB2EN_ADC2EN               BIT(10)                   /*!< ADC2 clock enable */
+#define RCU_APB2EN_SDIOEN               BIT(11)                   /*!< SDIO clock enable */
+#define RCU_APB2EN_SPI0EN               BIT(12)                   /*!< SPI0 clock enable */
+#define RCU_APB2EN_SPI3EN               BIT(13)                   /*!< SPI3 clock enable */
+#define RCU_APB2EN_SYSCFGEN             BIT(14)                   /*!< SYSCFG clock enable */
+#define RCU_APB2EN_TIMER8EN             BIT(16)                   /*!< TIMER8 clock enable */
+#define RCU_APB2EN_TIMER9EN             BIT(17)                   /*!< TIMER9 clock enable */
+#define RCU_APB2EN_TIMER10EN            BIT(18)                   /*!< TIMER10 clock enable */
+#define RCU_APB2EN_SPI4EN               BIT(20)                   /*!< SPI4 clock enable */
+#define RCU_APB2EN_SPI5EN               BIT(21)                   /*!< SPI5 clock enable */
+#define RCU_APB2EN_TLIEN                BIT(26)                   /*!< TLI clock enable */
+
+/* RCU_AHB1SPEN */
+#define RCU_AHB1SPEN_PASPEN             BIT(0)                    /*!< GPIO port A clock enable when sleep mode */
+#define RCU_AHB1SPEN_PBSPEN             BIT(1)                    /*!< GPIO port B clock enable when sleep mode */
+#define RCU_AHB1SPEN_PCSPEN             BIT(2)                    /*!< GPIO port C clock enable when sleep mode */
+#define RCU_AHB1SPEN_PDSPEN             BIT(3)                    /*!< GPIO port D clock enable when sleep mode */
+#define RCU_AHB1SPEN_PESPEN             BIT(4)                    /*!< GPIO port E clock enable when sleep mode */
+#define RCU_AHB1SPEN_PFSPEN             BIT(5)                    /*!< GPIO port F clock enable when sleep mode */
+#define RCU_AHB1SPEN_PGSPEN             BIT(6)                    /*!< GPIO port G clock enable when sleep mode */
+#define RCU_AHB1SPEN_PHSPEN             BIT(7)                    /*!< GPIO port H clock enable when sleep mode */
+#define RCU_AHB1SPEN_PISPEN             BIT(8)                    /*!< GPIO port I clock enable when sleep mode */
+#define RCU_AHB1SPEN_CRCSPEN            BIT(12)                   /*!< CRC clock enable when sleep mode */
+#define RCU_AHB1SPEN_FMCSPEN            BIT(15)                   /*!< FMC clock enable when sleep mode */
+#define RCU_AHB1SPEN_SRAM0SPEN          BIT(16)                   /*!< SRAM0 clock enable when sleep mode */
+#define RCU_AHB1SPEN_SRAM1SPEN          BIT(17)                   /*!< SRAM1 clock enable when sleep mode */
+#define RCU_AHB1SPEN_BKPSRAMSPEN        BIT(18)                   /*!< BKPSRAM clock enable when sleep mode */
+#define RCU_AHB1SPEN_SRAM2SPEN          BIT(19)                   /*!< SRAM2 clock enable when sleep mode */
+#define RCU_AHB1SPEN_DMA0SPEN           BIT(21)                   /*!< DMA0 clock when sleep mode enable */
+#define RCU_AHB1SPEN_DMA1SPEN           BIT(22)                   /*!< DMA1 clock when sleep mode enable */
+#define RCU_AHB1SPEN_IPASPEN            BIT(23)                   /*!< IPA clock enable when sleep mode */
+#define RCU_AHB1SPEN_ENETSPEN           BIT(25)                   /*!< ENET clock enable when sleep mode */
+#define RCU_AHB1SPEN_ENETTXSPEN         BIT(26)                   /*!< Ethernet TX clock enable when sleep mode */
+#define RCU_AHB1SPEN_ENETRXSPEN         BIT(27)                   /*!< Ethernet RX clock enable when sleep mode */
+#define RCU_AHB1SPEN_ENETPTPSPEN        BIT(28)                   /*!< Ethernet PTP clock enable when sleep mode */
+#define RCU_AHB1SPEN_USBHSSPEN          BIT(29)                   /*!< USBHS clock enable when sleep mode */
+#define RCU_AHB1SPEN_USBHSULPISPEN      BIT(30)                   /*!< USBHS ULPI clock enable when sleep mode */
+
+/* RCU_AHB2SPEN */
+#define RCU_AHB2SPEN_DCISPEN            BIT(0)                    /*!< DCI clock enable when sleep mode */
+#define RCU_AHB2SPEN_TRNGSPEN           BIT(6)                    /*!< TRNG clock enable when sleep mode */
+#define RCU_AHB2SPEN_USBFSSPEN          BIT(7)                    /*!< USBFS clock enable when sleep mode */
+
+/* RCU_AHB3SPEN */
+#define RCU_AHB3SPEN_EXMCSPEN           BIT(0)                    /*!< EXMC clock enable when sleep mode */
+
+/* RCU_APB1SPEN */
+#define RCU_APB1SPEN_TIMER1SPEN         BIT(0)                    /*!< TIMER1 clock enable when sleep mode */
+#define RCU_APB1SPEN_TIMER2SPEN         BIT(1)                    /*!< TIMER2 clock enable when sleep mode */
+#define RCU_APB1SPEN_TIMER3SPEN         BIT(2)                    /*!< TIMER3 clock enable when sleep mode */
+#define RCU_APB1SPEN_TIMER4SPEN         BIT(3)                    /*!< TIMER4 clock enable when sleep mode */
+#define RCU_APB1SPEN_TIMER5SPEN         BIT(4)                    /*!< TIMER5 clock enable when sleep mode */
+#define RCU_APB1SPEN_TIMER6SPEN         BIT(5)                    /*!< TIMER6 clock enable when sleep mode */
+#define RCU_APB1SPEN_TIMER11SPEN        BIT(6)                    /*!< TIMER11 clock enable when sleep mode */
+#define RCU_APB1SPEN_TIMER12SPEN        BIT(7)                    /*!< TIMER12 clock enable when sleep mode */
+#define RCU_APB1SPEN_TIMER13SPEN        BIT(8)                    /*!< TIMER13 clock enable when sleep mode */
+#define RCU_APB1SPEN_WWDGTSPEN          BIT(11)                   /*!< WWDGT clock enable when sleep mode */
+#define RCU_APB1SPEN_SPI1SPEN           BIT(14)                   /*!< SPI1 clock enable when sleep mode */
+#define RCU_APB1SPEN_SPI2SPEN           BIT(15)                   /*!< SPI2 clock enable when sleep mode */
+#define RCU_APB1SPEN_USART1SPEN         BIT(17)                   /*!< USART1 clock enable when sleep mode*/
+#define RCU_APB1SPEN_USART2SPEN         BIT(18)                   /*!< USART2 clock enable when sleep mode*/
+#define RCU_APB1SPEN_UART3SPEN          BIT(19)                   /*!< UART3 clock enable when sleep mode*/
+#define RCU_APB1SPEN_UART4SPEN          BIT(20)                   /*!< UART4 clock enable when sleep mode */
+#define RCU_APB1SPEN_I2C0SPEN           BIT(21)                   /*!< I2C0 clock enable when sleep mode */
+#define RCU_APB1SPEN_I2C1SPEN           BIT(22)                   /*!< I2C1 clock enable when sleep mode*/
+#define RCU_APB1SPEN_I2C2SPEN           BIT(23)                   /*!< I2C2 clock enable when sleep mode */
+#define RCU_APB1SPEN_CAN0SPEN           BIT(25)                   /*!< CAN0 clock enable when sleep mode*/
+#define RCU_APB1SPEN_CAN1SPEN           BIT(26)                   /*!< CAN1 clock enable when sleep mode */
+#define RCU_APB1SPEN_PMUSPEN            BIT(28)                   /*!< PMU clock enable when sleep mode */
+#define RCU_APB1SPEN_DACSPEN            BIT(29)                   /*!< DAC clock enable when sleep mode */
+#define RCU_APB1SPEN_UART6SPEN          BIT(30)                   /*!< UART6 clock enable when sleep mode */
+#define RCU_APB1SPEN_UART7SPEN          BIT(31)                   /*!< UART7 clock enable when sleep mode */
+
+/* RCU_APB2SPEN */
+#define RCU_APB2SPEN_TIMER0SPEN         BIT(0)                    /*!< TIMER0 clock enable when sleep mode */
+#define RCU_APB2SPEN_TIMER7SPEN         BIT(1)                    /*!< TIMER7 clock enable when sleep mode */
+#define RCU_APB2SPEN_USART0SPEN         BIT(4)                    /*!< USART0 clock enable when sleep mode */
+#define RCU_APB2SPEN_USART5SPEN         BIT(5)                    /*!< USART5 clock enable when sleep mode */
+#define RCU_APB2SPEN_ADC0SPEN           BIT(8)                    /*!< ADC0 clock enable when sleep mode */
+#define RCU_APB2SPEN_ADC1SPEN           BIT(9)                    /*!< ADC1 clock enable when sleep mode */
+#define RCU_APB2SPEN_ADC2SPEN           BIT(10)                   /*!< ADC2 clock enable when sleep mode */
+#define RCU_APB2SPEN_SDIOSPEN           BIT(11)                   /*!< SDIO clock enable when sleep mode */
+#define RCU_APB2SPEN_SPI0SPEN           BIT(12)                   /*!< SPI0 clock enable when sleep mode */
+#define RCU_APB2SPEN_SPI3SPEN           BIT(13)                   /*!< SPI3 clock enable when sleep mode */
+#define RCU_APB2SPEN_SYSCFGSPEN         BIT(14)                   /*!< SYSCFG clock enable when sleep mode */
+#define RCU_APB2SPEN_TIMER8SPEN         BIT(16)                   /*!< TIMER8 clock enable when sleep mode */
+#define RCU_APB2SPEN_TIMER9SPEN         BIT(17)                   /*!< TIMER9 clock enable when sleep mode */
+#define RCU_APB2SPEN_TIMER10SPEN        BIT(18)                   /*!< TIMER10 clock enable when sleep mode */
+#define RCU_APB2SPEN_SPI4SPEN           BIT(20)                   /*!< SPI4 clock enable when sleep mode */
+#define RCU_APB2SPEN_SPI5SPEN           BIT(21)                   /*!< SPI5 clock enable when sleep mode */
+#define RCU_APB2SPEN_TLISPEN            BIT(26)                   /*!< TLI clock enable when sleep mode*/
+
+/* RCU_BDCTL */
+#define RCU_BDCTL_LXTALEN               BIT(0)                    /*!< LXTAL enable */
+#define RCU_BDCTL_LXTALSTB              BIT(1)                    /*!< low speed crystal oscillator stabilization flag */
+#define RCU_BDCTL_LXTALBPS              BIT(2)                    /*!< LXTAL bypass mode enable */
+#define RCU_BDCTL_LXTALDRI              BIT(3)                    /*!< LXTAL drive capability */
+#define RCU_BDCTL_RTCSRC                BITS(8,9)                 /*!< RTC clock entry selection */
+#define RCU_BDCTL_RTCEN                 BIT(15)                   /*!< RTC clock enable */
+#define RCU_BDCTL_BKPRST                BIT(16)                   /*!< backup domain reset */
+
+/* RCU_RSTSCK */
+#define RCU_RSTSCK_IRC32KEN             BIT(0)                    /*!< IRC32K enable */
+#define RCU_RSTSCK_IRC32KSTB            BIT(1)                    /*!< IRC32K stabilization flag */
+#define RCU_RSTSCK_RSTFC                BIT(24)                   /*!< reset flag clear */
+#define RCU_RSTSCK_BORRSTF              BIT(25)                   /*!< BOR reset flag */
+#define RCU_RSTSCK_EPRSTF               BIT(26)                   /*!< external pin reset flag */
+#define RCU_RSTSCK_PORRSTF              BIT(27)                   /*!< power reset flag */
+#define RCU_RSTSCK_SWRSTF               BIT(28)                   /*!< software reset flag */
+#define RCU_RSTSCK_FWDGTRSTF            BIT(29)                   /*!< free watchdog timer reset flag */
+#define RCU_RSTSCK_WWDGTRSTF            BIT(30)                   /*!< window watchdog timer reset flag */
+#define RCU_RSTSCK_LPRSTF               BIT(31)                   /*!< low-power reset flag */
+
+/* RCU_PLLSSCTL */
+#define RCU_PLLSSCTL_MODCNT             BITS(0,12)                /*!< these bits configure PLL spread spectrum modulation 
+                                                                       profile amplitude and frequency. the following criteria 
+                                                                       must be met: MODSTEP*MODCNT=215-1 */
+#define RCU_PLLSSCTL_MODSTEP            BITS(13,27)               /*!< these bits configure PLL spread spectrum modulation 
+                                                                       profile amplitude and frequency. the following criteria 
+                                                                       must be met: MODSTEP*MODCNT=215-1 */
+#define RCU_PLLSSCTL_SS_TYPE            BIT(30)                   /*!< PLL spread spectrum modulation type select */
+#define RCU_PLLSSCTL_SSCGON             BIT(31)                   /*!< PLL spread spectrum modulation enable */
+
+/* RCU_PLLI2S */
+#define RCU_PLLI2S_PLLI2SN              BITS(6,14)                /*!< the PLLI2S VCO clock multi factor */
+#define RCU_PLLI2S_PLLI2SR              BITS(28,30)               /*!< the PLLI2S R output frequency division factor from PLLI2S VCO clock */
+
+/* RCU_PLLSAI */
+#define RCU_PLLSAI_PLLSAIN              BITS(6,14)                /*!< the PLLSAI VCO clock multi factor */
+#define RCU_PLLSAI_PLLSAIP              BITS(16,17)               /*!< the PLLSAI P output frequency division factor from PLLSAI VCO clock */
+#define RCU_PLLSAI_PLLSAIR              BITS(28,30)               /*!< the PLLSAI R output frequency division factor from PLLSAI VCO clock */
+
+/* RCU_CFG1 */
+#define RCU_CFG1_PLLSAIRDIV             BITS(16,17)               /*!< the divider factor from PLLSAIR clock */
+#define RCU_CFG1_TIMERSEL               BIT(24)                   /*!< TIMER clock selection */
+
+/* RCU_ADDCTL */
+#define RCU_ADDCTL_CK48MSEL             BIT(0)                    /*!< 48MHz clock selection */
+#define RCU_ADDCTL_PLL48MSEL            BIT(1)                    /*!< PLL48M clock selection */
+#define RCU_ADDCTL_IRC48MEN             BIT(16)                   /*!< internal 48MHz RC oscillator enable */
+#define RCU_ADDCTL_IRC48MSTB            BIT(17)                   /*!< internal 48MHz RC oscillator clock stabilization flag */
+#define RCU_ADDCTL_IRC48MCAL            BITS(24,31)               /*!< internal 48MHz RC oscillator calibration value register */
+
+/* RCU_ADDINT */
+#define RCU_ADDINT_IRC48MSTBIF          BIT(6)                    /*!< IRC48M stabilization interrupt flag */
+#define RCU_ADDINT_IRC48MSTBIE          BIT(14)                   /*!< internal 48 MHz RC oscillator stabilization interrupt enable */
+#define RCU_ADDINT_IRC48MSTBIC          BIT(22)                   /*!< internal 48 MHz RC oscillator stabilization interrupt clear */
+
+/* RCU_ADDAPB1RST */
+#define RCU_ADDAPB1RST_CTCRST           BIT(27)                   /*!< CTC reset */
+#define RCU_ADDAPB1RST_IREFRST          BIT(31)                   /*!< IREF reset */
+
+/* RCU_ADDAPB1EN */
+#define RCU_ADDAPB1EN_CTCEN             BIT(27)                   /*!< CTC clock enable */
+#define RCU_ADDAPB1EN_IREFEN            BIT(31)                   /*!< IREF interface clock enable */
+
+/* RCU_ADDAPB1SPEN */
+#define RCU_ADDAPB1SPEN_CTCSPEN         BIT(27)                   /*!< CTC clock enable during sleep mode */
+#define RCU_ADDAPB1SPEN_IREFSPEN        BIT(31)                   /*!< IREF interface clock enable during sleep mode */
+
+/* RCU_VKEY */
+#define RCU_VKEY_KEY                    BITS(0,31)                /*!< RCU_DSV key register */
+
+/* RCU_DSV */
+#define RCU_DSV_DSLPVS                  BITS(0,2)                 /*!< deep-sleep mode voltage select */
+
+/* constants definitions */
+/* define the peripheral clock enable bit position and its register index offset */
+#define RCU_REGIDX_BIT(regidx, bitpos)      (((uint32_t)(regidx) << 6) | (uint32_t)(bitpos))
+#define RCU_REG_VAL(periph)                 (REG32(RCU + ((uint32_t)(periph) >> 6)))
+#define RCU_BIT_POS(val)                    ((uint32_t)(val) & 0x1FU)
+/* define the voltage key unlock value */
+#define RCU_VKEY_UNLOCK                 ((uint32_t)0x1A2B3C4DU)
+
+/* register offset */
+/* peripherals enable */
+#define AHB1EN_REG_OFFSET               0x30U                     /*!< AHB1 enable register offset */
+#define AHB2EN_REG_OFFSET               0x34U                     /*!< AHB2 enable register offset */
+#define AHB3EN_REG_OFFSET               0x38U                     /*!< AHB3 enable register offset */
+#define APB1EN_REG_OFFSET               0x40U                     /*!< APB1 enable register offset */
+#define APB2EN_REG_OFFSET               0x44U                     /*!< APB2 enable register offset */
+#define AHB1SPEN_REG_OFFSET             0x50U                     /*!< AHB1 sleep mode enable register offset */
+#define AHB2SPEN_REG_OFFSET             0x54U                     /*!< AHB2 sleep mode enable register offset */
+#define AHB3SPEN_REG_OFFSET             0x58U                     /*!< AHB3 sleep mode enable register offset */
+#define APB1SPEN_REG_OFFSET             0x60U                     /*!< APB1 sleep mode enable register offset */
+#define APB2SPEN_REG_OFFSET             0x64U                     /*!< APB2 sleep mode enable register offset */
+#define ADD_APB1EN_REG_OFFSET           0xE4U                     /*!< APB1 additional enable register offset */
+#define ADD_APB1SPEN_REG_OFFSET         0xE8U                     /*!< APB1 additional sleep mode enable register offset */
+
+/* peripherals reset */                                        
+#define AHB1RST_REG_OFFSET              0x10U                     /*!< AHB1 reset register offset */
+#define AHB2RST_REG_OFFSET              0x14U                     /*!< AHB2 reset register offset */
+#define AHB3RST_REG_OFFSET              0x18U                     /*!< AHB3 reset register offset */
+#define APB1RST_REG_OFFSET              0x20U                     /*!< APB1 reset register offset */
+#define APB2RST_REG_OFFSET              0x24U                     /*!< APB2 reset register offset */
+#define ADD_APB1RST_REG_OFFSET          0xE0U                     /*!< APB1 additional reset register offset */
+#define RSTSCK_REG_OFFSET               0x74U                     /*!< reset source/clock register offset */
+
+/* clock control */
+#define CTL_REG_OFFSET                  0x00U                     /*!< control register offset */
+#define BDCTL_REG_OFFSET                0x70U                     /*!< backup domain control register offset */
+#define ADDCTL_REG_OFFSET               0xC0U                     /*!< additional clock control register offset */
+
+/* clock stabilization and stuck interrupt */
+#define INT_REG_OFFSET                  0x0CU                     /*!< clock interrupt register offset */
+#define ADDINT_REG_OFFSET               0xCCU                     /*!< additional clock interrupt register offset */
+
+/* configuration register */
+#define PLL_REG_OFFSET                  0x04U                     /*!< PLL register offset */
+#define CFG0_REG_OFFSET                 0x08U                     /*!< clock configuration register 0 offset */
+#define PLLSSCTL_REG_OFFSET             0x80U                     /*!< PLL clock spread spectrum control register offset */
+#define PLLI2S_REG_OFFSET               0x84U                     /*!< PLLI2S register offset */
+#define PLLSAI_REG_OFFSET               0x88U                     /*!< PLLSAI register offset */
+#define CFG1_REG_OFFSET                 0x8CU                     /*!< clock configuration register 1 offset */
+
+/* peripheral clock enable */
+typedef enum
+{
+    /* AHB1 peripherals */
+    RCU_GPIOA     = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 0U),                  /*!< GPIOA clock */
+    RCU_GPIOB     = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 1U),                  /*!< GPIOB clock */
+    RCU_GPIOC     = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 2U),                  /*!< GPIOC clock */
+    RCU_GPIOD     = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 3U),                  /*!< GPIOD clock */
+    RCU_GPIOE     = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 4U),                  /*!< GPIOE clock */
+    RCU_GPIOF     = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 5U),                  /*!< GPIOF clock */
+    RCU_GPIOG     = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 6U),                  /*!< GPIOG clock */
+    RCU_GPIOH     = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 7U),                  /*!< GPIOH clock */
+    RCU_GPIOI     = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 8U),                  /*!< GPIOI clock */
+    RCU_CRC       = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 12U),                 /*!< CRC clock */
+    RCU_BKPSRAM   = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 18U),                 /*!< BKPSRAM clock */
+    RCU_TCMSRAM   = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 20U),                 /*!< TCMSRAM clock */
+    RCU_DMA0      = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 21U),                 /*!< DMA0 clock */
+    RCU_DMA1      = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 22U),                 /*!< DMA1 clock */
+    RCU_IPA       = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 23U),                 /*!< IPA clock */
+    RCU_ENET      = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 25U),                 /*!< ENET clock */
+    RCU_ENETTX    = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 26U),                 /*!< ENETTX clock */
+    RCU_ENETRX    = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 27U),                 /*!< ENETRX clock */
+    RCU_ENETPTP   = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 28U),                 /*!< ENETPTP clock */
+    RCU_USBHS     = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 29U),                 /*!< USBHS clock */
+    RCU_USBHSULPI = RCU_REGIDX_BIT(AHB1EN_REG_OFFSET, 30U),                 /*!< USBHSULPI clock */
+    /* AHB2 peripherals */
+    RCU_DCI       = RCU_REGIDX_BIT(AHB2EN_REG_OFFSET, 0U),                  /*!< DCI clock */
+    RCU_TRNG      = RCU_REGIDX_BIT(AHB2EN_REG_OFFSET, 6U),                  /*!< TRNG clock */
+    RCU_USBFS     = RCU_REGIDX_BIT(AHB2EN_REG_OFFSET, 7U),                  /*!< USBFS clock */
+    /* AHB3 peripherals */
+    RCU_EXMC      = RCU_REGIDX_BIT(AHB3EN_REG_OFFSET, 0U),                  /*!< EXMC clock */
+    /* APB1 peripherals */
+    RCU_TIMER1    = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 0U),                  /*!< TIMER1 clock */
+    RCU_TIMER2    = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 1U),                  /*!< TIMER2 clock */
+    RCU_TIMER3    = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 2U),                  /*!< TIMER3 clock */
+    RCU_TIMER4    = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 3U),                  /*!< TIMER4 clock */
+    RCU_TIMER5    = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 4U),                  /*!< TIMER5 clock */
+    RCU_TIMER6    = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 5U),                  /*!< TIMER6 clock */
+    RCU_TIMER11   = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 6U),                  /*!< TIMER11 clock */
+    RCU_TIMER12   = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 7U),                  /*!< TIMER12 clock */
+    RCU_TIMER13   = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 8U),                  /*!< TIMER13 clock */   
+    RCU_WWDGT     = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 11U),                 /*!< WWDGT clock */
+    RCU_SPI1      = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 14U),                 /*!< SPI1 clock */
+    RCU_SPI2      = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 15U),                 /*!< SPI2 clock */
+    RCU_USART1    = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 17U),                 /*!< USART1 clock */
+    RCU_USART2    = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 18U),                 /*!< USART2 clock */
+    RCU_UART3     = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 19U),                 /*!< UART3 clock */
+    RCU_UART4     = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 20U),                 /*!< UART4 clock */
+    RCU_I2C0      = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 21U),                 /*!< I2C0 clock */
+    RCU_I2C1      = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 22U),                 /*!< I2C1 clock */
+    RCU_I2C2      = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 23U),                 /*!< I2C2 clock */   
+    RCU_CAN0      = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 25U),                 /*!< CAN0 clock */
+    RCU_CAN1      = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 26U),                 /*!< CAN1 clock */
+    RCU_PMU       = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 28U),                 /*!< PMU clock */
+    RCU_DAC       = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 29U),                 /*!< DAC clock */
+    RCU_UART6     = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 30U),                 /*!< UART6 clock */
+    RCU_UART7     = RCU_REGIDX_BIT(APB1EN_REG_OFFSET, 31U),                 /*!< UART7 clock */
+    RCU_RTC       = RCU_REGIDX_BIT(BDCTL_REG_OFFSET, 15U),                  /*!< RTC clock */
+    /* APB2 peripherals */
+    RCU_TIMER0    = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 0U),                  /*!< TIMER0 clock */
+    RCU_TIMER7    = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 1U),                  /*!< TIMER7 clock */
+    RCU_USART0    = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 4U),                  /*!< USART0 clock */
+    RCU_USART5    = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 5U),                  /*!< USART5 clock */
+    RCU_ADC0      = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 8U),                  /*!< ADC0 clock */
+    RCU_ADC1      = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 9U),                  /*!< ADC1 clock */
+    RCU_ADC2      = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 10U),                 /*!< ADC2 clock */
+    RCU_SDIO      = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 11U),                 /*!< SDIO clock */
+    RCU_SPI0      = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 12U),                 /*!< SPI0 clock */
+    RCU_SPI3      = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 13U),                 /*!< SPI3 clock */
+    RCU_SYSCFG    = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 14U),                 /*!< SYSCFG clock */
+    RCU_TIMER8    = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 16U),                 /*!< TIMER8 clock */
+    RCU_TIMER9    = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 17U),                 /*!< TIMER9 clock */
+    RCU_TIMER10   = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 18U),                 /*!< TIMER10 clock */
+    RCU_SPI4      = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 20U),                 /*!< SPI4 clock */
+    RCU_SPI5      = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 21U),                 /*!< SPI5 clock */
+    RCU_TLI       = RCU_REGIDX_BIT(APB2EN_REG_OFFSET, 26U),                 /*!< TLI clock */
+    /* APB1 additional peripherals */
+    RCU_CTC       = RCU_REGIDX_BIT(ADD_APB1EN_REG_OFFSET, 27U),             /*!< CTC clock */
+    RCU_IREF      = RCU_REGIDX_BIT(ADD_APB1EN_REG_OFFSET, 31U),             /*!< IREF clock */
+}rcu_periph_enum;
+
+/* peripheral clock enable when sleep mode*/
+typedef enum
+{
+    /* AHB1 peripherals */
+    RCU_GPIOA_SLP     = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 0U),            /*!< GPIOA clock */
+    RCU_GPIOB_SLP     = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 1U),            /*!< GPIOB clock */
+    RCU_GPIOC_SLP     = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 2U),            /*!< GPIOC clock */
+    RCU_GPIOD_SLP     = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 3U),            /*!< GPIOD clock */
+    RCU_GPIOE_SLP     = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 4U),            /*!< GPIOE clock */
+    RCU_GPIOF_SLP     = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 5U),            /*!< GPIOF clock */
+    RCU_GPIOG_SLP     = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 6U),            /*!< GPIOG clock */
+    RCU_GPIOH_SLP     = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 7U),            /*!< GPIOH clock */
+    RCU_GPIOI_SLP     = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 8U),            /*!< GPIOI clock */
+    RCU_CRC_SLP       = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 12U),           /*!< CRC clock */
+    RCU_FMC_SLP       = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 15U),           /*!< FMC clock */
+    RCU_SRAM0_SLP     = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 16U),           /*!< SRAM0 clock */
+    RCU_SRAM1_SLP     = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 17U),           /*!< SRAM1 clock */
+    RCU_BKPSRAM_SLP   = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 18U),           /*!< BKPSRAM clock */
+    RCU_SRAM2_SLP     = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 19U),           /*!< SRAM2 clock */
+    RCU_DMA0_SLP      = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 21U),           /*!< DMA0 clock */
+    RCU_DMA1_SLP      = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 22U),           /*!< DMA1 clock */
+    RCU_IPA_SLP       = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 23U),           /*!< IPA clock */
+    RCU_ENET_SLP      = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 25U),           /*!< ENET clock */
+    RCU_ENETTX_SLP    = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 26U),           /*!< ENETTX clock */
+    RCU_ENETRX_SLP    = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 27U),           /*!< ENETRX clock */
+    RCU_ENETPTP_SLP   = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 28U),           /*!< ENETPTP clock */
+    RCU_USBHS_SLP     = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 29U),           /*!< USBHS clock */
+    RCU_USBHSULPI_SLP = RCU_REGIDX_BIT(AHB1SPEN_REG_OFFSET, 30U),           /*!< USBHSULPI clock */
+    /* AHB2 peripherals */
+    RCU_DCI_SLP       = RCU_REGIDX_BIT(AHB2SPEN_REG_OFFSET, 0U),            /*!< DCI clock */
+    RCU_TRNG_SLP      = RCU_REGIDX_BIT(AHB2SPEN_REG_OFFSET, 6U),            /*!< TRNG clock */
+    RCU_USBFS_SLP     = RCU_REGIDX_BIT(AHB2SPEN_REG_OFFSET, 7U),            /*!< USBFS clock */
+    /* AHB3 peripherals */
+    RCU_EXMC_SLP      = RCU_REGIDX_BIT(AHB3SPEN_REG_OFFSET, 0U),            /*!< EXMC clock */
+    /* APB1 peripherals */
+    RCU_TIMER1_SLP    = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 0U),            /*!< TIMER1 clock */
+    RCU_TIMER2_SLP    = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 1U),            /*!< TIMER2 clock */
+    RCU_TIMER3_SLP    = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 2U),            /*!< TIMER3 clock */
+    RCU_TIMER4_SLP    = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 3U),            /*!< TIMER4 clock */
+    RCU_TIMER5_SLP    = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 4U),            /*!< TIMER5 clock */
+    RCU_TIMER6_SLP    = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 5U),            /*!< TIMER6 clock */
+    RCU_TIMER11_SLP   = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 6U),            /*!< TIMER11 clock */
+    RCU_TIMER12_SLP   = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 7U),            /*!< TIMER12 clock */
+    RCU_TIMER13_SLP   = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 8U),            /*!< TIMER13 clock */   
+    RCU_WWDGT_SLP     = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 11U),           /*!< WWDGT clock */
+    RCU_SPI1_SLP      = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 14U),           /*!< SPI1 clock */
+    RCU_SPI2_SLP      = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 15U),           /*!< SPI2 clock */
+    RCU_USART1_SLP    = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 17U),           /*!< USART1 clock */
+    RCU_USART2_SLP    = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 18U),           /*!< USART2 clock */
+    RCU_UART3_SLP     = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 19U),           /*!< UART3 clock */
+    RCU_UART4_SLP     = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 20U),           /*!< UART4 clock */
+    RCU_I2C0_SLP      = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 21U),           /*!< I2C0 clock */
+    RCU_I2C1_SLP      = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 22U),           /*!< I2C1 clock */
+    RCU_I2C2_SLP      = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 23U),           /*!< I2C2 clock */   
+    RCU_CAN0_SLP      = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 25U),           /*!< CAN0 clock */
+    RCU_CAN1_SLP      = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 26U),           /*!< CAN1 clock */
+    RCU_PMU_SLP       = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 28U),           /*!< PMU clock */
+    RCU_DAC_SLP       = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 29U),           /*!< DAC clock */
+    RCU_UART6_SLP     = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 30U),           /*!< UART6 clock */
+    RCU_UART7_SLP     = RCU_REGIDX_BIT(APB1SPEN_REG_OFFSET, 31U),           /*!< UART7 clock */
+    /* APB2 peripherals */
+    RCU_TIMER0_SLP    = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 0U),            /*!< TIMER0 clock */
+    RCU_TIMER7_SLP    = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 1U),            /*!< TIMER7 clock */
+    RCU_USART0_SLP    = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 4U),            /*!< USART0 clock */
+    RCU_USART5_SLP    = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 5U),            /*!< USART5 clock */
+    RCU_ADC0_SLP      = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 8U),            /*!< ADC0 clock */
+    RCU_ADC1_SLP      = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 9U),            /*!< ADC1 clock */
+    RCU_ADC2_SLP      = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 10U),           /*!< ADC2 clock */
+    RCU_SDIO_SLP      = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 11U),           /*!< SDIO clock */
+    RCU_SPI0_SLP      = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 12U),           /*!< SPI0 clock */
+    RCU_SPI3_SLP      = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 13U),           /*!< SPI3 clock */
+    RCU_SYSCFG_SLP    = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 14U),           /*!< SYSCFG clock */
+    RCU_TIMER8_SLP    = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 16U),           /*!< TIMER8 clock */
+    RCU_TIMER9_SLP    = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 17U),           /*!< TIMER9 clock */
+    RCU_TIMER10_SLP   = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 18U),           /*!< TIMER10 clock */
+    RCU_SPI4_SLP      = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 20U),           /*!< SPI4 clock */
+    RCU_SPI5_SLP      = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 21U),           /*!< SPI5 clock */
+    RCU_TLI_SLP       = RCU_REGIDX_BIT(APB2SPEN_REG_OFFSET, 26U),           /*!< TLI clock */
+    /* APB1 additional peripherals */
+    RCU_CTC_SLP       = RCU_REGIDX_BIT(ADD_APB1SPEN_REG_OFFSET, 27U),       /*!< CTC clock */
+    RCU_IREF_SLP      = RCU_REGIDX_BIT(ADD_APB1SPEN_REG_OFFSET, 31U),       /*!< IREF clock */
+}rcu_periph_sleep_enum;
+
+/* peripherals reset */
+typedef enum
+{
+    /* AHB1 peripherals */
+    RCU_GPIOARST     = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 0U),              /*!< GPIOA clock reset */
+    RCU_GPIOBRST     = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 1U),              /*!< GPIOB clock reset */
+    RCU_GPIOCRST     = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 2U),              /*!< GPIOC clock reset */
+    RCU_GPIODRST     = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 3U),              /*!< GPIOD clock reset */
+    RCU_GPIOERST     = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 4U),              /*!< GPIOE clock reset */
+    RCU_GPIOFRST     = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 5U),              /*!< GPIOF clock reset */
+    RCU_GPIOGRST     = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 6U),              /*!< GPIOG clock reset */
+    RCU_GPIOHRST     = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 7U),              /*!< GPIOH clock reset */
+    RCU_GPIOIRST     = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 8U),              /*!< GPIOI clock reset */
+    RCU_CRCRST       = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 12U),             /*!< CRC clock reset */
+    RCU_DMA0RST      = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 21U),             /*!< DMA0 clock reset */
+    RCU_DMA1RST      = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 22U),             /*!< DMA1 clock reset */
+    RCU_IPARST       = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 23U),             /*!< IPA clock reset */
+    RCU_ENETRST      = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 25U),             /*!< ENET clock reset */   
+    RCU_USBHSRST     = RCU_REGIDX_BIT(AHB1RST_REG_OFFSET, 29U),             /*!< USBHS clock reset */
+    /* AHB2 peripherals */
+    RCU_DCIRST       = RCU_REGIDX_BIT(AHB2RST_REG_OFFSET, 0U),              /*!< DCI clock reset */
+    RCU_TRNGRST      = RCU_REGIDX_BIT(AHB2RST_REG_OFFSET, 6U),              /*!< TRNG clock reset */
+    RCU_USBFSRST     = RCU_REGIDX_BIT(AHB2RST_REG_OFFSET, 7U),              /*!< USBFS clock reset */
+    /* AHB3 peripherals */
+    RCU_EXMCRST      = RCU_REGIDX_BIT(AHB3RST_REG_OFFSET, 0U),              /*!< EXMC clock reset */
+    /* APB1 peripherals */
+    RCU_TIMER1RST    = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 0U),              /*!< TIMER1 clock reset */
+    RCU_TIMER2RST    = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 1U),              /*!< TIMER2 clock reset */
+    RCU_TIMER3RST    = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 2U),              /*!< TIMER3 clock reset */
+    RCU_TIMER4RST    = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 3U),              /*!< TIMER4 clock reset */
+    RCU_TIMER5RST    = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 4U),              /*!< TIMER5 clock reset */
+    RCU_TIMER6RST    = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 5U),              /*!< TIMER6 clock reset */
+    RCU_TIMER11RST   = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 6U),              /*!< TIMER11 clock reset */
+    RCU_TIMER12RST   = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 7U),              /*!< TIMER12 clock reset */
+    RCU_TIMER13RST   = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 8U),              /*!< TIMER13 clock reset */   
+    RCU_WWDGTRST     = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 11U),             /*!< WWDGT clock reset */
+    RCU_SPI1RST      = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 14U),             /*!< SPI1 clock reset */
+    RCU_SPI2RST      = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 15U),             /*!< SPI2 clock reset */
+    RCU_USART1RST    = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 17U),             /*!< USART1 clock reset */
+    RCU_USART2RST    = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 18U),             /*!< USART2 clock reset */
+    RCU_UART3RST     = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 19U),             /*!< UART3 clock reset */
+    RCU_UART4RST     = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 20U),             /*!< UART4 clock reset */
+    RCU_I2C0RST      = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 21U),             /*!< I2C0 clock reset */
+    RCU_I2C1RST      = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 22U),             /*!< I2C1 clock reset */
+    RCU_I2C2RST      = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 23U),             /*!< I2C2 clock reset */   
+    RCU_CAN0RST      = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 25U),             /*!< CAN0 clock reset */
+    RCU_CAN1RST      = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 26U),             /*!< CAN1 clock reset */
+    RCU_PMURST       = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 28U),             /*!< PMU clock reset */
+    RCU_DACRST       = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 29U),             /*!< DAC clock reset */
+    RCU_UART6RST     = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 30U),             /*!< UART6 clock reset */
+    RCU_UART7RST     = RCU_REGIDX_BIT(APB1RST_REG_OFFSET, 31U),             /*!< UART7 clock reset */
+    /* APB2 peripherals */
+    RCU_TIMER0RST    = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 0U),              /*!< TIMER0 clock reset */
+    RCU_TIMER7RST    = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 1U),              /*!< TIMER7 clock reset */
+    RCU_USART0RST    = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 4U),              /*!< USART0 clock reset */
+    RCU_USART5RST    = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 5U),              /*!< USART5 clock reset */
+    RCU_ADCRST       = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 8U),              /*!< ADCs all clock reset */
+    RCU_SDIORST      = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 11U),             /*!< SDIO clock reset */
+    RCU_SPI0RST      = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 12U),             /*!< SPI0 clock reset */
+    RCU_SPI3RST      = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 13U),             /*!< SPI3 clock reset */
+    RCU_SYSCFGRST    = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 14U),             /*!< SYSCFG clock reset */
+    RCU_TIMER8RST    = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 16U),             /*!< TIMER8 clock reset */
+    RCU_TIMER9RST    = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 17U),             /*!< TIMER9 clock reset */
+    RCU_TIMER10RST   = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 18U),             /*!< TIMER10 clock reset */
+    RCU_SPI4RST      = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 20U),             /*!< SPI4 clock reset */
+    RCU_SPI5RST      = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 21U),             /*!< SPI5 clock reset */
+    RCU_TLIRST       = RCU_REGIDX_BIT(APB2RST_REG_OFFSET, 26U),             /*!< TLI clock reset */
+    /* APB1 additional peripherals */
+    RCU_CTCRST       = RCU_REGIDX_BIT(ADD_APB1RST_REG_OFFSET, 27U),         /*!< CTC clock reset */
+    RCU_IREFRST      = RCU_REGIDX_BIT(ADD_APB1RST_REG_OFFSET, 31U)          /*!< IREF clock reset */
+}rcu_periph_reset_enum;
+
+/* clock stabilization and peripheral reset flags */
+typedef enum
+{
+    /* clock stabilization flags */
+    RCU_FLAG_IRC16MSTB     = RCU_REGIDX_BIT(CTL_REG_OFFSET, 1U),            /*!< IRC16M stabilization flags */
+    RCU_FLAG_HXTALSTB      = RCU_REGIDX_BIT(CTL_REG_OFFSET, 17U),           /*!< HXTAL stabilization flags */
+    RCU_FLAG_PLLSTB        = RCU_REGIDX_BIT(CTL_REG_OFFSET, 25U),           /*!< PLL stabilization flags */
+    RCU_FLAG_PLLI2SSTB     = RCU_REGIDX_BIT(CTL_REG_OFFSET, 27U),           /*!< PLLI2S stabilization flags */
+    RCU_FLAG_PLLSAISTB     = RCU_REGIDX_BIT(CTL_REG_OFFSET, 29U),           /*!< PLLSAI stabilization flags */
+    RCU_FLAG_LXTALSTB      = RCU_REGIDX_BIT(BDCTL_REG_OFFSET, 1U),          /*!< LXTAL stabilization flags */
+    RCU_FLAG_IRC32KSTB     = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 1U),         /*!< IRC32K stabilization flags */
+    RCU_FLAG_IRC48MSTB     = RCU_REGIDX_BIT(ADDCTL_REG_OFFSET, 17U),        /*!< IRC48M stabilization flags */
+    /* reset source flags */
+    RCU_FLAG_BORRST        = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 25U),        /*!< BOR reset flags */
+    RCU_FLAG_EPRST         = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 26U),        /*!< External PIN reset flags */
+    RCU_FLAG_PORRST        = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 27U),        /*!< power reset flags */
+    RCU_FLAG_SWRST         = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 28U),        /*!< Software reset flags */
+    RCU_FLAG_FWDGTRST      = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 29U),        /*!< FWDGT reset flags */
+    RCU_FLAG_WWDGTRST      = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 30U),        /*!< WWDGT reset flags */
+    RCU_FLAG_LPRST         = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 31U),        /*!< Low-power reset flags */
+}rcu_flag_enum;
+
+/* clock stabilization and ckm interrupt flags */
+typedef enum
+{
+    RCU_INT_FLAG_IRC32KSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 0U),            /*!< IRC32K stabilization interrupt flag */
+    RCU_INT_FLAG_LXTALSTB  = RCU_REGIDX_BIT(INT_REG_OFFSET, 1U),            /*!< LXTAL stabilization interrupt flag */
+    RCU_INT_FLAG_IRC16MSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 2U),            /*!< IRC16M stabilization interrupt flag */
+    RCU_INT_FLAG_HXTALSTB  = RCU_REGIDX_BIT(INT_REG_OFFSET, 3U),            /*!< HXTAL stabilization interrupt flag */
+    RCU_INT_FLAG_PLLSTB    = RCU_REGIDX_BIT(INT_REG_OFFSET, 4U),            /*!< PLL stabilization interrupt flag */
+    RCU_INT_FLAG_PLLI2SSTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 5U),            /*!< PLLI2S stabilization interrupt flag */
+    RCU_INT_FLAG_PLLSAISTB = RCU_REGIDX_BIT(INT_REG_OFFSET, 6U),            /*!< PLLSAI stabilization interrupt flag */
+    RCU_INT_FLAG_CKM       = RCU_REGIDX_BIT(INT_REG_OFFSET, 7U),            /*!< HXTAL clock stuck interrupt flag */
+    RCU_INT_FLAG_IRC48MSTB = RCU_REGIDX_BIT(ADDINT_REG_OFFSET, 6U),         /*!< IRC48M stabilization interrupt flag */
+}rcu_int_flag_enum;
+
+/* clock stabilization and stuck interrupt flags clear */
+typedef enum
+{
+    RCU_INT_FLAG_IRC32KSTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 16U),       /*!< IRC32K stabilization interrupt flags clear */
+    RCU_INT_FLAG_LXTALSTB_CLR  = RCU_REGIDX_BIT(INT_REG_OFFSET, 17U),       /*!< LXTAL stabilization interrupt flags clear */
+    RCU_INT_FLAG_IRC16MSTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 18U),       /*!< IRC16M stabilization interrupt flags clear */
+    RCU_INT_FLAG_HXTALSTB_CLR  = RCU_REGIDX_BIT(INT_REG_OFFSET, 19U),       /*!< HXTAL stabilization interrupt flags clear */
+    RCU_INT_FLAG_PLLSTB_CLR    = RCU_REGIDX_BIT(INT_REG_OFFSET, 20U),       /*!< PLL stabilization interrupt flags clear */
+    RCU_INT_FLAG_PLLI2SSTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 21U),       /*!< PLLI2S stabilization interrupt flags clear */
+    RCU_INT_FLAG_PLLSAISTB_CLR = RCU_REGIDX_BIT(INT_REG_OFFSET, 22U),       /*!< PLLSAI stabilization interrupt flags clear */
+    RCU_INT_FLAG_CKM_CLR       = RCU_REGIDX_BIT(INT_REG_OFFSET, 23U),       /*!< CKM interrupt flags clear */
+    RCU_INT_FLAG_IRC48MSTB_CLR = RCU_REGIDX_BIT(ADDINT_REG_OFFSET, 22U),    /*!< internal 48 MHz RC oscillator stabilization interrupt clear */
+}rcu_int_flag_clear_enum;
+
+/* clock stabilization interrupt enable or disable */
+typedef enum
+{
+    RCU_INT_IRC32KSTB       = RCU_REGIDX_BIT(INT_REG_OFFSET, 8U),           /*!< IRC32K stabilization interrupt */
+    RCU_INT_LXTALSTB        = RCU_REGIDX_BIT(INT_REG_OFFSET, 9U),           /*!< LXTAL stabilization interrupt */
+    RCU_INT_IRC16MSTB       = RCU_REGIDX_BIT(INT_REG_OFFSET, 10U),          /*!< IRC16M stabilization interrupt */
+    RCU_INT_HXTALSTB        = RCU_REGIDX_BIT(INT_REG_OFFSET, 11U),          /*!< HXTAL stabilization interrupt */
+    RCU_INT_PLLSTB          = RCU_REGIDX_BIT(INT_REG_OFFSET, 12U),          /*!< PLL stabilization interrupt */
+    RCU_INT_PLLI2SSTB       = RCU_REGIDX_BIT(INT_REG_OFFSET, 13U),          /*!< PLLI2S stabilization interrupt */
+    RCU_INT_PLLSAISTB       = RCU_REGIDX_BIT(INT_REG_OFFSET, 14U),          /*!< PLLSAI stabilization interrupt */
+    RCU_INT_IRC48MSTB       = RCU_REGIDX_BIT(ADDINT_REG_OFFSET, 14U),       /*!< internal 48 MHz RC oscillator stabilization interrupt */
+}rcu_int_enum;
+
+/* oscillator types */
+typedef enum
+{
+    RCU_HXTAL      = RCU_REGIDX_BIT(CTL_REG_OFFSET, 16U),                   /*!< HXTAL */
+    RCU_LXTAL      = RCU_REGIDX_BIT(BDCTL_REG_OFFSET, 0U),                  /*!< LXTAL */
+    RCU_IRC16M     = RCU_REGIDX_BIT(CTL_REG_OFFSET, 0U),                    /*!< IRC16M */
+    RCU_IRC48M     = RCU_REGIDX_BIT(ADDCTL_REG_OFFSET, 16U),                /*!< IRC48M */
+    RCU_IRC32K     = RCU_REGIDX_BIT(RSTSCK_REG_OFFSET, 0U),                 /*!< IRC32K */
+    RCU_PLL_CK     = RCU_REGIDX_BIT(CTL_REG_OFFSET, 24U),                   /*!< PLL */
+    RCU_PLLI2S_CK  = RCU_REGIDX_BIT(CTL_REG_OFFSET, 26U),                   /*!< PLLI2S */
+    RCU_PLLSAI_CK  = RCU_REGIDX_BIT(CTL_REG_OFFSET, 28U),                   /*!< PLLSAI */
+}rcu_osci_type_enum;
+
+/* rcu clock frequency */
+typedef enum
+{
+    CK_SYS      = 0,                                                        /*!< system clock */
+    CK_AHB,                                                                 /*!< AHB clock */
+    CK_APB1,                                                                /*!< APB1 clock */
+    CK_APB2,                                                                /*!< APB2 clock */
+}rcu_clock_freq_enum;
+
+/* RCU_CFG0 register bit define */
+/* system clock source select */
+#define CFG0_SCS(regval)                (BITS(0,1) & ((uint32_t)(regval) << 0))
+#define RCU_CKSYSSRC_IRC16M             CFG0_SCS(0)                        /*!< system clock source select IRC16M */
+#define RCU_CKSYSSRC_HXTAL              CFG0_SCS(1)                        /*!< system clock source select HXTAL */
+#define RCU_CKSYSSRC_PLLP               CFG0_SCS(2)                        /*!< system clock source select PLLP */
+
+/* system clock source select status */
+#define CFG0_SCSS(regval)               (BITS(2,3) & ((uint32_t)(regval) << 2))
+#define RCU_SCSS_IRC16M                 CFG0_SCSS(0)                       /*!< system clock source select IRC16M */
+#define RCU_SCSS_HXTAL                  CFG0_SCSS(1)                       /*!< system clock source select HXTAL */
+#define RCU_SCSS_PLLP                   CFG0_SCSS(2)                       /*!< system clock source select PLLP */
+
+/* AHB prescaler selection */
+#define CFG0_AHBPSC(regval)             (BITS(4,7) & ((uint32_t)(regval) << 4))
+#define RCU_AHB_CKSYS_DIV1              CFG0_AHBPSC(0)                     /*!< AHB prescaler select CK_SYS */
+#define RCU_AHB_CKSYS_DIV2              CFG0_AHBPSC(8)                     /*!< AHB prescaler select CK_SYS/2 */
+#define RCU_AHB_CKSYS_DIV4              CFG0_AHBPSC(9)                     /*!< AHB prescaler select CK_SYS/4 */
+#define RCU_AHB_CKSYS_DIV8              CFG0_AHBPSC(10)                    /*!< AHB prescaler select CK_SYS/8 */
+#define RCU_AHB_CKSYS_DIV16             CFG0_AHBPSC(11)                    /*!< AHB prescaler select CK_SYS/16 */
+#define RCU_AHB_CKSYS_DIV64             CFG0_AHBPSC(12)                    /*!< AHB prescaler select CK_SYS/64 */
+#define RCU_AHB_CKSYS_DIV128            CFG0_AHBPSC(13)                    /*!< AHB prescaler select CK_SYS/128 */
+#define RCU_AHB_CKSYS_DIV256            CFG0_AHBPSC(14)                    /*!< AHB prescaler select CK_SYS/256 */
+#define RCU_AHB_CKSYS_DIV512            CFG0_AHBPSC(15)                    /*!< AHB prescaler select CK_SYS/512 */
+
+/* APB1 prescaler selection */
+#define CFG0_APB1PSC(regval)            (BITS(10,12) & ((uint32_t)(regval) << 10))
+#define RCU_APB1_CKAHB_DIV1             CFG0_APB1PSC(0)                    /*!< APB1 prescaler select CK_AHB */
+#define RCU_APB1_CKAHB_DIV2             CFG0_APB1PSC(4)                    /*!< APB1 prescaler select CK_AHB/2 */
+#define RCU_APB1_CKAHB_DIV4             CFG0_APB1PSC(5)                    /*!< APB1 prescaler select CK_AHB/4 */
+#define RCU_APB1_CKAHB_DIV8             CFG0_APB1PSC(6)                    /*!< APB1 prescaler select CK_AHB/8 */
+#define RCU_APB1_CKAHB_DIV16            CFG0_APB1PSC(7)                    /*!< APB1 prescaler select CK_AHB/16 */
+
+/* APB2 prescaler selection */
+#define CFG0_APB2PSC(regval)            (BITS(13,15) & ((uint32_t)(regval) << 13))
+#define RCU_APB2_CKAHB_DIV1             CFG0_APB2PSC(0)                    /*!< APB2 prescaler select CK_AHB */
+#define RCU_APB2_CKAHB_DIV2             CFG0_APB2PSC(4)                    /*!< APB2 prescaler select CK_AHB/2 */
+#define RCU_APB2_CKAHB_DIV4             CFG0_APB2PSC(5)                    /*!< APB2 prescaler select CK_AHB/4 */
+#define RCU_APB2_CKAHB_DIV8             CFG0_APB2PSC(6)                    /*!< APB2 prescaler select CK_AHB/8 */
+#define RCU_APB2_CKAHB_DIV16            CFG0_APB2PSC(7)                    /*!< APB2 prescaler select CK_AHB/16 */
+
+/* RTC clock divider factor from HXTAL clock */
+#define CFG0_RTCDIV(regval)             (BITS(16,20) & ((uint32_t)(regval) << 16))
+#define RCU_RTC_HXTAL_NONE              CFG0_RTCDIV(0)                     /*!< no clock for RTC */
+#define RCU_RTC_HXTAL_DIV2              CFG0_RTCDIV(2)                     /*!< RTCDIV clock select CK_HXTAL/2 */
+#define RCU_RTC_HXTAL_DIV3              CFG0_RTCDIV(3)                     /*!< RTCDIV clock select CK_HXTAL/3 */
+#define RCU_RTC_HXTAL_DIV4              CFG0_RTCDIV(4)                     /*!< RTCDIV clock select CK_HXTAL/4 */
+#define RCU_RTC_HXTAL_DIV5              CFG0_RTCDIV(5)                     /*!< RTCDIV clock select CK_HXTAL/5 */
+#define RCU_RTC_HXTAL_DIV6              CFG0_RTCDIV(6)                     /*!< RTCDIV clock select CK_HXTAL/6 */
+#define RCU_RTC_HXTAL_DIV7              CFG0_RTCDIV(7)                     /*!< RTCDIV clock select CK_HXTAL/7 */
+#define RCU_RTC_HXTAL_DIV8              CFG0_RTCDIV(8)                     /*!< RTCDIV clock select CK_HXTAL/8 */
+#define RCU_RTC_HXTAL_DIV9              CFG0_RTCDIV(9)                     /*!< RTCDIV clock select CK_HXTAL/9 */
+#define RCU_RTC_HXTAL_DIV10             CFG0_RTCDIV(10)                    /*!< RTCDIV clock select CK_HXTAL/10 */
+#define RCU_RTC_HXTAL_DIV11             CFG0_RTCDIV(11)                    /*!< RTCDIV clock select CK_HXTAL/11 */
+#define RCU_RTC_HXTAL_DIV12             CFG0_RTCDIV(12)                    /*!< RTCDIV clock select CK_HXTAL/12 */
+#define RCU_RTC_HXTAL_DIV13             CFG0_RTCDIV(13)                    /*!< RTCDIV clock select CK_HXTAL/13 */
+#define RCU_RTC_HXTAL_DIV14             CFG0_RTCDIV(14)                    /*!< RTCDIV clock select CK_HXTAL/14 */
+#define RCU_RTC_HXTAL_DIV15             CFG0_RTCDIV(15)                    /*!< RTCDIV clock select CK_HXTAL/15 */
+#define RCU_RTC_HXTAL_DIV16             CFG0_RTCDIV(16)                    /*!< RTCDIV clock select CK_HXTAL/16 */
+#define RCU_RTC_HXTAL_DIV17             CFG0_RTCDIV(17)                    /*!< RTCDIV clock select CK_HXTAL/17 */
+#define RCU_RTC_HXTAL_DIV18             CFG0_RTCDIV(18)                    /*!< RTCDIV clock select CK_HXTAL/18 */
+#define RCU_RTC_HXTAL_DIV19             CFG0_RTCDIV(19)                    /*!< RTCDIV clock select CK_HXTAL/19 */
+#define RCU_RTC_HXTAL_DIV20             CFG0_RTCDIV(20)                    /*!< RTCDIV clock select CK_HXTAL/20 */
+#define RCU_RTC_HXTAL_DIV21             CFG0_RTCDIV(21)                    /*!< RTCDIV clock select CK_HXTAL/21 */
+#define RCU_RTC_HXTAL_DIV22             CFG0_RTCDIV(22)                    /*!< RTCDIV clock select CK_HXTAL/22 */
+#define RCU_RTC_HXTAL_DIV23             CFG0_RTCDIV(23)                    /*!< RTCDIV clock select CK_HXTAL/23 */
+#define RCU_RTC_HXTAL_DIV24             CFG0_RTCDIV(24)                    /*!< RTCDIV clock select CK_HXTAL/24 */
+#define RCU_RTC_HXTAL_DIV25             CFG0_RTCDIV(25)                    /*!< RTCDIV clock select CK_HXTAL/25 */
+#define RCU_RTC_HXTAL_DIV26             CFG0_RTCDIV(26)                    /*!< RTCDIV clock select CK_HXTAL/26 */
+#define RCU_RTC_HXTAL_DIV27             CFG0_RTCDIV(27)                    /*!< RTCDIV clock select CK_HXTAL/27 */
+#define RCU_RTC_HXTAL_DIV28             CFG0_RTCDIV(28)                    /*!< RTCDIV clock select CK_HXTAL/28 */
+#define RCU_RTC_HXTAL_DIV29             CFG0_RTCDIV(29)                    /*!< RTCDIV clock select CK_HXTAL/29 */
+#define RCU_RTC_HXTAL_DIV30             CFG0_RTCDIV(30)                    /*!< RTCDIV clock select CK_HXTAL/30 */
+#define RCU_RTC_HXTAL_DIV31             CFG0_RTCDIV(31)                    /*!< RTCDIV clock select CK_HXTAL/31 */
+
+/* CKOUT0 Clock source selection */
+#define CFG0_CKOUT0SEL(regval)          (BITS(21,22) & ((uint32_t)(regval) << 21))
+#define RCU_CKOUT0SRC_IRC16M            CFG0_CKOUT0SEL(0)                  /*!< internal 16M RC oscillator clock selected */
+#define RCU_CKOUT0SRC_LXTAL             CFG0_CKOUT0SEL(1)                  /*!< low speed crystal oscillator clock (LXTAL) selected */
+#define RCU_CKOUT0SRC_HXTAL             CFG0_CKOUT0SEL(2)                  /*!< high speed crystal oscillator clock (HXTAL) selected */
+#define RCU_CKOUT0SRC_PLLP              CFG0_CKOUT0SEL(3)                  /*!< CK_PLLP clock selected */
+
+/* I2S Clock source selection */
+#define RCU_I2SSRC_PLLI2S               ((uint32_t)0x00000000U)             /*!< PLLI2S output clock selected as I2S source clock */
+#define RCU_I2SSRC_I2S_CKIN             RCU_CFG0_I2SSEL                    /*!< external I2S_CKIN pin selected as I2S source clock */
+
+/* The CK_OUT0 divider */
+#define CFG0_CKOUT0DIV(regval)          (BITS(24,26) & ((uint32_t)(regval) << 24))
+#define RCU_CKOUT0_DIV1                 CFG0_CKOUT0DIV(0)                  /*!< CK_OUT0 is divided by 1 */
+#define RCU_CKOUT0_DIV2                 CFG0_CKOUT0DIV(4)                  /*!< CK_OUT0 is divided by 2 */
+#define RCU_CKOUT0_DIV3                 CFG0_CKOUT0DIV(5)                  /*!< CK_OUT0 is divided by 3 */
+#define RCU_CKOUT0_DIV4                 CFG0_CKOUT0DIV(6)                  /*!< CK_OUT0 is divided by 4 */
+#define RCU_CKOUT0_DIV5                 CFG0_CKOUT0DIV(7)                  /*!< CK_OUT0 is divided by 5 */
+
+/* The CK_OUT1 divider */
+#define CFG0_CKOUT1DIV(regval)          (BITS(27,29) & ((uint32_t)(regval) << 27))
+#define RCU_CKOUT1_DIV1                 CFG0_CKOUT1DIV(0)                  /*!< CK_OUT1 is divided by 1 */
+#define RCU_CKOUT1_DIV2                 CFG0_CKOUT1DIV(4)                  /*!< CK_OUT1 is divided by 2 */
+#define RCU_CKOUT1_DIV3                 CFG0_CKOUT1DIV(5)                  /*!< CK_OUT1 is divided by 3 */
+#define RCU_CKOUT1_DIV4                 CFG0_CKOUT1DIV(6)                  /*!< CK_OUT1 is divided by 4 */
+#define RCU_CKOUT1_DIV5                 CFG0_CKOUT1DIV(7)                  /*!< CK_OUT1 is divided by 5 */
+
+/* CKOUT1 Clock source selection */
+#define CFG0_CKOUT1SEL(regval)          (BITS(30,31) & ((uint32_t)(regval) << 30))
+#define RCU_CKOUT1SRC_SYSTEMCLOCK       CFG0_CKOUT1SEL(0)                  /*!< system clock selected */
+#define RCU_CKOUT1SRC_PLLI2SR           CFG0_CKOUT1SEL(1)                  /*!< CK_PLLI2SR clock selected */
+#define RCU_CKOUT1SRC_HXTAL             CFG0_CKOUT1SEL(2)                  /*!< high speed crystal oscillator clock (HXTAL) selected */
+#define RCU_CKOUT1SRC_PLLP              CFG0_CKOUT1SEL(3)                  /*!< CK_PLLP clock selected */
+
+/* RCU_CFG1 register bit define */
+/* the divider factor from PLLI2SQ clock */
+#define CFG1_PLLI2SQDIV(regval)         (BITS(0,4) & ((uint32_t)(regval) << 0))
+#define RCU_PLLI2SQ_DIV1                CFG1_PLLI2SQDIV(0)                 /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/1 */
+#define RCU_PLLI2SQ_DIV2                CFG1_PLLI2SQDIV(1)                 /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/2 */
+#define RCU_PLLI2SQ_DIV3                CFG1_PLLI2SQDIV(2)                 /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/3 */
+#define RCU_PLLI2SQ_DIV4                CFG1_PLLI2SQDIV(3)                 /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/4 */
+#define RCU_PLLI2SQ_DIV5                CFG1_PLLI2SQDIV(4)                 /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/5 */
+#define RCU_PLLI2SQ_DIV6                CFG1_PLLI2SQDIV(5)                 /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/6 */
+#define RCU_PLLI2SQ_DIV7                CFG1_PLLI2SQDIV(6)                 /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/7 */
+#define RCU_PLLI2SQ_DIV8                CFG1_PLLI2SQDIV(7)                 /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/8 */
+#define RCU_PLLI2SQ_DIV9                CFG1_PLLI2SQDIV(8)                 /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/9 */
+#define RCU_PLLI2SQ_DIV10               CFG1_PLLI2SQDIV(9)                 /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/10 */
+#define RCU_PLLI2SQ_DIV11               CFG1_PLLI2SQDIV(10)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/11 */
+#define RCU_PLLI2SQ_DIV12               CFG1_PLLI2SQDIV(11)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/12 */
+#define RCU_PLLI2SQ_DIV13               CFG1_PLLI2SQDIV(12)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/13 */
+#define RCU_PLLI2SQ_DIV14               CFG1_PLLI2SQDIV(13)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/14 */
+#define RCU_PLLI2SQ_DIV15               CFG1_PLLI2SQDIV(14)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/15 */
+#define RCU_PLLI2SQ_DIV16               CFG1_PLLI2SQDIV(15)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/16 */
+#define RCU_PLLI2SQ_DIV17               CFG1_PLLI2SQDIV(16)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/17 */
+#define RCU_PLLI2SQ_DIV18               CFG1_PLLI2SQDIV(17)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/18 */
+#define RCU_PLLI2SQ_DIV19               CFG1_PLLI2SQDIV(18)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/19 */
+#define RCU_PLLI2SQ_DIV20               CFG1_PLLI2SQDIV(19)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/20 */
+#define RCU_PLLI2SQ_DIV21               CFG1_PLLI2SQDIV(20)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/21 */
+#define RCU_PLLI2SQ_DIV22               CFG1_PLLI2SQDIV(21)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/22 */
+#define RCU_PLLI2SQ_DIV23               CFG1_PLLI2SQDIV(22)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/23 */
+#define RCU_PLLI2SQ_DIV24               CFG1_PLLI2SQDIV(23)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/24 */
+#define RCU_PLLI2SQ_DIV25               CFG1_PLLI2SQDIV(24)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/25 */
+#define RCU_PLLI2SQ_DIV26               CFG1_PLLI2SQDIV(25)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/26 */
+#define RCU_PLLI2SQ_DIV27               CFG1_PLLI2SQDIV(26)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/27 */
+#define RCU_PLLI2SQ_DIV28               CFG1_PLLI2SQDIV(27)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/28 */
+#define RCU_PLLI2SQ_DIV29               CFG1_PLLI2SQDIV(28)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/29 */
+#define RCU_PLLI2SQ_DIV30               CFG1_PLLI2SQDIV(29)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/30 */
+#define RCU_PLLI2SQ_DIV31               CFG1_PLLI2SQDIV(30)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/31 */
+#define RCU_PLLI2SQ_DIV32               CFG1_PLLI2SQDIV(31)                /*!< CK_PLLI2SQDIV clock select CK_PLLI2SQ/32 */
+
+/* the divider factor from PLLSAIR clock */
+#define CFG1_PLLSAIRDIV(regval)         (BITS(16,17) & ((uint32_t)(regval) << 16))
+#define RCU_PLLSAIR_DIV2                CFG1_PLLSAIRDIV(0)                 /*!< CK_PLLSAIRDIV clock select CK_PLLSAIR/2 */
+#define RCU_PLLSAIR_DIV4                CFG1_PLLSAIRDIV(1)                 /*!< CK_PLLSAIRDIV clock select CK_PLLSAIR/4 */
+#define RCU_PLLSAIR_DIV8                CFG1_PLLSAIRDIV(2)                 /*!< CK_PLLSAIRDIV clock select CK_PLLSAIR/8 */
+#define RCU_PLLSAIR_DIV16               CFG1_PLLSAIRDIV(3)                 /*!< CK_PLLSAIRDIV clock select CK_PLLSAIR/16 */
+
+/* TIMER clock selection */
+#define RCU_TIMER_PSC_MUL2              ~RCU_CFG1_TIMERSEL                 /*!< if APB1PSC/APB2PSC in RCU_CFG0 register is 0b0xx(CK_APBx = CK_AHB) 
+                                                                                or 0b100(CK_APBx = CK_AHB/2), the TIMER clock is equal to CK_AHB(CK_TIMERx = CK_AHB).
+                                                                                or else, the TIMER clock is twice the corresponding APB clock (TIMER in APB1 domain: CK_TIMERx = 2 x CK_APB1; 
+                                                                                TIMER in APB2 domain: CK_TIMERx = 2 x CK_APB2) */
+#define RCU_TIMER_PSC_MUL4              RCU_CFG1_TIMERSEL                  /*!< if APB1PSC/APB2PSC in RCU_CFG0 register is 0b0xx(CK_APBx = CK_AHB), 
+                                                                                0b100(CK_APBx = CK_AHB/2), or 0b101(CK_APBx = CK_AHB/4), the TIMER clock is equal to CK_AHB(CK_TIMERx = CK_AHB). 
+                                                                                or else, the TIMER clock is four timers the corresponding APB clock (TIMER in APB1 domain: CK_TIMERx = 4 x CK_APB1;  
+                                                                                TIMER in APB2 domain: CK_TIMERx = 4 x CK_APB2) */
+
+/* RCU_PLLSSCTL register bit define */
+/* PLL spread spectrum modulation type select */
+#define RCU_SS_TYPE_CENTER              ((uint32_t)0x00000000U)            /*!< center type is selected */
+#define RCU_SS_TYPE_DOWN                RCU_PLLSSCTL_SS_TYPE               /*!< down type is selected */
+
+/* RCU_PLL register bit define */
+/* The PLL VCO source clock prescaler */
+#define RCU_PLLPSC_DIV_MIN              ((uint32_t)2U)                     /*!< PLLPSC_DIV min value */
+#define RCU_PLLPSC_DIV_MAX              ((uint32_t)63U)                    /*!< PLLPSC_DIV max value */
+
+/* The PLL VCO clock multi factor */
+#define RCU_PLLN_MUL_MIN                ((uint32_t)64U)                    /*!< PLLN_MUL min value */
+#define RCU_PLLN_MUL_MAX                ((uint32_t)500U)                   /*!< PLLN_MUL max value */
+#define RCU_SS_MODULATION_CENTER_INC    ((uint32_t)5U)                     /*!< minimum factor of PLLN in center mode */
+#define RCU_SS_MODULATION_DOWN_INC      ((uint32_t)7U)                     /*!< minimum factor of PLLN in down mode */
+
+/* The PLLP output frequency division factor from PLL VCO clock */
+#define RCU_PLLP_DIV_MIN                ((uint32_t)2U)                     /*!< PLLP_DIV min value */
+#define RCU_PLLP_DIV_MAX                ((uint32_t)8U)                     /*!< PLLP_DIV max value */
+                                         
+/* PLL Clock Source Selection  */
+#define RCU_PLLSRC_IRC16M               ((uint32_t)0x00000000U)            /*!< IRC16M clock selected as source clock of PLL, PLLSAI, PLLI2S */
+#define RCU_PLLSRC_HXTAL                RCU_PLL_PLLSEL                     /*!< HXTAL clock selected as source clock of PLL, PLLSAI, PLLI2S */
+
+/* The PLL Q output frequency division factor from PLL VCO clock */
+#define RCU_PLLQ_DIV_MIN                ((uint32_t)2U)                     /*!< PLLQ_DIV min value */
+#define RCU_PLLQ_DIV_MAX                ((uint32_t)15U)                    /*!< PLLQ_DIV max value */
+
+#define CHECK_PLL_PSC_VALID(val)        (((val) >= RCU_PLLPSC_DIV_MIN)&&((val) <= RCU_PLLPSC_DIV_MAX))            
+#define CHECK_PLL_N_VALID(val, inc)     (((val) >= (RCU_PLLN_MUL_MIN + (inc)))&&((val) <= RCU_PLLN_MUL_MAX))      
+#define CHECK_PLL_P_VALID(val)          (((val) == 2U) || ((val) == 4U) || ((val) == 6U) || ((val) == 8U))         
+#define CHECK_PLL_Q_VALID(val)          (((val) >= RCU_PLLQ_DIV_MIN)&&((val) <= RCU_PLLQ_DIV_MAX))                 
+
+/* RCU_BDCTL register bit define */
+/* LXTAL drive capability */
+#define RCU_LXTALDRI_LOWER_DRIVE        ((uint32_t)0x00000000)             /*!< LXTAL drive capability is selected lower */
+#define RCU_LXTALDRI_HIGHER_DRIVE       RCU_BDCTL_LXTALDRI                 /*!< LXTAL drive capability is selected higher */
+
+/* RTC clock entry selection */
+#define BDCTL_RTCSRC(regval)            (BITS(8,9) & ((uint32_t)(regval) << 8))
+#define RCU_RTCSRC_NONE                 BDCTL_RTCSRC(0)                    /*!< no clock selected */
+#define RCU_RTCSRC_LXTAL                BDCTL_RTCSRC(1)                    /*!< RTC source clock select LXTAL  */
+#define RCU_RTCSRC_IRC32K               BDCTL_RTCSRC(2)                    /*!< RTC source clock select IRC32K */
+#define RCU_RTCSRC_HXTAL_DIV_RTCDIV     BDCTL_RTCSRC(3)                    /*!< RTC source clock select HXTAL/RTCDIV */
+
+/* RCU_PLLI2S register bit define */
+/* The PLLI2S VCO clock multi factor */
+#define RCU_PLLI2SN_MUL_MIN             50U
+#define RCU_PLLI2SN_MUL_MAX             500U
+
+/* The PLLI2S Q output frequency division factor from PLLI2S VCO clock */
+#define RCU_PLLI2SQ_DIV_MIN             2U
+#define RCU_PLLI2SQ_DIV_MAX             15U
+
+/* The PLLI2S R output frequency division factor from PLLI2S VCO clock */
+#define RCU_PLLI2SR_DIV_MIN             2U
+#define RCU_PLLI2SR_DIV_MAX             7U
+
+/* RCU_PLLSAI register bit define */
+/* The PLLSAI VCO clock multi factor */
+#define RCU_PLLSAIN_MUL_MIN             50U
+#define RCU_PLLSAIN_MUL_MAX             500U
+
+/* The PLLSAI P output frequency division factor from PLLSAI VCO clock */
+#define RCU_PLLSAIP_DIV_MIN             2U
+#define RCU_PLLSAIP_DIV_MAX             8U
+
+/* The PLLSAI Q output frequency division factor from PLLSAI VCO clock */
+#define RCU_PLLSAIQ_DIV_MIN             2U
+#define RCU_PLLSAIQ_DIV_MAX             15U
+
+/* The PLLSAI R output frequency division factor from PLLSAI VCO clock */
+#define RCU_PLLSAIR_DIV_MIN             2U
+#define RCU_PLLSAIR_DIV_MAX             7U
+
+#define CHECK_PLLI2S_PSC_VALID(val)     (((val) >= RCU_PLLI2SPSC_DIV_MIN)&&((val) <= RCU_PLLI2SPSC_DIV_MAX))
+#define CHECK_PLLI2S_N_VALID(val)       (((val) >= RCU_PLLI2SN_MUL_MIN)&&((val) <= RCU_PLLI2SN_MUL_MAX))
+#define CHECK_PLLI2S_Q_VALID(val)       (((val) >= RCU_PLLI2SQ_DIV_MIN)&&((val) <= RCU_PLLI2SQ_DIV_MAX))
+#define CHECK_PLLI2S_R_VALID(val)       (((val) >= RCU_PLLI2SR_DIV_MIN)&&((val) <= RCU_PLLI2SR_DIV_MAX))
+
+#define CHECK_PLLSAI_N_VALID(val)       (((val) >= (RCU_PLLSAIN_MUL_MIN))&&((val) <= RCU_PLLSAIN_MUL_MAX))
+#define CHECK_PLLSAI_P_VALID(val)       (((val) == 2U) || ((val) == 4U) || ((val) == 6U) || ((val) == 8U))
+#define CHECK_PLLSAI_Q_VALID(val)       (((val) >= RCU_PLLSAIQ_DIV_MIN)&&((val) <= RCU_PLLSAIQ_DIV_MAX))
+#define CHECK_PLLSAI_R_VALID(val)       (((val) >= RCU_PLLSAIR_DIV_MIN)&&((val) <= RCU_PLLSAIR_DIV_MAX))
+
+/* RCU_ADDCTL register bit define */
+/* 48MHz clock selection */ 
+#define RCU_CK48MSRC_PLL48M             ((uint32_t)0x00000000U)            /*!< CK48M source clock select PLL48M */
+#define RCU_CK48MSRC_IRC48M             RCU_ADDCTL_CK48MSEL                /*!< CK48M source clock select IRC48M */
+
+/* PLL48M clock selection */
+#define RCU_PLL48MSRC_PLLQ              ((uint32_t)0x00000000U)            /*!< PLL48M source clock select PLLQ */
+#define RCU_PLL48MSRC_PLLSAIP           RCU_ADDCTL_PLL48MSEL               /*!< PLL48M source clock select PLLSAIP */
+
+/* Deep-sleep mode voltage */
+#define DSV_DSLPVS(regval)              (BITS(0,2) & ((uint32_t)(regval) << 0))
+#define RCU_DEEPSLEEP_V_0               DSV_DSLPVS(0)                      /*!< core voltage is default value in deep-sleep mode */
+#define RCU_DEEPSLEEP_V_1               DSV_DSLPVS(1)                      /*!< core voltage is (default value-0.1)V in deep-sleep mode(customers are not recommended to use it)*/
+#define RCU_DEEPSLEEP_V_2               DSV_DSLPVS(2)                      /*!< core voltage is (default value-0.2)V in deep-sleep mode(customers are not recommended to use it)*/
+#define RCU_DEEPSLEEP_V_3               DSV_DSLPVS(3)                      /*!< core voltage is (default value-0.3)V in deep-sleep mode(customers are not recommended to use it)*/
+
+
+/* function declarations */
+/* peripherals clock configure functions */
+/* deinitialize the RCU */
+void rcu_deinit(void);
+/* enable the peripherals clock */
+void rcu_periph_clock_enable(rcu_periph_enum periph);
+/* disable the peripherals clock */
+void rcu_periph_clock_disable(rcu_periph_enum periph);
+/* enable the peripherals clock when sleep mode */
+void rcu_periph_clock_sleep_enable(rcu_periph_sleep_enum periph);
+/* disable the peripherals clock when sleep mode */
+void rcu_periph_clock_sleep_disable(rcu_periph_sleep_enum periph);
+/* reset the peripherals */
+void rcu_periph_reset_enable(rcu_periph_reset_enum periph_reset);
+/* disable reset the peripheral */
+void rcu_periph_reset_disable(rcu_periph_reset_enum periph_reset);
+/* reset the BKP */
+void rcu_bkp_reset_enable(void);
+/* disable the BKP reset */
+void rcu_bkp_reset_disable(void);
+
+/* system and peripherals clock source, system reset configure functions */
+/* configure the system clock source */
+void rcu_system_clock_source_config(uint32_t ck_sys);
+/* get the system clock source */
+uint32_t rcu_system_clock_source_get(void);
+/* configure the AHB prescaler selection */
+void rcu_ahb_clock_config(uint32_t ck_ahb);
+/* configure the APB1 prescaler selection */
+void rcu_apb1_clock_config(uint32_t ck_apb1);
+/* configure the APB2 prescaler selection */
+void rcu_apb2_clock_config(uint32_t ck_apb2);
+/* configure the CK_OUT0 clock source and divider */
+void rcu_ckout0_config(uint32_t ckout0_src, uint32_t ckout0_div);
+/* configure the CK_OUT1 clock source and divider */
+void rcu_ckout1_config(uint32_t ckout1_src, uint32_t ckout1_div);
+/* configure the PLL clock source selection and PLL multiply factor */
+ErrStatus rcu_pll_config(uint32_t pll_src, uint32_t pll_psc, uint32_t pll_n, uint32_t pll_p, uint32_t pll_q);
+/* configure the PLLI2S clock */
+ErrStatus rcu_plli2s_config(uint32_t plli2s_n, uint32_t plli2s_r);
+/* configure the PLLSAI clock */
+ErrStatus rcu_pllsai_config(uint32_t pllsai_n, uint32_t pllsai_p, uint32_t pllsai_r);
+/* configure the RTC clock source selection */
+void rcu_rtc_clock_config(uint32_t rtc_clock_source);
+/* cconfigure the frequency division of RTC clock when HXTAL was selected as its clock source */
+void rcu_rtc_div_config(uint32_t rtc_div);
+/* configure the I2S clock source selection */
+void rcu_i2s_clock_config(uint32_t i2s_clock_source);
+/* configure the CK48M clock selection */
+void rcu_ck48m_clock_config(uint32_t ck48m_clock_source);
+/* configure the PLL48M clock selection */
+void rcu_pll48m_clock_config(uint32_t pll48m_clock_source);
+/* configure the TIMER clock prescaler selection */
+void rcu_timer_clock_prescaler_config(uint32_t timer_clock_prescaler);       
+/* configure the TLI clock division selection */
+void rcu_tli_clock_div_config(uint32_t pllsai_r_div);
+
+/* LXTAL, IRC8M, PLL and other oscillator configure functions */
+/* configure the LXTAL drive capability */
+void rcu_lxtal_drive_capability_config(uint32_t lxtal_dricap);
+/* wait for oscillator stabilization flags is SET or oscillator startup is timeout */
+ErrStatus rcu_osci_stab_wait(rcu_osci_type_enum osci);
+/* turn on the oscillator */
+void rcu_osci_on(rcu_osci_type_enum osci);
+/* turn off the oscillator */
+void rcu_osci_off(rcu_osci_type_enum osci);
+/* enable the oscillator bypass mode, HXTALEN or LXTALEN must be reset before it */
+void rcu_osci_bypass_mode_enable(rcu_osci_type_enum osci);
+/* disable the oscillator bypass mode, HXTALEN or LXTALEN must be reset before it */
+void rcu_osci_bypass_mode_disable(rcu_osci_type_enum osci);
+/* set the IRC16M adjust value */
+void rcu_irc16m_adjust_value_set(uint32_t irc16m_adjval);
+/* configure the spread spectrum modulation for the main PLL clock */
+void rcu_spread_spectrum_config(uint32_t spread_spectrum_type, uint32_t modstep, uint32_t modcnt);
+/* enable the spread spectrum modulation for the main PLL clock */
+void rcu_spread_spectrum_enable(void);
+/* disable the spread spectrum modulation for the main PLL clock */
+void rcu_spread_spectrum_disable(void);
+
+/* clock monitor configure functions */
+/* enable the HXTAL clock monitor */
+void rcu_hxtal_clock_monitor_enable(void);
+/* disable the HXTAL clock monitor */
+void rcu_hxtal_clock_monitor_disable(void);
+
+/* voltage configure and clock frequency get functions */
+/* unlock the voltage key */
+void rcu_voltage_key_unlock(void);
+/* set the deep sleep mode voltage */
+void rcu_deepsleep_voltage_set(uint32_t dsvol);
+/* get the system clock, bus and peripheral clock frequency */
+uint32_t rcu_clock_freq_get(rcu_clock_freq_enum clock);
+
+/* flag & interrupt functions */
+/* get the clock stabilization and periphral reset flags */
+FlagStatus rcu_flag_get(rcu_flag_enum flag);
+/* clear the reset flag */
+void rcu_all_reset_flag_clear(void);
+/* get the clock stabilization interrupt and ckm flags */
+FlagStatus rcu_interrupt_flag_get(rcu_int_flag_enum int_flag);
+/* clear the interrupt flags */
+void rcu_interrupt_flag_clear(rcu_int_flag_clear_enum int_flag);
+/* enable the stabilization interrupt */
+void rcu_interrupt_enable(rcu_int_enum interrupt);
+/* disable the stabilization interrupt */
+void rcu_interrupt_disable(rcu_int_enum interrupt);
+
+#endif /* GD32F4XX_RCU_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_rtc.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_rtc.h
@@ -1,0 +1,641 @@
+/*!
+    \file    gd32f4xx_rtc.c
+    \brief   definitions for the RTC
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+
+#ifndef GD32F4XX_RTC_H
+#define GD32F4XX_RTC_H
+
+#include "gd32f4xx.h"
+
+/* RTC definitions */
+#define RTC                                RTC_BASE
+
+/* registers definitions */
+#define RTC_TIME                           REG32((RTC) + 0x00U)                 /*!< RTC time of day register */
+#define RTC_DATE                           REG32((RTC) + 0x04U)                 /*!< RTC date register */
+#define RTC_CTL                            REG32((RTC) + 0x08U)                 /*!< RTC control register */
+#define RTC_STAT                           REG32((RTC) + 0x0CU)                 /*!< RTC status register */
+#define RTC_PSC                            REG32((RTC) + 0x10U)                 /*!< RTC time prescaler register */
+#define RTC_WUT                            REG32((RTC) + 0x14U)                 /*!< RTC wakeup timer regiser */
+#define RTC_COSC                           REG32((RTC) + 0x18U)                 /*!< RTC coarse calibration register */
+#define RTC_ALRM0TD                        REG32((RTC) + 0x1CU)                 /*!< RTC alarm 0 time and date register */
+#define RTC_ALRM1TD                        REG32((RTC) + 0x20U)                 /*!< RTC alarm 1 time and date register */
+#define RTC_WPK                            REG32((RTC) + 0x24U)                 /*!< RTC write protection key register */
+#define RTC_SS                             REG32((RTC) + 0x28U)                 /*!< RTC sub second register */
+#define RTC_SHIFTCTL                       REG32((RTC) + 0x2CU)                 /*!< RTC shift function control register */
+#define RTC_TTS                            REG32((RTC) + 0x30U)                 /*!< RTC time of timestamp register */
+#define RTC_DTS                            REG32((RTC) + 0x34U)                 /*!< RTC date of timestamp register */
+#define RTC_SSTS                           REG32((RTC) + 0x38U)                 /*!< RTC sub second of timestamp register */
+#define RTC_HRFC                           REG32((RTC) + 0x3CU)                 /*!< RTC high resolution frequency compensation registor */
+#define RTC_TAMP                           REG32((RTC) + 0x40U)                 /*!< RTC tamper register */
+#define RTC_ALRM0SS                        REG32((RTC) + 0x44U)                 /*!< RTC alarm 0 sub second register */
+#define RTC_ALRM1SS                        REG32((RTC) + 0x48U)                 /*!< RTC alarm 1 sub second register */
+#define RTC_BKP0                           REG32((RTC) + 0x50U)                 /*!< RTC backup register */
+#define RTC_BKP1                           REG32((RTC) + 0x54U)                 /*!< RTC backup register */
+#define RTC_BKP2                           REG32((RTC) + 0x58U)                 /*!< RTC backup register */
+#define RTC_BKP3                           REG32((RTC) + 0x5CU)                 /*!< RTC backup register */
+#define RTC_BKP4                           REG32((RTC) + 0x60U)                 /*!< RTC backup register */
+#define RTC_BKP5                           REG32((RTC) + 0x64U)                 /*!< RTC backup register */
+#define RTC_BKP6                           REG32((RTC) + 0x68U)                 /*!< RTC backup register */
+#define RTC_BKP7                           REG32((RTC) + 0x6CU)                 /*!< RTC backup register */
+#define RTC_BKP8                           REG32((RTC) + 0x70U)                 /*!< RTC backup register */
+#define RTC_BKP9                           REG32((RTC) + 0x74U)                 /*!< RTC backup register */
+#define RTC_BKP10                          REG32((RTC) + 0x78U)                 /*!< RTC backup register */
+#define RTC_BKP11                          REG32((RTC) + 0x7CU)                 /*!< RTC backup register */
+#define RTC_BKP12                          REG32((RTC) + 0x80U)                 /*!< RTC backup register */
+#define RTC_BKP13                          REG32((RTC) + 0x84U)                 /*!< RTC backup register */
+#define RTC_BKP14                          REG32((RTC) + 0x88U)                 /*!< RTC backup register */
+#define RTC_BKP15                          REG32((RTC) + 0x8CU)                 /*!< RTC backup register */
+#define RTC_BKP16                          REG32((RTC) + 0x90U)                 /*!< RTC backup register */
+#define RTC_BKP17                          REG32((RTC) + 0x94U)                 /*!< RTC backup register */
+#define RTC_BKP18                          REG32((RTC) + 0x98U)                 /*!< RTC backup register */
+#define RTC_BKP19                          REG32((RTC) + 0x9CU)                 /*!< RTC backup register */
+
+/* bits definitions */
+/* RTC_TIME */
+#define RTC_TIME_SCU                       BITS(0,3)                            /*!< second units in BCD code */
+#define RTC_TIME_SCT                       BITS(4,6)                            /*!< second tens in BCD code */
+#define RTC_TIME_MNU                       BITS(8,11)                           /*!< minute units in BCD code */
+#define RTC_TIME_MNT                       BITS(12,14)                          /*!< minute tens in BCD code */
+#define RTC_TIME_HRU                       BITS(16,19)                          /*!< hour units in BCD code */
+#define RTC_TIME_HRT                       BITS(20,21)                          /*!< hour tens in BCD code */
+#define RTC_TIME_PM                        BIT(22)                              /*!< AM/PM notation */
+
+/* RTC_DATE */
+#define RTC_DATE_DAYU                      BITS(0,3)                            /*!< date units in BCD code */
+#define RTC_DATE_DAYT                      BITS(4,5)                            /*!< date tens in BCD code */
+#define RTC_DATE_MONU                      BITS(8,11)                           /*!< month units in BCD code */
+#define RTC_DATE_MONT                      BIT(12)                              /*!< month tens in BCD code */
+#define RTC_DATE_DOW                       BITS(13,15)                          /*!< day of week units */
+#define RTC_DATE_YRU                       BITS(16,19)                          /*!< year units in BCD code */
+#define RTC_DATE_YRT                       BITS(20,23)                          /*!< year tens in BCD code */
+
+/* RTC_CTL */
+#define RTC_CTL_WTCS                       BITS(0,2)                            /*!< auto wakeup timer clock selection */
+#define RTC_CTL_TSEG                       BIT(3)                               /*!< valid event edge of time-stamp */
+#define RTC_CTL_REFEN                      BIT(4)                               /*!< reference clock detection function enable */
+#define RTC_CTL_BPSHAD                     BIT(5)                               /*!< shadow registers bypass control */
+#define RTC_CTL_CS                         BIT(6)                               /*!< display format of clock system */
+#define RTC_CTL_CCEN                       BIT(7)                               /*!< coarse calibration function enable */
+#define RTC_CTL_ALRM0EN                    BIT(8)                               /*!< alarm0 function enable */
+#define RTC_CTL_ALRM1EN                    BIT(9)                               /*!< alarm1 function enable */
+#define RTC_CTL_WTEN                       BIT(10)                              /*!< auto wakeup timer function enable */
+#define RTC_CTL_TSEN                       BIT(11)                              /*!< time-stamp function enable */
+#define RTC_CTL_ALRM0IE                    BIT(12)                              /*!< RTC alarm0 interrupt enable */
+#define RTC_CTL_ALRM1IE                    BIT(13)                              /*!< RTC alarm1 interrupt enable */
+#define RTC_CTL_WTIE                       BIT(14)                              /*!< auto wakeup timer interrupt enable */
+#define RTC_CTL_TSIE                       BIT(15)                              /*!< time-stamp interrupt enable */
+#define RTC_CTL_A1H                        BIT(16)                              /*!< add 1 hour(summer time change) */
+#define RTC_CTL_S1H                        BIT(17)                              /*!< subtract 1 hour(winter time change) */
+#define RTC_CTL_DSM                        BIT(18)                              /*!< daylight saving mark */
+#define RTC_CTL_COS                        BIT(19)                              /*!< calibration output selection */
+#define RTC_CTL_OPOL                       BIT(20)                              /*!< output polarity */
+#define RTC_CTL_OS                         BITS(21,22)                          /*!< output selection */
+#define RTC_CTL_COEN                       BIT(23)                              /*!< calibration output enable */
+
+/* RTC_STAT */
+#define RTC_STAT_ALRM0WF                   BIT(0)                               /*!< alarm0 configuration can be write flag */
+#define RTC_STAT_ALRM1WF                   BIT(1)                               /*!< alarm1 configuration can be write flag */
+#define RTC_STAT_WTWF                      BIT(2)                               /*!< wakeup timer can be write flag */
+#define RTC_STAT_SOPF                      BIT(3)                               /*!< shift function operation pending flag */
+#define RTC_STAT_YCM                       BIT(4)                               /*!< year configuration mark status flag */
+#define RTC_STAT_RSYNF                     BIT(5)                               /*!< register synchronization flag */
+#define RTC_STAT_INITF                     BIT(6)                               /*!< initialization state flag */
+#define RTC_STAT_INITM                     BIT(7)                               /*!< enter initialization mode */
+#define RTC_STAT_ALRM0F                    BIT(8)                               /*!< alarm0 occurs flag */
+#define RTC_STAT_ALRM1F                    BIT(9)                               /*!< alarm1 occurs flag */
+#define RTC_STAT_WTF                       BIT(10)                              /*!< wakeup timer occurs flag */
+#define RTC_STAT_TSF                       BIT(11)                              /*!< time-stamp flag */
+#define RTC_STAT_TSOVRF                    BIT(12)                              /*!< time-stamp overflow flag */
+#define RTC_STAT_TP0F                      BIT(13)                              /*!< RTC tamper 0 detected flag */
+#define RTC_STAT_TP1F                      BIT(14)                              /*!< RTC tamper 1 detected flag */
+#define RTC_STAT_SCPF                      BIT(16)                              /*!< smooth calibration pending flag */
+
+/* RTC_PSC */
+#define RTC_PSC_FACTOR_S                   BITS(0,14)                           /*!< synchronous prescaler factor */
+#define RTC_PSC_FACTOR_A                   BITS(16,22)                          /*!< asynchronous prescaler factor */
+
+/* RTC_WUT */
+#define RTC_WUT_WTRV                       BITS(0,15)                           /*!< auto wakeup timer reloads value */
+
+/* RTC_COSC */
+#define RTC_COSC_COSS                      BITS(0,4)                            /*!< coarse calibration step */
+#define RTC_COSC_COSD                      BIT(7)                               /*!< coarse calibration direction */
+
+/* RTC_ALRMxTD */
+#define RTC_ALRMXTD_SCU                    BITS(0,3)                            /*!< second units in BCD code */
+#define RTC_ALRMXTD_SCT                    BITS(4,6)                            /*!< second tens in BCD code */
+#define RTC_ALRMXTD_MSKS                   BIT(7)                               /*!< alarm second mask bit */
+#define RTC_ALRMXTD_MNU                    BITS(8,11)                           /*!< minutes units in BCD code */
+#define RTC_ALRMXTD_MNT                    BITS(12,14)                          /*!< minutes tens in BCD code */
+#define RTC_ALRMXTD_MSKM                   BIT(15)                              /*!< alarm minutes mask bit */
+#define RTC_ALRMXTD_HRU                    BITS(16,19)                          /*!< hour units in BCD code */
+#define RTC_ALRMXTD_HRT                    BITS(20,21)                          /*!< hour units in BCD code */
+#define RTC_ALRMXTD_PM                     BIT(22)                              /*!< AM/PM flag */
+#define RTC_ALRMXTD_MSKH                   BIT(23)                              /*!< alarm hour mask bit */
+#define RTC_ALRMXTD_DAYU                   BITS(24,27)                          /*!< date units or week day in BCD code */
+#define RTC_ALRMXTD_DAYT                   BITS(28,29)                          /*!< date tens in BCD code */
+#define RTC_ALRMXTD_DOWS                   BIT(30)                              /*!< day of week  selection */
+#define RTC_ALRMXTD_MSKD                   BIT(31)                              /*!< alarm date mask bit */
+
+/* RTC_WPK */
+#define RTC_WPK_WPK                        BITS(0,7)                            /*!< key for write protection */
+
+/* RTC_SS */
+#define RTC_SS_SSC                         BITS(0,15)                           /*!< sub second value */
+
+/* RTC_SHIFTCTL */
+#define RTC_SHIFTCTL_SFS                   BITS(0,14)                           /*!< subtract a fraction of a second */
+#define RTC_SHIFTCTL_A1S                   BIT(31)                              /*!< one second add */
+
+/* RTC_TTS */
+#define RTC_TTS_SCU                        BITS(0,3)                            /*!< second units in BCD code */
+#define RTC_TTS_SCT                        BITS(4,6)                            /*!< second units in BCD code */
+#define RTC_TTS_MNU                        BITS(8,11)                           /*!< minute units in BCD code */
+#define RTC_TTS_MNT                        BITS(12,14)                          /*!< minute tens in BCD code */
+#define RTC_TTS_HRU                        BITS(16,19)                          /*!< hour units in BCD code */
+#define RTC_TTS_HRT                        BITS(20,21)                          /*!< hour tens in BCD code */
+#define RTC_TTS_PM                         BIT(22)                              /*!< AM/PM notation */
+
+/* RTC_DTS */
+#define RTC_DTS_DAYU                       BITS(0,3)                            /*!< date units in BCD code */
+#define RTC_DTS_DAYT                       BITS(4,5)                            /*!< date tens in BCD code */
+#define RTC_DTS_MONU                       BITS(8,11)                           /*!< month units in BCD code */
+#define RTC_DTS_MONT                       BIT(12)                              /*!< month tens in BCD code */
+#define RTC_DTS_DOW                        BITS(13,15)                          /*!< day of week units */
+
+/* RTC_SSTS */
+#define RTC_SSTS_SSC                       BITS(0,15)                           /*!< timestamp sub second units */
+
+/* RTC_HRFC */
+#define RTC_HRFC_CMSK                      BITS(0,8)                            /*!< calibration mask number */
+#define RTC_HRFC_CWND16                    BIT(13)                              /*!< calibration window select 16 seconds */
+#define RTC_HRFC_CWND8                     BIT(14)                              /*!< calibration window select 16 seconds */
+#define RTC_HRFC_FREQI                     BIT(15)                              /*!< increase RTC frequency by 488.5ppm */
+
+/* RTC_TAMP */
+#define RTC_TAMP_TP0EN                     BIT(0)                               /*!< tamper 0 detection enable */
+#define RTC_TAMP_TP0EG                     BIT(1)                               /*!< tamper 0 event trigger edge for RTC tamp 0 input */
+#define RTC_TAMP_TPIE                      BIT(2)                               /*!< tamper detection interrupt enable */
+#define RTC_TAMP_TP1EN                     BIT(3)                               /*!< tamper 1 detection enable */
+#define RTC_TAMP_TP1EG                     BIT(4)                               /*!< Tamper 1 event trigger edge for RTC tamp 1 input */
+#define RTC_TAMP_TPTS                      BIT(7)                               /*!< make tamper function used for timestamp function */
+#define RTC_TAMP_FREQ                      BITS(8,10)                           /*!< sample frequency of tamper event detection */
+#define RTC_TAMP_FLT                       BITS(11,12)                          /*!< RTC tamp x filter count setting */
+#define RTC_TAMP_PRCH                      BITS(13,14)                          /*!< precharge duration time of RTC tamp x */
+#define RTC_TAMP_DISPU                     BIT(15)                              /*!< RTC tamp x pull up disable bit */
+#define RTC_TAMP_TP0SEL                    BIT(16)                              /*!< Tamper 0 function input mapping selection */
+#define RTC_TAMP_TSSEL                     BIT(17)                              /*!< Timestamp input mapping selection */
+#define RTC_TAMP_AOT                       BIT(18)                              /*!< RTC_ALARM output Type */
+
+/* RTC_ALRM0SS */
+#define RTC_ALRM0SS_SSC                    BITS(0,14)                           /*!< alarm0 sub second value */
+#define RTC_ALRM0SS_MASKSSC                BITS(24,27)                          /*!< mask control bit of SS */
+
+/* RTC_ALRM1SS */
+#define RTC_ALRM1SS_SSC                    BITS(0,14)                           /*!< alarm1 sub second value */
+#define RTC_ALRM1SS_MASKSSC                BITS(24,27)                          /*!< mask control bit of SS */
+
+/* constants definitions */
+/* structure for initialization of the RTC */
+typedef struct
+{
+    uint8_t year;                                                               /*!< RTC year value: 0x0 - 0x99(BCD format) */
+    uint8_t month;                                                              /*!< RTC month value */
+    uint8_t date;                                                               /*!< RTC date value: 0x1 - 0x31(BCD format) */
+    uint8_t day_of_week;                                                        /*!< RTC weekday value */
+    uint8_t hour;                                                               /*!< RTC hour value */
+    uint8_t minute;                                                             /*!< RTC minute value: 0x0 - 0x59(BCD format) */
+    uint8_t second;                                                             /*!< RTC second value: 0x0 - 0x59(BCD format) */
+    uint16_t factor_asyn;                                                       /*!< RTC asynchronous prescaler value: 0x0 - 0x7F */
+    uint16_t factor_syn;                                                        /*!< RTC synchronous prescaler value: 0x0 - 0x7FFF */
+    uint32_t am_pm;                                                             /*!< RTC AM/PM value */
+    uint32_t display_format;                                                    /*!< RTC time notation */
+}rtc_parameter_struct;
+
+/* structure for RTC alarm configuration */
+typedef struct
+{
+    uint32_t alarm_mask;                                                        /*!< RTC alarm mask */
+    uint32_t weekday_or_date;                                                   /*!< specify RTC alarm is on date or weekday */
+    uint8_t alarm_day;                                                          /*!< RTC alarm date or weekday value*/
+    uint8_t alarm_hour;                                                         /*!< RTC alarm hour value */
+    uint8_t alarm_minute;                                                       /*!< RTC alarm minute value: 0x0 - 0x59(BCD format) */
+    uint8_t alarm_second;                                                       /*!< RTC alarm second value: 0x0 - 0x59(BCD format) */
+    uint32_t am_pm;                                                             /*!< RTC alarm AM/PM value */
+}rtc_alarm_struct;
+
+/* structure for RTC time-stamp configuration */
+typedef struct
+{
+    uint8_t timestamp_month;                                                    /*!< RTC time-stamp month value */
+    uint8_t timestamp_date;                                                     /*!< RTC time-stamp date value: 0x1 - 0x31(BCD format) */
+    uint8_t timestamp_day;                                                      /*!< RTC time-stamp weekday value */
+    uint8_t timestamp_hour;                                                     /*!< RTC time-stamp hour value */
+    uint8_t timestamp_minute;                                                   /*!< RTC time-stamp minute value: 0x0 - 0x59(BCD format) */
+    uint8_t timestamp_second;                                                   /*!< RTC time-stamp second value: 0x0 - 0x59(BCD format) */
+    uint32_t am_pm;                                                             /*!< RTC time-stamp AM/PM value */
+}rtc_timestamp_struct;
+
+/* structure for RTC tamper configuration */
+typedef struct
+{
+    uint32_t tamper_source;                                                     /*!< RTC tamper source */
+    uint32_t tamper_trigger;                                                    /*!< RTC tamper trigger */
+    uint32_t tamper_filter;                                                     /*!< RTC tamper consecutive samples needed during a voltage level detection */
+    uint32_t tamper_sample_frequency;                                           /*!< RTC tamper sampling frequency during a voltage level detection */
+    ControlStatus tamper_precharge_enable;                                      /*!< RTC tamper precharge feature during a voltage level detection */
+    uint32_t tamper_precharge_time;                                             /*!< RTC tamper precharge duration if precharge feature is enabled */
+    ControlStatus tamper_with_timestamp;                                        /*!< RTC tamper time-stamp feature */
+}rtc_tamper_struct; 
+
+/* time register value */
+#define TIME_SC(regval)                    (BITS(0,6) & ((uint32_t)(regval) << 0))    /*!< write value to RTC_TIME_SC bit field */
+#define GET_TIME_SC(regval)                GET_BITS((regval),0,6)                     /*!< get value of RTC_TIME_SC bit field */
+
+#define TIME_MN(regval)                    (BITS(8,14) & ((uint32_t)(regval) << 8))   /*!< write value to RTC_TIME_MN bit field */
+#define GET_TIME_MN(regval)                GET_BITS((regval),8,14)                    /*!< get value of RTC_TIME_MN bit field */
+
+#define TIME_HR(regval)                    (BITS(16,21) & ((uint32_t)(regval) << 16)) /*!< write value to RTC_TIME_HR bit field */
+#define GET_TIME_HR(regval)                GET_BITS((regval),16,21)                   /*!< get value of RTC_TIME_HR bit field */
+
+#define RTC_AM                             ((uint32_t)0x00000000U)                    /*!< AM format */
+#define RTC_PM                             RTC_TIME_PM                                /*!< PM format */
+
+/* date register value */
+#define DATE_DAY(regval)                   (BITS(0,5) & ((uint32_t)(regval) << 0))    /*!< write value to RTC_DATE_DAY bit field */
+#define GET_DATE_DAY(regval)               GET_BITS((regval),0,5)                     /*!< get value of RTC_DATE_DAY bit field */
+
+#define DATE_MON(regval)                   (BITS(8,12) & ((uint32_t)(regval) << 8))   /*!< write value to RTC_DATE_MON bit field */
+#define GET_DATE_MON(regval)               GET_BITS((regval),8,12)                    /*!< get value of RTC_DATE_MON bit field */
+#define RTC_JAN                            ((uint8_t)0x01U)                           /*!< janurary */
+#define RTC_FEB                            ((uint8_t)0x02U)                           /*!< february */
+#define RTC_MAR                            ((uint8_t)0x03U)                           /*!< march */
+#define RTC_APR                            ((uint8_t)0x04U)                           /*!< april */
+#define RTC_MAY                            ((uint8_t)0x05U)                           /*!< may */
+#define RTC_JUN                            ((uint8_t)0x06U)                           /*!< june */
+#define RTC_JUL                            ((uint8_t)0x07U)                           /*!< july */
+#define RTC_AUG                            ((uint8_t)0x08U)                           /*!< august */
+#define RTC_SEP                            ((uint8_t)0x09U)                           /*!< september */
+#define RTC_OCT                            ((uint8_t)0x10U)                           /*!< october */
+#define RTC_NOV                            ((uint8_t)0x11U)                           /*!< november */
+#define RTC_DEC                            ((uint8_t)0x12U)                           /*!< december */
+
+#define DATE_DOW(regval)                   (BITS(13,15) & ((uint32_t)(regval) << 13)) /*!< write value to RTC_DATE_DOW bit field */
+#define GET_DATE_DOW(regval)               GET_BITS((uint32_t)(regval),13,15)         /*!< get value of RTC_DATE_DOW bit field */
+#define RTC_MONDAY                         ((uint8_t)0x01)                            /*!< monday */
+#define RTC_TUESDAY                        ((uint8_t)0x02)                            /*!< tuesday */
+#define RTC_WEDSDAY                        ((uint8_t)0x03)                            /*!< wednesday */
+#define RTC_THURSDAY                       ((uint8_t)0x04)                            /*!< thursday */
+#define RTC_FRIDAY                         ((uint8_t)0x05)                            /*!< friday */
+#define RTC_SATURDAY                       ((uint8_t)0x06)                            /*!< saturday */
+#define RTC_SUNDAY                         ((uint8_t)0x07)                            /*!< sunday */
+
+#define DATE_YR(regval)                    (BITS(16,23) & ((uint32_t)(regval) << 16)) /*!< write value to RTC_DATE_YR bit field */
+#define GET_DATE_YR(regval)                GET_BITS((regval),16,23)                   /*!< get value of RTC_DATE_YR bit field */
+
+/* ctl register value */
+#define CTL_OS(regval)                     (BITS(21,22) & ((uint32_t)(regval) << 21)) /*!< write value to RTC_CTL_OS bit field */
+#define RTC_OS_DISABLE                     CTL_OS(0)                                  /*!< disable output RTC_ALARM */
+#define RTC_OS_ALARM0                      CTL_OS(1)                                  /*!< enable alarm0 flag output */
+#define RTC_OS_ALARM1                      CTL_OS(2)                                  /*!< enable alarm1 flag output */
+#define RTC_OS_WAKEUP                      CTL_OS(3)                                  /*!< enable wakeup flag output */
+
+#define RTC_CALIBRATION_512HZ              RTC_CTL_COEN                               /*!< calibration output of 512Hz is enable */
+#define RTC_CALIBRATION_1HZ                (RTC_CTL_COEN | RTC_CTL_COS)               /*!< calibration output of 1Hz is enable */
+#define RTC_ALARM0_HIGH                    RTC_OS_ALARM0                              /*!< enable alarm0 flag output with high level */
+#define RTC_ALARM0_LOW                     (RTC_OS_ALARM0 | RTC_CTL_OPOL)             /*!< enable alarm0 flag output with low level*/
+#define RTC_ALARM1_HIGH                    RTC_OS_ALARM1                              /*!< enable alarm1 flag output with high level */
+#define RTC_ALARM1_LOW                     (RTC_OS_ALARM1 | RTC_CTL_OPOL)             /*!< enable alarm1 flag output with low level*/
+#define RTC_WAKEUP_HIGH                    RTC_OS_WAKEUP                              /*!< enable wakeup flag output with high level */
+#define RTC_WAKEUP_LOW                     (RTC_OS_WAKEUP | RTC_CTL_OPOL)             /*!< enable wakeup flag output with low level*/
+
+#define RTC_24HOUR                         ((uint32_t)0x00000000U)                    /*!< 24-hour format */
+#define RTC_12HOUR                         RTC_CTL_CS                                 /*!< 12-hour format */
+
+#define RTC_TIMESTAMP_RISING_EDGE          ((uint32_t)0x00000000U)                    /*!< rising edge is valid event edge for time-stamp event */
+#define RTC_TIMESTAMP_FALLING_EDGE         RTC_CTL_TSEG                               /*!< falling edge is valid event edge for time-stamp event */
+
+/* psc register value */
+#define PSC_FACTOR_S(regval)               (BITS(0,14) & ((uint32_t)(regval) << 0))   /*!< write value to RTC_PSC_FACTOR_S bit field */
+#define GET_PSC_FACTOR_S(regval)           GET_BITS((regval),0,14)                    /*!< get value of RTC_PSC_FACTOR_S bit field */
+
+#define PSC_FACTOR_A(regval)               (BITS(16,22) & ((uint32_t)(regval) << 16)) /*!< write value to RTC_PSC_FACTOR_A bit field */
+#define GET_PSC_FACTOR_A(regval)           GET_BITS((regval),16,22)                   /*!< get value of RTC_PSC_FACTOR_A bit field */
+
+/* alrmtd register value */
+#define ALRMTD_SC(regval)                  (BITS(0,6) & ((uint32_t)(regval)<< 0))     /*!< write value to RTC_ALRMTD_SC bit field */
+#define GET_ALRMTD_SC(regval)              GET_BITS((regval),0,6)                     /*!< get value of RTC_ALRMTD_SC bit field */
+
+#define ALRMTD_MN(regval)                  (BITS(8,14) & ((uint32_t)(regval) << 8))   /*!< write value to RTC_ALRMTD_MN bit field */
+#define GET_ALRMTD_MN(regval)              GET_BITS((regval),8,14)                    /*!< get value of RTC_ALRMTD_MN bit field */
+
+#define ALRMTD_HR(regval)                  (BITS(16,21) & ((uint32_t)(regval) << 16)) /*!< write value to RTC_ALRMTD_HR bit field */
+#define GET_ALRMTD_HR(regval)              GET_BITS((regval),16,21)                   /*!< get value of RTC_ALRMTD_HR bit field */
+
+#define ALRMTD_DAY(regval)                 (BITS(24,29) & ((uint32_t)(regval) << 24)) /*!< write value to RTC_ALRMTD_DAY bit field */
+#define GET_ALRMTD_DAY(regval)             GET_BITS((regval),24,29)                   /*!< get value of RTC_ALRMTD_DAY bit field */
+
+#define RTC_ALARM_NONE_MASK                ((uint32_t)0x00000000U)                    /*!< alarm none mask */
+#define RTC_ALARM_DATE_MASK                RTC_ALRMXTD_MSKD                           /*!< alarm date mask */
+#define RTC_ALARM_HOUR_MASK                RTC_ALRMXTD_MSKH                           /*!< alarm hour mask */
+#define RTC_ALARM_MINUTE_MASK              RTC_ALRMXTD_MSKM                           /*!< alarm minute mask */
+#define RTC_ALARM_SECOND_MASK              RTC_ALRMXTD_MSKS                           /*!< alarm second mask */
+#define RTC_ALARM_ALL_MASK                 (RTC_ALRMXTD_MSKD|RTC_ALRMXTD_MSKH|RTC_ALRMXTD_MSKM|RTC_ALRMXTD_MSKS)   /*!< alarm all mask */
+
+#define RTC_ALARM_DATE_SELECTED            ((uint32_t)0x00000000U)                    /*!< alarm date format selected */
+#define RTC_ALARM_WEEKDAY_SELECTED         RTC_ALRMXTD_DOWS                           /*!< alarm weekday format selected */
+
+/* wpk register value */
+#define WPK_WPK(regval)                    (BITS(0,7) & ((uint32_t)(regval) << 0))    /*!< write value to RTC_WPK_WPK bit field */
+
+/* ss register value */
+#define SS_SSC(regval)                     (BITS(0,15) & ((uint32_t)(regval) << 0))   /*!< write value to RTC_SS_SSC bit field */
+
+/* shiftctl register value */
+#define SHIFTCTL_SFS(regval)               (BITS(0,14) & ((uint32_t)(regval) << 0))   /*!< write value to RTC_SHIFTCTL_SFS bit field */
+
+#define RTC_SHIFT_ADD1S_RESET              ((uint32_t)0x00000000U)                    /*!< not add 1 second */
+#define RTC_SHIFT_ADD1S_SET                RTC_SHIFTCTL_A1S                           /*!< add one second to the clock */
+
+/* tts register value */
+#define TTS_SC(regval)                     (BITS(0,6) & ((uint32_t)(regval) << 0))    /*!< write value to RTC_TTS_SC bit field */
+#define GET_TTS_SC(regval)                 GET_BITS((regval),0,6)                     /*!< get value of RTC_TTS_SC bit field */
+
+#define TTS_MN(regval)                     (BITS(8,14) & ((uint32_t)(regval) << 8))   /*!< write value to RTC_TTS_MN bit field */
+#define GET_TTS_MN(regval)                 GET_BITS((regval),8,14)                    /*!< get value of RTC_TTS_MN bit field */
+
+#define TTS_HR(regval)                     (BITS(16,21) & ((uint32_t)(regval) << 16)) /*!< write value to RTC_TTS_HR bit field */
+#define GET_TTS_HR(regval)                 GET_BITS((regval),16,21)                   /*!< get value of RTC_TTS_HR bit field */
+
+/* dts register value */
+#define DTS_DAY(regval)                    (BITS(0,5) & ((uint32_t)(regval) << 0))    /*!< write value to RTC_DTS_DAY bit field */
+#define GET_DTS_DAY(regval)                GET_BITS((regval),0,5)                     /*!< get value of RTC_DTS_DAY bit field */
+
+#define DTS_MON(regval)                    (BITS(8,12) & ((uint32_t)(regval) << 8))   /*!< write value to RTC_DTS_MON bit field */
+#define GET_DTS_MON(regval)                GET_BITS((regval),8,12)                    /*!< get value of RTC_DTS_MON bit field */
+
+#define DTS_DOW(regval)                    (BITS(13,15) & ((uint32_t)(regval) << 13)) /*!< write value to RTC_DTS_DOW bit field */
+#define GET_DTS_DOW(regval)                GET_BITS((regval),13,15)                   /*!< get value of RTC_DTS_DOW bit field */
+
+/* ssts register value */
+#define SSTS_SSC(regval)                   (BITS(0,15) & ((uint32_t)(regval) << 0))   /*!< write value to RTC_SSTS_SSC bit field */
+
+/* hrfc register value */
+#define HRFC_CMSK(regval)                  (BITS(0,8) & ((uint32_t)(regval) << 0))    /*!< write value to RTC_HRFC_CMSK bit field */
+
+#define RTC_CALIBRATION_WINDOW_32S         ((uint32_t)0x00000000U)                    /*!< 2exp20 RTCCLK cycles, 32s if RTCCLK = 32768 Hz */
+#define RTC_CALIBRATION_WINDOW_16S         RTC_HRFC_CWND16                            /*!< 2exp19 RTCCLK cycles, 16s if RTCCLK = 32768 Hz */
+#define RTC_CALIBRATION_WINDOW_8S          RTC_HRFC_CWND8                             /*!< 2exp18 RTCCLK cycles, 8s if RTCCLK = 32768 Hz */
+
+#define RTC_CALIBRATION_PLUS_SET           RTC_HRFC_FREQI                             /*!< increase RTC frequency by 488.5ppm */
+#define RTC_CALIBRATION_PLUS_RESET         ((uint32_t)0x00000000U)                    /*!< no effect */
+
+/* tamp register value */
+#define TAMP_FREQ(regval)                  (BITS(8,10) & ((uint32_t)(regval) << 8))  /*!< write value to RTC_TAMP_FREQ bit field */
+#define RTC_FREQ_DIV32768                  TAMP_FREQ(0)                               /*!< sample once every 32768 RTCCLK(1Hz if RTCCLK=32.768KHz) */
+#define RTC_FREQ_DIV16384                  TAMP_FREQ(1)                               /*!< sample once every 16384 RTCCLK(2Hz if RTCCLK=32.768KHz) */
+#define RTC_FREQ_DIV8192                   TAMP_FREQ(2)                               /*!< sample once every 8192 RTCCLK(4Hz if RTCCLK=32.768KHz) */
+#define RTC_FREQ_DIV4096                   TAMP_FREQ(3)                               /*!< sample once every 4096 RTCCLK(8Hz if RTCCLK=32.768KHz) */
+#define RTC_FREQ_DIV2048                   TAMP_FREQ(4)                               /*!< sample once every 2048 RTCCLK(16Hz if RTCCLK=32.768KHz) */
+#define RTC_FREQ_DIV1024                   TAMP_FREQ(5)                               /*!< sample once every 1024 RTCCLK(32Hz if RTCCLK=32.768KHz) */
+#define RTC_FREQ_DIV512                    TAMP_FREQ(6)                               /*!< sample once every 512 RTCCLK(64Hz if RTCCLK=32.768KHz) */
+#define RTC_FREQ_DIV256                    TAMP_FREQ(7)                               /*!< sample once every 256 RTCCLK(128Hz if RTCCLK=32.768KHz) */
+
+#define TAMP_FLT(regval)                   (BITS(11,12) & ((uint32_t)(regval) << 11)) /*!< write value to RTC_TAMP_FLT bit field */
+#define RTC_FLT_EDGE                       TAMP_FLT(0)                                /*!< detecting tamper event using edge mode. precharge duration is disabled automatically */
+#define RTC_FLT_2S                         TAMP_FLT(1)                                /*!< detecting tamper event using level mode.2 consecutive valid level samples will make a effective tamper event  */
+#define RTC_FLT_4S                         TAMP_FLT(2)                                /*!< detecting tamper event using level mode.4 consecutive valid level samples will make an effective tamper event */
+#define RTC_FLT_8S                         TAMP_FLT(3)                                /*!< detecting tamper event using level mode.8 consecutive valid level samples will make a effective tamper event  */
+
+#define TAMP_PRCH(regval)                  (BITS(13,14) & ((uint32_t)(regval) << 13)) /*!< write value to RTC_TAMP_PRCH bit field */
+#define RTC_PRCH_1C                        TAMP_PRCH(0)                               /*!< 1 RTC clock prechagre time before each sampling */
+#define RTC_PRCH_2C                        TAMP_PRCH(1)                               /*!< 2 RTC clock prechagre time before each sampling  */
+#define RTC_PRCH_4C                        TAMP_PRCH(2)                               /*!< 4 RTC clock prechagre time before each sampling */
+#define RTC_PRCH_8C                        TAMP_PRCH(3)                               /*!< 8 RTC clock prechagre time before each sampling */
+
+#define RTC_TAMPER0                        RTC_TAMP_TP0EN                             /*!< tamper 0 detection enable */
+#define RTC_TAMPER1                        RTC_TAMP_TP1EN                             /*!< tamper 1 detection enable */
+
+#define RTC_TAMPER_TRIGGER_EDGE_RISING     ((uint32_t)0x00000000U)                    /*!< tamper detection is in rising edge mode */
+#define RTC_TAMPER_TRIGGER_EDGE_FALLING    RTC_TAMP_TP0EG                             /*!< tamper detection is in falling edge mode */
+#define RTC_TAMPER_TRIGGER_LEVEL_LOW       ((uint32_t)0x00000000U)                    /*!< tamper detection is in low level mode */
+#define RTC_TAMPER_TRIGGER_LEVEL_HIGH      RTC_TAMP_TP0EG                             /*!< tamper detection is in high level mode */
+
+#define RTC_TAMPER_TRIGGER_POS             ((uint32_t)0x00000001U)                    /* shift position of trigger relative to source */
+
+#define RTC_ALARM_OUTPUT_OD                ((uint32_t)0x00000000U)                    /*!< RTC alarm output open-drain mode */
+#define RTC_ALARM_OUTPUT_PP                RTC_TAMP_AOT                               /*!< RTC alarm output push-pull mode */
+
+/* ALRMXSS register value */
+#define ALRMXSS_SSC(regval)                (BITS(0,14) & ((uint32_t)(regval)<< 0))    /*!< write value to RTC_ALRMXSS_SSC bit field */
+
+#define ALRMXSS_MASKSSC(regval)            (BITS(24,27) & ((uint32_t)(regval) << 24)) /*!< write value to RTC_ALRMXSS_MASKSSC bit field */
+#define RTC_MASKSSC_0_14                   ALRMXSS_MASKSSC(0)                         /*!< mask alarm subsecond configuration */
+#define RTC_MASKSSC_1_14                   ALRMXSS_MASKSSC(1)                         /*!< mask RTC_ALRMXSS_SSC[14:1], and RTC_ALRMXSS_SSC[0] is to be compared */
+#define RTC_MASKSSC_2_14                   ALRMXSS_MASKSSC(2)                         /*!< mask RTC_ALRMXSS_SSC[14:2], and RTC_ALRMXSS_SSC[1:0] is to be compared */
+#define RTC_MASKSSC_3_14                   ALRMXSS_MASKSSC(3)                         /*!< mask RTC_ALRMXSS_SSC[14:3], and RTC_ALRMXSS_SSC[2:0] is to be compared */
+#define RTC_MASKSSC_4_14                   ALRMXSS_MASKSSC(4)                         /*!< mask RTC_ALRMXSS_SSC[14:4]], and RTC_ALRMXSS_SSC[3:0] is to be compared */
+#define RTC_MASKSSC_5_14                   ALRMXSS_MASKSSC(5)                         /*!< mask RTC_ALRMXSS_SSC[14:5], and RTC_ALRMXSS_SSC[4:0] is to be compared */
+#define RTC_MASKSSC_6_14                   ALRMXSS_MASKSSC(6)                         /*!< mask RTC_ALRMXSS_SSC[14:6], and RTC_ALRMXSS_SSC[5:0] is to be compared */
+#define RTC_MASKSSC_7_14                   ALRMXSS_MASKSSC(7)                         /*!< mask RTC_ALRMXSS_SSC[14:7], and RTC_ALRMXSS_SSC[6:0] is to be compared */
+#define RTC_MASKSSC_8_14                   ALRMXSS_MASKSSC(8)                         /*!< mask RTC_ALRMXSS_SSC[14:7], and RTC_ALRMXSS_SSC[6:0] is to be compared */
+#define RTC_MASKSSC_9_14                   ALRMXSS_MASKSSC(9)                         /*!< mask RTC_ALRMXSS_SSC[14:9], and RTC_ALRMXSS_SSC[8:0] is to be compared */
+#define RTC_MASKSSC_10_14                  ALRMXSS_MASKSSC(10)                        /*!< mask RTC_ALRMXSS_SSC[14:10], and RTC_ALRMXSS_SSC[9:0] is to be compared */
+#define RTC_MASKSSC_11_14                  ALRMXSS_MASKSSC(11)                        /*!< mask RTC_ALRMXSS_SSC[14:11], and RTC_ALRMXSS_SSC[10:0] is to be compared */
+#define RTC_MASKSSC_12_14                  ALRMXSS_MASKSSC(12)                        /*!< mask RTC_ALRMXSS_SSC[14:12], and RTC_ALRMXSS_SSC[11:0] is to be compared */
+#define RTC_MASKSSC_13_14                  ALRMXSS_MASKSSC(13)                        /*!< mask RTC_ALRMXSS_SSC[14:13], and RTC_ALRMXSS_SSC[12:0] is to be compared */
+#define RTC_MASKSSC_14                     ALRMXSS_MASKSSC(14)                        /*!< mask RTC_ALRMXSS_SSC[14], and RTC_ALRMXSS_SSC[13:0] is to be compared */
+#define RTC_MASKSSC_NONE                   ALRMXSS_MASKSSC(15)                        /*!< mask none, and RTC_ALRMXSS_SSC[14:0] is to be compared */
+
+/* RTC interrupt source */
+#define RTC_INT_TIMESTAMP                  RTC_CTL_TSIE                               /*!< time-stamp interrupt enable */
+#define RTC_INT_ALARM0                     RTC_CTL_ALRM0IE                            /*!< RTC alarm0 interrupt enable */
+#define RTC_INT_ALARM1                     RTC_CTL_ALRM1IE                            /*!< RTC alarm1 interrupt enable */
+#define RTC_INT_TAMP                       RTC_TAMP_TPIE                              /*!< tamper detection interrupt enable */
+#define RTC_INT_WAKEUP                     RTC_CTL_WTIE                               /*!< RTC wakeup timer interrupt enable */
+
+/* write protect key */
+#define RTC_UNLOCK_KEY1                    ((uint8_t)0xCAU)                           /*!< RTC unlock key1 */
+#define RTC_UNLOCK_KEY2                    ((uint8_t)0x53U)                           /*!< RTC unlock key2 */
+#define RTC_LOCK_KEY                       ((uint8_t)0xFFU)                           /*!< RTC lock key */
+
+/* registers reset value */
+#define RTC_REGISTER_RESET                 ((uint32_t)0x00000000U)                    /*!< RTC common register reset value */
+#define RTC_DATE_RESET                     ((uint32_t)0x00002101U)                    /*!< RTC_DATE register reset value */
+#define RTC_STAT_RESET                     ((uint32_t)0x00000000U)                    /*!< RTC_STAT register reset value */
+#define RTC_PSC_RESET                      ((uint32_t)0x007F00FFU)                    /*!< RTC_PSC register reset value */
+#define RTC_WUT_RESET                      ((uint32_t)0x0000FFFFU)                    /*!< RTC_WUT register reset value */
+
+/* RTC alarm */
+#define RTC_ALARM0                         ((uint8_t)0x01U)                           /*!< RTC alarm 0 */              
+#define RTC_ALARM1                         ((uint8_t)0x02U)                           /*!< RTC alarm 1 */   
+
+/* RTC coarse calibration direction */
+#define CALIB_INCREASE                     ((uint8_t)0x01U)                           /*!< RTC coarse calibration increase */  
+#define CALIB_DECREASE                     ((uint8_t)0x02U)                           /*!< RTC coarse calibration decrease */  
+
+/* RTC wakeup timer clock */
+#define CTL_WTCS(regval)                   (BITS(0,2) & ((regval)<< 0))
+#define WAKEUP_RTCCK_DIV16                 CTL_WTCS(0)                                /*!< wakeup timer clock is RTC clock divided by 16 */
+#define WAKEUP_RTCCK_DIV8                  CTL_WTCS(1)                                /*!< wakeup timer clock is RTC clock divided by 8 */
+#define WAKEUP_RTCCK_DIV4                  CTL_WTCS(2)                                /*!< wakeup timer clock is RTC clock divided by 4 */
+#define WAKEUP_RTCCK_DIV2                  CTL_WTCS(3)                                /*!< wakeup timer clock is RTC clock divided by 2 */
+#define WAKEUP_CKSPRE                      CTL_WTCS(4)                                /*!< wakeup timer clock is ckapre */
+#define WAKEUP_CKSPRE_2EXP16               CTL_WTCS(6)                                /*!< wakeup timer clock is ckapre and wakeup timer add 2exp16 */
+ 
+/* RTC_AF pin */
+#define RTC_AF0_TIMESTAMP                  ((uint32_t)0x00000000)                     /*!< RTC_AF0 use for timestamp */
+#define RTC_AF1_TIMESTAMP                  RTC_TAMP_TSSEL                             /*!< RTC_AF1 use for timestamp */
+#define RTC_AF0_TAMPER0                    ((uint32_t)0x00000000)                     /*!< RTC_AF0 use for tamper0 */
+#define RTC_AF1_TAMPER0                    RTC_TAMP_TP0SEL                            /*!< RTC_AF1 use for tamper0 */
+
+/* RTC flags */
+#define RTC_FLAG_ALRM0W                    RTC_STAT_ALRM0WF                           /*!< alarm0 configuration can be write flag */
+#define RTC_FLAG_ALRM1W                    RTC_STAT_ALRM1WF                           /*!< alarm1 configuration can be write flag */
+#define RTC_FLAG_WTW                       RTC_STAT_WTWF                              /*!< wakeup timer can be write flag */
+#define RTC_FLAG_SOP                       RTC_STAT_SOPF                              /*!< shift function operation pending flag */
+#define RTC_FLAG_YCM                       RTC_STAT_YCM                               /*!< year configuration mark status flag */
+#define RTC_FLAG_RSYN                      RTC_STAT_RSYNF                             /*!< register synchronization flag */
+#define RTC_FLAG_INIT                      RTC_STAT_INITF                             /*!< initialization state flag */
+#define RTC_FLAG_ALRM0                     RTC_STAT_ALRM0F                            /*!< alarm0 occurs flag */
+#define RTC_FLAG_ALRM1                     RTC_STAT_ALRM1F                            /*!< alarm1 occurs flag */
+#define RTC_FLAG_WT                        RTC_STAT_WTF                               /*!< wakeup timer occurs flag */
+#define RTC_FLAG_TS                        RTC_STAT_TSF                               /*!< time-stamp flag */
+#define RTC_FLAG_TSOVR                     RTC_STAT_TSOVRF                            /*!< time-stamp overflow flag */
+#define RTC_FLAG_TP0                       RTC_STAT_TP0F                              /*!< RTC tamper 0 detected flag */
+#define RTC_FLAG_TP1                       RTC_STAT_TP1F                              /*!< RTC tamper 1 detected flag */
+#define RTC_STAT_SCP                       RTC_STAT_SCPF                              /*!< smooth calibration pending flag */
+
+/* function declarations */
+/* reset most of the RTC registers */
+ErrStatus rtc_deinit(void);
+/* initialize RTC registers */
+ErrStatus rtc_init(rtc_parameter_struct* rtc_initpara_struct);
+/* enter RTC init mode */
+ErrStatus rtc_init_mode_enter(void);
+/* exit RTC init mode */
+void rtc_init_mode_exit(void);
+/* wait until RTC_TIME and RTC_DATE registers are synchronized with APB clock, and the shadow registers are updated */
+ErrStatus rtc_register_sync_wait(void);
+
+/* get current time and date */
+void rtc_current_time_get(rtc_parameter_struct* rtc_initpara_struct);
+/* get current subsecond value */
+uint32_t rtc_subsecond_get(void);
+
+/* configure RTC alarm */
+void rtc_alarm_config(uint8_t rtc_alarm, rtc_alarm_struct* rtc_alarm_time);
+/* configure subsecond of RTC alarm */
+void rtc_alarm_subsecond_config(uint8_t rtc_alarm, uint32_t mask_subsecond, uint32_t subsecond);
+/* get RTC alarm */
+void rtc_alarm_get(uint8_t rtc_alarm,rtc_alarm_struct* rtc_alarm_time);
+/* get RTC alarm subsecond */
+uint32_t rtc_alarm_subsecond_get(uint8_t rtc_alarm);
+/* enable RTC alarm */
+void rtc_alarm_enable(uint8_t rtc_alarm);
+/* disable RTC alarm */
+ErrStatus rtc_alarm_disable(uint8_t rtc_alarm);
+
+/* enable RTC time-stamp */
+void rtc_timestamp_enable(uint32_t edge);
+/* disable RTC time-stamp */
+void rtc_timestamp_disable(void);
+/* get RTC timestamp time and date */
+void rtc_timestamp_get(rtc_timestamp_struct* rtc_timestamp);
+/* get RTC time-stamp subsecond */
+uint32_t rtc_timestamp_subsecond_get(void);
+/* RTC time-stamp pin map */
+void rtc_timestamp_pin_map(uint32_t rtc_af);
+
+/* enable RTC tamper */
+void rtc_tamper_enable(rtc_tamper_struct* rtc_tamper);
+/* disable RTC tamper */
+void rtc_tamper_disable(uint32_t source);
+/* RTC tamper0 pin map */
+void rtc_tamper0_pin_map(uint32_t rtc_af);
+
+/* enable specified RTC interrupt */
+void rtc_interrupt_enable(uint32_t interrupt);
+/* disble specified RTC interrupt */
+void rtc_interrupt_disable(uint32_t interrupt);
+/* check specified flag */
+FlagStatus rtc_flag_get(uint32_t flag);
+/* clear specified flag */
+void rtc_flag_clear(uint32_t flag);
+
+/* configure RTC alarm output source */
+void rtc_alarm_output_config(uint32_t source, uint32_t mode);
+/* configure RTC calibration output source */
+void rtc_calibration_output_config(uint32_t source);
+
+/* adjust the daylight saving time by adding or substracting one hour from the current time */
+void rtc_hour_adjust(uint32_t operation);
+/* adjust RTC second or subsecond value of current time */
+ErrStatus rtc_second_adjust(uint32_t add, uint32_t minus);
+
+/* enable RTC bypass shadow registers function */
+void rtc_bypass_shadow_enable(void);
+/* disable RTC bypass shadow registers function */
+void rtc_bypass_shadow_disable(void);
+
+/* enable RTC reference clock detection function */
+ErrStatus rtc_refclock_detection_enable(void);
+/* disable RTC reference clock detection function */
+ErrStatus rtc_refclock_detection_disable(void);
+
+/* enable RTC wakeup timer */
+void rtc_wakeup_enable(void);
+/* disable RTC wakeup timer */
+ErrStatus rtc_wakeup_disable(void);
+/* set auto wakeup timer clock */
+ErrStatus rtc_wakeup_clock_set(uint8_t wakeup_clock);
+/* set auto wakeup timer value */
+ErrStatus rtc_wakeup_timer_set(uint16_t wakeup_timer);
+/* get auto wakeup timer value */
+uint16_t rtc_wakeup_timer_get(void);
+
+/* configure RTC smooth calibration */
+ErrStatus rtc_smooth_calibration_config(uint32_t window, uint32_t plus, uint32_t minus);
+/* enable RTC coarse calibration */
+ErrStatus rtc_coarse_calibration_enable(void);
+/* disable RTC coarse calibration */
+ErrStatus rtc_coarse_calibration_disable(void);
+/* configure RTC coarse calibration direction and step */
+ErrStatus rtc_coarse_calibration_config(uint8_t direction, uint8_t step);
+
+#endif /* GD32F4XX_RTC_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_sdio.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_sdio.h
@@ -1,0 +1,434 @@
+/*!
+    \file    gd32f4xx_sdio.h
+    \brief   definitions for the SDIO
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_SDIO_H
+#define GD32F4XX_SDIO_H
+
+#include "gd32f4xx.h"
+
+/* SDIO definitions */
+#define SDIO                            SDIO_BASE
+
+/* registers definitions */
+#define SDIO_PWRCTL                     REG32(SDIO + 0x00000000U)    /*!< SDIO power control register */
+#define SDIO_CLKCTL                     REG32(SDIO + 0x00000004U)    /*!< SDIO clock control register */
+#define SDIO_CMDAGMT                    REG32(SDIO + 0x00000008U)    /*!< SDIO command argument register */
+#define SDIO_CMDCTL                     REG32(SDIO + 0x0000000CU)    /*!< SDIO command control register */
+#define SDIO_RSPCMDIDX                  REG32(SDIO + 0x00000010U)    /*!< SDIO command index response register */
+#define SDIO_RESP0                      REG32(SDIO + 0x00000014U)    /*!< SDIO response register 0 */
+#define SDIO_RESP1                      REG32(SDIO + 0x00000018U)    /*!< SDIO response register 1 */
+#define SDIO_RESP2                      REG32(SDIO + 0x0000001CU)    /*!< SDIO response register 2 */
+#define SDIO_RESP3                      REG32(SDIO + 0x00000020U)    /*!< SDIO response register 3 */
+#define SDIO_DATATO                     REG32(SDIO + 0x00000024U)    /*!< SDIO data timeout register */
+#define SDIO_DATALEN                    REG32(SDIO + 0x00000028U)    /*!< SDIO data length register */
+#define SDIO_DATACTL                    REG32(SDIO + 0x0000002CU)    /*!< SDIO data control register */
+#define SDIO_DATACNT                    REG32(SDIO + 0x00000030U)    /*!< SDIO data counter register */
+#define SDIO_STAT                       REG32(SDIO + 0x00000034U)    /*!< SDIO status register */
+#define SDIO_INTC                       REG32(SDIO + 0x00000038U)    /*!< SDIO interrupt clear register */
+#define SDIO_INTEN                      REG32(SDIO + 0x0000003CU)    /*!< SDIO interrupt enable register */
+#define SDIO_FIFOCNT                    REG32(SDIO + 0x00000048U)    /*!< SDIO FIFO counter register */
+#define SDIO_FIFO                       REG32(SDIO + 0x00000080U)    /*!< SDIO FIFO data register */
+
+/* bits definitions */
+/* SDIO_PWRCTL */
+#define SDIO_PWRCTL_PWRCTL              BITS(0,1)              /*!< SDIO power control bits */
+
+/* SDIO_CLKCTL */
+#define SDIO_CLKCTL_DIV                 BITS(0,7)              /*!< clock division */
+#define SDIO_CLKCTL_CLKEN               BIT(8)                 /*!< SDIO_CLK clock output enable bit */
+#define SDIO_CLKCTL_CLKPWRSAV           BIT(9)                 /*!< SDIO_CLK clock dynamic switch on/off for power saving */
+#define SDIO_CLKCTL_CLKBYP              BIT(10)                /*!< clock bypass enable bit */
+#define SDIO_CLKCTL_BUSMODE             BITS(11,12)            /*!< SDIO card bus mode control bit */
+#define SDIO_CLKCTL_CLKEDGE             BIT(13)                /*!< SDIO_CLK clock edge selection bit */
+#define SDIO_CLKCTL_HWCLKEN             BIT(14)                /*!< hardware clock control enable bit */
+#define SDIO_CLKCTL_DIV8                BIT(31)                /*!< MSB of clock division */
+
+/* SDIO_CMDAGMT */
+#define SDIO_CMDAGMT_CMDAGMT            BITS(0,31)             /*!< SDIO card command argument */
+
+/* SDIO_CMDCTL */
+#define SDIO_CMDCTL_CMDIDX              BITS(0,5)              /*!< command index */
+#define SDIO_CMDCTL_CMDRESP             BITS(6,7)              /*!< command response type bits */
+#define SDIO_CMDCTL_INTWAIT             BIT(8)                 /*!< interrupt wait instead of timeout */
+#define SDIO_CMDCTL_WAITDEND            BIT(9)                 /*!< wait for ends of data transfer */
+#define SDIO_CMDCTL_CSMEN               BIT(10)                /*!< command state machine(CSM) enable bit */
+#define SDIO_CMDCTL_SUSPEND             BIT(11)                /*!< SD I/O suspend command(SD I/O only) */
+#define SDIO_CMDCTL_ENCMDC              BIT(12)                /*!< CMD completion signal enabled (CE-ATA only) */
+#define SDIO_CMDCTL_NINTEN              BIT(13)                /*!< no CE-ATA interrupt (CE-ATA only) */
+#define SDIO_CMDCTL_ATAEN               BIT(14)                /*!< CE-ATA command enable(CE-ATA only) */
+
+/* SDIO_DATATO */
+#define SDIO_DATATO_DATATO              BITS(0,31)             /*!< data timeout period */
+
+/* SDIO_DATALEN */
+#define SDIO_DATALEN_DATALEN            BITS(0,24)             /*!< data transfer length */
+
+/* SDIO_DATACTL */
+#define SDIO_DATACTL_DATAEN             BIT(0)                 /*!< data transfer enabled bit */
+#define SDIO_DATACTL_DATADIR            BIT(1)                 /*!< data transfer direction */
+#define SDIO_DATACTL_TRANSMOD           BIT(2)                 /*!< data transfer mode */
+#define SDIO_DATACTL_DMAEN              BIT(3)                 /*!< DMA enable bit */
+#define SDIO_DATACTL_BLKSZ              BITS(4,7)              /*!< data block size */
+#define SDIO_DATACTL_RWEN               BIT(8)                 /*!< read wait mode enabled(SD I/O only) */
+#define SDIO_DATACTL_RWSTOP             BIT(9)                 /*!< read wait stop(SD I/O only) */
+#define SDIO_DATACTL_RWTYPE             BIT(10)                /*!< read wait type(SD I/O only) */
+#define SDIO_DATACTL_IOEN               BIT(11)                /*!< SD I/O specific function enable(SD I/O only) */
+
+/* SDIO_STAT */
+#define SDIO_STAT_CCRCERR               BIT(0)                 /*!< command response received (CRC check failed) */
+#define SDIO_STAT_DTCRCERR              BIT(1)                 /*!< data block sent/received (CRC check failed) */
+#define SDIO_STAT_CMDTMOUT              BIT(2)                 /*!< command response timeout */
+#define SDIO_STAT_DTTMOUT               BIT(3)                 /*!< data timeout */
+#define SDIO_STAT_TXURE                 BIT(4)                 /*!< transmit FIFO underrun error occurs */
+#define SDIO_STAT_RXORE                 BIT(5)                 /*!< received FIFO overrun error occurs */
+#define SDIO_STAT_CMDRECV               BIT(6)                 /*!< command response received (CRC check passed) */
+#define SDIO_STAT_CMDSEND               BIT(7)                 /*!< command sent (no response required) */
+#define SDIO_STAT_DTEND                 BIT(8)                 /*!< data end (data counter, SDIO_DATACNT, is zero) */
+#define SDIO_STAT_STBITE                BIT(9)                 /*!< start bit error in the bus */
+#define SDIO_STAT_DTBLKEND              BIT(10)                /*!< data block sent/received (CRC check passed) */
+#define SDIO_STAT_CMDRUN                BIT(11)                /*!< command transmission in progress */
+#define SDIO_STAT_TXRUN                 BIT(12)                /*!< data transmission in progress */
+#define SDIO_STAT_RXRUN                 BIT(13)                /*!< data reception in progress */
+#define SDIO_STAT_TFH                   BIT(14)                /*!< transmit FIFO is half empty: at least 8 words can be written into the FIFO */
+#define SDIO_STAT_RFH                   BIT(15)                /*!< receive FIFO is half full: at least 8 words can be read in the FIFO */
+#define SDIO_STAT_TFF                   BIT(16)                /*!< transmit FIFO is full */
+#define SDIO_STAT_RFF                   BIT(17)                /*!< receive FIFO is full */
+#define SDIO_STAT_TFE                   BIT(18)                /*!< transmit FIFO is empty */
+#define SDIO_STAT_RFE                   BIT(19)                /*!< receive FIFO is empty */
+#define SDIO_STAT_TXDTVAL               BIT(20)                /*!< data is valid in transmit FIFO */
+#define SDIO_STAT_RXDTVAL               BIT(21)                /*!< data is valid in receive FIFO */
+#define SDIO_STAT_SDIOINT               BIT(22)                /*!< SD I/O interrupt received */
+#define SDIO_STAT_ATAEND                BIT(23)                /*!< CE-ATA command completion signal received (only for CMD61) */
+
+/* SDIO_INTC */
+#define SDIO_INTC_CCRCERRC              BIT(0)                 /*!< CCRCERR flag clear bit */
+#define SDIO_INTC_DTCRCERRC             BIT(1)                 /*!< DTCRCERR flag clear bit */
+#define SDIO_INTC_CMDTMOUTC             BIT(2)                 /*!< CMDTMOUT flag clear bit */
+#define SDIO_INTC_DTTMOUTC              BIT(3)                 /*!< DTTMOUT flag clear bit */
+#define SDIO_INTC_TXUREC                BIT(4)                 /*!< TXURE flag clear bit */
+#define SDIO_INTC_RXOREC                BIT(5)                 /*!< RXORE flag clear bit */
+#define SDIO_INTC_CMDRECVC              BIT(6)                 /*!< CMDRECV flag clear bit */
+#define SDIO_INTC_CMDSENDC              BIT(7)                 /*!< CMDSEND flag clear bit */
+#define SDIO_INTC_DTENDC                BIT(8)                 /*!< DTEND flag clear bit */
+#define SDIO_INTC_STBITEC               BIT(9)                 /*!< STBITE flag clear bit */
+#define SDIO_INTC_DTBLKENDC             BIT(10)                /*!< DTBLKEND flag clear bit */
+#define SDIO_INTC_SDIOINTC              BIT(22)                /*!< SDIOINT flag clear bit */
+#define SDIO_INTC_ATAENDC               BIT(23)                /*!< ATAEND flag clear bit */
+
+/* SDIO_INTEN */
+#define SDIO_INTEN_CCRCERRIE            BIT(0)                 /*!< command response CRC fail interrupt enable */
+#define SDIO_INTEN_DTCRCERRIE           BIT(1)                 /*!< data CRC fail interrupt enable */
+#define SDIO_INTEN_CMDTMOUTIE           BIT(2)                 /*!< command response timeout interrupt enable */
+#define SDIO_INTEN_DTTMOUTIE            BIT(3)                 /*!< data timeout interrupt enable */
+#define SDIO_INTEN_TXUREIE              BIT(4)                 /*!< transmit FIFO underrun error interrupt enable */
+#define SDIO_INTEN_RXOREIE              BIT(5)                 /*!< received FIFO overrun error interrupt enable */
+#define SDIO_INTEN_CMDRECVIE            BIT(6)                 /*!< command response received interrupt enable */
+#define SDIO_INTEN_CMDSENDIE            BIT(7)                 /*!< command sent interrupt enable */
+#define SDIO_INTEN_DTENDIE              BIT(8)                 /*!< data end interrupt enable */
+#define SDIO_INTEN_STBITEIE             BIT(9)                 /*!< start bit error interrupt enable */
+#define SDIO_INTEN_DTBLKENDIE           BIT(10)                /*!< data block end interrupt enable */
+#define SDIO_INTEN_CMDRUNIE             BIT(11)                /*!< command transmission interrupt enable */
+#define SDIO_INTEN_TXRUNIE              BIT(12)                /*!< data transmission interrupt enable */
+#define SDIO_INTEN_RXRUNIE              BIT(13)                /*!< data reception interrupt enable */
+#define SDIO_INTEN_TFHIE                BIT(14)                /*!< transmit FIFO half empty interrupt enable */
+#define SDIO_INTEN_RFHIE                BIT(15)                /*!< receive FIFO half full interrupt enable */
+#define SDIO_INTEN_TFFIE                BIT(16)                /*!< transmit FIFO full interrupt enable */
+#define SDIO_INTEN_RFFIE                BIT(17)                /*!< receive FIFO full interrupt enable */
+#define SDIO_INTEN_TFEIE                BIT(18)                /*!< transmit FIFO empty interrupt enable */
+#define SDIO_INTEN_RFEIE                BIT(19)                /*!< receive FIFO empty interrupt enable */
+#define SDIO_INTEN_TXDTVALIE            BIT(20)                /*!< data valid in transmit FIFO interrupt enable */
+#define SDIO_INTEN_RXDTVALIE            BIT(21)                /*!< data valid in receive FIFO interrupt enable */
+#define SDIO_INTEN_SDIOINTIE            BIT(22)                /*!< SD I/O interrupt received interrupt enable */
+#define SDIO_INTEN_ATAENDIE             BIT(23)                /*!< CE-ATA command completion signal received interrupt enable */
+
+/* SDIO_FIFO */
+#define SDIO_FIFO_FIFODT                BITS(0,31)             /*!< receive FIFO data or transmit FIFO data */
+
+/* constants definitions */
+/* SDIO flags */
+#define SDIO_FLAG_CCRCERR               BIT(0)                 /*!< command response received (CRC check failed) flag */
+#define SDIO_FLAG_DTCRCERR              BIT(1)                 /*!< data block sent/received (CRC check failed) flag */
+#define SDIO_FLAG_CMDTMOUT              BIT(2)                 /*!< command response timeout flag */
+#define SDIO_FLAG_DTTMOUT               BIT(3)                 /*!< data timeout flag */
+#define SDIO_FLAG_TXURE                 BIT(4)                 /*!< transmit FIFO underrun error occurs flag */
+#define SDIO_FLAG_RXORE                 BIT(5)                 /*!< received FIFO overrun error occurs flag */
+#define SDIO_FLAG_CMDRECV               BIT(6)                 /*!< command response received (CRC check passed) flag */
+#define SDIO_FLAG_CMDSEND               BIT(7)                 /*!< command sent (no response required) flag */
+#define SDIO_FLAG_DTEND                 BIT(8)                 /*!< data end (data counter, SDIO_DATACNT, is zero) flag */
+#define SDIO_FLAG_STBITE                BIT(9)                 /*!< start bit error in the bus flag */
+#define SDIO_FLAG_DTBLKEND              BIT(10)                /*!< data block sent/received (CRC check passed) flag */
+#define SDIO_FLAG_CMDRUN                BIT(11)                /*!< command transmission in progress flag */
+#define SDIO_FLAG_TXRUN                 BIT(12)                /*!< data transmission in progress flag */
+#define SDIO_FLAG_RXRUN                 BIT(13)                /*!< data reception in progress flag */
+#define SDIO_FLAG_TFH                   BIT(14)                /*!< transmit FIFO is half empty flag: at least 8 words can be written into the FIFO */
+#define SDIO_FLAG_RFH                   BIT(15)                /*!< receive FIFO is half full flag: at least 8 words can be read in the FIFO */
+#define SDIO_FLAG_TFF                   BIT(16)                /*!< transmit FIFO is full flag */
+#define SDIO_FLAG_RFF                   BIT(17)                /*!< receive FIFO is full flag */
+#define SDIO_FLAG_TFE                   BIT(18)                /*!< transmit FIFO is empty flag */
+#define SDIO_FLAG_RFE                   BIT(19)                /*!< receive FIFO is empty flag */
+#define SDIO_FLAG_TXDTVAL               BIT(20)                /*!< data is valid in transmit FIFO flag */
+#define SDIO_FLAG_RXDTVAL               BIT(21)                /*!< data is valid in receive FIFO flag */
+#define SDIO_FLAG_SDIOINT               BIT(22)                /*!< SD I/O interrupt received flag */
+#define SDIO_FLAG_ATAEND                BIT(23)                /*!< CE-ATA command completion signal received (only for CMD61) flag */
+
+/* SDIO interrupt enable or disable */
+#define SDIO_INT_CCRCERR                BIT(0)                 /*!< SDIO CCRCERR interrupt */
+#define SDIO_INT_DTCRCERR               BIT(1)                 /*!< SDIO DTCRCERR interrupt */
+#define SDIO_INT_CMDTMOUT               BIT(2)                 /*!< SDIO CMDTMOUT interrupt */
+#define SDIO_INT_DTTMOUT                BIT(3)                 /*!< SDIO DTTMOUT interrupt */
+#define SDIO_INT_TXURE                  BIT(4)                 /*!< SDIO TXURE interrupt */
+#define SDIO_INT_RXORE                  BIT(5)                 /*!< SDIO RXORE interrupt */
+#define SDIO_INT_CMDRECV                BIT(6)                 /*!< SDIO CMDRECV interrupt */
+#define SDIO_INT_CMDSEND                BIT(7)                 /*!< SDIO CMDSEND interrupt */
+#define SDIO_INT_DTEND                  BIT(8)                 /*!< SDIO DTEND interrupt */
+#define SDIO_INT_STBITE                 BIT(9)                 /*!< SDIO STBITE interrupt */
+#define SDIO_INT_DTBLKEND               BIT(10)                /*!< SDIO DTBLKEND interrupt */
+#define SDIO_INT_CMDRUN                 BIT(11)                /*!< SDIO CMDRUN interrupt */
+#define SDIO_INT_TXRUN                  BIT(12)                /*!< SDIO TXRUN interrupt */
+#define SDIO_INT_RXRUN                  BIT(13)                /*!< SDIO RXRUN interrupt */
+#define SDIO_INT_TFH                    BIT(14)                /*!< SDIO TFH interrupt */
+#define SDIO_INT_RFH                    BIT(15)                /*!< SDIO RFH interrupt */
+#define SDIO_INT_TFF                    BIT(16)                /*!< SDIO TFF interrupt */
+#define SDIO_INT_RFF                    BIT(17)                /*!< SDIO RFF interrupt */
+#define SDIO_INT_TFE                    BIT(18)                /*!< SDIO TFE interrupt */
+#define SDIO_INT_RFE                    BIT(19)                /*!< SDIO RFE interrupt */
+#define SDIO_INT_TXDTVAL                BIT(20)                /*!< SDIO TXDTVAL interrupt */
+#define SDIO_INT_RXDTVAL                BIT(21)                /*!< SDIO RXDTVAL interrupt */
+#define SDIO_INT_SDIOINT                BIT(22)                /*!< SDIO SDIOINT interrupt */
+#define SDIO_INT_ATAEND                 BIT(23)                /*!< SDIO ATAEND interrupt */
+
+/* SDIO interrupt flags */
+#define SDIO_INT_FLAG_CCRCERR           BIT(0)                 /*!< SDIO CCRCERR interrupt flag */
+#define SDIO_INT_FLAG_DTCRCERR          BIT(1)                 /*!< SDIO DTCRCERR interrupt flag */
+#define SDIO_INT_FLAG_CMDTMOUT          BIT(2)                 /*!< SDIO CMDTMOUT interrupt flag */
+#define SDIO_INT_FLAG_DTTMOUT           BIT(3)                 /*!< SDIO DTTMOUT interrupt flag */
+#define SDIO_INT_FLAG_TXURE             BIT(4)                 /*!< SDIO TXURE interrupt flag */
+#define SDIO_INT_FLAG_RXORE             BIT(5)                 /*!< SDIO RXORE interrupt flag */
+#define SDIO_INT_FLAG_CMDRECV           BIT(6)                 /*!< SDIO CMDRECV interrupt flag */
+#define SDIO_INT_FLAG_CMDSEND           BIT(7)                 /*!< SDIO CMDSEND interrupt flag */
+#define SDIO_INT_FLAG_DTEND             BIT(8)                 /*!< SDIO DTEND interrupt flag */
+#define SDIO_INT_FLAG_STBITE            BIT(9)                 /*!< SDIO STBITE interrupt flag */
+#define SDIO_INT_FLAG_DTBLKEND          BIT(10)                /*!< SDIO DTBLKEND interrupt flag */
+#define SDIO_INT_FLAG_CMDRUN            BIT(11)                /*!< SDIO CMDRUN interrupt flag */
+#define SDIO_INT_FLAG_TXRUN             BIT(12)                /*!< SDIO TXRUN interrupt flag */
+#define SDIO_INT_FLAG_RXRUN             BIT(13)                /*!< SDIO RXRUN interrupt flag */
+#define SDIO_INT_FLAG_TFH               BIT(14)                /*!< SDIO TFH interrupt flag */
+#define SDIO_INT_FLAG_RFH               BIT(15)                /*!< SDIO RFH interrupt flag */
+#define SDIO_INT_FLAG_TFF               BIT(16)                /*!< SDIO TFF interrupt flag */
+#define SDIO_INT_FLAG_RFF               BIT(17)                /*!< SDIO RFF interrupt flag */
+#define SDIO_INT_FLAG_TFE               BIT(18)                /*!< SDIO TFE interrupt flag */
+#define SDIO_INT_FLAG_RFE               BIT(19)                /*!< SDIO RFE interrupt flag */
+#define SDIO_INT_FLAG_TXDTVAL           BIT(20)                /*!< SDIO TXDTVAL interrupt flag */
+#define SDIO_INT_FLAG_RXDTVAL           BIT(21)                /*!< SDIO RXDTVAL interrupt flag */
+#define SDIO_INT_FLAG_SDIOINT           BIT(22)                /*!< SDIO SDIOINT interrupt flag */
+#define SDIO_INT_FLAG_ATAEND            BIT(23)                /*!< SDIO ATAEND interrupt flag */
+
+/* SDIO power control */
+#define PWRCTL_PWRCTL(regval)           (BITS(0,1) & ((uint32_t)(regval) << 0))
+#define SDIO_POWER_OFF                  PWRCTL_PWRCTL(0)       /*!< SDIO power off */
+#define SDIO_POWER_ON                   PWRCTL_PWRCTL(3)       /*!< SDIO power on */
+
+/* SDIO card bus mode control */
+#define CLKCTL_BUSMODE(regval)          (BITS(11,12) & ((uint32_t)(regval) << 11))
+#define SDIO_BUSMODE_1BIT               CLKCTL_BUSMODE(0)      /*!< 1-bit SDIO card bus mode */
+#define SDIO_BUSMODE_4BIT               CLKCTL_BUSMODE(1)      /*!< 4-bit SDIO card bus mode */
+#define SDIO_BUSMODE_8BIT               CLKCTL_BUSMODE(2)      /*!< 8-bit SDIO card bus mode */
+
+/* SDIO_CLK clock edge selection */
+#define SDIO_SDIOCLKEDGE_RISING         (uint32_t)0x00000000U  /*!< select the rising edge of the SDIOCLK to generate SDIO_CLK */
+#define SDIO_SDIOCLKEDGE_FALLING        SDIO_CLKCTL_CLKEDGE    /*!< select the falling edge of the SDIOCLK to generate SDIO_CLK */
+
+/* clock bypass enable or disable */
+#define SDIO_CLOCKBYPASS_DISABLE        (uint32_t)0x00000000U  /*!< no bypass */
+#define SDIO_CLOCKBYPASS_ENABLE         SDIO_CLKCTL_CLKBYP     /*!< clock bypass */
+
+/* SDIO_CLK clock dynamic switch on/off for power saving */
+#define SDIO_CLOCKPWRSAVE_DISABLE       (uint32_t)0x00000000U  /*!< SDIO_CLK clock is always on */
+#define SDIO_CLOCKPWRSAVE_ENABLE        SDIO_CLKCTL_CLKPWRSAV  /*!< SDIO_CLK closed when bus is idle */
+
+/* SDIO command response type */
+#define CMDCTL_CMDRESP(regval)          (BITS(6,7) & ((uint32_t)(regval) << 6))
+#define SDIO_RESPONSETYPE_NO            CMDCTL_CMDRESP(0)      /*!< no response */
+#define SDIO_RESPONSETYPE_SHORT         CMDCTL_CMDRESP(1)      /*!< short response */
+#define SDIO_RESPONSETYPE_LONG          CMDCTL_CMDRESP(3)      /*!< long response */
+
+/* command state machine wait type */
+#define SDIO_WAITTYPE_NO                (uint32_t)0x00000000U  /*!< not wait interrupt */
+#define SDIO_WAITTYPE_INTERRUPT         SDIO_CMDCTL_INTWAIT    /*!< wait interrupt */
+#define SDIO_WAITTYPE_DATAEND           SDIO_CMDCTL_WAITDEND   /*!< wait the end of data transfer */
+
+#define SDIO_RESPONSE0                  (uint32_t)0x00000000U  /*!< card response[31:0]/card response[127:96] */
+#define SDIO_RESPONSE1                  (uint32_t)0x00000001U  /*!< card response[95:64] */
+#define SDIO_RESPONSE2                  (uint32_t)0x00000002U  /*!< card response[63:32] */
+#define SDIO_RESPONSE3                  (uint32_t)0x00000003U  /*!< card response[31:1], plus bit 0 */
+
+/* SDIO data block size */
+#define DATACTL_BLKSZ(regval)           (BITS(4,7) & ((uint32_t)(regval) << 4))
+#define SDIO_DATABLOCKSIZE_1BYTE        DATACTL_BLKSZ(0)       /*!< block size = 1 byte */
+#define SDIO_DATABLOCKSIZE_2BYTES       DATACTL_BLKSZ(1)       /*!< block size = 2 bytes */
+#define SDIO_DATABLOCKSIZE_4BYTES       DATACTL_BLKSZ(2)       /*!< block size = 4 bytes */
+#define SDIO_DATABLOCKSIZE_8BYTES       DATACTL_BLKSZ(3)       /*!< block size = 8 bytes */
+#define SDIO_DATABLOCKSIZE_16BYTES      DATACTL_BLKSZ(4)       /*!< block size = 16 bytes */
+#define SDIO_DATABLOCKSIZE_32BYTES      DATACTL_BLKSZ(5)       /*!< block size = 32 bytes */
+#define SDIO_DATABLOCKSIZE_64BYTES      DATACTL_BLKSZ(6)       /*!< block size = 64 bytes */
+#define SDIO_DATABLOCKSIZE_128BYTES     DATACTL_BLKSZ(7)       /*!< block size = 128 bytes */
+#define SDIO_DATABLOCKSIZE_256BYTES     DATACTL_BLKSZ(8)       /*!< block size = 256 bytes */
+#define SDIO_DATABLOCKSIZE_512BYTES     DATACTL_BLKSZ(9)       /*!< block size = 512 bytes */
+#define SDIO_DATABLOCKSIZE_1024BYTES    DATACTL_BLKSZ(10)      /*!< block size = 1024 bytes */
+#define SDIO_DATABLOCKSIZE_2048BYTES    DATACTL_BLKSZ(11)      /*!< block size = 2048 bytes */
+#define SDIO_DATABLOCKSIZE_4096BYTES    DATACTL_BLKSZ(12)      /*!< block size = 4096 bytes */
+#define SDIO_DATABLOCKSIZE_8192BYTES    DATACTL_BLKSZ(13)      /*!< block size = 8192 bytes */
+#define SDIO_DATABLOCKSIZE_16384BYTES   DATACTL_BLKSZ(14)      /*!< block size = 16384 bytes */
+
+/* SDIO data transfer mode */
+#define SDIO_TRANSMODE_BLOCK            (uint32_t)0x00000000U  /*!< block transfer */
+#define SDIO_TRANSMODE_STREAM           SDIO_DATACTL_TRANSMOD  /*!< stream transfer or SDIO multibyte transfer */
+
+/* SDIO data transfer direction */
+#define SDIO_TRANSDIRECTION_TOCARD      (uint32_t)0x00000000U  /*!< write data to card */
+#define SDIO_TRANSDIRECTION_TOSDIO      SDIO_DATACTL_DATADIR   /*!< read data from card */
+
+/* SDIO read wait type */
+#define SDIO_READWAITTYPE_DAT2          (uint32_t)0x00000000U  /*!< read wait control using SDIO_DAT[2] */
+#define SDIO_READWAITTYPE_CLK           SDIO_DATACTL_RWTYPE    /*!< read wait control by stopping SDIO_CLK */
+
+/* function declarations */
+/* de/initialization functions, hardware clock, bus mode, power_state and SDIO clock configuration */
+/* deinitialize the SDIO */
+void sdio_deinit(void);
+/* configure the SDIO clock */
+void sdio_clock_config(uint32_t clock_edge, uint32_t clock_bypass, uint32_t clock_powersave, uint16_t clock_division);
+/* enable hardware clock control */
+void sdio_hardware_clock_enable(void);
+/* disable hardware clock control */
+void sdio_hardware_clock_disable(void);
+/* set different SDIO card bus mode */
+void sdio_bus_mode_set(uint32_t bus_mode);
+/* set the SDIO power state */
+void sdio_power_state_set(uint32_t power_state);
+/* get the SDIO power state */
+uint32_t sdio_power_state_get(void);
+/* enable SDIO_CLK clock output */
+void sdio_clock_enable(void);
+/* disable SDIO_CLK clock output */
+void sdio_clock_disable(void);
+
+/* configure the command index, argument, response type, wait type and CSM to send command functions */
+/* configure the command and response */
+void sdio_command_response_config(uint32_t cmd_index, uint32_t cmd_argument, uint32_t response_type);
+/* set the command state machine wait type */
+void sdio_wait_type_set(uint32_t wait_type);
+/* enable the CSM(command state machine) */
+void sdio_csm_enable(void);
+/* disable the CSM(command state machine) */
+void sdio_csm_disable(void);
+/* get the last response command index */
+uint8_t sdio_command_index_get(void);
+/* get the response for the last received command */
+uint32_t sdio_response_get(uint32_t sdio_responsex);
+
+/* configure the data timeout, length, block size, transfer mode, direction and DSM for data transfer functions */
+/* configure the data timeout, data length and data block size */
+void sdio_data_config(uint32_t data_timeout, uint32_t data_length, uint32_t data_blocksize);
+/* configure the data transfer mode and direction */
+void sdio_data_transfer_config(uint32_t transfer_mode, uint32_t transfer_direction);
+/* enable the DSM(data state machine) for data transfer */
+void sdio_dsm_enable(void);
+/* disable the DSM(data state machine) */
+void sdio_dsm_disable(void);
+/* write data(one word) to the transmit FIFO */
+void sdio_data_write(uint32_t data);
+/* read data(one word) from the receive FIFO */
+uint32_t sdio_data_read(void);
+/* get the number of remaining data bytes to be transferred to card */
+uint32_t sdio_data_counter_get(void);
+/* get the number of words remaining to be written or read from FIFO */
+uint32_t sdio_fifo_counter_get(void);
+/* enable the DMA request for SDIO */
+void sdio_dma_enable(void);
+/* disable the DMA request for SDIO */
+void sdio_dma_disable(void);
+
+/* flag and interrupt functions */
+/* get the flags state of SDIO */
+FlagStatus sdio_flag_get(uint32_t flag);
+/* clear the pending flags of SDIO */
+void sdio_flag_clear(uint32_t flag);
+/* enable the SDIO interrupt */
+void sdio_interrupt_enable(uint32_t int_flag);
+/* disable the SDIO interrupt */
+void sdio_interrupt_disable(uint32_t int_flag);
+/* get the interrupt flags state of SDIO */
+FlagStatus sdio_interrupt_flag_get(uint32_t int_flag);
+/* clear the interrupt pending flags of SDIO */
+void sdio_interrupt_flag_clear(uint32_t int_flag);
+
+/* SD I/O card functions */
+/* enable the read wait mode(SD I/O only) */
+void sdio_readwait_enable(void);
+/* disable the read wait mode(SD I/O only) */
+void sdio_readwait_disable(void);
+/* enable the function that stop the read wait process(SD I/O only) */
+void sdio_stop_readwait_enable(void);
+/* disable the function that stop the read wait process(SD I/O only) */
+void sdio_stop_readwait_disable(void);
+/* set the read wait type(SD I/O only) */
+void sdio_readwait_type_set(uint32_t readwait_type);
+/* enable the SD I/O mode specific operation(SD I/O only) */
+void sdio_operation_enable(void);
+/* disable the SD I/O mode specific operation(SD I/O only) */
+void sdio_operation_disable(void);
+/* enable the SD I/O suspend operation(SD I/O only) */
+void sdio_suspend_enable(void);
+/* disable the SD I/O suspend operation(SD I/O only) */
+void sdio_suspend_disable(void);
+
+/* CE-ATA functions */
+/* enable the CE-ATA command(CE-ATA only) */
+void sdio_ceata_command_enable(void);
+/* disable the CE-ATA command(CE-ATA only) */
+void sdio_ceata_command_disable(void);
+/* enable the CE-ATA interrupt(CE-ATA only) */
+void sdio_ceata_interrupt_enable(void);
+/* disable the CE-ATA interrupt(CE-ATA only) */
+void sdio_ceata_interrupt_disable(void);
+/* enable the CE-ATA command completion signal(CE-ATA only) */
+void sdio_ceata_command_completion_enable(void);
+/* disable the CE-ATA command completion signal(CE-ATA only) */
+void sdio_ceata_command_completion_disable(void);
+
+#endif /* GD32F4XX_SDIO_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_spi.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_spi.h
@@ -1,0 +1,379 @@
+/*!
+    \file    gd32f4xx_spi.h
+    \brief   definitions for the SPI
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+
+#ifndef GD32F4XX_SPI_H
+#define GD32F4XX_SPI_H
+
+#include "gd32f4xx.h"
+
+/* SPIx(x=0,1,2,3,4,5) definitions */
+#define SPI0                            (SPI_BASE + 0x0000F800U)
+#define SPI1                            SPI_BASE
+#define SPI2                            (SPI_BASE + 0x00000400U)
+#define SPI3                            (SPI_BASE + 0x0000FC00U)
+#define SPI4                            (SPI_BASE + 0x00011800U)
+#define SPI5                            (SPI_BASE + 0x00011C00U)
+
+/* I2Sx_ADD(x=1,2) definitions */
+#define I2S1_ADD                        I2S_ADD_BASE
+#define I2S2_ADD                        (I2S_ADD_BASE + 0x00000C00U)
+
+/* SPI registers definitions */
+#define SPI_CTL0(spix)                  REG32((spix) + 0x00U)                   /*!< SPI control register 0 */
+#define SPI_CTL1(spix)                  REG32((spix) + 0x04U)                   /*!< SPI control register 1*/
+#define SPI_STAT(spix)                  REG32((spix) + 0x08U)                   /*!< SPI status register */
+#define SPI_DATA(spix)                  REG32((spix) + 0x0CU)                   /*!< SPI data register */
+#define SPI_CRCPOLY(spix)               REG32((spix) + 0x10U)                   /*!< SPI CRC polynomial register */
+#define SPI_RCRC(spix)                  REG32((spix) + 0x14U)                   /*!< SPI receive CRC register */
+#define SPI_TCRC(spix)                  REG32((spix) + 0x18U)                   /*!< SPI transmit CRC register */
+#define SPI_I2SCTL(spix)                REG32((spix) + 0x1CU)                   /*!< SPI I2S control register */
+#define SPI_I2SPSC(spix)                REG32((spix) + 0x20U)                   /*!< SPI I2S clock prescaler register */
+#define SPI_QCTL(spix)                  REG32((spix) + 0x80U)                   /*!< SPI quad mode control register */
+
+/* I2S_ADD registers definitions */
+#define I2S_ADD_CTL0(i2sx_add)          REG32((i2sx_add) + 0x00U)               /*!< I2S_ADD control register 0 */
+#define I2S_ADD_CTL1(i2sx_add)          REG32((i2sx_add) + 0x04U)               /*!< I2S_ADD control register 1*/
+#define I2S_ADD_STAT(i2sx_add)          REG32((i2sx_add) + 0x08U)               /*!< I2S_ADD status register */
+#define I2S_ADD_DATA(i2sx_add)          REG32((i2sx_add) + 0x0CU)               /*!< I2S_ADD data register */
+#define I2S_ADD_CRCPOLY(i2sx_add)       REG32((i2sx_add) + 0x10U)               /*!< I2S_ADD CRC polynomial register */
+#define I2S_ADD_RCRC(i2sx_add)          REG32((i2sx_add) + 0x14U)               /*!< I2S_ADD receive CRC register */
+#define I2S_ADD_TCRC(i2sx_add)          REG32((i2sx_add) + 0x18U)               /*!< I2S_ADD transmit CRC register */
+#define I2S_ADD_I2SCTL(i2sx_add)        REG32((i2sx_add) + 0x1CU)               /*!< I2S_ADD I2S control register */
+#define I2S_ADD_I2SPSC(i2sx_add)        REG32((i2sx_add) + 0x20U)               /*!< I2S_ADD I2S clock prescaler register */
+
+/* bits definitions */
+/* SPI_CTL0 */
+#define SPI_CTL0_CKPH                   BIT(0)                                  /*!< clock phase selection*/
+#define SPI_CTL0_CKPL                   BIT(1)                                  /*!< clock polarity selection */
+#define SPI_CTL0_MSTMOD                 BIT(2)                                  /*!< master mode enable */
+#define SPI_CTL0_PSC                    BITS(3,5)                               /*!< master clock prescaler selection */
+#define SPI_CTL0_SPIEN                  BIT(6)                                  /*!< SPI enable*/
+#define SPI_CTL0_LF                     BIT(7)                                  /*!< lsb first mode */
+#define SPI_CTL0_SWNSS                  BIT(8)                                  /*!< nss pin selection in nss software mode */
+#define SPI_CTL0_SWNSSEN                BIT(9)                                  /*!< nss software mode selection */
+#define SPI_CTL0_RO                     BIT(10)                                 /*!< receive only */
+#define SPI_CTL0_FF16                   BIT(11)                                 /*!< data frame size */
+#define SPI_CTL0_CRCNT                  BIT(12)                                 /*!< CRC next transfer */
+#define SPI_CTL0_CRCEN                  BIT(13)                                 /*!< CRC calculation enable */
+#define SPI_CTL0_BDOEN                  BIT(14)                                 /*!< bidirectional transmit output enable*/
+#define SPI_CTL0_BDEN                   BIT(15)                                 /*!< bidirectional enable */
+
+/* SPI_CTL1 */
+#define SPI_CTL1_DMAREN                 BIT(0)                                  /*!< receive buffer dma enable */
+#define SPI_CTL1_DMATEN                 BIT(1)                                  /*!< transmit buffer dma enable */
+#define SPI_CTL1_NSSDRV                 BIT(2)                                  /*!< drive nss output */
+#define SPI_CTL1_TMOD                   BIT(4)                                  /*!< SPI TI mode enable */
+#define SPI_CTL1_ERRIE                  BIT(5)                                  /*!< errors interrupt enable */
+#define SPI_CTL1_RBNEIE                 BIT(6)                                  /*!< receive buffer not empty interrupt enable */
+#define SPI_CTL1_TBEIE                  BIT(7)                                  /*!< transmit buffer empty interrupt enable */
+
+/* SPI_STAT */
+#define SPI_STAT_RBNE                   BIT(0)                                  /*!< receive buffer not empty */
+#define SPI_STAT_TBE                    BIT(1)                                  /*!< transmit buffer empty */
+#define SPI_STAT_I2SCH                  BIT(2)                                  /*!< I2S channel side */
+#define SPI_STAT_TXURERR                BIT(3)                                  /*!< I2S transmission underrun error bit */
+#define SPI_STAT_CRCERR                 BIT(4)                                  /*!< SPI CRC error bit */
+#define SPI_STAT_CONFERR                BIT(5)                                  /*!< SPI configuration error bit */
+#define SPI_STAT_RXORERR                BIT(6)                                  /*!< SPI reception overrun error bit */
+#define SPI_STAT_TRANS                  BIT(7)                                  /*!< transmitting on-going bit */
+#define SPI_STAT_FERR                   BIT(8)                                  /*!< format error bit */
+
+/* SPI_DATA */
+#define SPI_DATA_DATA                   BITS(0,15)                              /*!< data transfer register */
+
+/* SPI_CRCPOLY */
+#define SPI_CRCPOLY_CPR                 BITS(0,15)                              /*!< CRC polynomial register */
+
+/* SPI_RCRC */
+#define SPI_RCRC_RCR                    BITS(0,15)                              /*!< RX CRC register */
+
+/* SPI_TCRC */
+#define SPI_TCRC_TCR                    BITS(0,15)                              /*!< TX CRC register */
+
+/* SPI_I2SCTL */
+#define SPI_I2SCTL_CHLEN                BIT(0)                                  /*!< channel length */
+#define SPI_I2SCTL_DTLEN                BITS(1,2)                               /*!< data length */
+#define SPI_I2SCTL_CKPL                 BIT(3)                                  /*!< idle state clock polarity */
+#define SPI_I2SCTL_I2SSTD               BITS(4,5)                               /*!< I2S standard selection */
+#define SPI_I2SCTL_PCMSMOD              BIT(7)                                  /*!< PCM frame synchronization mode */
+#define SPI_I2SCTL_I2SOPMOD             BITS(8,9)                               /*!< I2S operation mode */
+#define SPI_I2SCTL_I2SEN                BIT(10)                                 /*!< I2S enable */
+#define SPI_I2SCTL_I2SSEL               BIT(11)                                 /*!< I2S mode selection */
+
+/* SPI_I2S_PSC */
+#define SPI_I2SPSC_DIV                  BITS(0,7)                               /*!< dividing factor for the prescaler */
+#define SPI_I2SPSC_OF                   BIT(8)                                  /*!< odd factor for the prescaler */
+#define SPI_I2SPSC_MCKOEN               BIT(9)                                  /*!< I2S MCK output enable */
+
+/* SPI_SPI_QCTL(only SPI5) */
+#define SPI_QCTL_QMOD                   BIT(0)                                  /*!< quad-SPI mode enable */
+#define SPI_QCTL_QRD                    BIT(1)                                  /*!< quad-SPI mode read select */
+#define SPI_QCTL_IO23_DRV               BIT(2)                                  /*!< drive SPI_IO2 and SPI_IO3 enable */
+
+/* constants definitions */
+/* SPI and I2S parameter struct definitions */
+typedef struct {
+    uint32_t device_mode;                                                       /*!< SPI master or slave */
+    uint32_t trans_mode;                                                        /*!< SPI transtype */
+    uint32_t frame_size;                                                        /*!< SPI frame size */
+    uint32_t nss;                                                               /*!< SPI nss control by handware or software */
+    uint32_t endian;                                                            /*!< SPI big endian or little endian */
+    uint32_t clock_polarity_phase;                                              /*!< SPI clock phase and polarity */
+    uint32_t prescale;                                                          /*!< SPI prescale factor */
+} spi_parameter_struct;
+
+/* SPI mode definitions */
+#define SPI_MASTER                      (SPI_CTL0_MSTMOD | SPI_CTL0_SWNSS)      /*!< SPI as master */
+#define SPI_SLAVE                       ((uint32_t)0x00000000U)                 /*!< SPI as slave */
+
+/* SPI bidirectional transfer direction */
+#define SPI_BIDIRECTIONAL_TRANSMIT      SPI_CTL0_BDOEN                          /*!< SPI work in transmit-only mode */
+#define SPI_BIDIRECTIONAL_RECEIVE       (~SPI_CTL0_BDOEN)                       /*!< SPI work in receive-only mode */
+
+/* SPI transmit type */
+#define SPI_TRANSMODE_FULLDUPLEX        ((uint32_t)0x00000000U)                 /*!< SPI receive and send data at fullduplex communication */
+#define SPI_TRANSMODE_RECEIVEONLY       SPI_CTL0_RO                             /*!< SPI only receive data */
+#define SPI_TRANSMODE_BDRECEIVE         SPI_CTL0_BDEN                           /*!< bidirectional receive data */
+#define SPI_TRANSMODE_BDTRANSMIT        (SPI_CTL0_BDEN | SPI_CTL0_BDOEN)        /*!< bidirectional transmit data*/
+
+/* SPI frame size */
+#define SPI_FRAMESIZE_16BIT             SPI_CTL0_FF16                           /*!< SPI frame size is 16 bits */
+#define SPI_FRAMESIZE_8BIT              ((uint32_t)0x00000000U)                 /*!< SPI frame size is 8 bits */
+
+/* SPI NSS control mode */
+#define SPI_NSS_SOFT                    SPI_CTL0_SWNSSEN                        /*!< SPI nss control by sofrware */
+#define SPI_NSS_HARD                    ((uint32_t)0x00000000U)                 /*!< SPI nss control by hardware */
+
+/* SPI transmit way */
+#define SPI_ENDIAN_MSB                  ((uint32_t)0x00000000U)                 /*!< SPI transmit way is big endian: transmit MSB first */
+#define SPI_ENDIAN_LSB                  SPI_CTL0_LF                             /*!< SPI transmit way is little endian: transmit LSB first */
+
+/* SPI clock polarity and phase */
+#define SPI_CK_PL_LOW_PH_1EDGE          ((uint32_t)0x00000000U)                 /*!< SPI clock polarity is low level and phase is first edge */
+#define SPI_CK_PL_HIGH_PH_1EDGE         SPI_CTL0_CKPL                           /*!< SPI clock polarity is high level and phase is first edge */
+#define SPI_CK_PL_LOW_PH_2EDGE          SPI_CTL0_CKPH                           /*!< SPI clock polarity is low level and phase is second edge */
+#define SPI_CK_PL_HIGH_PH_2EDGE         (SPI_CTL0_CKPL|SPI_CTL0_CKPH)           /*!< SPI clock polarity is high level and phase is second edge */
+
+/* SPI clock prescale factor */
+#define CTL0_PSC(regval)                (BITS(3,5)&((uint32_t)(regval)<<3))
+#define SPI_PSC_2                       CTL0_PSC(0)                             /*!< SPI clock prescale factor is 2 */
+#define SPI_PSC_4                       CTL0_PSC(1)                             /*!< SPI clock prescale factor is 4 */
+#define SPI_PSC_8                       CTL0_PSC(2)                             /*!< SPI clock prescale factor is 8 */
+#define SPI_PSC_16                      CTL0_PSC(3)                             /*!< SPI clock prescale factor is 16 */
+#define SPI_PSC_32                      CTL0_PSC(4)                             /*!< SPI clock prescale factor is 32 */
+#define SPI_PSC_64                      CTL0_PSC(5)                             /*!< SPI clock prescale factor is 64 */
+#define SPI_PSC_128                     CTL0_PSC(6)                             /*!< SPI clock prescale factor is 128 */
+#define SPI_PSC_256                     CTL0_PSC(7)                             /*!< SPI clock prescale factor is 256 */
+
+/* I2S audio sample rate */
+#define I2S_AUDIOSAMPLE_8K              ((uint32_t)8000U)                       /*!< I2S audio sample rate is 8KHz */
+#define I2S_AUDIOSAMPLE_11K             ((uint32_t)11025U)                      /*!< I2S audio sample rate is 11KHz */
+#define I2S_AUDIOSAMPLE_16K             ((uint32_t)16000U)                      /*!< I2S audio sample rate is 16KHz */
+#define I2S_AUDIOSAMPLE_22K             ((uint32_t)22050U)                      /*!< I2S audio sample rate is 22KHz */
+#define I2S_AUDIOSAMPLE_32K             ((uint32_t)32000U)                      /*!< I2S audio sample rate is 32KHz */
+#define I2S_AUDIOSAMPLE_44K             ((uint32_t)44100U)                      /*!< I2S audio sample rate is 44KHz */
+#define I2S_AUDIOSAMPLE_48K             ((uint32_t)48000U)                      /*!< I2S audio sample rate is 48KHz */
+#define I2S_AUDIOSAMPLE_96K             ((uint32_t)96000U)                      /*!< I2S audio sample rate is 96KHz */
+#define I2S_AUDIOSAMPLE_192K            ((uint32_t)192000U)                     /*!< I2S audio sample rate is 192KHz */
+
+/* I2S frame format */
+#define I2SCTL_DTLEN(regval)            (BITS(1,2)&((uint32_t)(regval)<<1))
+#define I2S_FRAMEFORMAT_DT16B_CH16B     I2SCTL_DTLEN(0)                         /*!< I2S data length is 16 bit and channel length is 16 bit */
+#define I2S_FRAMEFORMAT_DT16B_CH32B     (I2SCTL_DTLEN(0)|SPI_I2SCTL_CHLEN)      /*!< I2S data length is 16 bit and channel length is 32 bit */
+#define I2S_FRAMEFORMAT_DT24B_CH32B     (I2SCTL_DTLEN(1)|SPI_I2SCTL_CHLEN)      /*!< I2S data length is 24 bit and channel length is 32 bit */
+#define I2S_FRAMEFORMAT_DT32B_CH32B     (I2SCTL_DTLEN(2)|SPI_I2SCTL_CHLEN)      /*!< I2S data length is 32 bit and channel length is 32 bit */
+
+/* I2S master clock output */
+#define I2S_MCKOUT_DISABLE              ((uint32_t)0x00000000U)                 /*!< I2S master clock output disable */
+#define I2S_MCKOUT_ENABLE               SPI_I2SPSC_MCKOEN                       /*!< I2S master clock output enable */
+
+/* I2S operation mode */
+#define I2SCTL_I2SOPMOD(regval)         (BITS(8,9)&((uint32_t)(regval)<<8))
+#define I2S_MODE_SLAVETX                I2SCTL_I2SOPMOD(0)                      /*!< I2S slave transmit mode */
+#define I2S_MODE_SLAVERX                I2SCTL_I2SOPMOD(1)                      /*!< I2S slave receive mode */
+#define I2S_MODE_MASTERTX               I2SCTL_I2SOPMOD(2)                      /*!< I2S master transmit mode */
+#define I2S_MODE_MASTERRX               I2SCTL_I2SOPMOD(3)                      /*!< I2S master receive mode */
+
+/* I2S standard */
+#define I2SCTL_I2SSTD(regval)           (BITS(4,5)&((uint32_t)(regval)<<4))
+#define I2S_STD_PHILLIPS                I2SCTL_I2SSTD(0)                        /*!< I2S phillips standard */
+#define I2S_STD_MSB                     I2SCTL_I2SSTD(1)                        /*!< I2S MSB standard */
+#define I2S_STD_LSB                     I2SCTL_I2SSTD(2)                        /*!< I2S LSB standard */
+#define I2S_STD_PCMSHORT                I2SCTL_I2SSTD(3)                        /*!< I2S PCM short standard */
+#define I2S_STD_PCMLONG                 (I2SCTL_I2SSTD(3) | SPI_I2SCTL_PCMSMOD)   /*!< I2S PCM long standard */
+
+/* I2S clock polarity */
+#define I2S_CKPL_LOW                    ((uint32_t)0x00000000U)                 /*!< I2S clock polarity low level */
+#define I2S_CKPL_HIGH                   SPI_I2SCTL_CKPL                         /*!< I2S clock polarity high level */
+
+/* SPI DMA constants definitions */
+#define SPI_DMA_TRANSMIT                ((uint8_t)0x00U)                        /*!< SPI transmit data use DMA */
+#define SPI_DMA_RECEIVE                 ((uint8_t)0x01U)                        /*!< SPI receive data use DMA */
+
+/* SPI CRC constants definitions */
+#define SPI_CRC_TX                      ((uint8_t)0x00U)                        /*!< SPI transmit CRC value */
+#define SPI_CRC_RX                      ((uint8_t)0x01U)                        /*!< SPI receive CRC value */
+
+/* SPI/I2S interrupt enable/disable constants definitions */
+#define SPI_I2S_INT_TBE                 ((uint8_t)0x00U)                        /*!< transmit buffer empty interrupt */
+#define SPI_I2S_INT_RBNE                ((uint8_t)0x01U)                        /*!< receive buffer not empty interrupt */
+#define SPI_I2S_INT_ERR                 ((uint8_t)0x02U)                        /*!< error interrupt */
+
+/* SPI/I2S interrupt flag constants definitions */
+#define SPI_I2S_INT_FLAG_TBE            ((uint8_t)0x00U)                        /*!< transmit buffer empty interrupt flag */
+#define SPI_I2S_INT_FLAG_RBNE           ((uint8_t)0x01U)                        /*!< receive buffer not empty interrupt flag */
+#define SPI_I2S_INT_FLAG_RXORERR        ((uint8_t)0x02U)                        /*!< overrun interrupt flag */
+#define SPI_INT_FLAG_CONFERR            ((uint8_t)0x03U)                        /*!< config error interrupt flag */
+#define SPI_INT_FLAG_CRCERR             ((uint8_t)0x04U)                        /*!< CRC error interrupt flag */
+#define I2S_INT_FLAG_TXURERR            ((uint8_t)0x05U)                        /*!< underrun error interrupt flag */
+#define SPI_I2S_INT_FLAG_FERR           ((uint8_t)0x06U)                        /*!< format error interrupt flag */
+
+/* SPI/I2S flag definitions */
+#define SPI_FLAG_RBNE                   SPI_STAT_RBNE                           /*!< receive buffer not empty flag */
+#define SPI_FLAG_TBE                    SPI_STAT_TBE                            /*!< transmit buffer empty flag */
+#define SPI_FLAG_CRCERR                 SPI_STAT_CRCERR                         /*!< CRC error flag */
+#define SPI_FLAG_CONFERR                SPI_STAT_CONFERR                        /*!< mode config error flag */
+#define SPI_FLAG_RXORERR                SPI_STAT_RXORERR                        /*!< receive overrun error flag */
+#define SPI_FLAG_TRANS                  SPI_STAT_TRANS                          /*!< transmit on-going flag */
+#define SPI_FLAG_FERR                   SPI_STAT_FERR                           /*!< format error flag */
+#define I2S_FLAG_RBNE                   SPI_STAT_RBNE                           /*!< receive buffer not empty flag */
+#define I2S_FLAG_TBE                    SPI_STAT_TBE                            /*!< transmit buffer empty flag */
+#define I2S_FLAG_CH                     SPI_STAT_I2SCH                          /*!< channel side flag */
+#define I2S_FLAG_TXURERR                SPI_STAT_TXURERR                        /*!< underrun error flag */
+#define I2S_FLAG_RXORERR                SPI_STAT_RXORERR                        /*!< overrun error flag */
+#define I2S_FLAG_TRANS                  SPI_STAT_TRANS                          /*!< transmit on-going flag */
+#define I2S_FLAG_FERR                   SPI_STAT_FERR                           /*!< format error flag */
+
+/* function declarations */
+/* initialization functions */
+/* deinitialize SPI and I2S */
+void spi_i2s_deinit(uint32_t spi_periph);
+/* initialize the parameters of SPI struct with default values */
+void spi_struct_para_init(spi_parameter_struct *spi_struct);
+/* initialize SPI parameter */
+void spi_init(uint32_t spi_periph, spi_parameter_struct *spi_struct);
+/* enable SPI */
+void spi_enable(uint32_t spi_periph);
+/* disable SPI */
+void spi_disable(uint32_t spi_periph);
+
+/* initialize I2S parameter */
+void i2s_init(uint32_t spi_periph, uint32_t i2s_mode, uint32_t i2s_standard, uint32_t i2s_ckpl);
+/* configure I2S prescale */
+void i2s_psc_config(uint32_t spi_periph, uint32_t i2s_audiosample, uint32_t i2s_frameformat, uint32_t i2s_mckout);
+/* enable I2S */
+void i2s_enable(uint32_t spi_periph);
+/* disable I2S */
+void i2s_disable(uint32_t spi_periph);
+
+/* NSS functions */
+/* enable SPI nss output */
+void spi_nss_output_enable(uint32_t spi_periph);
+/* disable SPI nss output */
+void spi_nss_output_disable(uint32_t spi_periph);
+/* SPI nss pin high level in software mode */
+void spi_nss_internal_high(uint32_t spi_periph);
+/* SPI nss pin low level in software mode */
+void spi_nss_internal_low(uint32_t spi_periph);
+
+/* SPI DMA functions */
+/* enable SPI DMA send or receive */
+void spi_dma_enable(uint32_t spi_periph, uint8_t spi_dma);
+/* diable SPI DMA send or receive */
+void spi_dma_disable(uint32_t spi_periph, uint8_t spi_dma);
+
+/* SPI/I2S transfer configure functions */
+/* configure SPI/I2S data frame format */
+void spi_i2s_data_frame_format_config(uint32_t spi_periph, uint16_t frame_format);
+/* SPI transmit data */
+void spi_i2s_data_transmit(uint32_t spi_periph, uint16_t data);
+/* SPI receive data */
+uint16_t spi_i2s_data_receive(uint32_t spi_periph);
+/* configure SPI bidirectional transfer direction  */
+void spi_bidirectional_transfer_config(uint32_t spi_periph, uint32_t transfer_direction);
+
+/* SPI CRC functions */
+/* set SPI CRC polynomial */
+void spi_crc_polynomial_set(uint32_t spi_periph, uint16_t crc_poly);
+/* get SPI CRC polynomial */
+uint16_t spi_crc_polynomial_get(uint32_t spi_periph);
+/* turn on SPI CRC function */
+void spi_crc_on(uint32_t spi_periph);
+/* turn off SPI CRC function */
+void spi_crc_off(uint32_t spi_periph);
+/* SPI next data is CRC value */
+void spi_crc_next(uint32_t spi_periph);
+/* get SPI CRC send value or receive value */
+uint16_t spi_crc_get(uint32_t spi_periph, uint8_t spi_crc);
+
+/* SPI TI mode functions */
+/* enable SPI TI mode */
+void spi_ti_mode_enable(uint32_t spi_periph);
+/* disable SPI TI mode */
+void spi_ti_mode_disable(uint32_t spi_periph);
+
+/* configure i2s full duplex mode */
+void i2s_full_duplex_mode_config(uint32_t i2s_add_periph, uint32_t i2s_mode, uint32_t i2s_standard, uint32_t i2s_ckpl, uint32_t i2s_frameformat);
+
+/* quad wire SPI functions */
+/* enable quad wire SPI */
+void spi_quad_enable(uint32_t spi_periph);
+/* disable quad wire SPI */
+void spi_quad_disable(uint32_t spi_periph);
+/* enable quad wire SPI write */
+void spi_quad_write_enable(uint32_t spi_periph);
+/* enable quad wire SPI read */
+void spi_quad_read_enable(uint32_t spi_periph);
+/* enable SPI_IO2 and SPI_IO3 pin output */
+void spi_quad_io23_output_enable(uint32_t spi_periph);
+/* disable SPI_IO2 and SPI_IO3 pin output */
+void spi_quad_io23_output_disable(uint32_t spi_periph);
+
+/* flag & interrupt functions */
+/* enable SPI and I2S interrupt */
+void spi_i2s_interrupt_enable(uint32_t spi_periph, uint8_t spi_i2s_int);
+/* disable SPI and I2S interrupt */
+void spi_i2s_interrupt_disable(uint32_t spi_periph, uint8_t spi_i2s_int);
+/* get SPI and I2S interrupt status*/
+FlagStatus spi_i2s_interrupt_flag_get(uint32_t spi_periph, uint8_t spi_i2s_int);
+/* get SPI and I2S flag status */
+FlagStatus spi_i2s_flag_get(uint32_t spi_periph, uint32_t spi_i2s_flag);
+/* clear SPI CRC error flag status */
+void spi_crc_error_clear(uint32_t spi_periph);
+
+#endif /* GD32F4XX_SPI_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_syscfg.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_syscfg.h
@@ -1,0 +1,182 @@
+/*!
+    \file    gd32f4xx_syscfg.h
+    \brief   definitions for the SYSCFG
+    
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_SYSCFG_H
+#define GD32F4XX_SYSCFG_H
+
+#include "gd32f4xx.h"
+
+/* SYSCFG definitions */
+#define SYSCFG                              SYSCFG_BASE
+
+/* registers definitions */
+#define SYSCFG_CFG0                         REG32(SYSCFG + 0x00U)    /*!< system configuration register 0 */
+#define SYSCFG_CFG1                         REG32(SYSCFG + 0x04U)    /*!< system configuration register 1 */
+#define SYSCFG_EXTISS0                      REG32(SYSCFG + 0x08U)    /*!< EXTI sources selection register 0 */
+#define SYSCFG_EXTISS1                      REG32(SYSCFG + 0x0CU)    /*!< EXTI sources selection register 1 */
+#define SYSCFG_EXTISS2                      REG32(SYSCFG + 0x10U)    /*!< EXTI sources selection register 2 */
+#define SYSCFG_EXTISS3                      REG32(SYSCFG + 0x14U)    /*!< EXTI sources selection register 3 */
+#define SYSCFG_CPSCTL                       REG32(SYSCFG + 0x20U)    /*!< system I/O compensation control register */
+
+/* SYSCFG_CFG0 bits definitions */
+#define SYSCFG_CFG0_BOOT_MODE               BITS(0,2)                /*!< SYSCFG memory remap config */
+#define SYSCFG_CFG0_FMC_SWP                 BIT(8)                   /*!< FMC memory swap config */
+#define SYSCFG_CFG0_EXMC_SWP                BITS(10,11)              /*!< EXMC memory swap config */
+
+/* SYSCFG_CFG1 bits definitions */
+#define SYSCFG_CFG1_ENET_PHY_SEL            BIT(23)                  /*!< Ethernet PHY selection config */
+
+/* SYSCFG_EXTISS0 bits definitions */
+#define SYSCFG_EXTISS0_EXTI0_SS             BITS(0,3)                /*!< EXTI 0 configuration */
+#define SYSCFG_EXTISS0_EXTI1_SS             BITS(4,7)                /*!< EXTI 1 configuration */
+#define SYSCFG_EXTISS0_EXTI2_SS             BITS(8,11)               /*!< EXTI 2 configuration */
+#define SYSCFG_EXTISS0_EXTI3_SS             BITS(12,15)              /*!< EXTI 3 configuration */
+
+/* SYSCFG_EXTISS1 bits definitions */
+#define SYSCFG_EXTISS1_EXTI4_SS             BITS(0,3)                /*!< EXTI 4 configuration */
+#define SYSCFG_EXTISS1_EXTI5_SS             BITS(4,7)                /*!< EXTI 5 configuration */
+#define SYSCFG_EXTISS1_EXTI6_SS             BITS(8,11)               /*!< EXTI 6 configuration */
+#define SYSCFG_EXTISS1_EXTI7_SS             BITS(12,15)              /*!< EXTI 7 configuration */
+
+/* SYSCFG_EXTISS2 bits definitions */
+#define SYSCFG_EXTISS2_EXTI8_SS             BITS(0,3)                /*!< EXTI 8 configuration */
+#define SYSCFG_EXTISS2_EXTI9_SS             BITS(4,7)                /*!< EXTI 9 configuration */
+#define SYSCFG_EXTISS2_EXTI10_SS            BITS(8,11)               /*!< EXTI 10 configuration */
+#define SYSCFG_EXTISS2_EXTI11_SS            BITS(12,15)              /*!< EXTI 11 configuration */
+
+/* SYSCFG_EXTISS3 bits definitions */
+#define SYSCFG_EXTISS3_EXTI12_SS            BITS(0,3)                /*!< EXTI 12 configuration */
+#define SYSCFG_EXTISS3_EXTI13_SS            BITS(4,7)                /*!< EXTI 13 configuration */
+#define SYSCFG_EXTISS3_EXTI14_SS            BITS(8,11)               /*!< EXTI 14 configuration */
+#define SYSCFG_EXTISS3_EXTI15_SS            BITS(12,15)              /*!< EXTI 15 configuration */
+
+/* SYSCFG_CPSCTL bits definitions */
+#define SYSCFG_CPSCTL_CPS_EN                BIT(0)                   /*!< I/O compensation cell enable */
+#define SYSCFG_CPSCTL_CPS_RDY               BIT(8)                   /*!< I/O compensation cell is ready or not */
+
+/* constants definitions */
+/* boot mode definitions */
+#define SYSCFG_BOOTMODE_FLASH               ((uint8_t)0x00U)          /*!< main flash memory remap */
+#define SYSCFG_BOOTMODE_BOOTLOADER          ((uint8_t)0x01U)          /*!< boot loader remap */
+#define SYSCFG_BOOTMODE_EXMC_SRAM           ((uint8_t)0x02U)          /*!< SRAM/NOR 0 and 1 of EXMC remap */
+#define SYSCFG_BOOTMODE_SRAM                ((uint8_t)0x03U)          /*!< SRAM0 of on-chip SRAM remap */
+#define SYSCFG_BOOTMODE_EXMC_SDRAM          ((uint8_t)0x04U)          /*!< SDRAM bank0 of EXMC remap */
+
+/* FMC swap definitions */
+#define SYSCFG_FMC_SWP_BANK0                ((uint32_t)0x00000000U)   /*!< main flash Bank 0 is mapped at address 0x08000000 */
+#define SYSCFG_FMC_SWP_BANK1                ((uint32_t)0x00000100U)   /*!< main flash Bank 1 is mapped at address 0x08000000 */
+
+/* EXMC swap enable/disable */
+#define SYSCFG_EXMC_SWP_ENABLE              ((uint32_t)0x00000400U)   /*!< SDRAM bank 0 and bank 1 are swapped with NAND bank 1 and PC card */
+#define SYSCFG_EXMC_SWP_DISABLE             ((uint32_t)0x00000000U)   /*!< no memory mapping swap */
+
+/* EXTI source select definition */
+#define EXTISS0                             ((uint8_t)0x00U)          /*!< EXTI source select GPIOx pin 0~3 */
+#define EXTISS1                             ((uint8_t)0x01U)          /*!< EXTI source select GPIOx pin 4~7 */
+#define EXTISS2                             ((uint8_t)0x02U)          /*!< EXTI source select GPIOx pin 8~11 */
+#define EXTISS3                             ((uint8_t)0x03U)          /*!< EXTI source select GPIOx pin 12~15 */
+
+/* EXTI source select mask bits definition */
+#define EXTI_SS_MASK                        BITS(0,3)                 /*!< EXTI source select mask */
+
+/* EXTI source select jumping step definition */
+#define EXTI_SS_JSTEP                       ((uint8_t)(0x04U))        /*!< EXTI source select jumping step */
+
+/* EXTI source select moving step definition */
+#define EXTI_SS_MSTEP(pin)                  (EXTI_SS_JSTEP*((pin)%EXTI_SS_JSTEP))   /*!< EXTI source select moving step */
+
+/* EXTI source port definitions */
+#define EXTI_SOURCE_GPIOA                   ((uint8_t)0x00U)          /*!< EXTI GPIOA configuration */
+#define EXTI_SOURCE_GPIOB                   ((uint8_t)0x01U)          /*!< EXTI GPIOB configuration */
+#define EXTI_SOURCE_GPIOC                   ((uint8_t)0x02U)          /*!< EXTI GPIOC configuration */
+#define EXTI_SOURCE_GPIOD                   ((uint8_t)0x03U)          /*!< EXTI GPIOD configuration */
+#define EXTI_SOURCE_GPIOE                   ((uint8_t)0x04U)          /*!< EXTI GPIOE configuration */
+#define EXTI_SOURCE_GPIOF                   ((uint8_t)0x05U)          /*!< EXTI GPIOF configuration */
+#define EXTI_SOURCE_GPIOG                   ((uint8_t)0x06U)          /*!< EXTI GPIOG configuration */
+#define EXTI_SOURCE_GPIOH                   ((uint8_t)0x07U)          /*!< EXTI GPIOH configuration */
+#define EXTI_SOURCE_GPIOI                   ((uint8_t)0x08U)          /*!< EXTI GPIOI configuration */
+
+/* EXTI source pin definitions */
+#define EXTI_SOURCE_PIN0                    ((uint8_t)0x00U)          /*!< EXTI GPIO pin0 configuration */
+#define EXTI_SOURCE_PIN1                    ((uint8_t)0x01U)          /*!< EXTI GPIO pin1 configuration */
+#define EXTI_SOURCE_PIN2                    ((uint8_t)0x02U)          /*!< EXTI GPIO pin2 configuration */
+#define EXTI_SOURCE_PIN3                    ((uint8_t)0x03U)          /*!< EXTI GPIO pin3 configuration */
+#define EXTI_SOURCE_PIN4                    ((uint8_t)0x04U)          /*!< EXTI GPIO pin4 configuration */
+#define EXTI_SOURCE_PIN5                    ((uint8_t)0x05U)          /*!< EXTI GPIO pin5 configuration */
+#define EXTI_SOURCE_PIN6                    ((uint8_t)0x06U)          /*!< EXTI GPIO pin6 configuration */
+#define EXTI_SOURCE_PIN7                    ((uint8_t)0x07U)          /*!< EXTI GPIO pin7 configuration */
+#define EXTI_SOURCE_PIN8                    ((uint8_t)0x08U)          /*!< EXTI GPIO pin8 configuration */
+#define EXTI_SOURCE_PIN9                    ((uint8_t)0x09U)          /*!< EXTI GPIO pin9 configuration */
+#define EXTI_SOURCE_PIN10                   ((uint8_t)0x0AU)          /*!< EXTI GPIO pin10 configuration */
+#define EXTI_SOURCE_PIN11                   ((uint8_t)0x0BU)          /*!< EXTI GPIO pin11 configuration */
+#define EXTI_SOURCE_PIN12                   ((uint8_t)0x0CU)          /*!< EXTI GPIO pin12 configuration */
+#define EXTI_SOURCE_PIN13                   ((uint8_t)0x0DU)          /*!< EXTI GPIO pin13 configuration */
+#define EXTI_SOURCE_PIN14                   ((uint8_t)0x0EU)          /*!< EXTI GPIO pin14 configuration */
+#define EXTI_SOURCE_PIN15                   ((uint8_t)0x0FU)          /*!< EXTI GPIO pin15 configuration */
+
+/* ethernet PHY selection */
+#define SYSCFG_ENET_PHY_MII                 ((uint32_t)0x00000000U)   /*!< MII is selected for the Ethernet MAC */
+#define SYSCFG_ENET_PHY_RMII                ((uint32_t)0x00800000U)   /*!< RMII is selected for the Ethernet MAC */
+
+/* I/O compensation cell enable/disable */
+#define SYSCFG_COMPENSATION_ENABLE          ((uint32_t)0x00000001U)   /*!< I/O compensation cell enable */
+#define SYSCFG_COMPENSATION_DISABLE         ((uint32_t)0x00000000U)   /*!< I/O compensation cell disable */
+
+/* function declarations */
+/* initialization functions */
+/* deinit syscfg module */
+void syscfg_deinit(void);
+
+/* function configuration */
+/* configure the boot mode */
+void syscfg_bootmode_config(uint8_t syscfg_bootmode);
+/* configure FMC memory mapping swap */
+void syscfg_fmc_swap_config(uint32_t syscfg_fmc_swap);
+/* configure the EXMC swap */
+void syscfg_exmc_swap_config(uint32_t syscfg_exmc_swap); 
+/* configure the GPIO pin as EXTI Line */
+void syscfg_exti_line_config(uint8_t exti_port, uint8_t exti_pin);
+/* configure the PHY interface for the ethernet MAC */
+void syscfg_enet_phy_interface_config(uint32_t syscfg_enet_phy_interface);
+/* configure the I/O compensation cell */
+void syscfg_compensation_config(uint32_t syscfg_compensation);
+
+/* interrupt & flag functions */
+/* check the I/O compensation cell is ready or not */
+FlagStatus syscfg_flag_get(void);
+
+#endif /* GD32F4XX_SYSCFG_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_timer.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_timer.h
@@ -1,0 +1,779 @@
+/*!
+    \file    gd32f4xx_timer.h
+    \brief   definitions for the TIMER
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_TIMER_H
+#define GD32F4XX_TIMER_H
+
+#include "gd32f4xx.h"
+
+/* TIMERx(x=0..13) definitions */
+#define TIMER0                           (TIMER_BASE + 0x00010000U)
+#define TIMER1                           (TIMER_BASE + 0x00000000U)
+#define TIMER2                           (TIMER_BASE + 0x00000400U)
+#define TIMER3                           (TIMER_BASE + 0x00000800U)
+#define TIMER4                           (TIMER_BASE + 0x00000C00U)
+#define TIMER5                           (TIMER_BASE + 0x00001000U)
+#define TIMER6                           (TIMER_BASE + 0x00001400U)
+#define TIMER7                           (TIMER_BASE + 0x00010400U)
+#define TIMER8                           (TIMER_BASE + 0x00014000U)
+#define TIMER9                           (TIMER_BASE + 0x00014400U)
+#define TIMER10                          (TIMER_BASE + 0x00014800U)
+#define TIMER11                          (TIMER_BASE + 0x00001800U)
+#define TIMER12                          (TIMER_BASE + 0x00001C00U)
+#define TIMER13                          (TIMER_BASE + 0x00002000U)
+
+/* registers definitions */
+#define TIMER_CTL0(timerx)               REG32((timerx) + 0x00U)           /*!< TIMER control register 0 */
+#define TIMER_CTL1(timerx)               REG32((timerx) + 0x04U)           /*!< TIMER control register 1 */
+#define TIMER_SMCFG(timerx)              REG32((timerx) + 0x08U)           /*!< TIMER slave mode configuration register */
+#define TIMER_DMAINTEN(timerx)           REG32((timerx) + 0x0CU)           /*!< TIMER DMA and interrupt enable register */
+#define TIMER_INTF(timerx)               REG32((timerx) + 0x10U)           /*!< TIMER interrupt flag register */
+#define TIMER_SWEVG(timerx)              REG32((timerx) + 0x14U)           /*!< TIMER software event generation register */
+#define TIMER_CHCTL0(timerx)             REG32((timerx) + 0x18U)           /*!< TIMER channel control register 0 */
+#define TIMER_CHCTL1(timerx)             REG32((timerx) + 0x1CU)           /*!< TIMER channel control register 1 */
+#define TIMER_CHCTL2(timerx)             REG32((timerx) + 0x20U)           /*!< TIMER channel control register 2 */
+#define TIMER_CNT(timerx)                REG32((timerx) + 0x24U)           /*!< TIMER counter register */
+#define TIMER_PSC(timerx)                REG32((timerx) + 0x28U)           /*!< TIMER prescaler register */
+#define TIMER_CAR(timerx)                REG32((timerx) + 0x2CU)           /*!< TIMER counter auto reload register */
+#define TIMER_CREP(timerx)               REG32((timerx) + 0x30U)           /*!< TIMER counter repetition register */
+#define TIMER_CH0CV(timerx)              REG32((timerx) + 0x34U)           /*!< TIMER channel 0 capture/compare value register */
+#define TIMER_CH1CV(timerx)              REG32((timerx) + 0x38U)           /*!< TIMER channel 1 capture/compare value register */
+#define TIMER_CH2CV(timerx)              REG32((timerx) + 0x3CU)           /*!< TIMER channel 2 capture/compare value register */
+#define TIMER_CH3CV(timerx)              REG32((timerx) + 0x40U)           /*!< TIMER channel 3 capture/compare value register */
+#define TIMER_CCHP(timerx)               REG32((timerx) + 0x44U)           /*!< TIMER complementary channel protection register */
+#define TIMER_DMACFG(timerx)             REG32((timerx) + 0x48U)           /*!< TIMER DMA configuration register */
+#define TIMER_DMATB(timerx)              REG32((timerx) + 0x4CU)           /*!< TIMER DMA transfer buffer register */
+#define TIMER_IRMP(timerx)               REG32((timerx) + 0x50U)           /*!< TIMER channel input remap register */
+#define TIMER_CFG(timerx)                REG32((timerx) + 0xFCU)           /*!< TIMER configuration register */
+
+/* bits definitions */
+/* TIMER_CTL0 */
+#define TIMER_CTL0_CEN                   BIT(0)              /*!< TIMER counter enable */
+#define TIMER_CTL0_UPDIS                 BIT(1)              /*!< update disable */
+#define TIMER_CTL0_UPS                   BIT(2)              /*!< update source */
+#define TIMER_CTL0_SPM                   BIT(3)              /*!< single pulse mode */
+#define TIMER_CTL0_DIR                   BIT(4)              /*!< timer counter direction */
+#define TIMER_CTL0_CAM                   BITS(5,6)           /*!< center-aligned mode selection */
+#define TIMER_CTL0_ARSE                  BIT(7)              /*!< auto-reload shadow enable */
+#define TIMER_CTL0_CKDIV                 BITS(8,9)           /*!< clock division */
+
+/* TIMER_CTL1 */
+#define TIMER_CTL1_CCSE                  BIT(0)              /*!< commutation control shadow enable */
+#define TIMER_CTL1_CCUC                  BIT(2)              /*!< commutation control shadow register update control */
+#define TIMER_CTL1_DMAS                  BIT(3)              /*!< DMA request source selection */
+#define TIMER_CTL1_MMC                   BITS(4,6)           /*!< master mode control */
+#define TIMER_CTL1_TI0S                  BIT(7)              /*!< channel 0 trigger input selection(hall mode selection) */
+#define TIMER_CTL1_ISO0                  BIT(8)              /*!< idle state of channel 0 output */
+#define TIMER_CTL1_ISO0N                 BIT(9)              /*!< idle state of channel 0 complementary output */
+#define TIMER_CTL1_ISO1                  BIT(10)             /*!< idle state of channel 1 output */
+#define TIMER_CTL1_ISO1N                 BIT(11)             /*!< idle state of channel 1 complementary output */
+#define TIMER_CTL1_ISO2                  BIT(12)             /*!< idle state of channel 2 output */
+#define TIMER_CTL1_ISO2N                 BIT(13)             /*!< idle state of channel 2 complementary output */
+#define TIMER_CTL1_ISO3                  BIT(14)             /*!< idle state of channel 3 output */
+
+/* TIMER_SMCFG */
+#define TIMER_SMCFG_SMC                  BITS(0,2)           /*!< slave mode control */
+#define TIMER_SMCFG_TRGS                 BITS(4,6)           /*!< trigger selection */
+#define TIMER_SMCFG_MSM                  BIT(7)              /*!< master-slave mode */
+#define TIMER_SMCFG_ETFC                 BITS(8,11)          /*!< external trigger filter control */
+#define TIMER_SMCFG_ETPSC                BITS(12,13)         /*!< external trigger prescaler */
+#define TIMER_SMCFG_SMC1                 BIT(14)             /*!< part of SMC for enable external clock mode 1 */
+#define TIMER_SMCFG_ETP                  BIT(15)             /*!< external trigger polarity */
+ 
+/* TIMER_DMAINTEN */
+#define TIMER_DMAINTEN_UPIE              BIT(0)              /*!< update interrupt enable */
+#define TIMER_DMAINTEN_CH0IE             BIT(1)              /*!< channel 0 capture/compare interrupt enable */
+#define TIMER_DMAINTEN_CH1IE             BIT(2)              /*!< channel 1 capture/compare interrupt enable */
+#define TIMER_DMAINTEN_CH2IE             BIT(3)              /*!< channel 2 capture/compare interrupt enable */
+#define TIMER_DMAINTEN_CH3IE             BIT(4)              /*!< channel 3 capture/compare interrupt enable */
+#define TIMER_DMAINTEN_CMTIE             BIT(5)              /*!< commutation interrupt request enable */
+#define TIMER_DMAINTEN_TRGIE             BIT(6)              /*!< trigger interrupt enable */
+#define TIMER_DMAINTEN_BRKIE             BIT(7)              /*!< break interrupt enable */
+#define TIMER_DMAINTEN_UPDEN             BIT(8)              /*!< update DMA request enable */
+#define TIMER_DMAINTEN_CH0DEN            BIT(9)              /*!< channel 0 DMA request enable */
+#define TIMER_DMAINTEN_CH1DEN            BIT(10)             /*!< channel 1 DMA request enable */
+#define TIMER_DMAINTEN_CH2DEN            BIT(11)             /*!< channel 2 DMA request enable */
+#define TIMER_DMAINTEN_CH3DEN            BIT(12)             /*!< channel 3 DMA request enable */
+#define TIMER_DMAINTEN_CMTDEN            BIT(13)             /*!< commutation DMA request enable */
+#define TIMER_DMAINTEN_TRGDEN            BIT(14)             /*!< trigger DMA request enable */
+
+/* TIMER_INTF */
+#define TIMER_INTF_UPIF                  BIT(0)              /*!< update interrupt flag */
+#define TIMER_INTF_CH0IF                 BIT(1)              /*!< channel 0 capture/compare interrupt flag */
+#define TIMER_INTF_CH1IF                 BIT(2)              /*!< channel 1 capture/compare interrupt flag */
+#define TIMER_INTF_CH2IF                 BIT(3)              /*!< channel 2 capture/compare interrupt flag */
+#define TIMER_INTF_CH3IF                 BIT(4)              /*!< channel 3 capture/compare interrupt flag */
+#define TIMER_INTF_CMTIF                 BIT(5)              /*!< channel commutation interrupt flag */
+#define TIMER_INTF_TRGIF                 BIT(6)              /*!< trigger interrupt flag */
+#define TIMER_INTF_BRKIF                 BIT(7)              /*!< break interrupt flag */
+#define TIMER_INTF_CH0OF                 BIT(9)              /*!< channel 0 overcapture flag */
+#define TIMER_INTF_CH1OF                 BIT(10)             /*!< channel 1 overcapture flag */
+#define TIMER_INTF_CH2OF                 BIT(11)             /*!< channel 2 overcapture flag */
+#define TIMER_INTF_CH3OF                 BIT(12)             /*!< channel 3 overcapture flag */
+
+/* TIMER_SWEVG */
+#define TIMER_SWEVG_UPG                  BIT(0)              /*!< update event generate */
+#define TIMER_SWEVG_CH0G                 BIT(1)              /*!< channel 0 capture or compare event generation */
+#define TIMER_SWEVG_CH1G                 BIT(2)              /*!< channel 1 capture or compare event generation */
+#define TIMER_SWEVG_CH2G                 BIT(3)              /*!< channel 2 capture or compare event generation */
+#define TIMER_SWEVG_CH3G                 BIT(4)              /*!< channel 3 capture or compare event generation */
+#define TIMER_SWEVG_CMTG                 BIT(5)              /*!< channel commutation event generation */
+#define TIMER_SWEVG_TRGG                 BIT(6)              /*!< trigger event generation */
+#define TIMER_SWEVG_BRKG                 BIT(7)              /*!< break event generation */
+
+/* TIMER_CHCTL0 */
+/* output compare mode */
+#define TIMER_CHCTL0_CH0MS               BITS(0,1)           /*!< channel 0 mode selection */
+#define TIMER_CHCTL0_CH0COMFEN           BIT(2)              /*!< channel 0 output compare fast enable */
+#define TIMER_CHCTL0_CH0COMSEN           BIT(3)              /*!< channel 0 output compare shadow enable */
+#define TIMER_CHCTL0_CH0COMCTL           BITS(4,6)           /*!< channel 0 output compare mode */
+#define TIMER_CHCTL0_CH0COMCEN           BIT(7)              /*!< channel 0 output compare clear enable */
+#define TIMER_CHCTL0_CH1MS               BITS(8,9)           /*!< channel 1 mode selection */
+#define TIMER_CHCTL0_CH1COMFEN           BIT(10)             /*!< channel 1 output compare fast enable */
+#define TIMER_CHCTL0_CH1COMSEN           BIT(11)             /*!< channel 1 output compare shadow enable */
+#define TIMER_CHCTL0_CH1COMCTL           BITS(12,14)         /*!< channel 1 output compare mode */
+#define TIMER_CHCTL0_CH1COMCEN           BIT(15)             /*!< channel 1 output compare clear enable */
+/* input capture mode */
+#define TIMER_CHCTL0_CH0CAPPSC           BITS(2,3)           /*!< channel 0 input capture prescaler */
+#define TIMER_CHCTL0_CH0CAPFLT           BITS(4,7)           /*!< channel 0 input capture filter control */
+#define TIMER_CHCTL0_CH1CAPPSC           BITS(10,11)         /*!< channel 1 input capture prescaler */
+#define TIMER_CHCTL0_CH1CAPFLT           BITS(12,15)         /*!< channel 1 input capture filter control */
+
+/* TIMER_CHCTL1 */
+/* output compare mode */
+#define TIMER_CHCTL1_CH2MS               BITS(0,1)           /*!< channel 2 mode selection */
+#define TIMER_CHCTL1_CH2COMFEN           BIT(2)              /*!< channel 2 output compare fast enable */
+#define TIMER_CHCTL1_CH2COMSEN           BIT(3)              /*!< channel 2 output compare shadow enable */
+#define TIMER_CHCTL1_CH2COMCTL           BITS(4,6)           /*!< channel 2 output compare mode */
+#define TIMER_CHCTL1_CH2COMCEN           BIT(7)              /*!< channel 2 output compare clear enable */
+#define TIMER_CHCTL1_CH3MS               BITS(8,9)           /*!< channel 3 mode selection */
+#define TIMER_CHCTL1_CH3COMFEN           BIT(10)             /*!< channel 3 output compare fast enable */
+#define TIMER_CHCTL1_CH3COMSEN           BIT(11)             /*!< channel 3 output compare shadow enable */
+#define TIMER_CHCTL1_CH3COMCTL           BITS(12,14)         /*!< channel 3 output compare mode */
+#define TIMER_CHCTL1_CH3COMCEN           BIT(15)             /*!< channel 3 output compare clear enable */
+/* input capture mode */
+#define TIMER_CHCTL1_CH2CAPPSC           BITS(2,3)           /*!< channel 2 input capture prescaler */
+#define TIMER_CHCTL1_CH2CAPFLT           BITS(4,7)           /*!< channel 2 input capture filter control */
+#define TIMER_CHCTL1_CH3CAPPSC           BITS(10,11)         /*!< channel 3 input capture prescaler */
+#define TIMER_CHCTL1_CH3CAPFLT           BITS(12,15)         /*!< channel 3 input capture filter control */
+
+/* TIMER_CHCTL2 */
+#define TIMER_CHCTL2_CH0EN               BIT(0)              /*!< channel 0 capture/compare function enable */
+#define TIMER_CHCTL2_CH0P                BIT(1)              /*!< channel 0 capture/compare function polarity */
+#define TIMER_CHCTL2_CH0NEN              BIT(2)              /*!< channel 0 complementary output enable */
+#define TIMER_CHCTL2_CH0NP               BIT(3)              /*!< channel 0 complementary output polarity */
+#define TIMER_CHCTL2_CH1EN               BIT(4)              /*!< channel 1 capture/compare function enable  */
+#define TIMER_CHCTL2_CH1P                BIT(5)              /*!< channel 1 capture/compare function polarity */
+#define TIMER_CHCTL2_CH1NEN              BIT(6)              /*!< channel 1 complementary output enable */
+#define TIMER_CHCTL2_CH1NP               BIT(7)              /*!< channel 1 complementary output polarity */
+#define TIMER_CHCTL2_CH2EN               BIT(8)              /*!< channel 2 capture/compare function enable  */
+#define TIMER_CHCTL2_CH2P                BIT(9)              /*!< channel 2 capture/compare function polarity */
+#define TIMER_CHCTL2_CH2NEN              BIT(10)             /*!< channel 2 complementary output enable */
+#define TIMER_CHCTL2_CH2NP               BIT(11)             /*!< channel 2 complementary output polarity */
+#define TIMER_CHCTL2_CH3EN               BIT(12)             /*!< channel 3 capture/compare function enable  */
+#define TIMER_CHCTL2_CH3P                BIT(13)             /*!< channel 3 capture/compare function polarity */
+
+/* TIMER_CNT */
+#define TIMER_CNT_CNT16                  BITS(0,15)          /*!< 16 bit timer counter */
+#define TIMER_CNT_CNT32                  BITS(0,31)          /*!< 32 bit(TIMER1,TIMER4) timer counter */
+
+/* TIMER_PSC */
+#define TIMER_PSC_PSC                    BITS(0,15)          /*!< prescaler value of the counter clock */
+
+/* TIMER_CAR */
+#define TIMER_CAR_CARL16                 BITS(0,15)          /*!< 16 bit counter auto reload value */
+#define TIMER_CAR_CARL32                 BITS(0,31)          /*!< 32 bit(TIMER1,TIMER4) counter auto reload value */
+
+/* TIMER_CREP */
+#define TIMER_CREP_CREP                  BITS(0,7)           /*!< counter repetition value */
+
+/* TIMER_CH0CV */
+#define TIMER_CH0CV_CH0VAL16             BITS(0,15)          /*!< 16 bit capture/compare value of channel 0 */
+#define TIMER_CH0CV_CH0VAL32             BITS(0,31)          /*!< 32 bit(TIMER1,TIMER4) capture/compare value of channel 0 */
+
+/* TIMER_CH1CV */
+#define TIMER_CH1CV_CH1VAL16             BITS(0,15)          /*!< 16 bit capture/compare value of channel 1 */
+#define TIMER_CH1CV_CH1VAL32             BITS(0,31)          /*!< 32 bit(TIMER1,TIMER4) capture/compare value of channel 1 */
+
+/* TIMER_CH2CV */
+#define TIMER_CH2CV_CH2VAL16             BITS(0,15)          /*!< 16 bit capture/compare value of channel 2 */
+#define TIMER_CH2CV_CH2VAL32             BITS(0,31)          /*!< 32 bit(TIMER1,TIMER4) capture/compare value of channel 2 */
+
+/* TIMER_CH3CV */
+#define TIMER_CH3CV_CH3VAL16             BITS(0,15)          /*!< 16 bit capture/compare value of channel 3 */
+#define TIMER_CH3CV_CH3VAL32             BITS(0,31)          /*!< 32 bit(TIMER1,TIMER4) capture/compare value of channel 3 */
+
+/* TIMER_CCHP */
+#define TIMER_CCHP_DTCFG                 BITS(0,7)           /*!< dead time configure */
+#define TIMER_CCHP_PROT                  BITS(8,9)           /*!< complementary register protect control */
+#define TIMER_CCHP_IOS                   BIT(10)             /*!< idle mode off-state configure */
+#define TIMER_CCHP_ROS                   BIT(11)             /*!< run mode off-state configure */
+#define TIMER_CCHP_BRKEN                 BIT(12)             /*!< break enable */
+#define TIMER_CCHP_BRKP                  BIT(13)             /*!< break polarity */
+#define TIMER_CCHP_OAEN                  BIT(14)             /*!< output automatic enable */
+#define TIMER_CCHP_POEN                  BIT(15)             /*!< primary output enable */
+
+/* TIMER_DMACFG */
+#define TIMER_DMACFG_DMATA               BITS(0,4)           /*!< DMA transfer access start address */
+#define TIMER_DMACFG_DMATC               BITS(8,12)          /*!< DMA transfer count */
+
+/* TIMER_DMATB */
+#define TIMER_DMATB_DMATB                BITS(0,15)          /*!< DMA transfer buffer address */
+
+/* TIMER_IRMP */
+#define TIMER1_IRMP_ITI1_RMP             BITS(10,11)         /*!< TIMER1 internal trigger input 1 remap */
+#define TIMER4_IRMP_CI3_RMP              BITS(6,7)           /*!< TIMER4 channel 3 input remap */
+#define TIMER10_IRMP_ITI1_RMP            BITS(0,1)           /*!< TIMER10 internal trigger input 1 remap */
+
+/* TIMER_CFG */
+#define TIMER_CFG_OUTSEL                 BIT(0)              /*!< the output value selection */
+#define TIMER_CFG_CHVSEL                 BIT(1)              /*!< write CHxVAL register selection */
+
+/* constants definitions */
+/* TIMER init parameter struct definitions*/
+typedef struct
+{ 
+    uint16_t prescaler;                         /*!< prescaler value */
+    uint16_t alignedmode;                       /*!< aligned mode */
+    uint16_t counterdirection;                  /*!< counter direction */
+    uint16_t clockdivision;                     /*!< clock division value */
+    uint32_t period;                            /*!< period value */
+    uint8_t  repetitioncounter;                 /*!< the counter repetition value */
+}timer_parameter_struct;
+
+/* break parameter struct definitions*/
+typedef struct
+{ 
+    uint16_t runoffstate;                       /*!< run mode off-state */
+    uint16_t ideloffstate;                      /*!< idle mode off-state */
+    uint16_t deadtime;                          /*!< dead time */
+    uint16_t breakpolarity;                     /*!< break polarity */
+    uint16_t outputautostate;                   /*!< output automatic enable */
+    uint16_t protectmode;                       /*!< complementary register protect control */
+    uint16_t breakstate;                        /*!< break enable */
+}timer_break_parameter_struct;
+
+/* channel output parameter struct definitions */
+typedef struct
+{ 
+    uint16_t outputstate;                       /*!< channel output state */
+    uint16_t outputnstate;                      /*!< channel complementary output state */
+    uint16_t ocpolarity;                        /*!< channel output polarity */
+    uint16_t ocnpolarity;                       /*!< channel complementary output polarity */
+    uint16_t ocidlestate;                       /*!< idle state of channel output */
+    uint16_t ocnidlestate;                      /*!< idle state of channel complementary output */
+}timer_oc_parameter_struct;
+
+/* channel input parameter struct definitions */
+typedef struct
+{ 
+    uint16_t icpolarity;                        /*!< channel input polarity */
+    uint16_t icselection;                       /*!< channel input mode selection */
+    uint16_t icprescaler;                       /*!< channel input capture prescaler */
+    uint16_t icfilter;                          /*!< channel input capture filter control */
+}timer_ic_parameter_struct;
+
+/* TIMER interrupt enable or disable */
+#define TIMER_INT_UP                        TIMER_DMAINTEN_UPIE                     /*!< update interrupt */
+#define TIMER_INT_CH0                       TIMER_DMAINTEN_CH0IE                    /*!< channel 0 interrupt */
+#define TIMER_INT_CH1                       TIMER_DMAINTEN_CH1IE                    /*!< channel 1 interrupt */
+#define TIMER_INT_CH2                       TIMER_DMAINTEN_CH2IE                    /*!< channel 2 interrupt */
+#define TIMER_INT_CH3                       TIMER_DMAINTEN_CH3IE                    /*!< channel 3 interrupt */
+#define TIMER_INT_CMT                       TIMER_DMAINTEN_CMTIE                    /*!< channel commutation interrupt flag */
+#define TIMER_INT_TRG                       TIMER_DMAINTEN_TRGIE                    /*!< trigger interrupt */
+#define TIMER_INT_BRK                       TIMER_DMAINTEN_BRKIE                    /*!< break interrupt */
+
+/* TIMER flag */
+#define TIMER_FLAG_UP                       TIMER_INTF_UPIF                         /*!< update flag */
+#define TIMER_FLAG_CH0                      TIMER_INTF_CH0IF                        /*!< channel 0 flag */
+#define TIMER_FLAG_CH1                      TIMER_INTF_CH1IF                        /*!< channel 1 flag */
+#define TIMER_FLAG_CH2                      TIMER_INTF_CH2IF                        /*!< channel 2 flag */
+#define TIMER_FLAG_CH3                      TIMER_INTF_CH3IF                        /*!< channel 3 flag */
+#define TIMER_FLAG_CMT                      TIMER_INTF_CMTIF                        /*!< channel commutation flag */
+#define TIMER_FLAG_TRG                      TIMER_INTF_TRGIF                        /*!< trigger flag */
+#define TIMER_FLAG_BRK                      TIMER_INTF_BRKIF                        /*!< break flag */
+#define TIMER_FLAG_CH0O                     TIMER_INTF_CH0OF                        /*!< channel 0 overcapture flag */
+#define TIMER_FLAG_CH1O                     TIMER_INTF_CH1OF                        /*!< channel 1 overcapture flag */
+#define TIMER_FLAG_CH2O                     TIMER_INTF_CH2OF                        /*!< channel 2 overcapture flag */
+#define TIMER_FLAG_CH3O                     TIMER_INTF_CH3OF                        /*!< channel 3 overcapture flag */
+
+/* TIMER interrupt flag */
+#define TIMER_INT_FLAG_UP                   TIMER_INTF_UPIF                         /*!< update interrupt flag */
+#define TIMER_INT_FLAG_CH0                  TIMER_INTF_CH0IF                        /*!< channel 0 interrupt flag */
+#define TIMER_INT_FLAG_CH1                  TIMER_INTF_CH1IF                        /*!< channel 1 interrupt flag */
+#define TIMER_INT_FLAG_CH2                  TIMER_INTF_CH2IF                        /*!< channel 2 interrupt flag */
+#define TIMER_INT_FLAG_CH3                  TIMER_INTF_CH3IF                        /*!< channel 3 interrupt flag */
+#define TIMER_INT_FLAG_CMT                  TIMER_INTF_CMTIF                        /*!< channel commutation interrupt flag */
+#define TIMER_INT_FLAG_TRG                  TIMER_INTF_TRGIF                        /*!< trigger interrupt flag */
+#define TIMER_INT_FLAG_BRK                  TIMER_INTF_BRKIF
+
+/* TIMER DMA source enable */
+#define TIMER_DMA_UPD                       ((uint16_t)TIMER_DMAINTEN_UPDEN)        /*!< update DMA enable */
+#define TIMER_DMA_CH0D                      ((uint16_t)TIMER_DMAINTEN_CH0DEN)       /*!< channel 0 DMA enable */
+#define TIMER_DMA_CH1D                      ((uint16_t)TIMER_DMAINTEN_CH1DEN)       /*!< channel 1 DMA enable */
+#define TIMER_DMA_CH2D                      ((uint16_t)TIMER_DMAINTEN_CH2DEN)       /*!< channel 2 DMA enable */
+#define TIMER_DMA_CH3D                      ((uint16_t)TIMER_DMAINTEN_CH3DEN)       /*!< channel 3 DMA enable */
+#define TIMER_DMA_CMTD                      ((uint16_t)TIMER_DMAINTEN_CMTDEN)       /*!< commutation DMA request enable */
+#define TIMER_DMA_TRGD                      ((uint16_t)TIMER_DMAINTEN_TRGDEN)       /*!< trigger DMA enable */
+
+/* channel DMA request source selection */ 
+#define TIMER_DMAREQUEST_UPDATEEVENT        ((uint8_t)0x00U)                        /*!< DMA request of channel y is sent when update event occurs */
+#define TIMER_DMAREQUEST_CHANNELEVENT       ((uint8_t)0x01U)                        /*!< DMA request of channel y is sent when channel y event occurs */
+
+/* DMA access base address */
+#define DMACFG_DMATA(regval)                (BITS(0, 4) & ((uint32_t)(regval) << 0U))
+#define TIMER_DMACFG_DMATA_CTL0             DMACFG_DMATA(0)                         /*!< DMA transfer address is TIMER_CTL0 */
+#define TIMER_DMACFG_DMATA_CTL1             DMACFG_DMATA(1)                         /*!< DMA transfer address is TIMER_CTL1 */
+#define TIMER_DMACFG_DMATA_SMCFG            DMACFG_DMATA(2)                         /*!< DMA transfer address is TIMER_SMCFG */
+#define TIMER_DMACFG_DMATA_DMAINTEN         DMACFG_DMATA(3)                         /*!< DMA transfer address is TIMER_DMAINTEN */
+#define TIMER_DMACFG_DMATA_INTF             DMACFG_DMATA(4)                         /*!< DMA transfer address is TIMER_INTF */
+#define TIMER_DMACFG_DMATA_SWEVG            DMACFG_DMATA(5)                         /*!< DMA transfer address is TIMER_SWEVG */
+#define TIMER_DMACFG_DMATA_CHCTL0           DMACFG_DMATA(6)                         /*!< DMA transfer address is TIMER_CHCTL0 */
+#define TIMER_DMACFG_DMATA_CHCTL1           DMACFG_DMATA(7)                         /*!< DMA transfer address is TIMER_CHCTL1 */
+#define TIMER_DMACFG_DMATA_CHCTL2           DMACFG_DMATA(8)                         /*!< DMA transfer address is TIMER_CHCTL2 */
+#define TIMER_DMACFG_DMATA_CNT              DMACFG_DMATA(9)                         /*!< DMA transfer address is TIMER_CNT */
+#define TIMER_DMACFG_DMATA_PSC              DMACFG_DMATA(10)                        /*!< DMA transfer address is TIMER_PSC */
+#define TIMER_DMACFG_DMATA_CAR              DMACFG_DMATA(11)                        /*!< DMA transfer address is TIMER_CAR */
+#define TIMER_DMACFG_DMATA_CREP             DMACFG_DMATA(12)                        /*!< DMA transfer address is TIMER_CREP */
+#define TIMER_DMACFG_DMATA_CH0CV            DMACFG_DMATA(13)                        /*!< DMA transfer address is TIMER_CH0CV */
+#define TIMER_DMACFG_DMATA_CH1CV            DMACFG_DMATA(14)                        /*!< DMA transfer address is TIMER_CH1CV */
+#define TIMER_DMACFG_DMATA_CH2CV            DMACFG_DMATA(15)                        /*!< DMA transfer address is TIMER_CH2CV */
+#define TIMER_DMACFG_DMATA_CH3CV            DMACFG_DMATA(16)                        /*!< DMA transfer address is TIMER_CH3CV */
+#define TIMER_DMACFG_DMATA_CCHP             DMACFG_DMATA(17)                        /*!< DMA transfer address is TIMER_CCHP */
+#define TIMER_DMACFG_DMATA_DMACFG           DMACFG_DMATA(18)                        /*!< DMA transfer address is TIMER_DMACFG */
+#define TIMER_DMACFG_DMATA_DMATB            DMACFG_DMATA(19)                        /*!< DMA transfer address is TIMER_DMATB */
+
+/* DMA access burst length */
+#define DMACFG_DMATC(regval)                (BITS(8, 12) & ((uint32_t)(regval) << 8U))
+#define TIMER_DMACFG_DMATC_1TRANSFER        DMACFG_DMATC(0)                         /*!< DMA transfer 1 time */
+#define TIMER_DMACFG_DMATC_2TRANSFER        DMACFG_DMATC(1)                         /*!< DMA transfer 2 times */
+#define TIMER_DMACFG_DMATC_3TRANSFER        DMACFG_DMATC(2)                         /*!< DMA transfer 3 times */
+#define TIMER_DMACFG_DMATC_4TRANSFER        DMACFG_DMATC(3)                         /*!< DMA transfer 4 times */
+#define TIMER_DMACFG_DMATC_5TRANSFER        DMACFG_DMATC(4)                         /*!< DMA transfer 5 times */
+#define TIMER_DMACFG_DMATC_6TRANSFER        DMACFG_DMATC(5)                         /*!< DMA transfer 6 times */
+#define TIMER_DMACFG_DMATC_7TRANSFER        DMACFG_DMATC(6)                         /*!< DMA transfer 7 times */
+#define TIMER_DMACFG_DMATC_8TRANSFER        DMACFG_DMATC(7)                         /*!< DMA transfer 8 times */
+#define TIMER_DMACFG_DMATC_9TRANSFER        DMACFG_DMATC(8)                         /*!< DMA transfer 9 times */
+#define TIMER_DMACFG_DMATC_10TRANSFER       DMACFG_DMATC(9)                         /*!< DMA transfer 10 times */
+#define TIMER_DMACFG_DMATC_11TRANSFER       DMACFG_DMATC(10)                        /*!< DMA transfer 11 times */
+#define TIMER_DMACFG_DMATC_12TRANSFER       DMACFG_DMATC(11)                        /*!< DMA transfer 12 times */
+#define TIMER_DMACFG_DMATC_13TRANSFER       DMACFG_DMATC(12)                        /*!< DMA transfer 13 times */
+#define TIMER_DMACFG_DMATC_14TRANSFER       DMACFG_DMATC(13)                        /*!< DMA transfer 14 times */
+#define TIMER_DMACFG_DMATC_15TRANSFER       DMACFG_DMATC(14)                        /*!< DMA transfer 15 times */
+#define TIMER_DMACFG_DMATC_16TRANSFER       DMACFG_DMATC(15)                        /*!< DMA transfer 16 times */
+#define TIMER_DMACFG_DMATC_17TRANSFER       DMACFG_DMATC(16)                        /*!< DMA transfer 17 times */
+#define TIMER_DMACFG_DMATC_18TRANSFER       DMACFG_DMATC(17)                        /*!< DMA transfer 18 times */
+
+/* TIMER software event generation source */
+#define TIMER_EVENT_SRC_UPG                 ((uint16_t)0x0001U)                     /*!< update event generation */
+#define TIMER_EVENT_SRC_CH0G                ((uint16_t)0x0002U)                     /*!< channel 0 capture or compare event generation */
+#define TIMER_EVENT_SRC_CH1G                ((uint16_t)0x0004U)                     /*!< channel 1 capture or compare event generation */
+#define TIMER_EVENT_SRC_CH2G                ((uint16_t)0x0008U)                     /*!< channel 2 capture or compare event generation */
+#define TIMER_EVENT_SRC_CH3G                ((uint16_t)0x0010U)                     /*!< channel 3 capture or compare event generation */
+#define TIMER_EVENT_SRC_CMTG                ((uint16_t)0x0020U)                     /*!< channel commutation event generation */
+#define TIMER_EVENT_SRC_TRGG                ((uint16_t)0x0040U)                     /*!< trigger event generation */
+#define TIMER_EVENT_SRC_BRKG                ((uint16_t)0x0080U)                     /*!< break event generation */
+
+/* center-aligned mode selection */
+#define CTL0_CAM(regval)                    ((uint16_t)(BITS(5, 6) & ((uint32_t)(regval) << 5U)))
+#define TIMER_COUNTER_EDGE                  CTL0_CAM(0)                             /*!< edge-aligned mode */
+#define TIMER_COUNTER_CENTER_DOWN           CTL0_CAM(1)                             /*!< center-aligned and counting down assert mode */
+#define TIMER_COUNTER_CENTER_UP             CTL0_CAM(2)                             /*!< center-aligned and counting up assert mode */
+#define TIMER_COUNTER_CENTER_BOTH           CTL0_CAM(3)                             /*!< center-aligned and counting up/down assert mode */
+
+/* TIMER prescaler reload mode */
+#define TIMER_PSC_RELOAD_NOW                ((uint32_t)0x00000000U)                 /*!< the prescaler is loaded right now */
+#define TIMER_PSC_RELOAD_UPDATE             ((uint32_t)0x00000001U)                 /*!< the prescaler is loaded at the next update event */
+
+/* count direction */
+#define TIMER_COUNTER_UP                    ((uint16_t)0x0000U)                     /*!< counter up direction */
+#define TIMER_COUNTER_DOWN                  ((uint16_t)TIMER_CTL0_DIR)              /*!< counter down direction */
+
+/* specify division ratio between TIMER clock and dead-time and sampling clock */
+#define CTL0_CKDIV(regval)                  ((uint16_t)(BITS(8, 9) & ((uint32_t)(regval) << 8U)))
+#define TIMER_CKDIV_DIV1                    CTL0_CKDIV(0)                           /*!< clock division value is 1,fDTS=fTIMER_CK */
+#define TIMER_CKDIV_DIV2                    CTL0_CKDIV(1)                           /*!< clock division value is 2,fDTS= fTIMER_CK/2 */
+#define TIMER_CKDIV_DIV4                    CTL0_CKDIV(2)                           /*!< clock division value is 4, fDTS= fTIMER_CK/4 */
+
+/* single pulse mode */
+#define TIMER_SP_MODE_SINGLE                ((uint32_t)0x00000000U)                 /*!< single pulse mode */
+#define TIMER_SP_MODE_REPETITIVE            ((uint32_t)0x00000001U)                 /*!< repetitive pulse mode */
+
+/* update source */
+#define TIMER_UPDATE_SRC_REGULAR            ((uint32_t)0x00000000U)                 /*!< update generate only by counter overflow/underflow */
+#define TIMER_UPDATE_SRC_GLOBAL             ((uint32_t)0x00000001U)                 /*!< update generate by setting of UPG bit or the counter overflow/underflow,or the slave mode controller trigger */
+
+/* run mode off-state configure */
+#define TIMER_ROS_STATE_ENABLE              ((uint16_t)TIMER_CCHP_ROS)              /*!< when POEN bit is set, the channel output signals (CHx_O/CHx_ON) are enabled, with relationship to CHxEN/CHxNEN bits */
+#define TIMER_ROS_STATE_DISABLE             ((uint16_t)0x0000U)                     /*!< when POEN bit is set, the channel output signals (CHx_O/CHx_ON) are disabled */
+
+/* idle mode off-state configure */                                                 
+#define TIMER_IOS_STATE_ENABLE              ((uint16_t)TIMER_CCHP_IOS)              /*!< when POEN bit is reset, the channel output signals (CHx_O/CHx_ON) are enabled, with relationship to CHxEN/CHxNEN bits */
+#define TIMER_IOS_STATE_DISABLE             ((uint16_t)0x0000U)                     /*!< when POEN bit is reset, the channel output signals (CHx_O/CHx_ON) are disabled */
+
+/* break input polarity */
+#define TIMER_BREAK_POLARITY_LOW            ((uint16_t)0x0000U)                     /*!< break input polarity is low */
+#define TIMER_BREAK_POLARITY_HIGH           ((uint16_t)TIMER_CCHP_BRKP)             /*!< break input polarity is high */
+
+/* output automatic enable */
+#define TIMER_OUTAUTO_ENABLE                ((uint16_t)TIMER_CCHP_OAEN)             /*!< output automatic enable */
+#define TIMER_OUTAUTO_DISABLE               ((uint16_t)0x0000U)                     /*!< output automatic disable */
+
+/* complementary register protect control */
+#define CCHP_PROT(regval)                   ((uint16_t)(BITS(8, 9) & ((uint32_t)(regval) << 8U)))
+#define TIMER_CCHP_PROT_OFF                 CCHP_PROT(0)                            /*!< protect disable */
+#define TIMER_CCHP_PROT_0                   CCHP_PROT(1)                            /*!< PROT mode 0 */
+#define TIMER_CCHP_PROT_1                   CCHP_PROT(2)                            /*!< PROT mode 1 */
+#define TIMER_CCHP_PROT_2                   CCHP_PROT(3)                            /*!< PROT mode 2 */
+
+/* break input enable */
+#define TIMER_BREAK_ENABLE                  ((uint16_t)TIMER_CCHP_BRKEN)            /*!< break input enable */
+#define TIMER_BREAK_DISABLE                 ((uint16_t)0x0000U)                     /*!< break input disable */
+
+/* TIMER channel n(n=0,1,2,3) */
+#define TIMER_CH_0                          ((uint16_t)0x0000U)                     /*!< TIMER channel 0(TIMERx(x=0..4,7..13)) */
+#define TIMER_CH_1                          ((uint16_t)0x0001U)                     /*!< TIMER channel 1(TIMERx(x=0..4,7,8,11)) */
+#define TIMER_CH_2                          ((uint16_t)0x0002U)                     /*!< TIMER channel 2(TIMERx(x=0..4,7)) */
+#define TIMER_CH_3                          ((uint16_t)0x0003U)                     /*!< TIMER channel 3(TIMERx(x=0..4,7)) */
+
+/* channel enable state*/
+#define TIMER_CCX_ENABLE                    ((uint32_t)0x00000001U)                 /*!< channel enable */
+#define TIMER_CCX_DISABLE                   ((uint32_t)0x00000000U)                 /*!< channel disable */
+
+/* channel complementary output enable state*/
+#define TIMER_CCXN_ENABLE                   ((uint16_t)0x0004U)                     /*!< channel complementary enable */
+#define TIMER_CCXN_DISABLE                  ((uint16_t)0x0000U)                     /*!< channel complementary disable */
+
+/* channel output polarity */
+#define TIMER_OC_POLARITY_HIGH              ((uint16_t)0x0000U)                     /*!< channel output polarity is high */
+#define TIMER_OC_POLARITY_LOW               ((uint16_t)0x0002U)                     /*!< channel output polarity is low */
+
+/* channel complementary output polarity */
+#define TIMER_OCN_POLARITY_HIGH             ((uint16_t)0x0000U)                     /*!< channel complementary output polarity is high */
+#define TIMER_OCN_POLARITY_LOW              ((uint16_t)0x0008U)                     /*!< channel complementary output polarity is low */
+
+/* idle state of channel output */ 
+#define TIMER_OC_IDLE_STATE_HIGH            ((uint16_t)0x0100)                      /*!< idle state of channel output is high */
+#define TIMER_OC_IDLE_STATE_LOW             ((uint16_t)0x0000)                      /*!< idle state of channel output is low */
+
+/* idle state of channel complementary output */ 
+#define TIMER_OCN_IDLE_STATE_HIGH           ((uint16_t)0x0200U)                     /*!< idle state of channel complementary output is high */
+#define TIMER_OCN_IDLE_STATE_LOW            ((uint16_t)0x0000U)                     /*!< idle state of channel complementary output is low */
+
+/* channel output compare mode */
+#define TIMER_OC_MODE_TIMING                ((uint16_t)0x0000U)                     /*!< timing mode */
+#define TIMER_OC_MODE_ACTIVE                ((uint16_t)0x0010U)                     /*!< active mode */
+#define TIMER_OC_MODE_INACTIVE              ((uint16_t)0x0020U)                     /*!< inactive mode */
+#define TIMER_OC_MODE_TOGGLE                ((uint16_t)0x0030U)                     /*!< toggle mode */
+#define TIMER_OC_MODE_LOW                   ((uint16_t)0x0040U)                     /*!< force low mode */
+#define TIMER_OC_MODE_HIGH                  ((uint16_t)0x0050U)                     /*!< force high mode */
+#define TIMER_OC_MODE_PWM0                  ((uint16_t)0x0060U)                     /*!< PWM0 mode */
+#define TIMER_OC_MODE_PWM1                  ((uint16_t)0x0070U)                     /*!< PWM1 mode*/
+
+/* channel output compare shadow enable */
+#define TIMER_OC_SHADOW_ENABLE              ((uint16_t)0x0008U)                     /*!< channel output shadow state enable */
+#define TIMER_OC_SHADOW_DISABLE             ((uint16_t)0x0000U)                     /*!< channel output shadow state disable */
+
+/* channel output compare fast enable */
+#define TIMER_OC_FAST_ENABLE                ((uint16_t)0x0004)                      /*!< channel output fast function enable */
+#define TIMER_OC_FAST_DISABLE               ((uint16_t)0x0000)                      /*!< channel output fast function disable */
+
+/* channel output compare clear enable */
+#define TIMER_OC_CLEAR_ENABLE               ((uint16_t)0x0080U)                     /*!< channel output clear function enable */
+#define TIMER_OC_CLEAR_DISABLE              ((uint16_t)0x0000U)                     /*!< channel output clear function disable */
+
+/* channel control shadow register update control */ 
+#define TIMER_UPDATECTL_CCU                 ((uint32_t)0x00000000U)                 /*!< the shadow registers are updated when CMTG bit is set */
+#define TIMER_UPDATECTL_CCUTRI              ((uint32_t)0x00000001U)                        /*!< the shadow registers update by when CMTG bit is set or an rising edge of TRGI occurs */
+
+/* channel input capture polarity */
+#define TIMER_IC_POLARITY_RISING            ((uint16_t)0x0000U)                     /*!< input capture rising edge */
+#define TIMER_IC_POLARITY_FALLING           ((uint16_t)0x0002U)                     /*!< input capture falling edge */
+#define TIMER_IC_POLARITY_BOTH_EDGE         ((uint16_t)0x000AU)                     /*!< input capture both edge */
+
+/* TIMER input capture selection */
+#define TIMER_IC_SELECTION_DIRECTTI         ((uint16_t)0x0001U)                     /*!< channel y is configured as input and icy is mapped on CIy */
+#define TIMER_IC_SELECTION_INDIRECTTI       ((uint16_t)0x0002U)                     /*!< channel y is configured as input and icy is mapped on opposite input */
+#define TIMER_IC_SELECTION_ITS              ((uint16_t)0x0003U)                     /*!< channel y is configured as input and icy is mapped on ITS */
+
+/* channel input capture prescaler */
+#define TIMER_IC_PSC_DIV1                   ((uint16_t)0x0000U)                     /*!< no prescaler */
+#define TIMER_IC_PSC_DIV2                   ((uint16_t)0x0004U)                     /*!< divided by 2 */
+#define TIMER_IC_PSC_DIV4                   ((uint16_t)0x0008U)                     /*!< divided by 4*/
+#define TIMER_IC_PSC_DIV8                   ((uint16_t)0x000CU)                     /*!< divided by 8 */
+
+/* trigger selection */
+#define SMCFG_TRGSEL(regval)                 (BITS(4, 6) & ((uint32_t)(regval) << 4U))
+#define TIMER_SMCFG_TRGSEL_ITI0              SMCFG_TRGSEL(0)                        /*!< internal trigger 0 */
+#define TIMER_SMCFG_TRGSEL_ITI1              SMCFG_TRGSEL(1)                        /*!< internal trigger 1 */
+#define TIMER_SMCFG_TRGSEL_ITI2              SMCFG_TRGSEL(2)                        /*!< internal trigger 2 */
+#define TIMER_SMCFG_TRGSEL_ITI3              SMCFG_TRGSEL(3)                        /*!< internal trigger 3 */
+#define TIMER_SMCFG_TRGSEL_CI0F_ED           SMCFG_TRGSEL(4)                        /*!< TI0 Edge Detector */
+#define TIMER_SMCFG_TRGSEL_CI0FE0            SMCFG_TRGSEL(5)                        /*!< filtered TIMER input 0 */
+#define TIMER_SMCFG_TRGSEL_CI1FE1            SMCFG_TRGSEL(6)                        /*!< filtered TIMER input 1 */
+#define TIMER_SMCFG_TRGSEL_ETIFP             SMCFG_TRGSEL(7)                        /*!< external trigger */
+
+/* master mode control */
+#define CTL1_MMC(regval)                    (BITS(4, 6) & ((uint32_t)(regval) << 4U))
+#define TIMER_TRI_OUT_SRC_RESET             CTL1_MMC(0)                             /*!< the UPG bit as trigger output */
+#define TIMER_TRI_OUT_SRC_ENABLE            CTL1_MMC(1)                             /*!< the counter enable signal TIMER_CTL0_CEN as trigger output */
+#define TIMER_TRI_OUT_SRC_UPDATE            CTL1_MMC(2)                             /*!< update event as trigger output */
+#define TIMER_TRI_OUT_SRC_CH0               CTL1_MMC(3)                             /*!< a capture or a compare match occurred in channal0 as trigger output TRGO */
+#define TIMER_TRI_OUT_SRC_O0CPRE            CTL1_MMC(4)                             /*!< O0CPRE as trigger output */
+#define TIMER_TRI_OUT_SRC_O1CPRE            CTL1_MMC(5)                             /*!< O1CPRE as trigger output */
+#define TIMER_TRI_OUT_SRC_O2CPRE            CTL1_MMC(6)                             /*!< O2CPRE as trigger output */
+#define TIMER_TRI_OUT_SRC_O3CPRE            CTL1_MMC(7)                             /*!< O3CPRE as trigger output */
+
+/* slave mode control */
+#define SMCFG_SMC(regval)                   (BITS(0, 2) & ((uint32_t)(regval) << 0U)) 
+#define TIMER_SLAVE_MODE_DISABLE            SMCFG_SMC(0)                            /*!< slave mode disable */
+#define TIMER_ENCODER_MODE0                 SMCFG_SMC(1)                            /*!< encoder mode 0 */
+#define TIMER_ENCODER_MODE1                 SMCFG_SMC(2)                            /*!< encoder mode 1 */
+#define TIMER_ENCODER_MODE2                 SMCFG_SMC(3)                            /*!< encoder mode 2 */
+#define TIMER_SLAVE_MODE_RESTART            SMCFG_SMC(4)                            /*!< restart mode */
+#define TIMER_SLAVE_MODE_PAUSE              SMCFG_SMC(5)                            /*!< pause mode */
+#define TIMER_SLAVE_MODE_EVENT              SMCFG_SMC(6)                            /*!< event mode */
+#define TIMER_SLAVE_MODE_EXTERNAL0          SMCFG_SMC(7)                            /*!< external clock mode 0 */
+
+/* master slave mode selection */ 
+#define TIMER_MASTER_SLAVE_MODE_ENABLE      ((uint32_t)0x00000000U)                 /*!< master slave mode enable */
+#define TIMER_MASTER_SLAVE_MODE_DISABLE     ((uint32_t)0x00000001U)                 /*!< master slave mode disable */
+
+/* external trigger prescaler */
+#define SMCFG_ETPSC(regval)                 (BITS(12, 13) & ((uint32_t)(regval) << 12U))
+#define TIMER_EXT_TRI_PSC_OFF               SMCFG_ETPSC(0)                          /*!< no divided */
+#define TIMER_EXT_TRI_PSC_DIV2              SMCFG_ETPSC(1)                          /*!< divided by 2 */
+#define TIMER_EXT_TRI_PSC_DIV4              SMCFG_ETPSC(2)                          /*!< divided by 4 */
+#define TIMER_EXT_TRI_PSC_DIV8              SMCFG_ETPSC(3)                          /*!< divided by 8 */
+
+/* external trigger polarity */
+#define TIMER_ETP_FALLING                   TIMER_SMCFG_ETP                         /*!< active low or falling edge active */
+#define TIMER_ETP_RISING                    ((uint32_t)0x00000000U)                 /*!< active high or rising edge active */
+
+/* channel 0 trigger input selection */ 
+#define TIMER_HALLINTERFACE_ENABLE          ((uint32_t)0x00000000U)                 /*!< TIMER hall sensor mode enable */
+#define TIMER_HALLINTERFACE_DISABLE         ((uint32_t)0x00000001U)                 /*!< TIMER hall sensor mode disable */
+
+/* timer1 internal trigger input1 remap */
+#define TIMER1_IRMP(regval)                 (BITS(10, 11) & ((uint32_t)(regval) << 10U))       
+#define TIMER1_ITI1_RMP_TIMER7_TRGO         TIMER1_IRMP(0)                          /*!< timer1 internal trigger input 1 remap to TIMER7_TRGO */
+#define TIMER1_ITI1_RMP_ETHERNET_PTP        TIMER1_IRMP(1)                          /*!< timer1 internal trigger input 1 remap to ethernet PTP */
+#define TIMER1_ITI1_RMP_USB_FS_SOF          TIMER1_IRMP(2)                          /*!< timer1 internal trigger input 1 remap to USB FS SOF */
+#define TIMER1_ITI1_RMP_USB_HS_SOF          TIMER1_IRMP(3)                          /*!< timer1 internal trigger input 1 remap to USB HS SOF */
+
+/* timer4 channel 3 input remap */
+#define TIMER4_IRMP(regval)                 (BITS(6, 7) & ((uint32_t)(regval) << 6U))          
+#define TIMER4_CI3_RMP_GPIO                 TIMER4_IRMP(0)                          /*!< timer4 channel 3 input remap to GPIO pin */
+#define TIMER4_CI3_RMP_IRC32K               TIMER4_IRMP(1)                          /*!< timer4 channel 3 input remap to IRC32K */
+#define TIMER4_CI3_RMP_LXTAL                TIMER4_IRMP(2)                          /*!< timer4 channel 3 input remap to  LXTAL */
+#define TIMER4_CI3_RMP_RTC_WAKEUP_INT       TIMER4_IRMP(3)                          /*!< timer4 channel 3 input remap to RTC wakeup interrupt */
+
+/* timer10 internal trigger input1 remap */
+#define TIMER10_IRMP(regval)                (BITS(0, 1) & ((uint32_t)(regval) << 0U))
+#define TIMER10_ITI1_RMP_GPIO               TIMER10_IRMP(0)                         /*!< timer10 internal trigger input1 remap based on GPIO setting */
+#define TIMER10_ITI1_RMP_RTC_HXTAL_DIV      TIMER10_IRMP(2)                         /*!< timer10 internal trigger input1 remap  HXTAL _DIV(clock used for RTC which is HXTAL clock divided by RTCDIV bits in RCU_CFG0 register) */
+
+/* timerx(x=0,1,2,13,14,15,16) write cc register selection */
+#define TIMER_CHVSEL_ENABLE                  ((uint16_t)0x0002U)                    /*!< write CHxVAL register selection enable  */
+#define TIMER_CHVSEL_DISABLE                 ((uint16_t)0x0000U)                    /*!< write CHxVAL register selection disable */
+
+/* the output value selection */
+#define TIMER_OUTSEL_ENABLE                 ((uint16_t)0x0001U)                     /*!< output value selection enable */
+#define TIMER_OUTSEL_DISABLE                ((uint16_t)0x0000U)                     /*!< output value selection disable */
+
+/* function declarations */
+/* TIMER timebase*/
+/* deinit a TIMER */
+void timer_deinit(uint32_t timer_periph);
+/* initialize TIMER init parameter struct */
+void timer_struct_para_init(timer_parameter_struct* initpara);
+/* initialize TIMER counter */
+void timer_init(uint32_t timer_periph, timer_parameter_struct* initpara);
+/* enable a TIMER */
+void timer_enable(uint32_t timer_periph);
+/* disable a TIMER */
+void timer_disable(uint32_t timer_periph);
+/* enable the auto reload shadow function */
+void timer_auto_reload_shadow_enable(uint32_t timer_periph);
+/* disable the auto reload shadow function */
+void timer_auto_reload_shadow_disable(uint32_t timer_periph);
+/* enable the update event */
+void timer_update_event_enable(uint32_t timer_periph);
+/* disable the update event */
+void timer_update_event_disable(uint32_t timer_periph);
+/* set TIMER counter alignment mode */
+void timer_counter_alignment(uint32_t timer_periph, uint16_t aligned);
+/* set TIMER counter up direction */
+void timer_counter_up_direction(uint32_t timer_periph);
+/* set TIMER counter down direction */
+void timer_counter_down_direction(uint32_t timer_periph);
+/* configure TIMER prescaler */
+void timer_prescaler_config(uint32_t timer_periph, uint16_t prescaler, uint8_t pscreload);
+/* configure TIMER repetition register value */
+void timer_repetition_value_config(uint32_t timer_periph, uint16_t repetition);
+/* configure TIMER autoreload register value */
+void timer_autoreload_value_config(uint32_t timer_periph,uint32_t autoreload);
+/* configure TIMER counter register value */
+void timer_counter_value_config(uint32_t timer_periph , uint32_t counter);
+/* read TIMER counter value */
+uint32_t timer_counter_read(uint32_t timer_periph);
+/* read TIMER prescaler value */
+uint16_t timer_prescaler_read(uint32_t timer_periph);
+/* configure TIMER single pulse mode */
+void timer_single_pulse_mode_config(uint32_t timer_periph, uint32_t spmode);
+/* configure TIMER update source */
+void timer_update_source_config(uint32_t timer_periph, uint32_t update);
+
+/* timer DMA and event*/
+/* enable the TIMER DMA */
+void timer_dma_enable(uint32_t timer_periph, uint16_t dma);
+/* disable the TIMER DMA */
+void timer_dma_disable(uint32_t timer_periph, uint16_t dma);
+/* channel DMA request source selection */
+void timer_channel_dma_request_source_select(uint32_t timer_periph, uint8_t dma_request);
+/* configure the TIMER DMA transfer */
+void timer_dma_transfer_config(uint32_t timer_periph,uint32_t dma_baseaddr, uint32_t dma_lenth);
+/* software generate events */
+void timer_event_software_generate(uint32_t timer_periph, uint16_t event);
+
+/* TIMER channel complementary protection */
+/* initialize TIMER break parameter struct */
+void timer_break_struct_para_init(timer_break_parameter_struct* breakpara);
+/* configure TIMER break function */
+void timer_break_config(uint32_t timer_periph, timer_break_parameter_struct* breakpara);
+/* enable TIMER break function */
+void timer_break_enable(uint32_t timer_periph);
+/* disable TIMER break function */
+void timer_break_disable(uint32_t timer_periph);
+/* enable TIMER output automatic function */
+void timer_automatic_output_enable(uint32_t timer_periph);
+/* disable TIMER output automatic function */
+void timer_automatic_output_disable(uint32_t timer_periph);
+/* enable or disable TIMER primary output function */
+void timer_primary_output_config(uint32_t timer_periph, ControlStatus newvalue);
+/* enable or disable channel capture/compare control shadow register */
+void timer_channel_control_shadow_config(uint32_t timer_periph, ControlStatus newvalue);
+/* configure TIMER channel control shadow register update control */
+void timer_channel_control_shadow_update_config(uint32_t timer_periph, uint8_t ccuctl);
+
+/* TIMER channel output */
+/* initialize TIMER channel output parameter struct */
+void timer_channel_output_struct_para_init(timer_oc_parameter_struct* ocpara);
+/* configure TIMER channel output function */
+void timer_channel_output_config(uint32_t timer_periph,uint16_t channel, timer_oc_parameter_struct* ocpara);
+/* configure TIMER channel output compare mode */
+void timer_channel_output_mode_config(uint32_t timer_periph, uint16_t channel,uint16_t ocmode);
+/* configure TIMER channel output pulse value */
+void timer_channel_output_pulse_value_config(uint32_t timer_periph, uint16_t channel, uint32_t pulse);
+/* configure TIMER channel output shadow function */
+void timer_channel_output_shadow_config(uint32_t timer_periph, uint16_t channel, uint16_t ocshadow);
+/* configure TIMER channel output fast function */
+void timer_channel_output_fast_config(uint32_t timer_periph, uint16_t channel, uint16_t ocfast);
+/* configure TIMER channel output clear function */
+void timer_channel_output_clear_config(uint32_t timer_periph,uint16_t channel,uint16_t occlear);
+/* configure TIMER channel output polarity */
+void timer_channel_output_polarity_config(uint32_t timer_periph, uint16_t channel, uint16_t ocpolarity);
+/* configure TIMER channel complementary output polarity */
+void timer_channel_complementary_output_polarity_config(uint32_t timer_periph, uint16_t channel, uint16_t ocnpolarity);
+/* configure TIMER channel enable state */
+void timer_channel_output_state_config(uint32_t timer_periph, uint16_t channel, uint32_t state);
+/* configure TIMER channel complementary output enable state */
+void timer_channel_complementary_output_state_config(uint32_t timer_periph, uint16_t channel, uint16_t ocnstate);
+
+/* TIMER channel input */
+/* initialize TIMER channel input parameter struct */
+void timer_channel_input_struct_para_init(timer_ic_parameter_struct* icpara);
+/* configure TIMER input capture parameter */
+void timer_input_capture_config(uint32_t timer_periph, uint16_t channel, timer_ic_parameter_struct* icpara);
+/* configure TIMER channel input capture prescaler value */
+void timer_channel_input_capture_prescaler_config(uint32_t timer_periph, uint16_t channel, uint16_t prescaler);
+/* read TIMER channel capture compare register value */
+uint32_t timer_channel_capture_value_register_read(uint32_t timer_periph, uint16_t channel);
+/* configure TIMER input pwm capture function */
+void timer_input_pwm_capture_config(uint32_t timer_periph, uint16_t channel, timer_ic_parameter_struct* icpwm);
+/* configure TIMER hall sensor mode */
+void timer_hall_mode_config(uint32_t timer_periph, uint32_t hallmode);
+
+/* TIMER master and slave */
+/* select TIMER input trigger source */
+void timer_input_trigger_source_select(uint32_t timer_periph, uint32_t intrigger);
+/* select TIMER master mode output trigger source */
+void timer_master_output_trigger_source_select(uint32_t timer_periph, uint32_t outrigger);
+/* select TIMER slave mode */
+void timer_slave_mode_select(uint32_t timer_periph,uint32_t slavemode);
+/* configure TIMER master slave mode */
+void timer_master_slave_mode_config(uint32_t timer_periph, uint32_t masterslave);
+/* configure TIMER external trigger input */
+void timer_external_trigger_config(uint32_t timer_periph, uint32_t extprescaler, uint32_t extpolarity, uint32_t extfilter);
+/* configure TIMER quadrature decoder mode */
+void timer_quadrature_decoder_mode_config(uint32_t timer_periph, uint32_t decomode, uint16_t ic0polarity, uint16_t ic1polarity);
+/* configure TIMER internal clock mode */
+void timer_internal_clock_config(uint32_t timer_periph);
+/* configure TIMER the internal trigger as external clock input */
+void timer_internal_trigger_as_external_clock_config(uint32_t timer_periph, uint32_t intrigger);
+/* configure TIMER the external trigger as external clock input */
+void timer_external_trigger_as_external_clock_config(uint32_t timer_periph, uint32_t extrigger, uint16_t extpolarity,uint32_t extfilter);
+/* configure TIMER the external clock mode 0 */
+void timer_external_clock_mode0_config(uint32_t timer_periph, uint32_t extprescaler, uint32_t extpolarity, uint32_t extfilter);
+/* configure TIMER the external clock mode 1 */
+void timer_external_clock_mode1_config(uint32_t timer_periph, uint32_t extprescaler, uint32_t extpolarity, uint32_t extfilter);
+/* disable TIMER the external clock mode 1 */
+void timer_external_clock_mode1_disable(uint32_t timer_periph);
+/* configure TIMER channel remap function */
+void timer_channel_remap_config(uint32_t timer_periph,uint32_t remap);
+
+/* TIMER configure */
+/* configure TIMER write CHxVAL register selection */
+void timer_write_chxval_register_config(uint32_t timer_periph, uint16_t ccsel);
+/* configure TIMER output value selection */
+void timer_output_value_selection_config(uint32_t timer_periph, uint16_t outsel);
+
+/* TIMER interrupt and flag*/
+/* get TIMER flags */
+FlagStatus timer_flag_get(uint32_t timer_periph, uint32_t flag);
+/* clear TIMER flags */
+void timer_flag_clear(uint32_t timer_periph, uint32_t flag);
+/* enable the TIMER interrupt */
+void timer_interrupt_enable(uint32_t timer_periph, uint32_t interrupt);
+/* disable the TIMER interrupt */
+void timer_interrupt_disable(uint32_t timer_periph, uint32_t interrupt);
+/* get timer interrupt flag */
+FlagStatus timer_interrupt_flag_get(uint32_t timer_periph, uint32_t interrupt);
+/* clear TIMER interrupt flag */
+void timer_interrupt_flag_clear(uint32_t timer_periph, uint32_t interrupt);
+
+#endif /* GD32F4XX_TIMER_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_tli.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_tli.h
@@ -1,0 +1,373 @@
+/*!
+    \file    gd32f4xx_tli.h
+    \brief   definitions for the TLI
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_TLI_H
+#define GD32F4XX_TLI_H
+
+#include "gd32f4xx.h"
+
+/* TLI definitions */
+#define TLI                               TLI_BASE                          /*!< TLI base address */
+/* TLI layer definitions */
+#define LAYER0                            TLI_BASE                          /*!< TLI layer0 base address */
+#define LAYER1                            (TLI_BASE + 0x00000080U)          /*!< TLI layer1 base address */
+
+/* registers definitions */
+#define TLI_SPSZ                          REG32(TLI + 0x00000008U)          /*!< TLI synchronous pulse size register */
+#define TLI_BPSZ                          REG32(TLI + 0x0000000CU)          /*!< TLI back-porch size register */
+#define TLI_ASZ                           REG32(TLI + 0x00000010U)          /*!< TLI active size register */
+#define TLI_TSZ                           REG32(TLI + 0x00000014U)          /*!< TLI total size register */
+#define TLI_CTL                           REG32(TLI + 0x00000018U)          /*!< TLI control register */
+#define TLI_RL                            REG32(TLI + 0x00000024U)          /*!< TLI reload Layer register */
+#define TLI_BGC                           REG32(TLI + 0x0000002CU)          /*!< TLI background color register */
+#define TLI_INTEN                         REG32(TLI + 0x00000034U)          /*!< TLI interrupt enable register */
+#define TLI_INTF                          REG32(TLI + 0x00000038U)          /*!< TLI interrupt flag register */
+#define TLI_INTC                          REG32(TLI + 0x0000003CU)          /*!< TLI interrupt flag clear register */
+#define TLI_LM                            REG32(TLI + 0x00000040U)          /*!< TLI line mark register */
+#define TLI_CPPOS                         REG32(TLI + 0x00000044U)          /*!< TLI current pixel position register */
+#define TLI_STAT                          REG32(TLI + 0x00000048U)          /*!< TLI status register */
+#define TLI_LxCTL(layerx)                 REG32((layerx) + 0x00000084U)     /*!< TLI layer x control register */
+#define TLI_LxHPOS(layerx)                REG32((layerx) + 0x00000088U)     /*!< TLI layer x horizontal position parameters register */
+#define TLI_LxVPOS(layerx)                REG32((layerx) + 0x0000008CU)     /*!< TLI layer x vertical position parameters register */
+#define TLI_LxCKEY(layerx)                REG32((layerx) + 0x00000090U)     /*!< TLI layer x color key register */
+#define TLI_LxPPF(layerx)                 REG32((layerx) + 0x00000094U)     /*!< TLI layer x packeted pixel format register */
+#define TLI_LxSA(layerx)                  REG32((layerx) + 0x00000098U)     /*!< TLI layer x specified alpha register */
+#define TLI_LxDC(layerx)                  REG32((layerx) + 0x0000009CU)     /*!< TLI layer x default color register */
+#define TLI_LxBLEND(layerx)               REG32((layerx) + 0x000000A0U)     /*!< TLI layer x blending register */
+#define TLI_LxFBADDR(layerx)              REG32((layerx) + 0x000000ACU)     /*!< TLI layer x frame base address register */
+#define TLI_LxFLLEN(layerx)               REG32((layerx) + 0x000000B0U)     /*!< TLI layer x frame line length register */
+#define TLI_LxFTLN(layerx)                REG32((layerx) + 0x000000B4U)     /*!< TLI layer x frame total line number register */
+#define TLI_LxLUT(layerx)                 REG32((layerx) + 0x000000C4U)     /*!< TLI layer x look up table register */
+
+/* bits definitions */
+/* TLI_SPSZ */
+#define TLI_SPSZ_VPSZ                     BITS(0,11)       /*!< size of the vertical synchronous pulse */
+#define TLI_SPSZ_HPSZ                     BITS(16,27)      /*!< size of the horizontal synchronous pulse */
+
+/* TLI_BPSZ */
+#define TLI_BPSZ_VBPSZ                    BITS(0,11)       /*!< size of the vertical back porch plus synchronous pulse */
+#define TLI_BPSZ_HBPSZ                    BITS(16,27)      /*!< size of the horizontal back porch plus synchronous pulse */
+
+/* TLI_ASZ */
+#define TLI_ASZ_VASZ                      BITS(0,11)       /*!< size of the vertical active area width plus back porch and synchronous pulse */
+#define TLI_ASZ_HASZ                      BITS(16,27)      /*!< size of the horizontal active area width plus back porch and synchronous pulse */
+
+/* TLI_SPSZ */
+#define TLI_TSZ_VTSZ                      BITS(0,11)       /*!< vertical total size of the display, including active area, back porch, synchronous pulse and front porch */
+#define TLI_TSZ_HTSZ                      BITS(16,27)      /*!< horizontal total size of the display, including active area, back porch, synchronous pulse and front porch */
+
+/* TLI_CTL */
+#define TLI_CTL_TLIEN                     BIT(0)           /*!< TLI enable bit */
+#define TLI_CTL_BDB                       BITS(4,6)        /*!< blue channel dither bits number */
+#define TLI_CTL_GDB                       BITS(8,10)       /*!< green channel dither bits number */
+#define TLI_CTL_RDB                       BITS(12,14)      /*!< red channel dither bits number */
+#define TLI_CTL_DFEN                      BIT(16)          /*!< dither function enable */
+#define TLI_CTL_CLKPS                     BIT(28)          /*!< pixel clock polarity selection */
+#define TLI_CTL_DEPS                      BIT(29)          /*!< data enable polarity selection */
+#define TLI_CTL_VPPS                      BIT(30)          /*!< vertical pulse polarity selection */
+#define TLI_CTL_HPPS                      BIT(31)          /*!< horizontal pulse polarity selection */
+
+/* TLI_RL */
+#define TLI_RL_RQR                        BIT(0)           /*!< request reload */
+#define TLI_RL_FBR                        BIT(1)           /*!< frame blank reload */
+
+/* TLI_BGC */
+#define TLI_BGC_BVB                       BITS(0,7)        /*!< background value blue */
+#define TLI_BGC_BVG                       BITS(8,15)       /*!< background value green */
+#define TLI_BGC_BVR                       BITS(16,23)      /*!< background value red */
+
+/* TLI_INTEN */
+#define TLI_INTEN_LMIE                    BIT(0)           /*!< line mark interrupt enable */
+#define TLI_INTEN_FEIE                    BIT(1)           /*!< FIFO error interrupt enable */
+#define TLI_INTEN_TEIE                    BIT(2)           /*!< transaction error interrupt enable */
+#define TLI_INTEN_LCRIE                   BIT(3)           /*!< layer configuration reloaded interrupt enable */
+
+/* TLI_INTF */
+#define TLI_INTF_LMF                      BIT(0)           /*!< line mark flag */
+#define TLI_INTF_FEF                      BIT(1)           /*!< FIFO error flag */
+#define TLI_INTF_TEF                      BIT(2)           /*!< transaction error flag */
+#define TLI_INTF_LCRF                     BIT(3)           /*!< layer configuration reloaded flag */
+
+/* TLI_INTC */
+#define TLI_INTC_LMC                      BIT(0)           /*!< line mark flag clear */
+#define TLI_INTC_FEC                      BIT(1)           /*!< FIFO error flag clear */
+#define TLI_INTC_TEC                      BIT(2)           /*!< transaction error flag clear */
+#define TLI_INTC_LCRC                     BIT(3)           /*!< layer configuration reloaded flag clear */
+
+/* TLI_LM */
+#define TLI_LM_LM                         BITS(0,10)       /*!< line mark value */
+
+/* TLI_CPPOS */
+#define TLI_CPPOS_VPOS                    BITS(0,15)       /*!< vertical position */
+#define TLI_CPPOS_HPOS                    BITS(16,31)      /*!< horizontal position */
+
+/* TLI_STAT */
+#define TLI_STAT_VDE                      BIT(0)           /*!< current VDE status */
+#define TLI_STAT_HDE                      BIT(1)           /*!< current HDE status */
+#define TLI_STAT_VS                       BIT(2)           /*!< current VS status of the TLI */
+#define TLI_STAT_HS                       BIT(3)           /*!< current HS status of the TLI  */
+
+/* TLI_LxCTL */
+#define TLI_LxCTL_LEN                     BIT(0)           /*!< layer enable */
+#define TLI_LxCTL_CKEYEN                  BIT(1)           /*!< color keying enable */
+#define TLI_LxCTL_LUTEN                   BIT(4)           /*!< LUT enable */
+
+/* TLI_LxHPOS */
+#define TLI_LxHPOS_WLP                    BITS(0,11)       /*!< window left position */
+#define TLI_LxHPOS_WRP                    BITS(16,27)      /*!< window right position */
+
+/* TLI_LxVPOS */
+#define TLI_LxVPOS_WTP                    BITS(0,11)       /*!< window top position */
+#define TLI_LxVPOS_WBP                    BITS(16,27)      /*!< window bottom position */
+
+/* TLI_LxCKEY */
+#define TLI_LxCKEY_CKEYB                  BITS(0,7)        /*!< color key blue */
+#define TLI_LxCKEY_CKEYG                  BITS(8,15)       /*!< color key green */
+#define TLI_LxCKEY_CKEYR                  BITS(16,23)      /*!< color key red */
+
+/* TLI_LxPPF */
+#define TLI_LxPPF_PPF                     BITS(0,2)        /*!< packeted pixel format */
+
+/* TLI_LxSA */
+#define TLI_LxSA_SA                       BITS(0,7)        /*!< specified alpha */
+
+/* TLI_LxDC */
+#define TLI_LxDC_DCB                      BITS(0,7)        /*!< the default color blue */
+#define TLI_LxDC_DCG                      BITS(8,15)       /*!< the default color green */
+#define TLI_LxDC_DCR                      BITS(16,23)      /*!< the default color red */
+#define TLI_LxDC_DCA                      BITS(24,31)      /*!< the default color alpha */
+
+/* TLI_LxBLEND */
+#define TLI_LxBLEND_ACF2                  BITS(0,2)        /*!< alpha calculation factor 2 of blending method */
+#define TLI_LxBLEND_ACF1                  BITS(8,10)       /*!< alpha calculation factor 1 of blending method */
+
+/* TLI_LxFBADDR */
+#define TLI_LxFBADDR_FBADD                BITS(0,31)       /*!< frame buffer base address */
+
+/* TLI_LxFLLEN */
+#define TLI_LxFLLEN_FLL                   BITS(0,13)       /*!< frame line length */
+#define TLI_LxFLLEN_STDOFF                BITS(16,29)      /*!< frame buffer stride offset */
+
+/* TLI_LxFTLN */
+#define TLI_LxFTLN_FTLN                   BITS(0,10)       /*!< frame total line number */
+
+/* TLI_LxLUT */
+#define TLI_LxLUT_TB                      BITS(0,7)        /*!< blue channel of a LUT entry */
+#define TLI_LxLUT_TG                      BITS(8,15)       /*!< green channel of a LUT entry */
+#define TLI_LxLUT_TR                      BITS(16,23)      /*!< red channel of a LUT entry */
+#define TLI_LxLUT_TADD                    BITS(24,31)      /*!< look up table write address */
+
+/* constants definitions */
+/* TLI parameter struct definitions */
+typedef struct {
+    uint16_t synpsz_vpsz;                     /*!< size of the vertical synchronous pulse */
+    uint16_t synpsz_hpsz;                     /*!< size of the horizontal synchronous pulse */
+    uint16_t backpsz_vbpsz;                   /*!< size of the vertical back porch plus synchronous pulse */
+    uint16_t backpsz_hbpsz;                   /*!< size of the horizontal back porch plus synchronous pulse */
+    uint32_t activesz_vasz;                   /*!< size of the vertical active area width plus back porch and synchronous pulse */
+    uint32_t activesz_hasz;                   /*!< size of the horizontal active area width plus back porch and synchronous pulse */
+    uint32_t totalsz_vtsz;                    /*!< vertical total size of the display */
+    uint32_t totalsz_htsz;                    /*!< horizontal total size of the display */
+    uint32_t backcolor_red;                   /*!< background value red */
+    uint32_t backcolor_green;                 /*!< background value green */
+    uint32_t backcolor_blue;                  /*!< background value blue */
+    uint32_t signalpolarity_hs;               /*!< horizontal pulse polarity selection */
+    uint32_t signalpolarity_vs;               /*!< vertical pulse polarity selection */
+    uint32_t signalpolarity_de;               /*!< data enable polarity selection */
+    uint32_t signalpolarity_pixelck;          /*!< pixel clock polarity selection */
+} tli_parameter_struct;
+
+/* TLI layer parameter struct definitions */
+typedef struct {
+    uint16_t layer_window_rightpos;           /*!< window right position */
+    uint16_t layer_window_leftpos;            /*!< window left position */
+    uint16_t layer_window_bottompos;          /*!< window bottom position */
+    uint16_t layer_window_toppos;             /*!< window top position */
+    uint32_t layer_ppf;                       /*!< packeted pixel format */
+    uint8_t  layer_sa;                        /*!< specified alpha */
+    uint8_t  layer_default_alpha;             /*!< the default color alpha */
+    uint8_t  layer_default_red;               /*!< the default color red */
+    uint8_t  layer_default_green;             /*!< the default color green */
+    uint8_t  layer_default_blue;              /*!< the default color blue */
+    uint32_t layer_acf1;                      /*!< alpha calculation factor 1 of blending method */
+    uint32_t layer_acf2;                      /*!< alpha calculation factor 2 of blending method */
+    uint32_t layer_frame_bufaddr;             /*!< frame buffer base address */
+    uint16_t layer_frame_buf_stride_offset;   /*!< frame buffer stride offset */
+    uint16_t layer_frame_line_length;         /*!< frame line length */
+    uint16_t layer_frame_total_line_number;   /*!< frame total line number */
+} tli_layer_parameter_struct;
+
+/* TLI layer LUT parameter struct definitions */
+typedef struct {
+    uint32_t layer_table_addr;                /*!< look up table write address */
+    uint8_t layer_lut_channel_red;            /*!< red channel of a LUT entry */
+    uint8_t layer_lut_channel_green;          /*!< green channel of a LUT entry */
+    uint8_t layer_lut_channel_blue;           /*!< blue channel of a LUT entry */
+} tli_layer_lut_parameter_struct;
+
+/* packeted pixel format */
+typedef enum {
+    LAYER_PPF_ARGB8888,                      /*!< layerx pixel format ARGB8888 */
+    LAYER_PPF_RGB888,                        /*!< layerx pixel format RGB888 */
+    LAYER_PPF_RGB565,                        /*!< layerx pixel format RGB565 */
+    LAYER_PPF_ARGB1555,                      /*!< layerx pixel format ARGB1555 */
+    LAYER_PPF_ARGB4444,                      /*!< layerx pixel format ARGB4444 */
+    LAYER_PPF_L8,                            /*!< layerx pixel format L8 */
+    LAYER_PPF_AL44,                          /*!< layerx pixel format AL44 */
+    LAYER_PPF_AL88                           /*!< layerx pixel format AL88 */
+} tli_layer_ppf_enum;
+
+/* TLI flags */
+#define TLI_FLAG_VDE                   TLI_STAT_VDE                /*!< current VDE status */
+#define TLI_FLAG_HDE                   TLI_STAT_HDE                /*!< current HDE status */
+#define TLI_FLAG_VS                    TLI_STAT_VS                 /*!< current VS status of the TLI */
+#define TLI_FLAG_HS                    TLI_STAT_HS                 /*!< current HS status of the TLI */
+#define TLI_FLAG_LM                    BIT(0) | BIT(31)            /*!< line mark interrupt flag */
+#define TLI_FLAG_FE                    BIT(1) | BIT(31)            /*!< FIFO error interrupt flag */
+#define TLI_FLAG_TE                    BIT(2) | BIT(31)            /*!< transaction error interrupt flag */
+#define TLI_FLAG_LCR                   BIT(3) | BIT(31)            /*!< layer configuration reloaded interrupt flag */
+
+/* TLI interrupt enable or disable */
+#define TLI_INT_LM                     BIT(0)                      /*!< line mark interrupt */
+#define TLI_INT_FE                     BIT(1)                      /*!< FIFO error interrupt */
+#define TLI_INT_TE                     BIT(2)                      /*!< transaction error interrupt */
+#define TLI_INT_LCR                    BIT(3)                      /*!< layer configuration reloaded interrupt */
+
+/* TLI interrupt flag */
+#define TLI_INT_FLAG_LM                BIT(0)                      /*!< line mark interrupt flag */
+#define TLI_INT_FLAG_FE                BIT(1)                      /*!< FIFO error interrupt flag */
+#define TLI_INT_FLAG_TE                BIT(2)                      /*!< transaction error interrupt flag */
+#define TLI_INT_FLAG_LCR               BIT(3)                      /*!< layer configuration reloaded interrupt flag */
+
+/* layer reload configure */
+#define TLI_FRAME_BLANK_RELOAD_EN     ((uint8_t)0x00U)             /*!< the layer configuration will be reloaded at frame blank */
+#define TLI_REQUEST_RELOAD_EN         ((uint8_t)0x01U)             /*!< the layer configuration will be reloaded after this bit sets */
+
+/* dither function */
+#define TLI_DITHER_DISABLE            ((uint8_t)0x00U)             /*!< dither function disable */
+#define TLI_DITHER_ENABLE             ((uint8_t)0x01U)             /*!< dither function enable */
+
+/* horizontal pulse polarity selection */
+#define TLI_HSYN_ACTLIVE_LOW          ((uint32_t)0x00000000U)      /*!< horizontal synchronous pulse active low */
+#define TLI_HSYN_ACTLIVE_HIGHT        TLI_CTL_HPPS                 /*!< horizontal synchronous pulse active high */
+
+/* vertical pulse polarity selection */
+#define TLI_VSYN_ACTLIVE_LOW          ((uint32_t)0x00000000U)      /*!< vertical synchronous pulse active low */
+#define TLI_VSYN_ACTLIVE_HIGHT        TLI_CTL_VPPS                 /*!< vertical synchronous pulse active high */
+
+/* pixel clock polarity selection */
+#define TLI_PIXEL_CLOCK_TLI           ((uint32_t)0x00000000U)      /*!< pixel clock is TLI clock */
+#define TLI_PIXEL_CLOCK_INVERTEDTLI   TLI_CTL_CLKPS                /*!< pixel clock is inverted TLI clock */
+
+/* data enable polarity selection */
+#define TLI_DE_ACTLIVE_LOW            ((uint32_t)0x00000000U)      /*!< data enable active low */
+#define TLI_DE_ACTLIVE_HIGHT          TLI_CTL_DEPS                 /*!< data enable active high */
+
+/* alpha calculation factor 1 of blending method */
+#define LxBLEND_ACF1(regval)          (BITS(8,10) & ((uint32_t)(regval)<<8))
+#define LAYER_ACF1_SA                 LxBLEND_ACF1(4)              /*!< normalization specified alpha */
+#define LAYER_ACF1_PASA               LxBLEND_ACF1(6)              /*!< normalization pixel alpha * normalization specified alpha */
+
+/* alpha calculation factor 2 of blending method */
+#define LxBLEND_ACF2(regval)          (BITS(0,2) & ((uint32_t)(regval)))
+#define LAYER_ACF2_SA                 LxBLEND_ACF2(5)              /*!< normalization specified alpha */
+#define LAYER_ACF2_PASA               LxBLEND_ACF2(7)              /*!< normalization pixel alpha * normalization specified alpha */
+
+/* function declarations */
+/* initialization functions, TLI enable or disable, TLI reload mode configuration */
+/* deinitialize TLI registers */
+void tli_deinit(void);
+/* initialize the parameters of TLI parameter structure with the default values, it is suggested
+  that call this function after a tli_parameter_struct structure is defined */
+void tli_struct_para_init(tli_parameter_struct *tli_struct);
+/* initialize TLI */
+void tli_init(tli_parameter_struct *tli_struct);
+/* configure TLI dither function */
+void tli_dither_config(uint8_t dither_stat);
+/* enable TLI */
+void tli_enable(void);
+/* disable TLI */
+void tli_disable(void);
+/* configurate TLI reload mode */
+void tli_reload_config(uint8_t reload_mod);
+
+/* TLI layer configuration functions */
+/* initialize the parameters of TLI layer structure with the default values, it is suggested
+  that call this function after a tli_layer_parameter_struct structure is defined */
+void tli_layer_struct_para_init(tli_layer_parameter_struct *layer_struct);
+/* initialize TLI layer */
+void tli_layer_init(uint32_t layerx, tli_layer_parameter_struct *layer_struct);
+/* reconfigure window position */
+void tli_layer_window_offset_modify(uint32_t layerx, uint16_t offset_x, uint16_t offset_y);
+/* initialize the parameters of TLI layer LUT structure with the default values, it is suggested
+  that call this function after a tli_layer_lut_parameter_struct structure is defined */
+void tli_lut_struct_para_init(tli_layer_lut_parameter_struct *lut_struct);
+/* initialize TLI layer LUT */
+void tli_lut_init(uint32_t layerx, tli_layer_lut_parameter_struct *lut_struct);
+/* initialize TLI layer color key */
+void tli_color_key_init(uint32_t layerx, uint8_t redkey, uint8_t greenkey, uint8_t bluekey);
+/* enable TLI layer */
+void tli_layer_enable(uint32_t layerx);
+/* disable TLI layer */
+void tli_layer_disable(uint32_t layerx);
+/* enable TLI layer color keying */
+void tli_color_key_enable(uint32_t layerx);
+/* disable TLI layer color keying */
+void tli_color_key_disable(uint32_t layerx);
+/* enable TLI layer LUT */
+void tli_lut_enable(uint32_t layerx);
+/* disable TLI layer LUT */
+void tli_lut_disable(uint32_t layerx);
+
+/* set line mark value */
+void tli_line_mark_set(uint16_t line_num);
+/* get current displayed position */
+uint32_t tli_current_pos_get(void);
+
+/* flag and interrupt functions */
+/* enable TLI interrupt */
+void tli_interrupt_enable(uint32_t int_flag);
+/* disable TLI interrupt */
+void tli_interrupt_disable(uint32_t int_flag);
+/* get TLI interrupt flag */
+FlagStatus tli_interrupt_flag_get(uint32_t int_flag);
+/* clear TLI interrupt flag */
+void tli_interrupt_flag_clear(uint32_t int_flag);
+/* get TLI flag or state in TLI_INTF register or TLI_STAT register */
+FlagStatus tli_flag_get(uint32_t flag);
+
+#endif /* GD32F4XX_TLI_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_trng.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_trng.h
@@ -1,0 +1,103 @@
+/*!
+    \file    gd32f4xx_trng.h
+    \brief   definitions for the TRNG
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_TRNG_H
+#define GD32F4XX_TRNG_H
+
+#include "gd32f4xx.h"
+
+/* TRNG definitions */
+#define TRNG                        TRNG_BASE
+
+/* registers definitions */
+#define TRNG_CTL                    REG32(TRNG + 0x00000000U)        /*!< control register */
+#define TRNG_STAT                   REG32(TRNG + 0x00000004U)        /*!< status register */
+#define TRNG_DATA                   REG32(TRNG + 0x00000008U)        /*!< data register */
+
+/* bits definitions */
+/* TRNG_CTL */
+#define TRNG_CTL_TRNGEN             BIT(2)                     /*!< TRNG enable bit */
+#define TRNG_CTL_TRNGIE             BIT(3)                     /*!< interrupt enable bit */
+
+/* TRNG_STAT */
+#define TRNG_STAT_DRDY              BIT(0)                     /*!< random data ready status bit */
+#define TRNG_STAT_CECS              BIT(1)                     /*!< clock error current status */
+#define TRNG_STAT_SECS              BIT(2)                     /*!< seed error current status */
+#define TRNG_STAT_CEIF              BIT(5)                     /*!< clock error interrupt flag */
+#define TRNG_STAT_SEIF              BIT(6)                     /*!< seed error interrupt flag */
+
+/* TRNG_DATA */
+#define TRNG_DATA_TRNGDATA          BITS(0,31)                 /*!< 32-Bit Random data */
+
+/* constants definitions */
+/* TRNG status flag */
+typedef enum { 
+    TRNG_FLAG_DRDY = TRNG_STAT_DRDY,                           /*!< random Data ready status */
+    TRNG_FLAG_CECS = TRNG_STAT_CECS,                           /*!< clock error current status */
+    TRNG_FLAG_SECS = TRNG_STAT_SECS                            /*!< seed error current status */
+} trng_flag_enum;
+
+/* TRNG inerrupt flag */
+typedef enum {
+    TRNG_INT_FLAG_CEIF = TRNG_STAT_CEIF,                       /*!< clock error interrupt flag */
+    TRNG_INT_FLAG_SEIF = TRNG_STAT_SEIF                        /*!< seed error interrupt flag */
+} trng_int_flag_enum;
+
+/* function declarations */
+/* initialization functions */
+/* reset TRNG */
+void trng_deinit(void);
+/* enable TRNG */
+void trng_enable(void);
+/* disable TRNG */
+void trng_disable(void);
+/* get the true random data */
+uint32_t trng_get_true_random_data(void);
+
+/* interrupt & flag functions */
+/* enable TRNG interrupt */
+void trng_interrupt_enable(void);
+/* disable TRNG interrupt  */
+void trng_interrupt_disable(void);
+/* get TRNG flag status */
+FlagStatus trng_flag_get(trng_flag_enum flag);
+/* get TRNG interrupt flag status */
+FlagStatus trng_interrupt_flag_get(trng_int_flag_enum int_flag);
+/* clear TRNG interrupt flag status */
+void trng_interrupt_flag_clear(trng_int_flag_enum int_flag);
+
+#endif /* GD32F4XX_TRNG_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_usart.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_usart.h
@@ -1,0 +1,492 @@
+/*!
+    \file    gd32f4xx_usart.h
+    \brief   definitions for the USART
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_USART_H
+#define GD32F4XX_USART_H
+
+#include "gd32f4xx.h"
+
+/* USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7) definitions */
+#define USART1                        USART_BASE                     /*!< USART1 base address */
+#define USART2                        (USART_BASE+0x00000400U)       /*!< USART2 base address */
+#define UART3                         (USART_BASE+0x00000800U)       /*!< UART3 base address */
+#define UART4                         (USART_BASE+0x00000C00U)       /*!< UART4 base address */
+#define UART6                         (USART_BASE+0x00003400U)       /*!< UART6 base address */
+#define UART7                         (USART_BASE+0x00003800U)       /*!< UART7 base address */
+#define USART0                        (USART_BASE+0x0000CC00U)       /*!< USART0 base address */
+#define USART5                        (USART_BASE+0x0000D000U)       /*!< USART5 base address */
+
+/* registers definitions */
+#define USART_STAT0(usartx)           REG32((usartx) + 0x00U)        /*!< USART status register 0 */
+#define USART_DATA(usartx)            REG32((usartx) + 0x04U)        /*!< USART data register */
+#define USART_BAUD(usartx)            REG32((usartx) + 0x08U)        /*!< USART baud rate register */
+#define USART_CTL0(usartx)            REG32((usartx) + 0x0CU)        /*!< USART control register 0 */
+#define USART_CTL1(usartx)            REG32((usartx) + 0x10U)        /*!< USART control register 1 */
+#define USART_CTL2(usartx)            REG32((usartx) + 0x14U)        /*!< USART control register 2 */
+#define USART_GP(usartx)              REG32((usartx) + 0x18U)        /*!< USART guard time and prescaler register */
+#define USART_CTL3(usartx)            REG32((usartx) + 0x80U)        /*!< USART control register 3 */
+#define USART_RT(usartx)              REG32((usartx) + 0x84U)        /*!< USART receiver timeout register */
+#define USART_STAT1(usartx)           REG32((usartx) + 0x88U)        /*!< USART status register 1 */
+#define USART_CHC(usartx)             REG32((usartx) + 0xC0U)        /*!< USART coherence control register */
+
+/* bits definitions */
+/* USARTx_STAT0 */
+#define USART_STAT0_PERR              BIT(0)       /*!< parity error flag */
+#define USART_STAT0_FERR              BIT(1)       /*!< frame error flag */
+#define USART_STAT0_NERR              BIT(2)       /*!< noise error flag */
+#define USART_STAT0_ORERR             BIT(3)       /*!< overrun error */
+#define USART_STAT0_IDLEF             BIT(4)       /*!< IDLE frame detected flag */
+#define USART_STAT0_RBNE              BIT(5)       /*!< read data buffer not empty */
+#define USART_STAT0_TC                BIT(6)       /*!< transmission complete */
+#define USART_STAT0_TBE               BIT(7)       /*!< transmit data buffer empty */
+#define USART_STAT0_LBDF              BIT(8)       /*!< LIN break detected flag */
+#define USART_STAT0_CTSF              BIT(9)       /*!< CTS change flag */
+
+/* USARTx_DATA */
+#define USART_DATA_DATA               BITS(0,8)    /*!< transmit or read data value */
+
+/* USARTx_BAUD */
+#define USART_BAUD_FRADIV             BITS(0,3)    /*!< fraction part of baud-rate divider */
+#define USART_BAUD_INTDIV             BITS(4,15)   /*!< integer part of baud-rate divider */
+
+/* USARTx_CTL0 */
+#define USART_CTL0_SBKCMD             BIT(0)       /*!< send break command */
+#define USART_CTL0_RWU                BIT(1)       /*!< receiver wakeup from mute mode */
+#define USART_CTL0_REN                BIT(2)       /*!< receiver enable */
+#define USART_CTL0_TEN                BIT(3)       /*!< transmitter enable */
+#define USART_CTL0_IDLEIE             BIT(4)       /*!< idle line detected interrupt enable */
+#define USART_CTL0_RBNEIE             BIT(5)       /*!< read data buffer not empty interrupt and overrun error interrupt enable */
+#define USART_CTL0_TCIE               BIT(6)       /*!< transmission complete interrupt enable */
+#define USART_CTL0_TBEIE              BIT(7)       /*!< transmitter buffer empty interrupt enable */
+#define USART_CTL0_PERRIE             BIT(8)       /*!< parity error interrupt enable */
+#define USART_CTL0_PM                 BIT(9)       /*!< parity mode */
+#define USART_CTL0_PCEN               BIT(10)      /*!< parity check function enable */
+#define USART_CTL0_WM                 BIT(11)      /*!< wakeup method in mute mode */
+#define USART_CTL0_WL                 BIT(12)      /*!< word length */
+#define USART_CTL0_UEN                BIT(13)      /*!< USART enable */
+#define USART_CTL0_OVSMOD             BIT(15)      /*!< oversample mode */
+
+/* USARTx_CTL1 */
+#define USART_CTL1_ADDR               BITS(0,3)    /*!< address of USART */
+#define USART_CTL1_LBLEN              BIT(5)       /*!< LIN break frame length */
+#define USART_CTL1_LBDIE              BIT(6)       /*!< LIN break detected interrupt eanble */
+#define USART_CTL1_CLEN               BIT(8)       /*!< CK length */
+#define USART_CTL1_CPH                BIT(9)       /*!< CK phase */
+#define USART_CTL1_CPL                BIT(10)      /*!< CK polarity */
+#define USART_CTL1_CKEN               BIT(11)      /*!< CK pin enable */
+#define USART_CTL1_STB                BITS(12,13)  /*!< STOP bits length */
+#define USART_CTL1_LMEN               BIT(14)      /*!< LIN mode enable */
+
+/* USARTx_CTL2 */
+#define USART_CTL2_ERRIE              BIT(0)       /*!< error interrupt enable */
+#define USART_CTL2_IREN               BIT(1)       /*!< IrDA mode enable */
+#define USART_CTL2_IRLP               BIT(2)       /*!< IrDA low-power */
+#define USART_CTL2_HDEN               BIT(3)       /*!< half-duplex enable */
+#define USART_CTL2_NKEN               BIT(4)       /*!< NACK enable in smartcard mode */
+#define USART_CTL2_SCEN               BIT(5)       /*!< smartcard mode enable */
+#define USART_CTL2_DENR               BIT(6)       /*!< DMA request enable for reception */
+#define USART_CTL2_DENT               BIT(7)       /*!< DMA request enable for transmission */
+#define USART_CTL2_RTSEN              BIT(8)       /*!< RTS enable */
+#define USART_CTL2_CTSEN              BIT(9)       /*!< CTS enable */
+#define USART_CTL2_CTSIE              BIT(10)      /*!< CTS interrupt enable */
+#define USART_CTL2_OSB                BIT(11)      /*!< one sample bit method */
+
+/* USARTx_GP */
+#define USART_GP_PSC                  BITS(0,7)    /*!< prescaler value for dividing the system clock */
+#define USART_GP_GUAT                 BITS(8,15)   /*!< guard time value in smartcard mode */
+
+/* USARTx_CTL3 */
+#define USART_CTL3_RTEN               BIT(0)       /*!< receiver timeout enable */
+#define USART_CTL3_SCRTNUM            BITS(1,3)    /*!< smartcard auto-retry number */
+#define USART_CTL3_RTIE               BIT(4)       /*!< interrupt enable bit of receive timeout event */
+#define USART_CTL3_EBIE               BIT(5)       /*!< interrupt enable bit of end of block event */
+#define USART_CTL3_RINV               BIT(8)       /*!< RX pin level inversion */
+#define USART_CTL3_TINV               BIT(9)       /*!< TX pin level inversion */
+#define USART_CTL3_DINV               BIT(10)      /*!< data bit level inversion */
+#define USART_CTL3_MSBF               BIT(11)      /*!< most significant bit first */
+
+/* USARTx_RT */
+#define USART_RT_RT                   BITS(0,23)   /*!< receiver timeout threshold */
+#define USART_RT_BL                   BITS(24,31)  /*!< block length */
+
+/* USARTx_STAT1 */
+#define USART_STAT1_RTF               BIT(11)      /*!< receiver timeout flag */
+#define USART_STAT1_EBF               BIT(12)      /*!< end of block flag */
+#define USART_STAT1_BSY               BIT(16)      /*!< busy flag */
+
+/* USARTx_CHC */
+#define USART_CHC_HCM                 BIT(0)       /*!< hardware flow control coherence mode */
+#define USART_CHC_PCM                 BIT(1)       /*!< parity check coherence mode */
+#define USART_CHC_BCM                 BIT(2)       /*!< break frame coherence mode */
+#define USART_CHC_EPERR               BIT(8)       /*!< early parity error flag */
+
+/* constants definitions */
+/* define the USART bit position and its register index offset */
+#define USART_REGIDX_BIT(regidx, bitpos)    (((uint32_t)(regidx) << 6) | (uint32_t)(bitpos))
+#define USART_REG_VAL(usartx, offset)       (REG32((usartx) + (((uint32_t)(offset) & 0xFFFFU) >> 6)))
+#define USART_BIT_POS(val)                  ((uint32_t)(val) & 0x1FU)
+#define USART_REGIDX_BIT2(regidx, bitpos, regidx2, bitpos2)   (((uint32_t)(regidx2) << 22) | (uint32_t)((bitpos2) << 16)\
+                                                              | (((uint32_t)(regidx) << 6) | (uint32_t)(bitpos)))
+#define USART_REG_VAL2(usartx, offset)      (REG32((usartx) + ((uint32_t)(offset) >> 22)))
+#define USART_BIT_POS2(val)                 (((uint32_t)(val) & 0x1F0000U) >> 16)
+
+/* register offset */
+#define USART_STAT0_REG_OFFSET              0x00U        /*!< STAT0 register offset */
+#define USART_STAT1_REG_OFFSET              0x88U        /*!< STAT1 register offset */
+#define USART_CTL0_REG_OFFSET               0x0CU        /*!< CTL0 register offset */
+#define USART_CTL1_REG_OFFSET               0x10U        /*!< CTL1 register offset */
+#define USART_CTL2_REG_OFFSET               0x14U        /*!< CTL2 register offset */
+#define USART_CTL3_REG_OFFSET               0x80U        /*!< CTL3 register offset */
+#define USART_CHC_REG_OFFSET                0xC0U        /*!< CHC register offset */
+
+/* USART flags */
+typedef enum {
+    /* flags in STAT0 register */
+    USART_FLAG_CTS = USART_REGIDX_BIT(USART_STAT0_REG_OFFSET, 9U),      /*!< CTS change flag */
+    USART_FLAG_LBD = USART_REGIDX_BIT(USART_STAT0_REG_OFFSET, 8U),      /*!< LIN break detected flag */
+    USART_FLAG_TBE = USART_REGIDX_BIT(USART_STAT0_REG_OFFSET, 7U),      /*!< transmit data buffer empty */
+    USART_FLAG_TC = USART_REGIDX_BIT(USART_STAT0_REG_OFFSET, 6U),       /*!< transmission complete */
+    USART_FLAG_RBNE = USART_REGIDX_BIT(USART_STAT0_REG_OFFSET, 5U),     /*!< read data buffer not empty */
+    USART_FLAG_IDLE = USART_REGIDX_BIT(USART_STAT0_REG_OFFSET, 4U),     /*!< IDLE frame detected flag */
+    USART_FLAG_ORERR = USART_REGIDX_BIT(USART_STAT0_REG_OFFSET, 3U),    /*!< overrun error */
+    USART_FLAG_NERR = USART_REGIDX_BIT(USART_STAT0_REG_OFFSET, 2U),     /*!< noise error flag */
+    USART_FLAG_FERR = USART_REGIDX_BIT(USART_STAT0_REG_OFFSET, 1U),     /*!< frame error flag */
+    USART_FLAG_PERR = USART_REGIDX_BIT(USART_STAT0_REG_OFFSET, 0U),     /*!< parity error flag */
+    /* flags in STAT1 register */
+    USART_FLAG_BSY = USART_REGIDX_BIT(USART_STAT1_REG_OFFSET, 16U),     /*!< busy flag */
+    USART_FLAG_EB = USART_REGIDX_BIT(USART_STAT1_REG_OFFSET, 12U),      /*!< end of block flag */
+    USART_FLAG_RT = USART_REGIDX_BIT(USART_STAT1_REG_OFFSET, 11U),      /*!< receiver timeout flag */
+    /* flags in CHC register */
+    USART_FLAG_EPERR = USART_REGIDX_BIT(USART_CHC_REG_OFFSET, 8U),      /*!< early parity error flag */
+} usart_flag_enum;
+
+/* USART interrupt flags */
+typedef enum {
+    /* interrupt flags in CTL0 register */
+    USART_INT_FLAG_PERR = USART_REGIDX_BIT2(USART_CTL0_REG_OFFSET, 8U, USART_STAT0_REG_OFFSET, 0U),       /*!< parity error interrupt and flag */
+    USART_INT_FLAG_TBE = USART_REGIDX_BIT2(USART_CTL0_REG_OFFSET, 7U, USART_STAT0_REG_OFFSET, 7U),        /*!< transmitter buffer empty interrupt and flag */
+    USART_INT_FLAG_TC = USART_REGIDX_BIT2(USART_CTL0_REG_OFFSET, 6U, USART_STAT0_REG_OFFSET, 6U),         /*!< transmission complete interrupt and flag */
+    USART_INT_FLAG_RBNE = USART_REGIDX_BIT2(USART_CTL0_REG_OFFSET, 5U, USART_STAT0_REG_OFFSET, 5U),       /*!< read data buffer not empty interrupt and flag */
+    USART_INT_FLAG_RBNE_ORERR = USART_REGIDX_BIT2(USART_CTL0_REG_OFFSET, 5U, USART_STAT0_REG_OFFSET, 3U), /*!< read data buffer not empty interrupt and overrun error flag */
+    USART_INT_FLAG_IDLE = USART_REGIDX_BIT2(USART_CTL0_REG_OFFSET, 4U, USART_STAT0_REG_OFFSET, 4U),       /*!< IDLE line detected interrupt and flag */
+    /* interrupt flags in CTL1 register */
+    USART_INT_FLAG_LBD = USART_REGIDX_BIT2(USART_CTL1_REG_OFFSET, 6U, USART_STAT0_REG_OFFSET, 8U),        /*!< LIN break detected interrupt and flag */
+    /* interrupt flags in CTL2 register */
+    USART_INT_FLAG_CTS = USART_REGIDX_BIT2(USART_CTL2_REG_OFFSET, 10U, USART_STAT0_REG_OFFSET, 9U),       /*!< CTS interrupt and flag */
+    USART_INT_FLAG_ERR_ORERR = USART_REGIDX_BIT2(USART_CTL2_REG_OFFSET, 0U, USART_STAT0_REG_OFFSET, 3U),  /*!< error interrupt and overrun error */
+    USART_INT_FLAG_ERR_NERR = USART_REGIDX_BIT2(USART_CTL2_REG_OFFSET, 0U, USART_STAT0_REG_OFFSET, 2U),   /*!< error interrupt and noise error flag */
+    USART_INT_FLAG_ERR_FERR = USART_REGIDX_BIT2(USART_CTL2_REG_OFFSET, 0U, USART_STAT0_REG_OFFSET, 1U),   /*!< error interrupt and frame error flag */
+    /* interrupt flags in CTL3 register */
+    USART_INT_FLAG_EB = USART_REGIDX_BIT2(USART_CTL3_REG_OFFSET, 5U, USART_STAT1_REG_OFFSET, 12U),        /*!< interrupt enable bit of end of block event and flag */
+    USART_INT_FLAG_RT = USART_REGIDX_BIT2(USART_CTL3_REG_OFFSET, 4U, USART_STAT1_REG_OFFSET, 11U),        /*!< interrupt enable bit of receive timeout event and flag */
+} usart_interrupt_flag_enum;
+
+/* USART interrupt flags */
+typedef enum {
+    /* interrupt in CTL0 register */
+    USART_INT_PERR = USART_REGIDX_BIT(USART_CTL0_REG_OFFSET, 8U),      /*!< parity error interrupt */
+    USART_INT_TBE = USART_REGIDX_BIT(USART_CTL0_REG_OFFSET, 7U),       /*!< transmitter buffer empty interrupt */
+    USART_INT_TC = USART_REGIDX_BIT(USART_CTL0_REG_OFFSET, 6U),        /*!< transmission complete interrupt */
+    USART_INT_RBNE = USART_REGIDX_BIT(USART_CTL0_REG_OFFSET, 5U),      /*!< read data buffer not empty interrupt and overrun error interrupt */
+    USART_INT_IDLE = USART_REGIDX_BIT(USART_CTL0_REG_OFFSET, 4U),      /*!< IDLE line detected interrupt */
+    /* interrupt in CTL1 register */
+    USART_INT_LBD = USART_REGIDX_BIT(USART_CTL1_REG_OFFSET, 6U),       /*!< LIN break detected interrupt */
+    /* interrupt in CTL2 register */
+    USART_INT_CTS = USART_REGIDX_BIT(USART_CTL2_REG_OFFSET, 10U),      /*!< CTS interrupt */
+    USART_INT_ERR = USART_REGIDX_BIT(USART_CTL2_REG_OFFSET, 0U),       /*!< error interrupt */
+    /* interrupt in CTL3 register */
+    USART_INT_EB = USART_REGIDX_BIT(USART_CTL3_REG_OFFSET, 5U),        /*!< interrupt enable bit of end of block event */
+    USART_INT_RT = USART_REGIDX_BIT(USART_CTL3_REG_OFFSET, 4U),        /*!< interrupt enable bit of receive timeout event */
+} usart_interrupt_enum;
+
+/* USART invert configure */
+typedef enum {
+    /* data bit level inversion */
+    USART_DINV_ENABLE,                             /*!< data bit level inversion */
+    USART_DINV_DISABLE,                            /*!< data bit level not inversion */
+    /* TX pin level inversion */
+    USART_TXPIN_ENABLE,                            /*!< TX pin level inversion */
+    USART_TXPIN_DISABLE,                           /*!< TX pin level not inversion */
+    /* RX pin level inversion */
+    USART_RXPIN_ENABLE,                            /*!< RX pin level inversion */
+    USART_RXPIN_DISABLE,                           /*!< RX pin level not inversion */
+} usart_invert_enum;
+
+/* USART receiver configure */
+#define CTL0_REN(regval)              (BIT(2) & ((uint32_t)(regval) << 2))
+#define USART_RECEIVE_ENABLE          CTL0_REN(1)                      /*!< enable receiver */
+#define USART_RECEIVE_DISABLE         CTL0_REN(0)                      /*!< disable receiver */
+
+/* USART transmitter configure */
+#define CTL0_TEN(regval)              (BIT(3) & ((uint32_t)(regval) << 3))
+#define USART_TRANSMIT_ENABLE         CTL0_TEN(1)                      /*!< enable transmitter */
+#define USART_TRANSMIT_DISABLE        CTL0_TEN(0)                      /*!< disable transmitter */
+
+/* USART parity bits definitions */
+#define CTL0_PM(regval)               (BITS(9,10) & ((uint32_t)(regval) << 9))
+#define USART_PM_NONE                 CTL0_PM(0)                       /*!< no parity */
+#define USART_PM_EVEN                 CTL0_PM(2)                       /*!< even parity */
+#define USART_PM_ODD                  CTL0_PM(3)                       /*!< odd parity */
+
+/* USART wakeup method in mute mode */
+#define CTL0_WM(regval)               (BIT(11) & ((uint32_t)(regval) << 11))
+#define USART_WM_IDLE                 CTL0_WM(0)                       /*!< idle Line */
+#define USART_WM_ADDR                 CTL0_WM(1)                       /*!< address mask */
+
+/* USART word length definitions */
+#define CTL0_WL(regval)               (BIT(12) & ((uint32_t)(regval) << 12))
+#define USART_WL_8BIT                 CTL0_WL(0)                       /*!< 8 bits */
+#define USART_WL_9BIT                 CTL0_WL(1)                       /*!< 9 bits */
+
+/* USART oversampling mode definitions */
+#define CTL0_OVSMOD(regval)           (BIT(15) & ((uint32_t)(regval) << 15))
+#define USART_OVSMOD_16               CTL0_OVSMOD(0)                   /*!< 16 bits */
+#define USART_OVSMOD_8                CTL0_OVSMOD(1)                   /*!< 8 bits */
+
+/* USART stop bits definitions */
+#define CTL1_STB(regval)              (BITS(12,13) & ((uint32_t)(regval) << 12))
+#define USART_STB_1BIT                CTL1_STB(0)                      /*!< 1 bit */
+#define USART_STB_0_5BIT              CTL1_STB(1)                      /*!< 0.5 bit */
+#define USART_STB_2BIT                CTL1_STB(2)                      /*!< 2 bits */
+#define USART_STB_1_5BIT              CTL1_STB(3)                      /*!< 1.5 bits */
+
+/* USART LIN break frame length */
+#define CTL1_LBLEN(regval)            (BIT(5) & ((uint32_t)(regval) << 5))
+#define USART_LBLEN_10B               CTL1_LBLEN(0)                    /*!< 10 bits */
+#define USART_LBLEN_11B               CTL1_LBLEN(1)                    /*!< 11 bits */
+
+/* USART CK length */
+#define CTL1_CLEN(regval)             (BIT(8) & ((uint32_t)(regval) << 8))
+#define USART_CLEN_NONE               CTL1_CLEN(0)                     /*!< there are 7 CK pulses for an 8 bit frame and 8 CK pulses for a 9 bit frame */
+#define USART_CLEN_EN                 CTL1_CLEN(1)                     /*!< there are 8 CK pulses for an 8 bit frame and 9 CK pulses for a 9 bit frame */
+
+/* USART clock phase */
+#define CTL1_CPH(regval)              (BIT(9) & ((uint32_t)(regval) << 9))
+#define USART_CPH_1CK                 CTL1_CPH(0)                      /*!< first clock transition is the first data capture edge */
+#define USART_CPH_2CK                 CTL1_CPH(1)                      /*!< second clock transition is the first data capture edge */
+
+/* USART clock polarity */
+#define CTL1_CPL(regval)              (BIT(10) & ((uint32_t)(regval) << 10))
+#define USART_CPL_LOW                 CTL1_CPL(0)                      /*!< steady low value on CK pin */
+#define USART_CPL_HIGH                CTL1_CPL(1)                      /*!< steady high value on CK pin */
+
+/* USART DMA request for receive configure */
+#define CLT2_DENR(regval)             (BIT(6) & ((uint32_t)(regval) << 6))
+#define USART_DENR_ENABLE             CLT2_DENR(1)                     /*!< DMA request enable for reception */
+#define USART_DENR_DISABLE            CLT2_DENR(0)                     /*!< DMA request disable for reception */
+
+/* USART DMA request for transmission configure */
+#define CLT2_DENT(regval)             (BIT(7) & ((uint32_t)(regval) << 7))
+#define USART_DENT_ENABLE             CLT2_DENT(1)                     /*!< DMA request enable for transmission */
+#define USART_DENT_DISABLE            CLT2_DENT(0)                     /*!< DMA request disable for transmission */
+
+/* USART RTS configure */
+#define CLT2_RTSEN(regval)            (BIT(8) & ((uint32_t)(regval) << 8))
+#define USART_RTS_ENABLE              CLT2_RTSEN(1)                    /*!< RTS enable */
+#define USART_RTS_DISABLE             CLT2_RTSEN(0)                    /*!< RTS disable */
+
+/* USART CTS configure */
+#define CLT2_CTSEN(regval)            (BIT(9) & ((uint32_t)(regval) << 9))
+#define USART_CTS_ENABLE              CLT2_CTSEN(1)                    /*!< CTS enable */
+#define USART_CTS_DISABLE             CLT2_CTSEN(0)                    /*!< CTS disable */
+
+/* USART one sample bit method configure */
+#define CTL2_OSB(regval)              (BIT(11) & ((uint32_t)(regval) << 11))
+#define USART_OSB_1bit                CTL2_OSB(1)                      /*!< 1 bit */
+#define USART_OSB_3bit                CTL2_OSB(0)                      /*!< 3 bits */
+
+/* USART IrDA low-power enable */
+#define CTL2_IRLP(regval)             (BIT(2) & ((uint32_t)(regval) << 2))
+#define USART_IRLP_LOW                CTL2_IRLP(1)                     /*!< low-power */
+#define USART_IRLP_NORMAL             CTL2_IRLP(0)                     /*!< normal */
+
+/* USART data is transmitted/received with the LSB/MSB first */
+#define CTL3_MSBF(regval)             (BIT(11) & ((uint32_t)(regval) << 11))
+#define USART_MSBF_LSB                CTL3_MSBF(0)                     /*!< LSB first */
+#define USART_MSBF_MSB                CTL3_MSBF(1)                     /*!< MSB first */
+
+/* break frame coherence mode */
+#define CHC_BCM(regval)               (BIT(2) & ((uint32_t)(regval) << 2))
+#define USART_BCM_NONE                CHC_BCM(0)                       /*!< no parity error is detected */
+#define USART_BCM_EN                  CHC_BCM(1)                       /*!< parity error is detected */
+
+/* USART parity check coherence mode */
+#define CHC_PCM(regval)               (BIT(1) & ((uint32_t)(regval) << 1))
+#define USART_PCM_NONE                CHC_PCM(0)                       /*!< not check parity */
+#define USART_PCM_EN                  CHC_PCM(1)                       /*!< check the parity */
+
+/* USART hardware flow control coherence mode */
+#define CHC_HCM(regval)               (BIT(0) & ((uint32_t)(regval) << 0))
+#define USART_HCM_NONE                CHC_HCM(0)                       /*!< nRTS signal equals to the rxne status register */
+#define USART_HCM_EN                  CHC_HCM(1)                       /*!< nRTS signal is set when the last data bit has been sampled */
+
+/* function declarations */
+/* initialization functions */
+/* reset USART */
+void usart_deinit(uint32_t usart_periph);
+/* configure usart baud rate value */
+void usart_baudrate_set(uint32_t usart_periph, uint32_t baudval);
+/* configure usart parity function */
+void usart_parity_config(uint32_t usart_periph, uint32_t paritycfg);
+/* configure usart word length */
+void usart_word_length_set(uint32_t usart_periph, uint32_t wlen);
+/* configure usart stop bit length */
+void usart_stop_bit_set(uint32_t usart_periph, uint32_t stblen);
+/* enable usart */
+void usart_enable(uint32_t usart_periph);
+/* disable usart */
+void usart_disable(uint32_t usart_periph);
+/* configure USART transmitter */
+void usart_transmit_config(uint32_t usart_periph, uint32_t txconfig);
+/* configure USART receiver */
+void usart_receive_config(uint32_t usart_periph, uint32_t rxconfig);
+
+/* USART normal mode communication */
+/* data is transmitted/received with the LSB/MSB first */
+void usart_data_first_config(uint32_t usart_periph, uint32_t msbf);
+/* configure USART inverted */
+void usart_invert_config(uint32_t usart_periph, usart_invert_enum invertpara);
+/* configure the USART oversample mode */
+void usart_oversample_config(uint32_t usart_periph, uint32_t oversamp);
+/* configure sample bit method */
+void usart_sample_bit_config(uint32_t usart_periph, uint32_t obsm);
+/* enable receiver timeout */
+void usart_receiver_timeout_enable(uint32_t usart_periph);
+/* disable receiver timeout */
+void usart_receiver_timeout_disable(uint32_t usart_periph);
+/* configure receiver timeout threshold */
+void usart_receiver_timeout_threshold_config(uint32_t usart_periph, uint32_t rtimeout);
+/* USART transmit data function */
+void usart_data_transmit(uint32_t usart_periph, uint32_t data);
+/* USART receive data function */
+uint16_t usart_data_receive(uint32_t usart_periph);
+
+/* multi-processor communication */
+/* configure address of the USART */
+void usart_address_config(uint32_t usart_periph, uint8_t addr);
+/* enable mute mode */
+void usart_mute_mode_enable(uint32_t usart_periph);
+/* disable mute mode */
+void usart_mute_mode_disable(uint32_t usart_periph);
+/* configure wakeup method in mute mode */
+void usart_mute_mode_wakeup_config(uint32_t usart_periph, uint32_t wmehtod);
+
+/* LIN mode communication */
+/* enable LIN mode */
+void usart_lin_mode_enable(uint32_t usart_periph);
+/* disable LIN mode */
+void usart_lin_mode_disable(uint32_t usart_periph);
+/* LIN break detection length */
+void usart_lin_break_detection_length_config(uint32_t usart_periph, uint32_t lblen);
+/* send break frame */
+void usart_send_break(uint32_t usart_periph);
+
+/* half-duplex communication */
+/* enable half-duplex mode */
+void usart_halfduplex_enable(uint32_t usart_periph);
+/* disable half-duplex mode */
+void usart_halfduplex_disable(uint32_t usart_periph);
+
+/* synchronous communication */
+/* enable CK pin in synchronous mode */
+void usart_synchronous_clock_enable(uint32_t usart_periph);
+/* disable CK pin in synchronous mode */
+void usart_synchronous_clock_disable(uint32_t usart_periph);
+/* configure usart synchronous mode parameters */
+void usart_synchronous_clock_config(uint32_t usart_periph, uint32_t clen, uint32_t cph, uint32_t cpl);
+
+/* smartcard communication */
+/* configure guard time value in smartcard mode */
+void usart_guard_time_config(uint32_t usart_periph, uint32_t guat);
+/* enable smartcard mode */
+void usart_smartcard_mode_enable(uint32_t usart_periph);
+/* disable smartcard mode */
+void usart_smartcard_mode_disable(uint32_t usart_periph);
+/* enable NACK in smartcard mode */
+void usart_smartcard_mode_nack_enable(uint32_t usart_periph);
+/* disable NACK in smartcard mode */
+void usart_smartcard_mode_nack_disable(uint32_t usart_periph);
+/* configure smartcard auto-retry number */
+void usart_smartcard_autoretry_config(uint32_t usart_periph, uint32_t scrtnum);
+/* configure block length */
+void usart_block_length_config(uint32_t usart_periph, uint32_t bl);
+
+/* IrDA communication */
+/* enable IrDA mode */
+void usart_irda_mode_enable(uint32_t usart_periph);
+/* disable IrDA mode */
+void usart_irda_mode_disable(uint32_t usart_periph);
+/* configure the peripheral clock prescaler */
+void usart_prescaler_config(uint32_t usart_periph, uint8_t psc);
+/* configure IrDA low-power */
+void usart_irda_lowpower_config(uint32_t usart_periph, uint32_t irlp);
+
+/* hardware flow communication */
+/* configure hardware flow control RTS */
+void usart_hardware_flow_rts_config(uint32_t usart_periph, uint32_t rtsconfig);
+/* configure hardware flow control CTS */
+void usart_hardware_flow_cts_config(uint32_t usart_periph, uint32_t ctsconfig);
+
+/* coherence control */
+/* configure break frame coherence mode */
+void usart_break_frame_coherence_config(uint32_t usart_periph, uint32_t bcm);
+/* configure parity check coherence mode */
+void usart_parity_check_coherence_config(uint32_t usart_periph, uint32_t pcm);
+/* configure hardware flow control coherence mode */
+void usart_hardware_flow_coherence_config(uint32_t usart_periph, uint32_t hcm);
+
+/* DMA communication */
+/* configure USART DMA for reception */
+void usart_dma_receive_config(uint32_t usart_periph, uint32_t dmacmd);
+/* configure USART DMA for transmission */
+void usart_dma_transmit_config(uint32_t usart_periph, uint32_t dmacmd);
+
+/* flag & interrupt functions */
+/* get flag in STAT0/STAT1 register */
+FlagStatus usart_flag_get(uint32_t usart_periph, usart_flag_enum flag);
+/* clear flag in STAT0/STAT1 register */
+void usart_flag_clear(uint32_t usart_periph, usart_flag_enum flag);
+/* enable USART interrupt */
+void usart_interrupt_enable(uint32_t usart_periph, usart_interrupt_enum interrupt);
+/* disable USART interrupt */
+void usart_interrupt_disable(uint32_t usart_periph, usart_interrupt_enum interrupt);
+/* get USART interrupt and flag status */
+FlagStatus usart_interrupt_flag_get(uint32_t usart_periph, usart_interrupt_flag_enum int_flag);
+/* clear interrupt flag in STAT0/STAT1 register */
+void usart_interrupt_flag_clear(uint32_t usart_periph, usart_interrupt_flag_enum int_flag);
+
+#endif /* GD32F4XX_USART_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_wwdgt.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Include/gd32f4xx_wwdgt.h
@@ -1,0 +1,94 @@
+/*!
+    \file    gd32f4xx_wwdgt.h
+    \brief   definitions for the WWDGT 
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef GD32F4XX_WWDGT_H
+#define GD32F4XX_WWDGT_H
+
+#include "gd32f4xx.h"
+
+/* WWDGT definitions */
+#define WWDGT                       WWDGT_BASE                      /*!< WWDGT base address */
+
+/* registers definitions */
+#define WWDGT_CTL                   REG32((WWDGT) + 0x00U)          /*!< WWDGT control register */
+#define WWDGT_CFG                   REG32((WWDGT) + 0x04U)          /*!< WWDGT configuration register */
+#define WWDGT_STAT                  REG32((WWDGT) + 0x08U)          /*!< WWDGT status register */
+
+/* bits definitions */
+/* WWDGT_CTL */
+#define WWDGT_CTL_CNT               BITS(0,6)                       /*!< WWDGT counter value */
+#define WWDGT_CTL_WDGTEN            BIT(7)                          /*!< WWDGT counter enable */
+
+/* WWDGT_CFG */
+#define WWDGT_CFG_WIN               BITS(0,6)                       /*!< WWDGT counter window value */
+#define WWDGT_CFG_PSC               BITS(7,8)                       /*!< WWDGT prescaler divider value */
+#define WWDGT_CFG_EWIE              BIT(9)                          /*!< early wakeup interrupt enable */
+
+/* WWDGT_STAT */
+#define WWDGT_STAT_EWIF             BIT(0)                          /*!< early wakeup interrupt flag */
+
+/* constants definitions */
+#define CFG_PSC(regval)             (BITS(7,8) & ((uint32_t)(regval) << 7))   /*!< write value to WWDGT_CFG_PSC bit field */
+#define WWDGT_CFG_PSC_DIV1          CFG_PSC(0)                      /*!< the time base of WWDGT = (PCLK1/4096)/1 */
+#define WWDGT_CFG_PSC_DIV2          CFG_PSC(1)                      /*!< the time base of WWDGT = (PCLK1/4096)/2 */
+#define WWDGT_CFG_PSC_DIV4          CFG_PSC(2)                      /*!< the time base of WWDGT = (PCLK1/4096)/4 */
+#define WWDGT_CFG_PSC_DIV8          CFG_PSC(3)                      /*!< the time base of WWDGT = (PCLK1/4096)/8 */
+
+/* write value to WWDGT_CTL_CNT bit field */
+#define CTL_CNT(regval)             (BITS(0,6) & ((uint32_t)(regval) << 0))
+/* write value to WWDGT_CFG_WIN bit field */
+#define CFG_WIN(regval)             (BITS(0,6) & ((uint32_t)(regval) << 0))
+
+/* function declarations */
+/* reset the window watchdog timer configuration */
+void wwdgt_deinit(void);
+/* start the window watchdog timer counter */
+void wwdgt_enable(void);
+
+/* configure the window watchdog timer counter value */
+void wwdgt_counter_update(uint16_t counter_value);
+/* configure counter value, window value, and prescaler divider value */
+void wwdgt_config(uint16_t counter, uint16_t window, uint32_t prescaler);
+
+/* check early wakeup interrupt state of WWDGT */
+FlagStatus wwdgt_flag_get(void);
+/* clear early wakeup interrupt state of WWDGT */
+void wwdgt_flag_clear(void);
+/* enable early wakeup interrupt of WWDGT */
+void wwdgt_interrupt_enable(void);
+
+#endif /* GD32F4XX_WWDGT_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_adc.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_adc.c
@@ -1,0 +1,1203 @@
+/*!
+    \file    gd32f4xx_adc.c
+    \brief   ADC driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_adc.h"
+
+#define REGULAR_TRIGGER_MODE                        ((uint32_t)28U)
+#define INSERTED_TRIGGER_MODE                       ((uint32_t)20U)
+/* discontinuous mode macro*/
+#define  ADC_CHANNEL_LENGTH_SUBTRACT_ONE            ((uint8_t)1U)
+
+/* ADC regular channel macro */
+#define  ADC_REGULAR_CHANNEL_RANK_SIX               ((uint8_t)6U)
+#define  ADC_REGULAR_CHANNEL_RANK_TWELVE            ((uint8_t)12U)
+#define  ADC_REGULAR_CHANNEL_RANK_SIXTEEN           ((uint8_t)16U)
+#define  ADC_REGULAR_CHANNEL_RANK_LENGTH            ((uint8_t)5U)
+
+/* ADC sampling time macro */
+#define  ADC_CHANNEL_SAMPLE_TEN                     ((uint8_t)10U)
+#define  ADC_CHANNEL_SAMPLE_EIGHTEEN                ((uint8_t)18U)
+#define  ADC_CHANNEL_SAMPLE_LENGTH                  ((uint8_t)3U)
+
+/* ADC inserted channel macro */
+#define  ADC_INSERTED_CHANNEL_RANK_LENGTH           ((uint8_t)5U)
+#define  ADC_INSERTED_CHANNEL_SHIFT_LENGTH          ((uint8_t)15U)
+
+/* ADC inserted channel offset macro */
+#define  ADC_OFFSET_LENGTH                          ((uint8_t)3U)
+#define  ADC_OFFSET_SHIFT_LENGTH                    ((uint8_t)4U)
+
+/*!
+    \brief    reset ADC
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void adc_deinit(void)
+{
+    rcu_periph_reset_enable(RCU_ADCRST);
+    rcu_periph_reset_disable(RCU_ADCRST);
+}
+
+/*!
+    \brief        configure the ADC clock for all the ADCs
+    \param[in]    prescaler: configure ADCs prescaler ratio
+                  only one parameter can be selected which is shown as below:
+      \arg        ADC_ADCCK_PCLK2_DIV2: PCLK2 div2
+      \arg        ADC_ADCCK_PCLK2_DIV4: PCLK2 div4
+      \arg        ADC_ADCCK_PCLK2_DIV6: PCLK2 div6
+      \arg        ADC_ADCCK_PCLK2_DIV8: PCLK2 div8
+      \arg        ADC_ADCCK_HCLK_DIV5: HCLK div5
+      \arg        ADC_ADCCK_HCLK_DIV6: HCLK div6
+      \arg        ADC_ADCCK_HCLK_DIV10: HCLK div10
+      \arg        ADC_ADCCK_HCLK_DIV20: HCLK div20
+    \param[out]   none
+    \retval       none
+*/
+void adc_clock_config(uint32_t prescaler)
+{
+    ADC_SYNCCTL &= ~((uint32_t)ADC_SYNCCTL_ADCCK);
+    ADC_SYNCCTL |= (uint32_t) prescaler;
+}
+
+/*!
+    \brief        enable or disable ADC special function
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    function: the function to config
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_SCAN_MODE: scan mode select
+    \arg          ADC_INSERTED_CHANNEL_AUTO: inserted channel group convert automatically
+    \arg          ADC_CONTINUOUS_MODE: continuous mode select
+    \param[in]    newvalue: ENABLE or DISABLE
+    \param[out]   none
+    \retval       none
+*/
+void adc_special_function_config(uint32_t adc_periph, uint32_t function, ControlStatus newvalue)
+{
+    if(newvalue) {
+        if(0U != (function & ADC_SCAN_MODE)) {
+            /* enable scan mode */
+            ADC_CTL0(adc_periph) |= ADC_SCAN_MODE;
+        }
+        if(0U != (function & ADC_INSERTED_CHANNEL_AUTO)) {
+            /* enable inserted channel group convert automatically */
+            ADC_CTL0(adc_periph) |= ADC_INSERTED_CHANNEL_AUTO;
+        }
+        if(0U != (function & ADC_CONTINUOUS_MODE)) {
+            /* enable continuous mode */
+            ADC_CTL1(adc_periph) |= ADC_CONTINUOUS_MODE;
+        }
+    } else {
+        if(0U != (function & ADC_SCAN_MODE)) {
+            /* disable scan mode */
+            ADC_CTL0(adc_periph) &= ~ADC_SCAN_MODE;
+        }
+        if(0U != (function & ADC_INSERTED_CHANNEL_AUTO)) {
+            /* disable inserted channel group convert automatically */
+            ADC_CTL0(adc_periph) &= ~ADC_INSERTED_CHANNEL_AUTO;
+        }
+        if(0U != (function & ADC_CONTINUOUS_MODE)) {
+            /* disable continuous mode */
+            ADC_CTL1(adc_periph) &= ~ADC_CONTINUOUS_MODE;
+        }
+    }
+}
+
+/*!
+    \brief        configure ADC data alignment
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    data_alignment: data alignment select
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_DATAALIGN_RIGHT: LSB alignment
+    \arg          ADC_DATAALIGN_LEFT: MSB alignment
+    \param[out]   none
+    \retval       none
+*/
+void adc_data_alignment_config(uint32_t adc_periph, uint32_t data_alignment)
+{
+    if(ADC_DATAALIGN_RIGHT != data_alignment) {
+        /* MSB alignment */
+        ADC_CTL1(adc_periph) |= ADC_CTL1_DAL;
+    } else {
+        /* LSB alignment */
+        ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_DAL);
+    }
+}
+
+/*!
+    \brief        enable ADC interface
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[out]   none
+    \retval       none
+*/
+void adc_enable(uint32_t adc_periph)
+{
+    if(RESET == (ADC_CTL1(adc_periph) & ADC_CTL1_ADCON)) {
+        /* enable ADC */
+        ADC_CTL1(adc_periph) |= (uint32_t)ADC_CTL1_ADCON;
+    }
+}
+
+/*!
+    \brief        disable ADC interface
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[out]   none
+    \retval       none
+*/
+void adc_disable(uint32_t adc_periph)
+{
+    /* disable ADC */
+    ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_ADCON);
+}
+
+/*!
+    \brief        ADC calibration and reset calibration
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[out]   none
+    \retval       none
+*/
+void adc_calibration_enable(uint32_t adc_periph)
+{
+    /* reset the selected ADC calibration registers */
+    ADC_CTL1(adc_periph) |= (uint32_t) ADC_CTL1_RSTCLB;
+    /* check the RSTCLB bit state */
+    while(RESET != (ADC_CTL1(adc_periph) & ADC_CTL1_RSTCLB)) {
+    }
+    /* enable ADC calibration process */
+    ADC_CTL1(adc_periph) |= ADC_CTL1_CLB;
+    /* check the CLB bit state */
+    while(RESET != (ADC_CTL1(adc_periph) & ADC_CTL1_CLB)) {
+    }
+}
+
+/*!
+    \brief        configure temperature sensor and internal reference voltage channel or VBAT channel function
+    \param[in]    function: temperature sensor and internal reference voltage channel or VBAT channel
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_VBAT_CHANNEL_SWITCH: channel 18 (1/4 voltate of external battery) switch of ADC0
+    \arg          ADC_TEMP_VREF_CHANNEL_SWITCH: channel 16 (temperature sensor) and 17 (internal reference voltage) switch of ADC0
+    \param[in]    newvalue: ENABLE or DISABLE
+    \param[out]   none
+    \retval       none
+*/
+void adc_channel_16_to_18(uint32_t function, ControlStatus newvalue)
+{
+    if(newvalue) {
+        if(RESET != (function & ADC_VBAT_CHANNEL_SWITCH)) {
+            /* enable ADC0 Vbat channel */
+            ADC_SYNCCTL |= ADC_VBAT_CHANNEL_SWITCH;
+        }
+        if(RESET != (function & ADC_TEMP_VREF_CHANNEL_SWITCH)) {
+            /* enable ADC0 Vref and Temperature channel */
+            ADC_SYNCCTL |= ADC_TEMP_VREF_CHANNEL_SWITCH;
+        }
+    } else {
+        if(RESET != (function & ADC_VBAT_CHANNEL_SWITCH)) {
+            /* disable ADC0 Vbat channel  */
+            ADC_SYNCCTL &= ~ADC_VBAT_CHANNEL_SWITCH;
+        }
+        if(RESET != (function & ADC_TEMP_VREF_CHANNEL_SWITCH)) {
+            /* disable ADC0 Vref and Temperature channel */
+            ADC_SYNCCTL &= ~ADC_TEMP_VREF_CHANNEL_SWITCH;
+        }
+    }
+}
+
+/*!
+    \brief        configure ADC resolution
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    resolution: ADC resolution
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_RESOLUTION_12B: 12-bit ADC resolution
+    \arg          ADC_RESOLUTION_10B: 10-bit ADC resolution
+    \arg          ADC_RESOLUTION_8B: 8-bit ADC resolution
+    \arg          ADC_RESOLUTION_6B: 6-bit ADC resolution
+    \param[out]   none
+    \retval       none
+*/
+void adc_resolution_config(uint32_t adc_periph, uint32_t resolution)
+{
+    ADC_CTL0(adc_periph) &= ~((uint32_t)ADC_CTL0_DRES);
+    ADC_CTL0(adc_periph) |= (uint32_t)resolution;
+}
+
+/*!
+    \brief        configure ADC oversample mode
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    mode: ADC oversampling mode
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_OVERSAMPLING_ALL_CONVERT: all oversampled conversions for a channel are done consecutively after a trigger
+    \arg          ADC_OVERSAMPLING_ONE_CONVERT: each oversampled conversion for a channel needs a trigger
+    \param[in]    shift: ADC oversampling shift
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_OVERSAMPLING_SHIFT_NONE: no oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_1B: 1-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_2B: 2-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_3B: 3-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_4B: 3-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_5B: 5-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_6B: 6-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_7B: 7-bit oversampling shift
+    \arg          ADC_OVERSAMPLING_SHIFT_8B: 8-bit oversampling shift
+    \param[in]    ratio: ADC oversampling ratio
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_OVERSAMPLING_RATIO_MUL2: oversampling ratio multiple 2
+    \arg          ADC_OVERSAMPLING_RATIO_MUL4: oversampling ratio multiple 4
+    \arg          ADC_OVERSAMPLING_RATIO_MUL8: oversampling ratio multiple 8
+    \arg          ADC_OVERSAMPLING_RATIO_MUL16: oversampling ratio multiple 16
+    \arg          ADC_OVERSAMPLING_RATIO_MUL32: oversampling ratio multiple 32
+    \arg          ADC_OVERSAMPLING_RATIO_MUL64: oversampling ratio multiple 64
+    \arg          ADC_OVERSAMPLING_RATIO_MUL128: oversampling ratio multiple 128
+    \arg          ADC_OVERSAMPLING_RATIO_MUL256: oversampling ratio multiple 256
+    \param[out]   none
+    \retval       none
+*/
+void adc_oversample_mode_config(uint32_t adc_periph, uint32_t mode, uint16_t shift, uint8_t ratio)
+{
+    if(ADC_OVERSAMPLING_ONE_CONVERT == mode) {
+        ADC_OVSAMPCTL(adc_periph) |= (uint32_t)ADC_OVSAMPCTL_TOVS;
+    } else {
+        ADC_OVSAMPCTL(adc_periph) &= ~((uint32_t)ADC_OVSAMPCTL_TOVS);
+    }
+    /* config the shift and ratio */
+    ADC_OVSAMPCTL(adc_periph) &= ~((uint32_t)(ADC_OVSAMPCTL_OVSR | ADC_OVSAMPCTL_OVSS));
+    ADC_OVSAMPCTL(adc_periph) |= ((uint32_t)shift | (uint32_t)ratio);
+}
+
+/*!
+    \brief        enable ADC oversample mode
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[out]   none
+    \retval       none
+*/
+void adc_oversample_mode_enable(uint32_t adc_periph)
+{
+    ADC_OVSAMPCTL(adc_periph) |= ADC_OVSAMPCTL_OVSEN;
+}
+
+/*!
+    \brief        disable ADC oversample mode
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[out]   none
+    \retval       none
+*/
+void adc_oversample_mode_disable(uint32_t adc_periph)
+{
+    ADC_OVSAMPCTL(adc_periph) &= ~((uint32_t)ADC_OVSAMPCTL_OVSEN);
+}
+
+/*!
+    \brief        enable DMA request
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[out]   none
+    \retval       none
+*/
+void adc_dma_mode_enable(uint32_t adc_periph)
+{
+    /* enable DMA request */
+    ADC_CTL1(adc_periph) |= (uint32_t)(ADC_CTL1_DMA);
+}
+
+/*!
+    \brief      disable DMA request
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[out] none
+    \retval     none
+*/
+void adc_dma_mode_disable(uint32_t adc_periph)
+{
+    /* disable DMA request */
+    ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_DMA);
+}
+
+/*!
+    \brief    when DMA=1, the DMA engine issues a request at end of each regular conversion
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[out] none
+    \retval     none
+*/
+void adc_dma_request_after_last_enable(uint32_t adc_periph)
+{
+    ADC_CTL1(adc_periph) |= (uint32_t)(ADC_CTL1_DDM);
+}
+
+/*!
+    \brief    the DMA engine is disabled after the end of transfer signal from DMA controller is detected
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[out] none
+    \retval     none
+*/
+void adc_dma_request_after_last_disable(uint32_t adc_periph)
+{
+    ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_DDM);
+}
+
+/*!
+    \brief        configure ADC discontinuous mode
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    adc_channel_group: select the channel group
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_REGULAR_CHANNEL: regular channel group
+    \arg          ADC_INSERTED_CHANNEL: inserted channel group
+    \arg          ADC_CHANNEL_DISCON_DISABLE: disable discontinuous mode of regular & inserted channel
+    \param[in]    length: number of conversions in discontinuous mode,the number can be 1..8
+                  for regular channel ,the number has no effect for inserted channel
+    \param[out]   none
+    \retval       none
+*/
+void adc_discontinuous_mode_config(uint32_t adc_periph, uint8_t adc_channel_group, uint8_t length)
+{
+    /* disable discontinuous mode of regular & inserted channel */
+    ADC_CTL0(adc_periph) &= ~((uint32_t)(ADC_CTL0_DISRC | ADC_CTL0_DISIC));
+    switch(adc_channel_group) {
+    case ADC_REGULAR_CHANNEL:
+        /* config the number of conversions in discontinuous mode  */
+        ADC_CTL0(adc_periph) &= ~((uint32_t)ADC_CTL0_DISNUM);
+        if((length <= 8U) && (length >= 1U)) {
+            ADC_CTL0(adc_periph) |= CTL0_DISNUM(((uint32_t)length - ADC_CHANNEL_LENGTH_SUBTRACT_ONE));
+        }
+        /* enable regular channel group discontinuous mode */
+        ADC_CTL0(adc_periph) |= (uint32_t)ADC_CTL0_DISRC;
+        break;
+    case ADC_INSERTED_CHANNEL:
+        /* enable inserted channel group discontinuous mode */
+        ADC_CTL0(adc_periph) |= (uint32_t)ADC_CTL0_DISIC;
+        break;
+    case ADC_CHANNEL_DISCON_DISABLE:
+    /* disable discontinuous mode of regular & inserted channel */
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief        configure the length of regular channel group or inserted channel group
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    adc_channel_group: select the channel group
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_REGULAR_CHANNEL: regular channel group
+    \arg          ADC_INSERTED_CHANNEL: inserted channel group
+    \param[in]    length: the length of the channel
+                  regular channel 1-16
+                  inserted channel 1-4
+    \param[out]   none
+    \retval       none
+*/
+void adc_channel_length_config(uint32_t adc_periph, uint8_t adc_channel_group, uint32_t length)
+{
+    switch(adc_channel_group) {
+    case ADC_REGULAR_CHANNEL:
+        if((length >= 1U) && (length <= 16U)) {
+            ADC_RSQ0(adc_periph) &= ~((uint32_t)ADC_RSQ0_RL);
+            ADC_RSQ0(adc_periph) |= RSQ0_RL((uint32_t)(length - ADC_CHANNEL_LENGTH_SUBTRACT_ONE));
+        }
+        break;
+    case ADC_INSERTED_CHANNEL:
+        if((length >= 1U) && (length <= 4U)) {
+            ADC_ISQ(adc_periph) &= ~((uint32_t)ADC_ISQ_IL);
+            ADC_ISQ(adc_periph) |= ISQ_IL((uint32_t)(length - ADC_CHANNEL_LENGTH_SUBTRACT_ONE));
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief        configure ADC regular channel
+    \param[in]    adc_periph: ADCx,x=0,1,2
+    \param[in]    rank: the regular group sequencer rank,this parameter must be between 0 to 15
+    \param[in]    adc_channel: the selected ADC channel
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_CHANNEL_x(x=0..18): ADC Channelx
+    \param[in]    sample_time: the sample time value
+                  only one parameter can be selected which is shown as below:
+    \arg          ADC_SAMPLETIME_3: 3 cycles
+    \arg          ADC_SAMPLETIME_15: 15 cycles
+    \arg          ADC_SAMPLETIME_28: 28 cycles
+    \arg          ADC_SAMPLETIME_56: 56 cycles
+    \arg          ADC_SAMPLETIME_84: 84 cycles
+    \arg          ADC_SAMPLETIME_112: 112 cycles
+    \arg          ADC_SAMPLETIME_144: 144 cycles
+    \arg          ADC_SAMPLETIME_480: 480 cycles
+    \param[out]   none
+    \retval       none
+*/
+void adc_regular_channel_config(uint32_t adc_periph, uint8_t rank, uint8_t adc_channel, uint32_t sample_time)
+{
+    uint32_t rsq, sampt;
+
+    /* ADC regular sequence config */
+    if(rank < ADC_REGULAR_CHANNEL_RANK_SIX) {
+        /* the regular group sequence rank is smaller than six */
+        rsq = ADC_RSQ2(adc_periph);
+        rsq &=  ~((uint32_t)(ADC_RSQX_RSQN << (ADC_REGULAR_CHANNEL_RANK_LENGTH * rank)));
+        /* the channel number is written to these bits to select a channel as the nth conversion in the regular channel group */
+        rsq |= ((uint32_t)adc_channel << (ADC_REGULAR_CHANNEL_RANK_LENGTH * rank));
+        ADC_RSQ2(adc_periph) = rsq;
+    } else if(rank < ADC_REGULAR_CHANNEL_RANK_TWELVE) {
+        /* the regular group sequence rank is smaller than twelve */
+        rsq = ADC_RSQ1(adc_periph);
+        rsq &= ~((uint32_t)(ADC_RSQX_RSQN << (ADC_REGULAR_CHANNEL_RANK_LENGTH * (rank - ADC_REGULAR_CHANNEL_RANK_SIX))));
+        /* the channel number is written to these bits to select a channel as the nth conversion in the regular channel group */
+        rsq |= ((uint32_t)adc_channel << (ADC_REGULAR_CHANNEL_RANK_LENGTH * (rank - ADC_REGULAR_CHANNEL_RANK_SIX)));
+        ADC_RSQ1(adc_periph) = rsq;
+    } else if(rank < ADC_REGULAR_CHANNEL_RANK_SIXTEEN) {
+        /* the regular group sequence rank is smaller than sixteen */
+        rsq = ADC_RSQ0(adc_periph);
+        rsq &= ~((uint32_t)(ADC_RSQX_RSQN << (ADC_REGULAR_CHANNEL_RANK_LENGTH * (rank - ADC_REGULAR_CHANNEL_RANK_TWELVE))));
+        /* the channel number is written to these bits to select a channel as the nth conversion in the regular channel group */
+        rsq |= ((uint32_t)adc_channel << (ADC_REGULAR_CHANNEL_RANK_LENGTH * (rank - ADC_REGULAR_CHANNEL_RANK_TWELVE)));
+        ADC_RSQ0(adc_periph) = rsq;
+    } else {
+    }
+
+    /* ADC sampling time config */
+    if(adc_channel < ADC_CHANNEL_SAMPLE_TEN) {
+        /* the regular group sequence rank is smaller than ten */
+        sampt = ADC_SAMPT1(adc_periph);
+        sampt &= ~((uint32_t)(ADC_SAMPTX_SPTN << (ADC_CHANNEL_SAMPLE_LENGTH * adc_channel)));
+        /* channel sample time set*/
+        sampt |= (uint32_t)(sample_time << (ADC_CHANNEL_SAMPLE_LENGTH * adc_channel));
+        ADC_SAMPT1(adc_periph) = sampt;
+    } else if(adc_channel <= ADC_CHANNEL_SAMPLE_EIGHTEEN) {
+        /* the regular group sequence rank is smaller than eighteen */
+        sampt = ADC_SAMPT0(adc_periph);
+        sampt &= ~((uint32_t)(ADC_SAMPTX_SPTN << (ADC_CHANNEL_SAMPLE_LENGTH * (adc_channel - ADC_CHANNEL_SAMPLE_TEN))));
+        /* channel sample time set*/
+        sampt |= (uint32_t)(sample_time << (ADC_CHANNEL_SAMPLE_LENGTH * (adc_channel - ADC_CHANNEL_SAMPLE_TEN)));
+        ADC_SAMPT0(adc_periph) = sampt;
+    } else {
+    }
+}
+
+/*!
+    \brief    configure ADC inserted channel
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  rank: the inserted group sequencer rank,this parameter must be between 0 to 3
+    \param[in]  adc_channel: the selected ADC channel
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_CHANNEL_x(x=0..18): ADC Channelx
+    \param[in]  sample_time: The sample time value
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_SAMPLETIME_3: 3 cycles
+    \arg        ADC_SAMPLETIME_15: 15 cycles
+    \arg        ADC_SAMPLETIME_28: 28 cycles
+    \arg        ADC_SAMPLETIME_56: 56 cycles
+    \arg        ADC_SAMPLETIME_84: 84 cycles
+    \arg        ADC_SAMPLETIME_112: 112 cycles
+    \arg        ADC_SAMPLETIME_144: 144 cycles
+    \arg        ADC_SAMPLETIME_480: 480 cycles
+    \param[out] none
+    \retval     none
+*/
+void adc_inserted_channel_config(uint32_t adc_periph, uint8_t rank, uint8_t adc_channel, uint32_t sample_time)
+{
+    uint8_t inserted_length;
+    uint32_t isq, sampt;
+
+    /* get inserted channel group length */
+    inserted_length = (uint8_t)GET_BITS(ADC_ISQ(adc_periph), 20U, 21U);
+    /* the channel number is written to these bits to select a channel as the nth conversion in the inserted channel group */
+    if(rank < 4U) {
+        isq = ADC_ISQ(adc_periph);
+        isq &= ~((uint32_t)(ADC_ISQ_ISQN << (ADC_INSERTED_CHANNEL_SHIFT_LENGTH - (inserted_length - rank) * ADC_INSERTED_CHANNEL_RANK_LENGTH)));
+        isq |= ((uint32_t)adc_channel << (ADC_INSERTED_CHANNEL_SHIFT_LENGTH - (inserted_length - rank) * ADC_INSERTED_CHANNEL_RANK_LENGTH));
+        ADC_ISQ(adc_periph) = isq;
+    }
+
+    /* ADC sampling time config */
+    if(adc_channel < ADC_CHANNEL_SAMPLE_TEN) {
+        /* the inserted group sequence rank is smaller than ten */
+        sampt = ADC_SAMPT1(adc_periph);
+        sampt &= ~((uint32_t)(ADC_SAMPTX_SPTN << (ADC_CHANNEL_SAMPLE_LENGTH * adc_channel)));
+        /* channel sample time set*/
+        sampt |= (uint32_t) sample_time << (ADC_CHANNEL_SAMPLE_LENGTH * adc_channel);
+        ADC_SAMPT1(adc_periph) = sampt;
+    } else if(adc_channel <= ADC_CHANNEL_SAMPLE_EIGHTEEN) {
+        /* the inserted group sequence rank is smaller than eighteen */
+        sampt = ADC_SAMPT0(adc_periph);
+        sampt &= ~((uint32_t)(ADC_SAMPTX_SPTN << (ADC_CHANNEL_SAMPLE_LENGTH * (adc_channel - ADC_CHANNEL_SAMPLE_TEN))));
+        /* channel sample time set*/
+        sampt |= ((uint32_t)sample_time << (ADC_CHANNEL_SAMPLE_LENGTH * (adc_channel - ADC_CHANNEL_SAMPLE_TEN)));
+        ADC_SAMPT0(adc_periph) = sampt;
+    } else {
+    }
+}
+
+/*!
+    \brief      configure ADC inserted channel offset
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  inserted_channel : insert channel select
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_INSERTED_CHANNEL_0: inserted channel0
+    \arg        ADC_INSERTED_CHANNEL_1: inserted channel1
+    \arg        ADC_INSERTED_CHANNEL_2: inserted channel2
+    \arg        ADC_INSERTED_CHANNEL_3: inserted channel3
+    \param[in]  offset : the offset data
+    \param[out] none
+    \retval     none
+*/
+void adc_inserted_channel_offset_config(uint32_t adc_periph, uint8_t inserted_channel, uint16_t offset)
+{
+    uint8_t inserted_length;
+    uint32_t num = 0U;
+
+    inserted_length = (uint8_t)GET_BITS(ADC_ISQ(adc_periph), 20U, 21U);
+    num = ((uint32_t)ADC_OFFSET_LENGTH - ((uint32_t)inserted_length - (uint32_t)inserted_channel));
+
+    if(num <= ADC_OFFSET_LENGTH) {
+        /* calculate the offset of the register */
+        num = num * ADC_OFFSET_SHIFT_LENGTH;
+        /* config the offset of the selected channels */
+        REG32((adc_periph) + 0x14U + num) = IOFFX_IOFF((uint32_t)offset);
+    }
+}
+
+/*!
+    \brief      configure ADC external trigger source
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  adc_channel_group: select the channel group
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_REGULAR_CHANNEL: regular channel group
+    \arg        ADC_INSERTED_CHANNEL: inserted channel group
+    \param[in]  external_trigger_source: regular or inserted group trigger source
+                for regular channel:
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_EXTTRIG_REGULAR_T0_CH0: external trigger timer 0 CC0 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T0_CH1: external trigger timer 0 CC1 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T0_CH2: external trigger timer 0 CC2 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T1_CH1: external trigger timer 1 CC1 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T1_CH2: external trigger timer 1 CC2 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T1_CH3: external trigger timer 1 CC3 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T1_TRGO: external trigger timer 1 TRGO event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T2_CH0 : external trigger timer 2 CC0 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T2_TRGO : external trigger timer 2 TRGO event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T3_CH3: external trigger timer 3 CC3 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T4_CH0: external trigger timer 4 CC0 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T4_CH1: external trigger timer 4 CC1 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T4_CH2: external trigger timer 4 CC2 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T7_CH0: external trigger timer 7 CC0 event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_T7_TRGO: external trigger timer 7 TRGO event select for regular channel
+    \arg        ADC_EXTTRIG_REGULAR_EXTI_11: external trigger extiline 11 select for regular channel
+                for inserted channel:
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_EXTTRIG_INSERTED_T0_CH3: timer0 capture compare 3
+    \arg        ADC_EXTTRIG_INSERTED_T0_TRGO: timer0 TRGO event
+    \arg        ADC_EXTTRIG_INSERTED_T1_CH0: timer1 capture compare 0
+    \arg        ADC_EXTTRIG_INSERTED_T1_TRGO: timer1 TRGO event
+    \arg        ADC_EXTTRIG_INSERTED_T2_CH1: timer2 capture compare 1
+    \arg        ADC_EXTTRIG_INSERTED_T2_CH3: timer2 capture compare 3
+    \arg        ADC_EXTTRIG_INSERTED_T3_CH0: timer3 capture compare 0
+    \arg        ADC_EXTTRIG_INSERTED_T3_CH1: timer3 capture compare 1
+    \arg        ADC_EXTTRIG_INSERTED_T3_CH2: timer3 capture compare 2
+    \arg        ADC_EXTTRIG_INSERTED_T3_TRGO: timer3 capture compare TRGO
+    \arg        ADC_EXTTRIG_INSERTED_T4_CH3: timer4 capture compare 3
+    \arg        ADC_EXTTRIG_INSERTED_T4_TRGO: timer4 capture compare TRGO
+    \arg        ADC_EXTTRIG_INSERTED_T7_CH1: timer7 capture compare 1
+    \arg        ADC_EXTTRIG_INSERTED_T7_CH2: timer7 capture compare 2
+    \arg        ADC_EXTTRIG_INSERTED_T7_CH3: timer7 capture compare 3
+    \arg        ADC_EXTTRIG_INSERTED_EXTI_15: external interrupt line 15
+    \param[out] none
+    \retval     none
+*/
+void adc_external_trigger_source_config(uint32_t adc_periph, uint8_t adc_channel_group, uint32_t external_trigger_source)
+{
+    switch(adc_channel_group) {
+    case ADC_REGULAR_CHANNEL:
+        /* configure ADC regular group external trigger source */
+        ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_ETSRC);
+        ADC_CTL1(adc_periph) |= (uint32_t)external_trigger_source;
+        break;
+    case ADC_INSERTED_CHANNEL:
+        /* configure ADC inserted group external trigger source */
+        ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_ETSIC);
+        ADC_CTL1(adc_periph) |= (uint32_t)external_trigger_source;
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      enable ADC external trigger
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  adc_channel_group: select the channel group
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_REGULAR_CHANNEL: regular channel group
+    \arg        ADC_INSERTED_CHANNEL: inserted channel group
+    \param[in]  trigger_mode: external trigger mode
+                only one parameter can be selected which is shown as below:
+    \arg        EXTERNAL_TRIGGER_DISABLE: external trigger disable
+    \arg        EXTERNAL_TRIGGER_RISING: rising edge of external trigger
+    \arg        EXTERNAL_TRIGGER_FALLING: falling edge of external trigger
+    \arg        EXTERNAL_TRIGGER_RISING_FALLING: rising and falling edge of external trigger
+    \param[out] none
+    \retval     none
+*/
+void adc_external_trigger_config(uint32_t adc_periph, uint8_t adc_channel_group, uint32_t trigger_mode)
+{
+    switch(adc_channel_group) {
+    case ADC_REGULAR_CHANNEL:
+        /* configure ADC regular channel group external trigger mode */
+        ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_ETMRC);
+        ADC_CTL1(adc_periph) |= (uint32_t)(trigger_mode << REGULAR_TRIGGER_MODE);
+        break;
+    case ADC_INSERTED_CHANNEL:
+        /* configure ADC inserted channel group external trigger mode */
+        ADC_CTL1(adc_periph) &=  ~((uint32_t)ADC_CTL1_ETMIC);
+        ADC_CTL1(adc_periph) |= (uint32_t)(trigger_mode << INSERTED_TRIGGER_MODE);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      enable ADC software trigger
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  adc_channel_group: select the channel group
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_REGULAR_CHANNEL: regular channel group
+    \arg        ADC_INSERTED_CHANNEL: inserted channel group
+    \param[out] none
+    \retval     none
+*/
+void adc_software_trigger_enable(uint32_t adc_periph, uint8_t adc_channel_group)
+{
+    switch(adc_channel_group) {
+    case ADC_REGULAR_CHANNEL:
+        /* enable ADC regular channel group software trigger */
+        ADC_CTL1(adc_periph) |= (uint32_t)ADC_CTL1_SWRCST;
+        break;
+    case ADC_INSERTED_CHANNEL:
+        /* enable ADC inserted channel group software trigger */
+        ADC_CTL1(adc_periph) |= (uint32_t)ADC_CTL1_SWICST;
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      configure end of conversion mode
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  end_selection: end of conversion mode
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_EOC_SET_SEQUENCE: only at the end of a sequence of regular conversions, the EOC bit is set.Overflow detection is disabled unless DMA=1.
+    \arg        ADC_EOC_SET_CONVERSION: at the end of each regular conversion, the EOC bit is set.Overflow is detected automatically.
+    \param[out] none
+    \retval     none
+*/
+void adc_end_of_conversion_config(uint32_t adc_periph, uint8_t end_selection)
+{
+    switch(end_selection) {
+    case ADC_EOC_SET_SEQUENCE:
+        /* only at the end of a sequence of regular conversions, the EOC bit is set */
+        ADC_CTL1(adc_periph) &= ~((uint32_t)ADC_CTL1_EOCM);
+        break;
+    case ADC_EOC_SET_CONVERSION:
+        /* at the end of each regular conversion, the EOC bit is set.Overflow is detected automatically */
+        ADC_CTL1(adc_periph) |= (uint32_t)(ADC_CTL1_EOCM);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      read ADC regular group data register
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  none
+    \param[out] none
+    \retval     the conversion value
+*/
+uint16_t adc_regular_data_read(uint32_t adc_periph)
+{
+    return (uint16_t)(ADC_RDATA(adc_periph));
+}
+
+/*!
+    \brief      read ADC inserted group data register
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  inserted_channel : insert channel select
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_INSERTED_CHANNEL_0: inserted Channel0
+    \arg        ADC_INSERTED_CHANNEL_1: inserted channel1
+    \arg        ADC_INSERTED_CHANNEL_2: inserted Channel2
+    \arg        ADC_INSERTED_CHANNEL_3: inserted Channel3
+    \param[out] none
+    \retval     the conversion value
+*/
+uint16_t adc_inserted_data_read(uint32_t adc_periph, uint8_t inserted_channel)
+{
+    uint32_t idata;
+    /* read the data of the selected channel */
+    switch(inserted_channel) {
+    case ADC_INSERTED_CHANNEL_0:
+        /* read the data of channel 0 */
+        idata = ADC_IDATA0(adc_periph);
+        break;
+    case ADC_INSERTED_CHANNEL_1:
+        /* read the data of channel 1 */
+        idata = ADC_IDATA1(adc_periph);
+        break;
+    case ADC_INSERTED_CHANNEL_2:
+        /* read the data of channel 2 */
+        idata = ADC_IDATA2(adc_periph);
+        break;
+    case ADC_INSERTED_CHANNEL_3:
+        /* read the data of channel 3 */
+        idata = ADC_IDATA3(adc_periph);
+        break;
+    default:
+        idata = 0U;
+        break;
+    }
+    return (uint16_t)idata;
+}
+
+/*!
+    \brief      disable ADC analog watchdog single channel
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[out] none
+    \retval     none
+*/
+void adc_watchdog_single_channel_disable(uint32_t adc_periph)
+{
+    ADC_CTL0(adc_periph) &= ~((uint32_t)ADC_CTL0_WDSC);
+}
+
+/*!
+    \brief      enable ADC analog watchdog single channel
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  adc_channel: the selected ADC channel
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_CHANNEL_x: ADC Channelx(x=0..18)
+    \param[out] none
+    \retval     none
+*/
+void adc_watchdog_single_channel_enable(uint32_t adc_periph, uint8_t adc_channel)
+{
+    ADC_CTL0(adc_periph) &= ~((uint32_t)ADC_CTL0_WDCHSEL);
+
+    /* analog watchdog channel select */
+    ADC_CTL0(adc_periph) |= (uint32_t)adc_channel;
+    ADC_CTL0(adc_periph) |= (uint32_t) ADC_CTL0_WDSC;
+}
+
+/*!
+    \brief      configure ADC analog watchdog group channel
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  adc_channel_group: the channel group use analog watchdog
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_REGULAR_CHANNEL: regular channel group
+    \arg        ADC_INSERTED_CHANNEL: inserted channel group
+    \arg        ADC_REGULAR_INSERTED_CHANNEL: both regular and inserted group
+    \param[out] none
+    \retval     none
+*/
+void adc_watchdog_group_channel_enable(uint32_t adc_periph, uint8_t adc_channel_group)
+{
+    ADC_CTL0(adc_periph) &= ~((uint32_t)(ADC_CTL0_RWDEN | ADC_CTL0_IWDEN | ADC_CTL0_WDSC));
+    /* select the group */
+    switch(adc_channel_group) {
+    case ADC_REGULAR_CHANNEL:
+        /* regular channel analog watchdog enable */
+        ADC_CTL0(adc_periph) |= (uint32_t) ADC_CTL0_RWDEN;
+        break;
+    case ADC_INSERTED_CHANNEL:
+        /* inserted channel analog watchdog enable */
+        ADC_CTL0(adc_periph) |= (uint32_t) ADC_CTL0_IWDEN;
+        break;
+    case ADC_REGULAR_INSERTED_CHANNEL:
+        /* regular and inserted channel analog watchdog enable */
+        ADC_CTL0(adc_periph) |= (uint32_t)(ADC_CTL0_RWDEN | ADC_CTL0_IWDEN);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      disable ADC analog watchdog
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  adc_channel_group: the channel group use analog watchdog
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_REGULAR_CHANNEL: regular channel group
+    \arg        ADC_INSERTED_CHANNEL: inserted channel group
+    \arg        ADC_REGULAR_INSERTED_CHANNEL: both regular and inserted group
+    \param[out] none
+    \retval     none
+*/
+void adc_watchdog_disable(uint32_t adc_periph, uint8_t adc_channel_group)
+{
+    /* select the group */
+    switch(adc_channel_group) {
+    case ADC_REGULAR_CHANNEL:
+        /* disable ADC analog watchdog regular channel group */
+        ADC_CTL0(adc_periph) &=  ~((uint32_t)ADC_CTL0_RWDEN);
+        break;
+    case ADC_INSERTED_CHANNEL:
+        /* disable ADC analog watchdog inserted channel group */
+        ADC_CTL0(adc_periph) &=  ~((uint32_t)ADC_CTL0_IWDEN);
+        break;
+    case ADC_REGULAR_INSERTED_CHANNEL:
+        /* disable ADC analog watchdog regular and inserted channel group */
+        ADC_CTL0(adc_periph) &=  ~((uint32_t)(ADC_CTL0_RWDEN | ADC_CTL0_IWDEN));
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      configure ADC analog watchdog threshold
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  low_threshold: analog watchdog low threshold,0..4095
+    \param[in]  high_threshold: analog watchdog high threshold,0..4095
+    \param[out] none
+    \retval     none
+*/
+void adc_watchdog_threshold_config(uint32_t adc_periph, uint16_t low_threshold, uint16_t high_threshold)
+{
+    /* configure ADC analog watchdog low threshold */
+    ADC_WDLT(adc_periph) = (uint32_t)WDLT_WDLT(low_threshold);
+    /* configure ADC analog watchdog high threshold */
+    ADC_WDHT(adc_periph) = (uint32_t)WDHT_WDHT(high_threshold);
+}
+
+/*!
+    \brief      get the ADC flag bits
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  adc_flag: the adc flag bits
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_FLAG_WDE: analog watchdog event flag
+    \arg        ADC_FLAG_EOC: end of group conversion flag
+    \arg        ADC_FLAG_EOIC: end of inserted group conversion flag
+    \arg        ADC_FLAG_STIC: start flag of inserted channel group
+    \arg        ADC_FLAG_STRC: start flag of regular channel group
+    \arg        ADC_FLAG_ROVF: regular data register overflow flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus adc_flag_get(uint32_t adc_periph, uint32_t adc_flag)
+{
+    FlagStatus reval = RESET;
+    if(ADC_STAT(adc_periph) & adc_flag) {
+        reval = SET;
+    }
+    return reval;
+
+}
+
+/*!
+    \brief      clear the ADC flag bits
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  adc_flag: the adc flag bits
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_FLAG_WDE: analog watchdog event flag
+    \arg        ADC_FLAG_EOC: end of group conversion flag
+    \arg        ADC_FLAG_EOIC: end of inserted group conversion flag
+    \arg        ADC_FLAG_STIC: start flag of inserted channel group
+    \arg        ADC_FLAG_STRC: start flag of regular channel group
+    \arg        ADC_FLAG_ROVF: regular data register overflow flag
+    \param[out] none
+    \retval     none
+*/
+void adc_flag_clear(uint32_t adc_periph, uint32_t adc_flag)
+{
+    ADC_STAT(adc_periph) &= ~((uint32_t)adc_flag);
+}
+
+/*!
+    \brief      get the bit state of ADCx software start conversion
+    \param[in]  adc_periph: ADCx, x=0,1,2 only one among these parameters can be selected
+    \param[in]  none
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus adc_regular_software_startconv_flag_get(uint32_t adc_periph)
+{
+    FlagStatus reval = RESET;
+    if((uint32_t)RESET != (ADC_STAT(adc_periph) & ADC_STAT_STRC)) {
+        reval = SET;
+    }
+    return reval;
+}
+
+/*!
+    \brief      get the bit state of ADCx software inserted channel start conversion
+    \param[in]  adc_periph: ADCx, x=0,1,2 only one among these parameters can be selected
+    \param[in]  none
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus adc_inserted_software_startconv_flag_get(uint32_t adc_periph)
+{
+    FlagStatus reval = RESET;
+    if((uint32_t)RESET != (ADC_STAT(adc_periph) & ADC_STAT_STIC)) {
+        reval = SET;
+    }
+    return reval;
+}
+
+/*!
+    \brief      get the ADC interrupt bits
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  adc_interrupt: the adc interrupt bits
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_INT_FLAG_WDE: analog watchdog interrupt
+    \arg        ADC_INT_FLAG_EOC: end of group conversion interrupt
+    \arg        ADC_INT_FLAG_EOIC: end of inserted group conversion interrupt
+    \arg        ADC_INT_FLAG_ROVF: regular data register overflow interrupt
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus adc_interrupt_flag_get(uint32_t adc_periph, uint32_t adc_interrupt)
+{
+    FlagStatus interrupt_flag = RESET;
+    uint32_t state;
+    /* check the interrupt bits */
+    switch(adc_interrupt) {
+    case ADC_INT_FLAG_WDE:
+        /* get the ADC analog watchdog interrupt bits */
+        state = ADC_STAT(adc_periph) & ADC_STAT_WDE;
+        if((ADC_CTL0(adc_periph) & ADC_CTL0_WDEIE) && state) {
+            interrupt_flag = SET;
+        }
+        break;
+    case ADC_INT_FLAG_EOC:
+        /* get the ADC end of group conversion interrupt bits */
+        state = ADC_STAT(adc_periph) & ADC_STAT_EOC;
+        if((ADC_CTL0(adc_periph) & ADC_CTL0_EOCIE) && state) {
+            interrupt_flag = SET;
+        }
+        break;
+    case ADC_INT_FLAG_EOIC:
+        /* get the ADC end of inserted group conversion interrupt bits */
+        state = ADC_STAT(adc_periph) & ADC_STAT_EOIC;
+        if((ADC_CTL0(adc_periph) & ADC_CTL0_EOICIE) && state) {
+            interrupt_flag = SET;
+        }
+        break;
+    case ADC_INT_FLAG_ROVF:
+        /* get the ADC regular data register overflow interrupt bits */
+        state = ADC_STAT(adc_periph) & ADC_STAT_ROVF;
+        if((ADC_CTL0(adc_periph) & ADC_CTL0_ROVFIE) && state) {
+            interrupt_flag = SET;
+        }
+        break;
+    default:
+        break;
+    }
+    return interrupt_flag;
+}
+
+/*!
+    \brief      clear the ADC flag
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  adc_interrupt: the adc status flag
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_INT_FLAG_WDE: analog watchdog interrupt
+    \arg        ADC_INT_FLAG_EOC: end of group conversion interrupt
+    \arg        ADC_INT_FLAG_EOIC: end of inserted group conversion interrupt
+    \arg        ADC_INT_FLAG_ROVF: regular data register overflow interrupt
+    \param[out] none
+    \retval     none
+*/
+void adc_interrupt_flag_clear(uint32_t adc_periph, uint32_t adc_interrupt)
+{
+    ADC_STAT(adc_periph) &= ~((uint32_t)adc_interrupt);
+}
+
+/*!
+    \brief      enable ADC interrupt
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  adc_interrupt: the adc interrupt flag
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_INT_WDE: analog watchdog interrupt flag
+    \arg        ADC_INT_EOC: end of group conversion interrupt flag
+    \arg        ADC_INT_EOIC: end of inserted group conversion interrupt flag
+    \arg        ADC_INT_ROVF: regular data register overflow interrupt flag
+    \param[out] none
+    \retval     none
+*/
+void adc_interrupt_enable(uint32_t adc_periph, uint32_t adc_interrupt)
+{
+    switch(adc_interrupt) {
+    case ADC_INT_WDE:
+        /* enable analog watchdog interrupt */
+        ADC_CTL0(adc_periph) |= (uint32_t) ADC_CTL0_WDEIE;
+        break;
+    case ADC_INT_EOC:
+        /* enable end of group conversion interrupt */
+        ADC_CTL0(adc_periph) |= (uint32_t) ADC_CTL0_EOCIE;
+        break;
+    case ADC_INT_EOIC:
+        /* enable end of inserted group conversion interrupt */
+        ADC_CTL0(adc_periph) |= (uint32_t) ADC_CTL0_EOICIE;
+        break;
+    case ADC_INT_ROVF:
+        ADC_CTL0(adc_periph) |= (uint32_t) ADC_CTL0_ROVFIE;
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      disable ADC interrupt
+    \param[in]  adc_periph: ADCx,x=0,1,2
+    \param[in]  adc_flag: the adc interrupt flag
+                only one parameter can be selected which is shown as below:
+      \arg      ADC_INT_WDE: analog watchdog interrupt flag
+      \arg      ADC_INT_EOC: end of group conversion interrupt flag
+      \arg      ADC_INT_EOIC: end of inserted group conversion interrupt flag
+      \arg      ADC_INT_ROVF: regular data register overflow interrupt flag
+    \param[out] none
+    \retval     none
+*/
+void adc_interrupt_disable(uint32_t adc_periph, uint32_t adc_interrupt)
+{
+    switch(adc_interrupt) {
+    /* select the interrupt source */
+    case ADC_INT_WDE:
+        ADC_CTL0(adc_periph) &= ~((uint32_t)ADC_CTL0_WDEIE);
+        break;
+    case ADC_INT_EOC:
+        ADC_CTL0(adc_periph) &= ~((uint32_t)ADC_CTL0_EOCIE);
+        break;
+    case ADC_INT_EOIC:
+        ADC_CTL0(adc_periph) &= ~((uint32_t)ADC_CTL0_EOICIE);
+        break;
+    case ADC_INT_ROVF:
+        ADC_CTL0(adc_periph) &= ~((uint32_t)ADC_CTL0_ROVFIE);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      configure the ADC sync mode
+    \param[in]  sync_mode: ADC sync mode
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_SYNC_MODE_INDEPENDENT: all the ADCs work independently
+    \arg        ADC_DAUL_REGULAL_PARALLEL_INSERTED_PARALLEL: ADC0 and ADC1 work in combined regular parallel & inserted parallel mode
+    \arg        ADC_DAUL_REGULAL_PARALLEL_INSERTED_ROTATION: ADC0 and ADC1 work in combined regular parallel & trigger rotation mode
+    \arg        ADC_DAUL_INSERTED_PARALLEL: ADC0 and ADC1 work in inserted parallel mode
+    \arg        ADC_DAUL_REGULAL_PARALLEL: ADC0 and ADC1 work in regular parallel mode
+    \arg        ADC_DAUL_REGULAL_FOLLOW_UP: ADC0 and ADC1 work in follow-up mode
+    \arg        ADC_DAUL_INSERTED_TRRIGGER_ROTATION: ADC0 and ADC1 work in trigger rotation mode
+    \arg        ADC_ALL_REGULAL_PARALLEL_INSERTED_PARALLEL: all ADCs work in combined regular parallel & inserted parallel mode
+    \arg        ADC_ALL_REGULAL_PARALLEL_INSERTED_ROTATION: all ADCs work in combined regular parallel & trigger rotation mode
+    \arg        ADC_ALL_INSERTED_PARALLEL: all ADCs work in inserted parallel mode
+    \arg        ADC_ALL_REGULAL_PARALLEL: all ADCs work in regular parallel mode
+    \arg        ADC_ALL_REGULAL_FOLLOW_UP: all ADCs work in follow-up mode
+    \arg        ADC_ALL_INSERTED_TRRIGGER_ROTATION: all ADCs work in trigger rotation mode
+    \param[out] none
+    \retval     none
+*/
+void adc_sync_mode_config(uint32_t sync_mode)
+{
+    ADC_SYNCCTL &= ~(ADC_SYNCCTL_SYNCM);
+    ADC_SYNCCTL |= sync_mode;
+}
+
+/*!
+    \brief      configure the delay between 2 sampling phases in ADC sync modes
+    \param[in]  sample_delay:  the delay between 2 sampling phases in ADC sync modes
+                only one parameter can be selected which is shown as below:
+      \arg      ADC_SYNC_DELAY_xCYCLE: x=5..20,the delay between 2 sampling phases in ADC sync modes is x ADC clock cycles
+    \param[out] none
+    \retval     none
+*/
+void adc_sync_delay_config(uint32_t sample_delay)
+{
+    ADC_SYNCCTL &= ~(ADC_SYNCCTL_SYNCDLY);
+    ADC_SYNCCTL |= sample_delay;
+}
+
+/*!
+    \brief      configure ADC sync DMA mode selection
+    \param[in]  dma_mode:  ADC sync DMA mode
+                only one parameter can be selected which is shown as below:
+    \arg        ADC_SYNC_DMA_DISABLE: ADC sync DMA disabled
+    \arg        ADC_SYNC_DMA_MODE0: ADC sync DMA mode 0
+    \arg        ADC_SYNC_DMA_MODE1: ADC sync DMA mode 1
+    \param[out] none
+    \retval     none
+*/
+void adc_sync_dma_config(uint32_t dma_mode)
+{
+    ADC_SYNCCTL &= ~(ADC_SYNCCTL_SYNCDMA);
+    ADC_SYNCCTL |= dma_mode;
+}
+
+/*!
+    \brief      configure ADC sync DMA engine is disabled after the end of transfer signal from DMA controller is detected
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void adc_sync_dma_request_after_last_enable(void)
+{
+    ADC_SYNCCTL |= ADC_SYNCCTL_SYNCDDM;
+}
+
+/*!
+    \brief      configure ADC sync DMA engine issues requests according to the SYNCDMA bits
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void adc_sync_dma_request_after_last_disable(void)
+{
+    ADC_SYNCCTL &= ~(ADC_SYNCCTL_SYNCDDM);
+}
+
+/*!
+    \brief      read ADC sync regular data register
+    \param[in]  none
+    \param[out] none
+    \retval     sync regular data
+*/
+uint32_t adc_sync_regular_data_read(void)
+{
+    return (uint32_t)ADC_SYNCDATA;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_can.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_can.c
@@ -1,0 +1,1021 @@
+/*!
+    \file    gd32f4xx_can.c
+    \brief   CAN driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2019-11-27, V2.0.1, firmware for GD32F4xx
+    \version 2020-07-14, V2.0.2, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2021-12-28, V2.1.1, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_can.h"
+
+#define CAN_ERROR_HANDLE(s)     do{}while(1)
+
+/*!
+    \brief      deinitialize CAN
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[out] none
+    \retval     none
+*/
+void can_deinit(uint32_t can_periph)
+{
+    if(CAN0 == can_periph) {
+        rcu_periph_reset_enable(RCU_CAN0RST);
+        rcu_periph_reset_disable(RCU_CAN0RST);
+    } else {
+        rcu_periph_reset_enable(RCU_CAN1RST);
+        rcu_periph_reset_disable(RCU_CAN1RST);
+    }
+}
+
+/*!
+    \brief      initialize CAN parameter struct with a default value
+    \param[in]  type: the type of CAN parameter struct
+                only one parameter can be selected which is shown as below:
+      \arg        CAN_INIT_STRUCT: the CAN initial struct
+      \arg        CAN_FILTER_STRUCT: the CAN filter struct
+      \arg        CAN_TX_MESSAGE_STRUCT: the CAN TX message struct
+      \arg        CAN_RX_MESSAGE_STRUCT: the CAN RX message struct
+    \param[out] p_struct: the pointer of the specific struct
+    \retval     none
+*/
+void can_struct_para_init(can_struct_type_enum type, void *p_struct)
+{
+    uint8_t i;
+
+    /* get type of the struct */
+    switch(type) {
+    /* used for can_init() */
+    case CAN_INIT_STRUCT:
+        ((can_parameter_struct *)p_struct)->auto_bus_off_recovery = DISABLE;
+        ((can_parameter_struct *)p_struct)->auto_retrans = ENABLE;
+        ((can_parameter_struct *)p_struct)->auto_wake_up = DISABLE;
+        ((can_parameter_struct *)p_struct)->prescaler = 0x03FFU;
+        ((can_parameter_struct *)p_struct)->rec_fifo_overwrite = ENABLE;
+        ((can_parameter_struct *)p_struct)->resync_jump_width = CAN_BT_SJW_1TQ;
+        ((can_parameter_struct *)p_struct)->time_segment_1 = CAN_BT_BS1_3TQ;
+        ((can_parameter_struct *)p_struct)->time_segment_2 = CAN_BT_BS2_1TQ;
+        ((can_parameter_struct *)p_struct)->time_triggered = DISABLE;
+        ((can_parameter_struct *)p_struct)->trans_fifo_order = DISABLE;
+        ((can_parameter_struct *)p_struct)->working_mode = CAN_NORMAL_MODE;
+
+        break;
+    /* used for can_filter_init() */
+    case CAN_FILTER_STRUCT:
+        ((can_filter_parameter_struct *)p_struct)->filter_bits = CAN_FILTERBITS_32BIT;
+        ((can_filter_parameter_struct *)p_struct)->filter_enable = DISABLE;
+        ((can_filter_parameter_struct *)p_struct)->filter_fifo_number = CAN_FIFO0;
+        ((can_filter_parameter_struct *)p_struct)->filter_list_high = 0x0000U;
+        ((can_filter_parameter_struct *)p_struct)->filter_list_low = 0x0000U;
+        ((can_filter_parameter_struct *)p_struct)->filter_mask_high = 0x0000U;
+        ((can_filter_parameter_struct *)p_struct)->filter_mask_low = 0x0000U;
+        ((can_filter_parameter_struct *)p_struct)->filter_mode = CAN_FILTERMODE_MASK;
+        ((can_filter_parameter_struct *)p_struct)->filter_number = 0U;
+
+        break;
+    /* used for can_message_transmit() */
+    case CAN_TX_MESSAGE_STRUCT:
+        for(i = 0U; i < 8U; i++) {
+            ((can_trasnmit_message_struct *)p_struct)->tx_data[i] = 0U;
+        }
+
+        ((can_trasnmit_message_struct *)p_struct)->tx_dlen = 0u;
+        ((can_trasnmit_message_struct *)p_struct)->tx_efid = 0U;
+        ((can_trasnmit_message_struct *)p_struct)->tx_ff = (uint8_t)CAN_FF_STANDARD;
+        ((can_trasnmit_message_struct *)p_struct)->tx_ft = (uint8_t)CAN_FT_DATA;
+        ((can_trasnmit_message_struct *)p_struct)->tx_sfid = 0U;
+
+        break;
+    /* used for can_message_receive() */
+    case CAN_RX_MESSAGE_STRUCT:
+        for(i = 0U; i < 8U; i++) {
+            ((can_receive_message_struct *)p_struct)->rx_data[i] = 0U;
+        }
+
+        ((can_receive_message_struct *)p_struct)->rx_dlen = 0U;
+        ((can_receive_message_struct *)p_struct)->rx_efid = 0U;
+        ((can_receive_message_struct *)p_struct)->rx_ff = (uint8_t)CAN_FF_STANDARD;
+        ((can_receive_message_struct *)p_struct)->rx_fi = 0U;
+        ((can_receive_message_struct *)p_struct)->rx_ft = (uint8_t)CAN_FT_DATA;
+        ((can_receive_message_struct *)p_struct)->rx_sfid = 0U;
+
+        break;
+
+    default:
+        CAN_ERROR_HANDLE("parameter is invalid \r\n");
+    }
+}
+
+/*!
+    \brief      initialize CAN
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  can_parameter_init: parameters for CAN initializtion
+      \arg        working_mode: CAN_NORMAL_MODE, CAN_LOOPBACK_MODE, CAN_SILENT_MODE, CAN_SILENT_LOOPBACK_MODE
+      \arg        resync_jump_width: CAN_BT_SJW_xTQ(x=1, 2, 3, 4)
+      \arg        time_segment_1: CAN_BT_BS1_xTQ(1..16)
+      \arg        time_segment_2: CAN_BT_BS2_xTQ(1..8)
+      \arg        time_triggered: ENABLE or DISABLE
+      \arg        auto_bus_off_recovery: ENABLE or DISABLE
+      \arg        auto_wake_up: ENABLE or DISABLE
+      \arg        auto_retrans: ENABLE or DISABLE
+      \arg        rec_fifo_overwrite: ENABLE or DISABLE
+      \arg        trans_fifo_order: ENABLE or DISABLE
+      \arg        prescaler: 0x0001 - 0x0400
+    \param[out] none
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus can_init(uint32_t can_periph, can_parameter_struct *can_parameter_init)
+{
+    uint32_t timeout = CAN_TIMEOUT;
+    ErrStatus flag = ERROR;
+
+    /* disable sleep mode */
+    CAN_CTL(can_periph) &= ~CAN_CTL_SLPWMOD;
+    /* enable initialize mode */
+    CAN_CTL(can_periph) |= CAN_CTL_IWMOD;
+    /* wait ACK */
+    while((CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)) {
+        timeout--;
+    }
+    /* check initialize working success */
+    if(CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)) {
+        flag = ERROR;
+    } else {
+        /* set the bit timing register */
+        CAN_BT(can_periph) = (BT_MODE((uint32_t)can_parameter_init->working_mode) | \
+                              BT_SJW((uint32_t)can_parameter_init->resync_jump_width) | \
+                              BT_BS1((uint32_t)can_parameter_init->time_segment_1) | \
+                              BT_BS2((uint32_t)can_parameter_init->time_segment_2) | \
+                              BT_BAUDPSC(((uint32_t)(can_parameter_init->prescaler) - 1U)));
+
+        /* time trigger communication mode */
+        if(ENABLE == can_parameter_init->time_triggered) {
+            CAN_CTL(can_periph) |= CAN_CTL_TTC;
+        } else {
+            CAN_CTL(can_periph) &= ~CAN_CTL_TTC;
+        }
+        /* automatic bus-off management */
+        if(ENABLE == can_parameter_init->auto_bus_off_recovery) {
+            CAN_CTL(can_periph) |= CAN_CTL_ABOR;
+        } else {
+            CAN_CTL(can_periph) &= ~CAN_CTL_ABOR;
+        }
+        /* automatic wakeup mode */
+        if(ENABLE == can_parameter_init->auto_wake_up) {
+            CAN_CTL(can_periph) |= CAN_CTL_AWU;
+        } else {
+            CAN_CTL(can_periph) &= ~CAN_CTL_AWU;
+        }
+        /* automatic retransmission mode disable */
+        if(ENABLE == can_parameter_init->auto_retrans) {
+            CAN_CTL(can_periph) &= ~CAN_CTL_ARD;
+        } else {
+            CAN_CTL(can_periph) |= CAN_CTL_ARD;
+        }
+        /* receive FIFO overwrite mode disable */
+        if(ENABLE == can_parameter_init->rec_fifo_overwrite) {
+            CAN_CTL(can_periph) &= ~CAN_CTL_RFOD;
+        } else {
+            CAN_CTL(can_periph) |= CAN_CTL_RFOD;
+        }
+        /* transmit FIFO order */
+        if(ENABLE == can_parameter_init->trans_fifo_order) {
+            CAN_CTL(can_periph) |= CAN_CTL_TFO;
+        } else {
+            CAN_CTL(can_periph) &= ~CAN_CTL_TFO;
+        }
+        /* disable initialize mode */
+        CAN_CTL(can_periph) &= ~CAN_CTL_IWMOD;
+        timeout = CAN_TIMEOUT;
+        /* wait the ACK */
+        while((CAN_STAT_IWS == (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)) {
+            timeout--;
+        }
+        /* check exit initialize mode */
+        if(0U != timeout) {
+            flag = SUCCESS;
+        }
+    }
+    return flag;
+}
+
+/*!
+    \brief      initialize CAN filter
+    \param[in]  can_filter_parameter_init: struct for CAN filter initialization
+      \arg        filter_list_high: 0x0000 - 0xFFFF
+      \arg        filter_list_low: 0x0000 - 0xFFFF
+      \arg        filter_mask_high: 0x0000 - 0xFFFF
+      \arg        filter_mask_low: 0x0000 - 0xFFFF
+      \arg        filter_fifo_number: CAN_FIFO0, CAN_FIFO1
+      \arg        filter_number: 0 - 27
+      \arg        filter_mode: CAN_FILTERMODE_MASK, CAN_FILTERMODE_LIST
+      \arg        filter_bits: CAN_FILTERBITS_32BIT, CAN_FILTERBITS_16BIT
+      \arg        filter_enable: ENABLE or DISABLE
+    \param[out] none
+    \retval     none
+*/
+void can_filter_init(can_filter_parameter_struct *can_filter_parameter_init)
+{
+    uint32_t val = 0U;
+
+    val = ((uint32_t)1) << (can_filter_parameter_init->filter_number);
+    /* filter lock disable */
+    CAN_FCTL(CAN0) |= CAN_FCTL_FLD;
+    /* disable filter */
+    CAN_FW(CAN0) &= ~(uint32_t)val;
+
+    /* filter 16 bits */
+    if(CAN_FILTERBITS_16BIT == can_filter_parameter_init->filter_bits) {
+        /* set filter 16 bits */
+        CAN_FSCFG(CAN0) &= ~(uint32_t)val;
+        /* first 16 bits list and first 16 bits mask or first 16 bits list and second 16 bits list */
+        CAN_FDATA0(CAN0, can_filter_parameter_init->filter_number) = \
+                FDATA_MASK_HIGH((can_filter_parameter_init->filter_mask_low) & CAN_FILTER_MASK_16BITS) | \
+                FDATA_MASK_LOW((can_filter_parameter_init->filter_list_low) & CAN_FILTER_MASK_16BITS);
+        /* second 16 bits list and second 16 bits mask or third 16 bits list and fourth 16 bits list */
+        CAN_FDATA1(CAN0, can_filter_parameter_init->filter_number) = \
+                FDATA_MASK_HIGH((can_filter_parameter_init->filter_mask_high) & CAN_FILTER_MASK_16BITS) | \
+                FDATA_MASK_LOW((can_filter_parameter_init->filter_list_high) & CAN_FILTER_MASK_16BITS);
+    }
+    /* filter 32 bits */
+    if(CAN_FILTERBITS_32BIT == can_filter_parameter_init->filter_bits) {
+        /* set filter 32 bits */
+        CAN_FSCFG(CAN0) |= (uint32_t)val;
+        /* 32 bits list or first 32 bits list */
+        CAN_FDATA0(CAN0, can_filter_parameter_init->filter_number) = \
+                FDATA_MASK_HIGH((can_filter_parameter_init->filter_list_high) & CAN_FILTER_MASK_16BITS) |
+                FDATA_MASK_LOW((can_filter_parameter_init->filter_list_low) & CAN_FILTER_MASK_16BITS);
+        /* 32 bits mask or second 32 bits list */
+        CAN_FDATA1(CAN0, can_filter_parameter_init->filter_number) = \
+                FDATA_MASK_HIGH((can_filter_parameter_init->filter_mask_high) & CAN_FILTER_MASK_16BITS) |
+                FDATA_MASK_LOW((can_filter_parameter_init->filter_mask_low) & CAN_FILTER_MASK_16BITS);
+    }
+
+    /* filter mode */
+    if(CAN_FILTERMODE_MASK == can_filter_parameter_init->filter_mode) {
+        /* mask mode */
+        CAN_FMCFG(CAN0) &= ~(uint32_t)val;
+    } else {
+        /* list mode */
+        CAN_FMCFG(CAN0) |= (uint32_t)val;
+    }
+
+    /* filter FIFO */
+    if(CAN_FIFO0 == (can_filter_parameter_init->filter_fifo_number)) {
+        /* FIFO0 */
+        CAN_FAFIFO(CAN0) &= ~(uint32_t)val;
+    } else {
+        /* FIFO1 */
+        CAN_FAFIFO(CAN0) |= (uint32_t)val;
+    }
+
+    /* filter working */
+    if(ENABLE == can_filter_parameter_init->filter_enable) {
+
+        CAN_FW(CAN0) |= (uint32_t)val;
+    }
+
+    /* filter lock enable */
+    CAN_FCTL(CAN0) &= ~CAN_FCTL_FLD;
+}
+
+/*!
+    \brief      set CAN1 filter start bank number
+    \param[in]  start_bank: CAN1 start bank number
+                only one parameter can be selected which is shown as below:
+      \arg        (1..27)
+    \param[out] none
+    \retval     none
+*/
+void can1_filter_start_bank(uint8_t start_bank)
+{
+    /* filter lock disable */
+    CAN_FCTL(CAN0) |= CAN_FCTL_FLD;
+    /* set CAN1 filter start number */
+    CAN_FCTL(CAN0) &= ~(uint32_t)CAN_FCTL_HBC1F;
+    CAN_FCTL(CAN0) |= FCTL_HBC1F(start_bank);
+    /* filter lock enable */
+    CAN_FCTL(CAN0) &= ~CAN_FCTL_FLD;
+}
+
+/*!
+    \brief      enable CAN debug freeze
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[out] none
+    \retval     none
+*/
+void can_debug_freeze_enable(uint32_t can_periph)
+{
+    /* set DFZ bit */
+    CAN_CTL(can_periph) |= CAN_CTL_DFZ;
+
+    if(CAN0 == can_periph) {
+        dbg_periph_enable(DBG_CAN0_HOLD);
+    } else {
+        dbg_periph_enable(DBG_CAN1_HOLD);
+    }
+}
+
+/*!
+    \brief      disable CAN debug freeze
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[out] none
+    \retval     none
+*/
+void can_debug_freeze_disable(uint32_t can_periph)
+{
+    /* set DFZ bit */
+    CAN_CTL(can_periph) &= ~CAN_CTL_DFZ;
+
+    if(CAN0 == can_periph) {
+        dbg_periph_disable(DBG_CAN0_HOLD);
+    } else {
+        dbg_periph_disable(DBG_CAN1_HOLD);
+    }
+}
+
+/*!
+    \brief      enable CAN time trigger mode
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[out] none
+    \retval     none
+*/
+void can_time_trigger_mode_enable(uint32_t can_periph)
+{
+    uint8_t mailbox_number;
+
+    /* enable the TTC mode */
+    CAN_CTL(can_periph) |= CAN_CTL_TTC;
+    /* enable time stamp */
+    for(mailbox_number = 0U; mailbox_number < 3U; mailbox_number++) {
+        CAN_TMP(can_periph, mailbox_number) |= CAN_TMP_TSEN;
+    }
+}
+
+/*!
+    \brief      disable CAN time trigger mode
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[out] none
+    \retval     none
+*/
+void can_time_trigger_mode_disable(uint32_t can_periph)
+{
+    uint8_t mailbox_number;
+
+    /* disable the TTC mode */
+    CAN_CTL(can_periph) &= ~CAN_CTL_TTC;
+    /* reset TSEN bits */
+    for(mailbox_number = 0U; mailbox_number < 3U; mailbox_number++) {
+        CAN_TMP(can_periph, mailbox_number) &= ~CAN_TMP_TSEN;
+    }
+}
+
+/*!
+    \brief      transmit CAN message
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  transmit_message: struct for CAN transmit message
+      \arg        tx_sfid: 0x00000000 - 0x000007FF
+      \arg        tx_efid: 0x00000000 - 0x1FFFFFFF
+      \arg        tx_ff: CAN_FF_STANDARD, CAN_FF_EXTENDED
+      \arg        tx_ft: CAN_FT_DATA, CAN_FT_REMOTE
+      \arg        tx_dlen: 0 - 8
+      \arg        tx_data[]: 0x00 - 0xFF
+    \param[out] none
+    \retval     mailbox_number
+*/
+uint8_t can_message_transmit(uint32_t can_periph, can_trasnmit_message_struct *transmit_message)
+{
+    uint8_t mailbox_number = CAN_MAILBOX0;
+
+    /* select one empty mailbox */
+    if(CAN_TSTAT_TME0 == (CAN_TSTAT(can_periph)&CAN_TSTAT_TME0)) {
+        mailbox_number = CAN_MAILBOX0;
+    } else if(CAN_TSTAT_TME1 == (CAN_TSTAT(can_periph)&CAN_TSTAT_TME1)) {
+        mailbox_number = CAN_MAILBOX1;
+    } else if(CAN_TSTAT_TME2 == (CAN_TSTAT(can_periph)&CAN_TSTAT_TME2)) {
+        mailbox_number = CAN_MAILBOX2;
+    } else {
+        mailbox_number = CAN_NOMAILBOX;
+    }
+    /* return no mailbox empty */
+    if(CAN_NOMAILBOX == mailbox_number) {
+        return CAN_NOMAILBOX;
+    }
+
+    CAN_TMI(can_periph, mailbox_number) &= CAN_TMI_TEN;
+    if(CAN_FF_STANDARD == transmit_message->tx_ff) {
+        /* set transmit mailbox standard identifier */
+        CAN_TMI(can_periph, mailbox_number) |= (uint32_t)(TMI_SFID(transmit_message->tx_sfid) | \
+                                               transmit_message->tx_ft);
+    } else {
+        /* set transmit mailbox extended identifier */
+        CAN_TMI(can_periph, mailbox_number) |= (uint32_t)(TMI_EFID(transmit_message->tx_efid) | \
+                                               transmit_message->tx_ff | \
+                                               transmit_message->tx_ft);
+    }
+    /* set the data length */
+    CAN_TMP(can_periph, mailbox_number) &= ~CAN_TMP_DLENC;
+    CAN_TMP(can_periph, mailbox_number) |= transmit_message->tx_dlen;
+    /* set the data */
+    CAN_TMDATA0(can_periph, mailbox_number) = TMDATA0_DB3(transmit_message->tx_data[3]) | \
+            TMDATA0_DB2(transmit_message->tx_data[2]) | \
+            TMDATA0_DB1(transmit_message->tx_data[1]) | \
+            TMDATA0_DB0(transmit_message->tx_data[0]);
+    CAN_TMDATA1(can_periph, mailbox_number) = TMDATA1_DB7(transmit_message->tx_data[7]) | \
+            TMDATA1_DB6(transmit_message->tx_data[6]) | \
+            TMDATA1_DB5(transmit_message->tx_data[5]) | \
+            TMDATA1_DB4(transmit_message->tx_data[4]);
+    /* enable transmission */
+    CAN_TMI(can_periph, mailbox_number) |= CAN_TMI_TEN;
+
+    return mailbox_number;
+}
+
+/*!
+    \brief      get CAN transmit state
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  mailbox_number
+                only one parameter can be selected which is shown as below:
+      \arg        CAN_MAILBOX(x=0,1,2)
+    \param[out] none
+    \retval     can_transmit_state_enum
+*/
+can_transmit_state_enum can_transmit_states(uint32_t can_periph, uint8_t mailbox_number)
+{
+    can_transmit_state_enum state = CAN_TRANSMIT_FAILED;
+    uint32_t val = 0U;
+
+    /* check selected mailbox state */
+    switch(mailbox_number) {
+    /* mailbox0 */
+    case CAN_MAILBOX0:
+        val = CAN_TSTAT(can_periph) & (CAN_TSTAT_MTF0 | CAN_TSTAT_MTFNERR0 | CAN_TSTAT_TME0);
+        break;
+    /* mailbox1 */
+    case CAN_MAILBOX1:
+        val = CAN_TSTAT(can_periph) & (CAN_TSTAT_MTF1 | CAN_TSTAT_MTFNERR1 | CAN_TSTAT_TME1);
+        break;
+    /* mailbox2 */
+    case CAN_MAILBOX2:
+        val = CAN_TSTAT(can_periph) & (CAN_TSTAT_MTF2 | CAN_TSTAT_MTFNERR2 | CAN_TSTAT_TME2);
+        break;
+    default:
+        val = CAN_TRANSMIT_FAILED;
+        break;
+    }
+
+    switch(val) {
+    /* transmit pending */
+    case(CAN_STATE_PENDING):
+        state = CAN_TRANSMIT_PENDING;
+        break;
+    /* mailbox0 transmit succeeded */
+    case(CAN_TSTAT_MTF0 | CAN_TSTAT_MTFNERR0 | CAN_TSTAT_TME0):
+        state = CAN_TRANSMIT_OK;
+        break;
+    /* mailbox1 transmit succeeded */
+    case(CAN_TSTAT_MTF1 | CAN_TSTAT_MTFNERR1 | CAN_TSTAT_TME1):
+        state = CAN_TRANSMIT_OK;
+        break;
+    /* mailbox2 transmit succeeded */
+    case(CAN_TSTAT_MTF2 | CAN_TSTAT_MTFNERR2 | CAN_TSTAT_TME2):
+        state = CAN_TRANSMIT_OK;
+        break;
+    /* transmit failed */
+    default:
+        state = CAN_TRANSMIT_FAILED;
+        break;
+    }
+    return state;
+}
+
+/*!
+    \brief      stop CAN transmission
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  mailbox_number
+                only one parameter can be selected which is shown as below:
+      \arg        CAN_MAILBOXx(x=0,1,2)
+    \param[out] none
+    \retval     none
+*/
+void can_transmission_stop(uint32_t can_periph, uint8_t mailbox_number)
+{
+    if(CAN_MAILBOX0 == mailbox_number) {
+        CAN_TSTAT(can_periph) |= CAN_TSTAT_MST0;
+        while(CAN_TSTAT_MST0 == (CAN_TSTAT(can_periph) & CAN_TSTAT_MST0)) {
+        }
+    } else if(CAN_MAILBOX1 == mailbox_number) {
+        CAN_TSTAT(can_periph) |= CAN_TSTAT_MST1;
+        while(CAN_TSTAT_MST1 == (CAN_TSTAT(can_periph) & CAN_TSTAT_MST1)) {
+        }
+    } else if(CAN_MAILBOX2 == mailbox_number) {
+        CAN_TSTAT(can_periph) |= CAN_TSTAT_MST2;
+        while(CAN_TSTAT_MST2 == (CAN_TSTAT(can_periph) & CAN_TSTAT_MST2)) {
+        }
+    } else {
+        /* illegal parameters */
+    }
+}
+
+/*!
+    \brief      CAN receive message
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  fifo_number
+      \arg        CAN_FIFOx(x=0,1)
+    \param[out] receive_message: struct for CAN receive message
+      \arg        rx_sfid: 0x00000000 - 0x000007FF
+      \arg        rx_efid: 0x00000000 - 0x1FFFFFFF
+      \arg        rx_ff: CAN_FF_STANDARD, CAN_FF_EXTENDED
+      \arg        rx_ft: CAN_FT_DATA, CAN_FT_REMOTE
+      \arg        rx_dlen: 0 - 8
+      \arg        rx_data[]: 0x00 - 0xFF
+      \arg        rx_fi: 0 - 27
+    \retval     none
+*/
+void can_message_receive(uint32_t can_periph, uint8_t fifo_number, can_receive_message_struct *receive_message)
+{
+    /* get the frame format */
+    receive_message->rx_ff = (uint8_t)(CAN_RFIFOMI_FF & CAN_RFIFOMI(can_periph, fifo_number));
+    if(CAN_FF_STANDARD == receive_message->rx_ff) {
+        /* get standard identifier */
+        receive_message->rx_sfid = (uint32_t)(GET_RFIFOMI_SFID(CAN_RFIFOMI(can_periph, fifo_number)));
+    } else {
+        /* get extended identifier */
+        receive_message->rx_efid = (uint32_t)(GET_RFIFOMI_EFID(CAN_RFIFOMI(can_periph, fifo_number)));
+    }
+
+    /* get frame type */
+    receive_message->rx_ft = (uint8_t)(CAN_RFIFOMI_FT & CAN_RFIFOMI(can_periph, fifo_number));
+    /* filtering index */
+    receive_message->rx_fi = (uint8_t)(GET_RFIFOMP_FI(CAN_RFIFOMP(can_periph, fifo_number)));
+    /* get receive data length */
+    receive_message->rx_dlen = (uint8_t)(GET_RFIFOMP_DLENC(CAN_RFIFOMP(can_periph, fifo_number)));
+
+    /* receive data */
+    receive_message -> rx_data[0] = (uint8_t)(GET_RFIFOMDATA0_DB0(CAN_RFIFOMDATA0(can_periph, fifo_number)));
+    receive_message -> rx_data[1] = (uint8_t)(GET_RFIFOMDATA0_DB1(CAN_RFIFOMDATA0(can_periph, fifo_number)));
+    receive_message -> rx_data[2] = (uint8_t)(GET_RFIFOMDATA0_DB2(CAN_RFIFOMDATA0(can_periph, fifo_number)));
+    receive_message -> rx_data[3] = (uint8_t)(GET_RFIFOMDATA0_DB3(CAN_RFIFOMDATA0(can_periph, fifo_number)));
+    receive_message -> rx_data[4] = (uint8_t)(GET_RFIFOMDATA1_DB4(CAN_RFIFOMDATA1(can_periph, fifo_number)));
+    receive_message -> rx_data[5] = (uint8_t)(GET_RFIFOMDATA1_DB5(CAN_RFIFOMDATA1(can_periph, fifo_number)));
+    receive_message -> rx_data[6] = (uint8_t)(GET_RFIFOMDATA1_DB6(CAN_RFIFOMDATA1(can_periph, fifo_number)));
+    receive_message -> rx_data[7] = (uint8_t)(GET_RFIFOMDATA1_DB7(CAN_RFIFOMDATA1(can_periph, fifo_number)));
+
+    /* release FIFO */
+    if(CAN_FIFO0 == fifo_number) {
+        CAN_RFIFO0(can_periph) |= CAN_RFIFO0_RFD0;
+    } else {
+        CAN_RFIFO1(can_periph) |= CAN_RFIFO1_RFD1;
+    }
+}
+
+/*!
+    \brief      release FIFO
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  fifo_number
+                only one parameter can be selected which is shown as below:
+      \arg        CAN_FIFOx(x=0,1)
+    \param[out] none
+    \retval     none
+*/
+void can_fifo_release(uint32_t can_periph, uint8_t fifo_number)
+{
+    if(CAN_FIFO0 == fifo_number) {
+        CAN_RFIFO0(can_periph) |= CAN_RFIFO0_RFD0;
+    } else if(CAN_FIFO1 == fifo_number) {
+        CAN_RFIFO1(can_periph) |= CAN_RFIFO1_RFD1;
+    } else {
+        /* illegal parameters */
+        CAN_ERROR_HANDLE("CAN FIFO NUM is invalid \r\n");
+    }
+}
+
+/*!
+    \brief      CAN receive message length
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  fifo_number
+                only one parameter can be selected which is shown as below:
+      \arg        CAN_FIFOx(x=0,1)
+    \param[out] none
+    \retval     message length
+*/
+uint8_t can_receive_message_length_get(uint32_t can_periph, uint8_t fifo_number)
+{
+    uint8_t val = 0U;
+
+    if(CAN_FIFO0 == fifo_number) {
+        /* FIFO0 */
+        val = (uint8_t)(CAN_RFIFO0(can_periph) & CAN_RFIF_RFL_MASK);
+    } else if(CAN_FIFO1 == fifo_number) {
+        /* FIFO1 */
+        val = (uint8_t)(CAN_RFIFO1(can_periph) & CAN_RFIF_RFL_MASK);
+    } else {
+        /* illegal parameters */
+    }
+    return val;
+}
+
+/*!
+    \brief      set CAN working mode
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  can_working_mode
+                only one parameter can be selected which is shown as below:
+      \arg        CAN_MODE_INITIALIZE
+      \arg        CAN_MODE_NORMAL
+      \arg        CAN_MODE_SLEEP
+    \param[out] none
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus can_working_mode_set(uint32_t can_periph, uint8_t working_mode)
+{
+    ErrStatus flag = ERROR;
+    /* timeout for IWS or also for SLPWS bits */
+    uint32_t timeout = CAN_TIMEOUT;
+
+    if(CAN_MODE_INITIALIZE == working_mode) {
+        /* disable sleep mode */
+        CAN_CTL(can_periph) &= (~(uint32_t)CAN_CTL_SLPWMOD);
+        /* set initialize mode */
+        CAN_CTL(can_periph) |= (uint8_t)CAN_CTL_IWMOD;
+        /* wait the acknowledge */
+        while((CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)) && (0U != timeout)) {
+            timeout--;
+        }
+        if(CAN_STAT_IWS != (CAN_STAT(can_periph) & CAN_STAT_IWS)) {
+            flag = ERROR;
+        } else {
+            flag = SUCCESS;
+        }
+    } else if(CAN_MODE_NORMAL == working_mode) {
+        /* enter normal mode */
+        CAN_CTL(can_periph) &= ~(uint32_t)(CAN_CTL_SLPWMOD | CAN_CTL_IWMOD);
+        /* wait the acknowledge */
+        while((0U != (CAN_STAT(can_periph) & (CAN_STAT_IWS | CAN_STAT_SLPWS))) && (0U != timeout)) {
+            timeout--;
+        }
+        if(0U != (CAN_STAT(can_periph) & (CAN_STAT_IWS | CAN_STAT_SLPWS))) {
+            flag = ERROR;
+        } else {
+            flag = SUCCESS;
+        }
+    } else if(CAN_MODE_SLEEP == working_mode) {
+        /* disable initialize mode */
+        CAN_CTL(can_periph) &= (~(uint32_t)CAN_CTL_IWMOD);
+        /* set sleep mode */
+        CAN_CTL(can_periph) |= (uint8_t)CAN_CTL_SLPWMOD;
+        /* wait the acknowledge */
+        while((CAN_STAT_SLPWS != (CAN_STAT(can_periph) & CAN_STAT_SLPWS)) && (0U != timeout)) {
+            timeout--;
+        }
+        if(CAN_STAT_SLPWS != (CAN_STAT(can_periph) & CAN_STAT_SLPWS)) {
+            flag = ERROR;
+        } else {
+            flag = SUCCESS;
+        }
+    } else {
+        flag = ERROR;
+    }
+    return flag;
+}
+
+/*!
+    \brief      wake up CAN
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[out] none
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus can_wakeup(uint32_t can_periph)
+{
+    ErrStatus flag = ERROR;
+    uint32_t timeout = CAN_TIMEOUT;
+
+    /* wakeup */
+    CAN_CTL(can_periph) &= ~CAN_CTL_SLPWMOD;
+
+    while((0U != (CAN_STAT(can_periph) & CAN_STAT_SLPWS)) && (0x00U != timeout)) {
+        timeout--;
+    }
+    /* check state */
+    if(0U != (CAN_STAT(can_periph) & CAN_STAT_SLPWS)) {
+        flag = ERROR;
+    } else {
+        flag = SUCCESS;
+    }
+    return flag;
+}
+
+/*!
+    \brief      get CAN error type
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[out] none
+    \retval     can_error_enum
+      \arg        CAN_ERROR_NONE: no error
+      \arg        CAN_ERROR_FILL: fill error
+      \arg        CAN_ERROR_FORMATE: format error
+      \arg        CAN_ERROR_ACK: ACK error
+      \arg        CAN_ERROR_BITRECESSIVE: bit recessive
+      \arg        CAN_ERROR_BITDOMINANTER: bit dominant error
+      \arg        CAN_ERROR_CRC: CRC error
+      \arg        CAN_ERROR_SOFTWARECFG: software configure
+*/
+can_error_enum can_error_get(uint32_t can_periph)
+{
+    can_error_enum error;
+    error = CAN_ERROR_NONE;
+
+    /* get error type */
+    error = (can_error_enum)(GET_ERR_ERRN(CAN_ERR(can_periph)));
+    return error;
+}
+
+/*!
+    \brief      get CAN receive error number
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[out] none
+    \retval     error number
+*/
+uint8_t can_receive_error_number_get(uint32_t can_periph)
+{
+    uint8_t val;
+
+    /* get error count */
+    val = (uint8_t)(GET_ERR_RECNT(CAN_ERR(can_periph)));
+    return val;
+}
+
+/*!
+    \brief      get CAN transmit error number
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[out] none
+    \retval     error number
+*/
+uint8_t can_transmit_error_number_get(uint32_t can_periph)
+{
+    uint8_t val;
+
+    val = (uint8_t)(GET_ERR_TECNT(CAN_ERR(can_periph)));
+    return val;
+}
+
+/*!
+    \brief      get CAN flag state
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  flag: CAN flags, refer to can_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg        CAN_FLAG_RXL: RX level
+      \arg        CAN_FLAG_LASTRX: last sample value of RX pin
+      \arg        CAN_FLAG_RS: receiving state
+      \arg        CAN_FLAG_TS: transmitting state
+      \arg        CAN_FLAG_SLPIF: status change flag of entering sleep working mode
+      \arg        CAN_FLAG_WUIF: status change flag of wakeup from sleep working mode
+      \arg        CAN_FLAG_ERRIF: error flag
+      \arg        CAN_FLAG_SLPWS: sleep working state
+      \arg        CAN_FLAG_IWS: initial working state
+      \arg        CAN_FLAG_TMLS2: transmit mailbox 2 last sending in TX FIFO
+      \arg        CAN_FLAG_TMLS1: transmit mailbox 1 last sending in TX FIFO
+      \arg        CAN_FLAG_TMLS0: transmit mailbox 0 last sending in TX FIFO
+      \arg        CAN_FLAG_TME2: transmit mailbox 2 empty
+      \arg        CAN_FLAG_TME1: transmit mailbox 1 empty
+      \arg        CAN_FLAG_TME0: transmit mailbox 0 empty
+      \arg        CAN_FLAG_MTE2: mailbox 2 transmit error
+      \arg        CAN_FLAG_MTE1: mailbox 1 transmit error
+      \arg        CAN_FLAG_MTE0: mailbox 0 transmit error
+      \arg        CAN_FLAG_MAL2: mailbox 2 arbitration lost
+      \arg        CAN_FLAG_MAL1: mailbox 1 arbitration lost
+      \arg        CAN_FLAG_MAL0: mailbox 0 arbitration lost
+      \arg        CAN_FLAG_MTFNERR2: mailbox 2 transmit finished with no error
+      \arg        CAN_FLAG_MTFNERR1: mailbox 1 transmit finished with no error
+      \arg        CAN_FLAG_MTFNERR0: mailbox 0 transmit finished with no error
+      \arg        CAN_FLAG_MTF2: mailbox 2 transmit finished
+      \arg        CAN_FLAG_MTF1: mailbox 1 transmit finished
+      \arg        CAN_FLAG_MTF0: mailbox 0 transmit finished
+      \arg        CAN_FLAG_RFO0: receive FIFO0 overfull
+      \arg        CAN_FLAG_RFF0: receive FIFO0 full
+      \arg        CAN_FLAG_RFO1: receive FIFO1 overfull
+      \arg        CAN_FLAG_RFF1: receive FIFO1 full
+      \arg        CAN_FLAG_BOERR: bus-off error
+      \arg        CAN_FLAG_PERR: passive error
+      \arg        CAN_FLAG_WERR: warning error
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus can_flag_get(uint32_t can_periph, can_flag_enum flag)
+{
+    /* get flag and interrupt enable state */
+    if(RESET != (CAN_REG_VAL(can_periph, flag) & BIT(CAN_BIT_POS(flag)))) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      clear CAN flag state
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  flag: CAN flags, refer to can_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg        CAN_FLAG_SLPIF: status change flag of entering sleep working mode
+      \arg        CAN_FLAG_WUIF: status change flag of wakeup from sleep working mode
+      \arg        CAN_FLAG_ERRIF: error flag
+      \arg        CAN_FLAG_MTE2: mailbox 2 transmit error
+      \arg        CAN_FLAG_MTE1: mailbox 1 transmit error
+      \arg        CAN_FLAG_MTE0: mailbox 0 transmit error
+      \arg        CAN_FLAG_MAL2: mailbox 2 arbitration lost
+      \arg        CAN_FLAG_MAL1: mailbox 1 arbitration lost
+      \arg        CAN_FLAG_MAL0: mailbox 0 arbitration lost
+      \arg        CAN_FLAG_MTFNERR2: mailbox 2 transmit finished with no error
+      \arg        CAN_FLAG_MTFNERR1: mailbox 1 transmit finished with no error
+      \arg        CAN_FLAG_MTFNERR0: mailbox 0 transmit finished with no error
+      \arg        CAN_FLAG_MTF2: mailbox 2 transmit finished
+      \arg        CAN_FLAG_MTF1: mailbox 1 transmit finished
+      \arg        CAN_FLAG_MTF0: mailbox 0 transmit finished
+      \arg        CAN_FLAG_RFO0: receive FIFO0 overfull
+      \arg        CAN_FLAG_RFF0: receive FIFO0 full
+      \arg        CAN_FLAG_RFO1: receive FIFO1 overfull
+      \arg        CAN_FLAG_RFF1: receive FIFO1 full
+    \param[out] none
+    \retval     none
+*/
+void can_flag_clear(uint32_t can_periph, can_flag_enum flag)
+{
+    CAN_REG_VAL(can_periph, flag) = BIT(CAN_BIT_POS(flag));
+}
+
+/*!
+    \brief      enable CAN interrupt
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  interrupt
+                one or more parameters can be selected which are shown as below:
+      \arg        CAN_INT_TME: transmit mailbox empty interrupt enable
+      \arg        CAN_INT_RFNE0: receive FIFO0 not empty interrupt enable
+      \arg        CAN_INT_RFF0: receive FIFO0 full interrupt enable
+      \arg        CAN_INT_RFO0: receive FIFO0 overfull interrupt enable
+      \arg        CAN_INT_RFNE1: receive FIFO1 not empty interrupt enable
+      \arg        CAN_INT_RFF1: receive FIFO1 full interrupt enable
+      \arg        CAN_INT_RFO1: receive FIFO1 overfull interrupt enable
+      \arg        CAN_INT_WERR: warning error interrupt enable
+      \arg        CAN_INT_PERR: passive error interrupt enable
+      \arg        CAN_INT_BO: bus-off interrupt enable
+      \arg        CAN_INT_ERRN: error number interrupt enable
+      \arg        CAN_INT_ERR: error interrupt enable
+      \arg        CAN_INT_WAKEUP: wakeup interrupt enable
+      \arg        CAN_INT_SLPW: sleep working interrupt enable
+    \param[out] none
+    \retval     none
+*/
+void can_interrupt_enable(uint32_t can_periph, uint32_t interrupt)
+{
+    CAN_INTEN(can_periph) |= interrupt;
+}
+
+/*!
+    \brief      disable CAN interrupt
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  interrupt
+                one or more parameters can be selected which are shown as below:
+      \arg        CAN_INT_TME: transmit mailbox empty interrupt enable
+      \arg        CAN_INT_RFNE0: receive FIFO0 not empty interrupt enable
+      \arg        CAN_INT_RFF0: receive FIFO0 full interrupt enable
+      \arg        CAN_INT_RFO0: receive FIFO0 overfull interrupt enable
+      \arg        CAN_INT_RFNE1: receive FIFO1 not empty interrupt enable
+      \arg        CAN_INT_RFF1: receive FIFO1 full interrupt enable
+      \arg        CAN_INT_RFO1: receive FIFO1 overfull interrupt enable
+      \arg        CAN_INT_WERR: warning error interrupt enable
+      \arg        CAN_INT_PERR: passive error interrupt enable
+      \arg        CAN_INT_BO: bus-off interrupt enable
+      \arg        CAN_INT_ERRN: error number interrupt enable
+      \arg        CAN_INT_ERR: error interrupt enable
+      \arg        CAN_INT_WAKEUP: wakeup interrupt enable
+      \arg        CAN_INT_SLPW: sleep working interrupt enable
+    \param[out] none
+    \retval     none
+*/
+void can_interrupt_disable(uint32_t can_periph, uint32_t interrupt)
+{
+    CAN_INTEN(can_periph) &= ~interrupt;
+}
+
+/*!
+    \brief      get CAN interrupt flag state
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  flag: CAN interrupt flags, refer to can_interrupt_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg        CAN_INT_FLAG_SLPIF: status change interrupt flag of sleep working mode entering
+      \arg        CAN_INT_FLAG_WUIF: status change interrupt flag of wakeup from sleep working mode
+      \arg        CAN_INT_FLAG_ERRIF: error interrupt flag
+      \arg        CAN_INT_FLAG_MTF2: mailbox 2 transmit finished interrupt flag
+      \arg        CAN_INT_FLAG_MTF1: mailbox 1 transmit finished interrupt flag
+      \arg        CAN_INT_FLAG_MTF0: mailbox 0 transmit finished interrupt flag
+      \arg        CAN_INT_FLAG_RFO0: receive FIFO0 overfull interrupt flag
+      \arg        CAN_INT_FLAG_RFF0: receive FIFO0 full interrupt flag
+      \arg        CAN_INT_FLAG_RFL0: receive FIFO0 not empty interrupt flag
+      \arg        CAN_INT_FLAG_RFO1: receive FIFO1 overfull interrupt flag
+      \arg        CAN_INT_FLAG_RFF1: receive FIFO1 full interrupt flag
+      \arg        CAN_INT_FLAG_RFL1: receive FIFO1 not empty interrupt flag
+      \arg        CAN_INT_FLAG_ERRN: error number interrupt flag
+      \arg        CAN_INT_FLAG_BOERR: bus-off error interrupt flag
+      \arg        CAN_INT_FLAG_PERR: passive error interrupt flag
+      \arg        CAN_INT_FLAG_WERR: warning error interrupt flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus can_interrupt_flag_get(uint32_t can_periph, can_interrupt_flag_enum flag)
+{
+    uint32_t ret1 = RESET;
+    uint32_t ret2 = RESET;
+
+    /* get the status of interrupt flag */
+    if(flag == CAN_INT_FLAG_RFL0) {
+        ret1 = can_receive_message_length_get(can_periph, CAN_FIFO0);
+    } else if(flag == CAN_INT_FLAG_RFL1) {
+        ret1 = can_receive_message_length_get(can_periph, CAN_FIFO1);
+    } else if(flag == CAN_INT_FLAG_ERRN) {
+        ret1 = can_error_get(can_periph);
+    } else {
+        ret1 = CAN_REG_VALS(can_periph, flag) & BIT(CAN_BIT_POS0(flag));
+    }
+    /* get the status of interrupt enable bit */
+    ret2 = CAN_INTEN(can_periph) & BIT(CAN_BIT_POS1(flag));
+    if(ret1 && ret2) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      clear CAN interrupt flag state
+    \param[in]  can_periph
+      \arg        CANx(x=0,1)
+    \param[in]  flag: CAN interrupt flags, refer to can_interrupt_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg        CAN_INT_FLAG_SLPIF: status change interrupt flag of sleep working mode entering
+      \arg        CAN_INT_FLAG_WUIF: status change interrupt flag of wakeup from sleep working mode
+      \arg        CAN_INT_FLAG_ERRIF: error interrupt flag
+      \arg        CAN_INT_FLAG_MTF2: mailbox 2 transmit finished interrupt flag
+      \arg        CAN_INT_FLAG_MTF1: mailbox 1 transmit finished interrupt flag
+      \arg        CAN_INT_FLAG_MTF0: mailbox 0 transmit finished interrupt flag
+      \arg        CAN_INT_FLAG_RFO0: receive FIFO0 overfull interrupt flag
+      \arg        CAN_INT_FLAG_RFF0: receive FIFO0 full interrupt flag
+      \arg        CAN_INT_FLAG_RFO1: receive FIFO1 overfull interrupt flag
+      \arg        CAN_INT_FLAG_RFF1: receive FIFO1 full interrupt flag
+    \param[out] none
+    \retval     none
+*/
+void can_interrupt_flag_clear(uint32_t can_periph, can_interrupt_flag_enum flag)
+{
+    CAN_REG_VALS(can_periph, flag) = BIT(CAN_BIT_POS0(flag));
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_crc.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_crc.c
@@ -1,0 +1,130 @@
+/*!
+    \file    gd32f4xx_crc.c
+    \brief   CRC driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_crc.h"
+
+#define CRC_DATA_RESET_VALUE      ((uint32_t)0xFFFFFFFFU)
+#define CRC_FDATA_RESET_VALUE     ((uint32_t)0x00000000U)
+
+/*!
+    \brief      deinit CRC calculation unit
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void crc_deinit(void)
+{
+    CRC_DATA  = CRC_DATA_RESET_VALUE;
+    CRC_FDATA = CRC_FDATA_RESET_VALUE;
+    CRC_CTL   = (uint32_t)CRC_CTL_RST;
+}
+
+/*!
+    \brief      reset data register(CRC_DATA) to the value of 0xFFFFFFFF
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void crc_data_register_reset(void)
+{
+    CRC_CTL |= (uint32_t)CRC_CTL_RST;
+}
+
+/*!
+    \brief      read the value of the data register
+    \param[in]  none
+    \param[out] none
+    \retval     32-bit value of the data register
+*/
+uint32_t crc_data_register_read(void)
+{
+    uint32_t data;
+    data = CRC_DATA;
+    return (data);
+}
+
+/*!
+    \brief      read the value of the free data register
+    \param[in]  none
+    \param[out] none
+    \retval     8-bit value of the free data register
+*/
+uint8_t crc_free_data_register_read(void)
+{
+    uint8_t fdata;
+    fdata = (uint8_t)CRC_FDATA;
+    return (fdata);
+}
+
+/*!
+    \brief      write data to the free data register
+    \param[in]  free_data: specified 8-bit data
+    \param[out] none
+    \retval     none
+*/
+void crc_free_data_register_write(uint8_t free_data)
+{
+    CRC_FDATA = (uint32_t)free_data;
+}
+
+/*!
+    \brief      calculate the CRC value of a 32-bit data
+    \param[in]  sdata: specified 32-bit data
+    \param[out] none
+    \retval     32-bit value calculated by CRC
+*/
+uint32_t crc_single_data_calculate(uint32_t sdata)
+{
+    CRC_DATA = sdata;
+    return (CRC_DATA);
+}
+
+/*!
+    \brief      calculate the CRC value of an array of 32-bit values
+    \param[in]  array: pointer to an array of 32-bit values
+    \param[in]  size: size of the array
+    \param[out] none
+    \retval     32-bit value calculated by CRC
+*/
+uint32_t crc_block_data_calculate(uint32_t array[], uint32_t size)
+{
+    uint32_t index;
+    for(index = 0U; index < size; index++) {
+        CRC_DATA = array[index];
+    }
+    return (CRC_DATA);
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_ctc.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_ctc.c
@@ -1,0 +1,391 @@
+/*!
+    \file    gd32f4xx_ctc.c
+    \brief   CTC driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_ctc.h"
+
+#define CTC_FLAG_MASK            ((uint32_t)0x00000700U)
+
+/* CTC register bit offset */
+#define CTC_TRIMVALUE_OFFSET     ((uint32_t)8U)
+#define CTC_TRIM_VALUE_OFFSET    ((uint32_t)8U)
+#define CTC_REFCAP_OFFSET        ((uint32_t)16U)
+#define CTC_LIMIT_VALUE_OFFSET   ((uint32_t)16U)
+
+/*!
+    \brief    reset CTC clock trim controller
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ctc_deinit(void)
+{
+    /* reset CTC */
+    rcu_periph_reset_enable(RCU_CTCRST);
+    rcu_periph_reset_disable(RCU_CTCRST);
+}
+
+/*!
+    \brief    enable CTC trim counter
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ctc_counter_enable(void)
+{
+    CTC_CTL0 |= (uint32_t)CTC_CTL0_CNTEN;
+}
+
+/*!
+    \brief    disable CTC trim counter
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ctc_counter_disable(void)
+{
+    CTC_CTL0 &= (uint32_t)(~CTC_CTL0_CNTEN);
+}
+
+/*!
+    \brief    configure the IRC48M trim value
+    \param[in]  ctc_trim_value: 8-bit IRC48M trim value
+      \arg        0x00 - 0x3F
+    \param[out] none
+    \retval     none
+*/
+void ctc_irc48m_trim_value_config(uint8_t trim_value)
+{
+    /* clear TRIMVALUE bits */
+    CTC_CTL0 &= (~(uint32_t)CTC_CTL0_TRIMVALUE);
+    /* set TRIMVALUE bits */
+    CTC_CTL0 |= ((uint32_t)trim_value << CTC_TRIM_VALUE_OFFSET);
+}
+
+/*!
+    \brief    generate software reference source sync pulse
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ctc_software_refsource_pulse_generate(void)
+{
+    CTC_CTL0 |= (uint32_t)CTC_CTL0_SWREFPUL;
+}
+
+/*!
+    \brief    configure hardware automatically trim mode
+    \param[in]  hardmode:
+                only one parameter can be selected which is shown as below:
+      \arg        CTC_HARDWARE_TRIM_MODE_ENABLE: hardware automatically trim mode enable
+      \arg        CTC_HARDWARE_TRIM_MODE_DISABLE: hardware automatically trim mode disable
+    \param[out] none
+    \retval     none
+*/
+void ctc_hardware_trim_mode_config(uint32_t hardmode)
+{
+    CTC_CTL0 &= (uint32_t)(~CTC_CTL0_AUTOTRIM);
+    CTC_CTL0 |= (uint32_t)hardmode;
+}
+
+/*!
+    \brief    configure reference signal source polarity
+    \param[in]  polarity:
+                only one parameter can be selected which is shown as below:
+      \arg        CTC_REFSOURCE_POLARITY_FALLING: reference signal source polarity is falling edge
+      \arg        CTC_REFSOURCE_POLARITY_RISING: reference signal source polarity is rising edge
+    \param[out] none
+    \retval     none
+*/
+void ctc_refsource_polarity_config(uint32_t polarity)
+{
+    CTC_CTL1 &= (uint32_t)(~CTC_CTL1_REFPOL);
+    CTC_CTL1 |= (uint32_t)polarity;
+}
+
+/*!
+    \brief    select reference signal source
+    \param[in]  refs:
+                only one parameter can be selected which is shown as below:
+      \arg        CTC_REFSOURCE_GPIO: GPIO is selected
+      \arg        CTC_REFSOURCE_LXTAL: LXTAL is selected
+    \param[out] none
+    \retval     none
+*/
+void ctc_refsource_signal_select(uint32_t refs)
+{
+    CTC_CTL1 &= (uint32_t)(~CTC_CTL1_REFSEL);
+    CTC_CTL1 |= (uint32_t)refs;
+}
+
+/*!
+    \brief    configure reference signal source prescaler
+    \param[in]  prescaler:
+                only one parameter can be selected which is shown as below:
+      \arg        CTC_REFSOURCE_PSC_OFF: reference signal not divided
+      \arg        CTC_REFSOURCE_PSC_DIV2: reference signal divided by 2
+      \arg        CTC_REFSOURCE_PSC_DIV4: reference signal divided by 4
+      \arg        CTC_REFSOURCE_PSC_DIV8: reference signal divided by 8
+      \arg        CTC_REFSOURCE_PSC_DIV16: reference signal divided by 16
+      \arg        CTC_REFSOURCE_PSC_DIV32: reference signal divided by 32
+      \arg        CTC_REFSOURCE_PSC_DIV64: reference signal divided by 64
+      \arg        CTC_REFSOURCE_PSC_DIV128: reference signal divided by 128
+    \param[out] none
+    \retval     none
+*/
+void ctc_refsource_prescaler_config(uint32_t prescaler)
+{
+    CTC_CTL1 &= (uint32_t)(~CTC_CTL1_REFPSC);
+    CTC_CTL1 |= (uint32_t)prescaler;
+}
+
+/*!
+    \brief    configure clock trim base limit value
+    \param[in]  limit_value: 8-bit clock trim base limit value
+      \arg        0x00 - 0xFF
+    \param[out] none
+    \retval     none
+*/
+void ctc_clock_limit_value_config(uint8_t limit_value)
+{
+    CTC_CTL1 &= (uint32_t)(~CTC_CTL1_CKLIM);
+    CTC_CTL1 |= (uint32_t)((uint32_t)limit_value << CTC_LIMIT_VALUE_OFFSET);
+}
+
+/*!
+    \brief    configure CTC counter reload value
+    \param[in]  reload_value: 16-bit CTC counter reload value
+      \arg        0x0000 - 0xFFFF
+    \param[out] none
+    \retval     none
+*/
+void ctc_counter_reload_value_config(uint16_t reload_value)
+{
+    CTC_CTL1 &= (uint32_t)(~CTC_CTL1_RLVALUE);
+    CTC_CTL1 |= (uint32_t)reload_value;
+}
+
+/*!
+    \brief    read CTC counter capture value when reference sync pulse occurred
+    \param[in]  none
+    \param[out] none
+    \retval     the 16-bit CTC counter capture value
+*/
+uint16_t ctc_counter_capture_value_read(void)
+{
+    uint16_t capture_value = 0U;
+    capture_value = (uint16_t)((CTC_STAT & CTC_STAT_REFCAP) >> CTC_REFCAP_OFFSET);
+    return (capture_value);
+}
+
+/*!
+    \brief    read CTC trim counter direction when reference sync pulse occurred
+    \param[in]  none
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+      \arg        SET: CTC trim counter direction is down-counting
+      \arg        RESET: CTC trim counter direction is up-counting
+*/
+FlagStatus ctc_counter_direction_read(void)
+{
+    if(RESET != (CTC_STAT & CTC_STAT_REFDIR)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    read CTC counter reload value
+    \param[in]  none
+    \param[out] none
+    \retval     the 16-bit CTC counter reload value
+*/
+uint16_t ctc_counter_reload_value_read(void)
+{
+    uint16_t reload_value = 0U;
+    reload_value = (uint16_t)(CTC_CTL1 & CTC_CTL1_RLVALUE);
+    return (reload_value);
+}
+
+/*!
+    \brief    read the IRC48M trim value
+    \param[in]  none
+    \param[out] none
+    \retval     the 8-bit IRC48M trim value
+*/
+uint8_t ctc_irc48m_trim_value_read(void)
+{
+    uint8_t trim_value = 0U;
+    trim_value = (uint8_t)((CTC_CTL0 & CTC_CTL0_TRIMVALUE) >> CTC_TRIMVALUE_OFFSET);
+    return (trim_value);
+}
+
+/*!
+    \brief    enable the CTC interrupt
+    \param[in]  interrupt: CTC interrupt enable
+                one or more parameters can be selected which are shown as below:
+      \arg        CTC_INT_CKOK: clock trim OK interrupt enable
+      \arg        CTC_INT_CKWARN: clock trim warning interrupt enable
+      \arg        CTC_INT_ERR: error interrupt enable
+      \arg        CTC_INT_EREF: expect reference interrupt enable
+    \param[out] none
+    \retval     none
+*/
+void ctc_interrupt_enable(uint32_t interrupt)
+{
+    CTC_CTL0 |= (uint32_t)interrupt;
+}
+
+/*!
+    \brief    disable the CTC interrupt
+    \param[in]  interrupt: CTC interrupt enable source
+                one or more parameters can be selected which are shown as below:
+      \arg        CTC_INT_CKOK: clock trim OK interrupt enable
+      \arg        CTC_INT_CKWARN: clock trim warning interrupt enable
+      \arg        CTC_INT_ERR: error interrupt enable
+      \arg        CTC_INT_EREF: expect reference interrupt enable
+    \param[out] none
+    \retval     none
+*/
+void ctc_interrupt_disable(uint32_t interrupt)
+{
+    CTC_CTL0 &= (uint32_t)(~interrupt);
+}
+
+/*!
+    \brief    get CTC interrupt flag
+    \param[in]  int_flag: the CTC interrupt flag
+                only one parameter can be selected which is shown as below:
+      \arg        CTC_INT_FLAG_CKOK: clock trim OK interrupt
+      \arg        CTC_INT_FLAG_CKWARN: clock trim warning interrupt
+      \arg        CTC_INT_FLAG_ERR: error interrupt
+      \arg        CTC_INT_FLAG_EREF: expect reference interrupt
+      \arg        CTC_INT_FLAG_CKERR: clock trim error bit interrupt
+      \arg        CTC_INT_FLAG_REFMISS: reference sync pulse miss interrupt
+      \arg        CTC_INT_FLAG_TRIMERR: trim value error interrupt
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus ctc_interrupt_flag_get(uint32_t int_flag)
+{
+    uint32_t interrupt_flag = 0U, intenable = 0U;
+
+    /* check whether the interrupt is enabled */
+    if(RESET != (int_flag & CTC_FLAG_MASK)) {
+        intenable = CTC_CTL0 & CTC_CTL0_ERRIE;
+    } else {
+        intenable = CTC_CTL0 & int_flag;
+    }
+
+    /* get interrupt flag status */
+    interrupt_flag = CTC_STAT & int_flag;
+
+    if(interrupt_flag && intenable) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    clear CTC interrupt flag
+    \param[in]  int_flag: the CTC interrupt flag
+                only one parameter can be selected which is shown as below:
+      \arg        CTC_INT_FLAG_CKOK: clock trim OK interrupt
+      \arg        CTC_INT_FLAG_CKWARN: clock trim warning interrupt
+      \arg        CTC_INT_FLAG_ERR: error interrupt
+      \arg        CTC_INT_FLAG_EREF: expect reference interrupt
+      \arg        CTC_INT_FLAG_CKERR: clock trim error bit interrupt
+      \arg        CTC_INT_FLAG_REFMISS: reference sync pulse miss interrupt
+      \arg        CTC_INT_FLAG_TRIMERR: trim value error interrupt
+    \param[out] none
+    \retval     none
+*/
+void ctc_interrupt_flag_clear(uint32_t int_flag)
+{
+    if(RESET != (int_flag & CTC_FLAG_MASK)) {
+        CTC_INTC |= CTC_INTC_ERRIC;
+    } else {
+        CTC_INTC |= int_flag;
+    }
+}
+
+/*!
+    \brief    get CTC flag
+    \param[in]  flag: the CTC flag
+                only one parameter can be selected which is shown as below:
+      \arg        CTC_FLAG_CKOK: clock trim OK flag
+      \arg        CTC_FLAG_CKWARN: clock trim warning flag
+      \arg        CTC_FLAG_ERR: error flag
+      \arg        CTC_FLAG_EREF: expect reference flag
+      \arg        CTC_FLAG_CKERR: clock trim error bit
+      \arg        CTC_FLAG_REFMISS: reference sync pulse miss
+      \arg        CTC_FLAG_TRIMERR: trim value error bit
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus ctc_flag_get(uint32_t flag)
+{
+    if(RESET != (CTC_STAT & flag)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    clear CTC flag
+    \param[in]  flag: the CTC flag
+                only one parameter can be selected which is shown as below:
+      \arg        CTC_FLAG_CKOK: clock trim OK flag
+      \arg        CTC_FLAG_CKWARN: clock trim warning flag
+      \arg        CTC_FLAG_ERR: error flag
+      \arg        CTC_FLAG_EREF: expect reference flag
+      \arg        CTC_FLAG_CKERR: clock trim error bit
+      \arg        CTC_FLAG_REFMISS: reference sync pulse miss
+      \arg        CTC_FLAG_TRIMERR: trim value error bit
+    \param[out] none
+    \retval     none
+*/
+void ctc_flag_clear(uint32_t flag)
+{
+    if(RESET != (flag & CTC_FLAG_MASK)) {
+        CTC_INTC |= CTC_INTC_ERRIC;
+    } else {
+        CTC_INTC |= flag;
+    }
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_dac.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_dac.c
@@ -1,0 +1,678 @@
+/*!
+    \file    gd32f4xx_dac.c
+    \brief   DAC driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_dac.h"
+
+/* DAC register bit offset */
+#define DAC1_REG_OFFSET           ((uint32_t)16U)
+#define DH_12BIT_OFFSET           ((uint32_t)16U)
+#define DH_8BIT_OFFSET            ((uint32_t)8U)
+
+/*!
+    \brief      deinitialize DAC
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dac_deinit(void)
+{
+    rcu_periph_reset_enable(RCU_DACRST);
+    rcu_periph_reset_disable(RCU_DACRST);
+}
+
+/*!
+    \brief      enable DAC
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_enable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_CTL |= DAC_CTL_DEN0;
+    } else {
+        DAC_CTL |= DAC_CTL_DEN1;
+    }
+}
+
+/*!
+    \brief      disable DAC
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_disable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_CTL &= ~DAC_CTL_DEN0;
+    } else {
+        DAC_CTL &= ~DAC_CTL_DEN1;
+    }
+}
+
+/*!
+    \brief      enable DAC DMA function
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_dma_enable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_CTL |= DAC_CTL_DDMAEN0;
+    } else {
+        DAC_CTL |= DAC_CTL_DDMAEN1;
+    }
+}
+
+/*!
+    \brief      disable DAC DMA function
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_dma_disable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_CTL &= ~DAC_CTL_DDMAEN0;
+    } else {
+        DAC_CTL &= ~DAC_CTL_DDMAEN1;
+    }
+}
+
+/*!
+    \brief      enable DAC output buffer
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_output_buffer_enable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_CTL &= ~DAC_CTL_DBOFF0;
+    } else {
+        DAC_CTL &= ~DAC_CTL_DBOFF1;
+    }
+}
+
+/*!
+    \brief      disable DAC output buffer
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_output_buffer_disable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_CTL |= DAC_CTL_DBOFF0;
+    } else {
+        DAC_CTL |= DAC_CTL_DBOFF1;
+    }
+}
+
+/*!
+    \brief      get DAC output value
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     DAC output data
+*/
+uint16_t dac_output_value_get(uint32_t dac_periph)
+{
+    uint16_t data = 0U;
+    if(DAC0 == dac_periph) {
+        /* store the DAC0 output value */
+        data = (uint16_t)DAC0_DO;
+    } else {
+        /* store the DAC1 output value */
+        data = (uint16_t)DAC1_DO;
+    }
+    return data;
+}
+
+/*!
+    \brief      set the DAC specified data holding register value
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[in]  dac_align: data alignment
+                only one parameter can be selected which is shown as below:
+      \arg        DAC_ALIGN_8B_R: data right 8 bit alignment
+      \arg        DAC_ALIGN_12B_R: data right 12 bit alignment
+      \arg        DAC_ALIGN_12B_L: data left 12 bit alignment
+    \param[in]  data: data to be loaded
+    \param[out] none
+    \retval     none
+*/
+void dac_data_set(uint32_t dac_periph, uint32_t dac_align, uint16_t data)
+{
+    if(DAC0 == dac_periph) {
+        switch(dac_align) {
+        /* data right 12 bit alignment */
+        case DAC_ALIGN_12B_R:
+            DAC0_R12DH = data;
+            break;
+        /* data left 12 bit alignment */
+        case DAC_ALIGN_12B_L:
+            DAC0_L12DH = data;
+            break;
+        /* data right 8 bit alignment */
+        case DAC_ALIGN_8B_R:
+            DAC0_R8DH = data;
+            break;
+        default:
+            break;
+        }
+    } else {
+        switch(dac_align) {
+        /* data right 12 bit alignment */
+        case DAC_ALIGN_12B_R:
+            DAC1_R12DH = data;
+            break;
+        /* data left 12 bit alignment */
+        case DAC_ALIGN_12B_L:
+            DAC1_L12DH = data;
+            break;
+        /* data right 8 bit alignment */
+        case DAC_ALIGN_8B_R:
+            DAC1_R8DH = data;
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+/*!
+    \brief      enable DAC trigger
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_trigger_enable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_CTL |= DAC_CTL_DTEN0;
+    } else {
+        DAC_CTL |= DAC_CTL_DTEN1;
+    }
+}
+
+/*!
+    \brief      disable DAC trigger
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_trigger_disable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_CTL &= ~DAC_CTL_DTEN0;
+    } else {
+        DAC_CTL &= ~DAC_CTL_DTEN1;
+    }
+}
+
+/*!
+    \brief      set DAC trigger source
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[in]  triggersource: external triggers of DAC
+                only one parameter can be selected which is shown as below:
+      \arg        DAC_TRIGGER_T1_TRGO: TIMER1 TRGO
+      \arg        DAC_TRIGGER_T3_TRGO: TIMER3 TRGO
+      \arg        DAC_TRIGGER_T4_TRGO: TIMER4 TRGO
+      \arg        DAC_TRIGGER_T5_TRGO: TIMER5 TRGO
+      \arg        DAC_TRIGGER_T6_TRGO: TIMER6 TRGO
+      \arg        DAC_TRIGGER_T7_TRGO: TIMER7 TRGO
+      \arg        DAC_TRIGGER_EXTI_9: EXTI interrupt line9 event
+      \arg        DAC_TRIGGER_SOFTWARE: software trigger
+    \param[out] none
+    \retval     none
+*/
+void dac_trigger_source_config(uint32_t dac_periph, uint32_t triggersource)
+{
+    if(DAC0 == dac_periph) {
+        /* configure DAC0 trigger source */
+        DAC_CTL &= ~DAC_CTL_DTSEL0;
+        DAC_CTL |= triggersource;
+    } else {
+        /* configure DAC1 trigger source */
+        DAC_CTL &= ~DAC_CTL_DTSEL1;
+        DAC_CTL |= (triggersource << DAC1_REG_OFFSET);
+    }
+}
+
+/*!
+    \brief      enable DAC software trigger
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \retval     none
+*/
+void dac_software_trigger_enable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_SWT |= DAC_SWT_SWTR0;
+    } else {
+        DAC_SWT |= DAC_SWT_SWTR1;
+    }
+}
+
+/*!
+    \brief      disable DAC software trigger
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_software_trigger_disable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_SWT &= ~DAC_SWT_SWTR0;
+    } else {
+        DAC_SWT &= ~DAC_SWT_SWTR1;
+    }
+}
+
+/*!
+    \brief      configure DAC wave mode
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[in]  wave_mode: noise wave mode
+                only one parameter can be selected which is shown as below:
+      \arg        DAC_WAVE_DISABLE: wave disable
+      \arg        DAC_WAVE_MODE_LFSR: LFSR noise mode
+      \arg        DAC_WAVE_MODE_TRIANGLE: triangle noise mode
+    \param[out] none
+    \retval     none
+*/
+void dac_wave_mode_config(uint32_t dac_periph, uint32_t wave_mode)
+{
+    if(DAC0 == dac_periph) {
+        /* configure DAC0 wave mode */
+        DAC_CTL &= ~DAC_CTL_DWM0;
+        DAC_CTL |= wave_mode;
+    } else {
+        /* configure DAC1 wave mode */
+        DAC_CTL &= ~DAC_CTL_DWM1;
+        DAC_CTL |= (wave_mode << DAC1_REG_OFFSET);
+    }
+}
+
+/*!
+    \brief      configure DAC wave bit width
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[in]  bit_width: noise wave bit width
+                only one parameter can be selected which is shown as below:
+      \arg        DAC_WAVE_BIT_WIDTH_1: bit width of the wave signal is 1
+      \arg        DAC_WAVE_BIT_WIDTH_2: bit width of the wave signal is 2
+      \arg        DAC_WAVE_BIT_WIDTH_3: bit width of the wave signal is 3
+      \arg        DAC_WAVE_BIT_WIDTH_4: bit width of the wave signal is 4
+      \arg        DAC_WAVE_BIT_WIDTH_5: bit width of the wave signal is 5
+      \arg        DAC_WAVE_BIT_WIDTH_6: bit width of the wave signal is 6
+      \arg        DAC_WAVE_BIT_WIDTH_7: bit width of the wave signal is 7
+      \arg        DAC_WAVE_BIT_WIDTH_8: bit width of the wave signal is 8
+      \arg        DAC_WAVE_BIT_WIDTH_9: bit width of the wave signal is 9
+      \arg        DAC_WAVE_BIT_WIDTH_10: bit width of the wave signal is 10
+      \arg        DAC_WAVE_BIT_WIDTH_11: bit width of the wave signal is 11
+      \arg        DAC_WAVE_BIT_WIDTH_12: bit width of the wave signal is 12
+    \param[out] none
+    \retval     none
+*/
+void dac_wave_bit_width_config(uint32_t dac_periph, uint32_t bit_width)
+{
+    if(DAC0 == dac_periph) {
+        /* configure DAC0 wave bit width */
+        DAC_CTL &= ~DAC_CTL_DWBW0;
+        DAC_CTL |= bit_width;
+    } else {
+        /* configure DAC1 wave bit width */
+        DAC_CTL &= ~DAC_CTL_DWBW1;
+        DAC_CTL |= (bit_width << DAC1_REG_OFFSET);
+    }
+}
+
+/*!
+    \brief      configure DAC LFSR noise mode
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[in]  unmask_bits: unmask LFSR bits in DAC LFSR noise mode
+                only one parameter can be selected which is shown as below:
+      \arg        DAC_LFSR_BIT0: unmask the LFSR bit0
+      \arg        DAC_LFSR_BITS1_0: unmask the LFSR bits[1:0]
+      \arg        DAC_LFSR_BITS2_0: unmask the LFSR bits[2:0]
+      \arg        DAC_LFSR_BITS3_0: unmask the LFSR bits[3:0]
+      \arg        DAC_LFSR_BITS4_0: unmask the LFSR bits[4:0]
+      \arg        DAC_LFSR_BITS5_0: unmask the LFSR bits[5:0]
+      \arg        DAC_LFSR_BITS6_0: unmask the LFSR bits[6:0]
+      \arg        DAC_LFSR_BITS7_0: unmask the LFSR bits[7:0]
+      \arg        DAC_LFSR_BITS8_0: unmask the LFSR bits[8:0]
+      \arg        DAC_LFSR_BITS9_0: unmask the LFSR bits[9:0]
+      \arg        DAC_LFSR_BITS10_0: unmask the LFSR bits[10:0]
+      \arg        DAC_LFSR_BITS11_0: unmask the LFSR bits[11:0]
+    \param[out] none
+    \retval     none
+*/
+void dac_lfsr_noise_config(uint32_t dac_periph, uint32_t unmask_bits)
+{
+    if(DAC0 == dac_periph) {
+        /* configure DAC0 LFSR noise mode */
+        DAC_CTL &= ~DAC_CTL_DWBW0;
+        DAC_CTL |= unmask_bits;
+    } else {
+        /* configure DAC1 LFSR noise mode */
+        DAC_CTL &= ~DAC_CTL_DWBW1;
+        DAC_CTL |= (unmask_bits << DAC1_REG_OFFSET);
+    }
+}
+
+/*!
+    \brief      configure DAC triangle noise mode
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[in]  amplitude: triangle amplitude in DAC triangle noise mode
+                only one parameter can be selected which is shown as below:
+      \arg        DAC_TRIANGLE_AMPLITUDE_1: triangle amplitude is 1
+      \arg        DAC_TRIANGLE_AMPLITUDE_3: triangle amplitude is 3
+      \arg        DAC_TRIANGLE_AMPLITUDE_7: triangle amplitude is 7
+      \arg        DAC_TRIANGLE_AMPLITUDE_15: triangle amplitude is 15
+      \arg        DAC_TRIANGLE_AMPLITUDE_31: triangle amplitude is 31
+      \arg        DAC_TRIANGLE_AMPLITUDE_63: triangle amplitude is 63
+      \arg        DAC_TRIANGLE_AMPLITUDE_127: triangle amplitude is 127
+      \arg        DAC_TRIANGLE_AMPLITUDE_255: triangle amplitude is 255
+      \arg        DAC_TRIANGLE_AMPLITUDE_511: triangle amplitude is 511
+      \arg        DAC_TRIANGLE_AMPLITUDE_1023: triangle amplitude is 1023
+      \arg        DAC_TRIANGLE_AMPLITUDE_2047: triangle amplitude is 2047
+      \arg        DAC_TRIANGLE_AMPLITUDE_4095: triangle amplitude is 4095
+    \param[out] none
+    \retval     none
+*/
+void dac_triangle_noise_config(uint32_t dac_periph, uint32_t amplitude)
+{
+    if(DAC0 == dac_periph) {
+        /* configure DAC0 triangle noise mode */
+        DAC_CTL &= ~DAC_CTL_DWBW0;
+        DAC_CTL |= amplitude;
+    } else {
+        /* configure DAC1 triangle noise mode */
+        DAC_CTL &= ~DAC_CTL_DWBW1;
+        DAC_CTL |= (amplitude << DAC1_REG_OFFSET);
+    }
+}
+
+/*!
+    \brief      enable DAC concurrent mode
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dac_concurrent_enable(void)
+{
+    uint32_t ctl = 0U;
+    ctl = DAC_CTL_DEN0 | DAC_CTL_DEN1;
+    DAC_CTL |= (ctl);
+}
+
+/*!
+    \brief      disable DAC concurrent mode
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dac_concurrent_disable(void)
+{
+    uint32_t ctl = 0U;
+    ctl = DAC_CTL_DEN0 | DAC_CTL_DEN1;
+    DAC_CTL &= (~ctl);
+}
+
+/*!
+    \brief      enable DAC concurrent software trigger function
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dac_concurrent_software_trigger_enable(void)
+{
+    uint32_t swt = 0U;
+    swt = DAC_SWT_SWTR0 | DAC_SWT_SWTR1;
+    DAC_SWT |= (swt);
+}
+
+/*!
+    \brief      disable DAC concurrent software trigger function
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dac_concurrent_software_trigger_disable(void)
+{
+    uint32_t swt = 0U;
+    swt = DAC_SWT_SWTR0 | DAC_SWT_SWTR1;
+    DAC_SWT &= (~swt);
+}
+
+/*!
+    \brief      enable DAC concurrent buffer function
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dac_concurrent_output_buffer_enable(void)
+{
+    uint32_t ctl = 0U;
+    ctl = DAC_CTL_DBOFF0 | DAC_CTL_DBOFF1;
+    DAC_CTL &= (~ctl);
+}
+
+/*!
+    \brief      disable DAC concurrent buffer function
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dac_concurrent_output_buffer_disable(void)
+{
+    uint32_t ctl = 0U;
+    ctl = DAC_CTL_DBOFF0 | DAC_CTL_DBOFF1;
+    DAC_CTL |= (ctl);
+}
+
+/*!
+    \brief      set DAC concurrent mode data holding register value
+    \param[in]  dac_align: data alignment
+                only one parameter can be selected which is shown as below:
+      \arg        DAC_ALIGN_8B_R: data right 8b alignment
+      \arg        DAC_ALIGN_12B_R: data right 12b alignment
+      \arg        DAC_ALIGN_12B_L: data left 12b alignment
+    \param[in]  data0: data to be loaded
+    \param[in]  data1: data to be loaded
+    \param[out] none
+    \retval     none
+*/
+void dac_concurrent_data_set(uint32_t dac_align, uint16_t data0, uint16_t data1)
+{
+    uint32_t data = 0U;
+    switch(dac_align) {
+    /* data right 12b alignment */
+    case DAC_ALIGN_12B_R:
+        data = ((uint32_t)data1 << DH_12BIT_OFFSET) | data0;
+        DACC_R12DH = data;
+        break;
+    /* data left 12b alignment */
+    case DAC_ALIGN_12B_L:
+        data = ((uint32_t)data1 << DH_12BIT_OFFSET) | data0;
+        DACC_L12DH = data;
+        break;
+    /* data right 8b alignment */
+    case DAC_ALIGN_8B_R:
+        data = ((uint32_t)data1 << DH_8BIT_OFFSET) | data0;
+        DACC_R8DH = data;
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      enable DAC concurrent interrupt funcution
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dac_concurrent_interrupt_enable(void)
+{
+    uint32_t ctl = 0U;
+    ctl = DAC_CTL_DDUDRIE0 | DAC_CTL_DDUDRIE1;
+    DAC_CTL |= (ctl);
+}
+
+/*!
+    \brief      disable DAC concurrent interrupt funcution
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dac_concurrent_interrupt_disable(void)
+{
+    uint32_t ctl = 0U;
+    ctl = DAC_CTL_DDUDRIE0 | DAC_CTL_DDUDRIE1;
+    DAC_CTL &= (~ctl);
+}
+
+/*!
+    \brief      get the specified DAC flag (DAC DMA underrun flag)
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus dac_flag_get(uint32_t dac_periph)
+{
+    FlagStatus temp_flag = RESET;
+    if(DAC0 == dac_periph) {
+        /* check the DMA underrun flag */
+        if(RESET != (DAC_STAT & DAC_STAT_DDUDR0)) {
+            temp_flag = SET;
+        }
+    } else {
+        /* check the DMA underrun flag */
+        if(RESET != (DAC_STAT & DAC_STAT_DDUDR1)) {
+            temp_flag = SET;
+        }
+    }
+    return temp_flag;
+}
+
+/*!
+    \brief      clear the specified DAC flag (DAC DMA underrun flag)
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_flag_clear(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_STAT |= DAC_STAT_DDUDR0;
+    } else {
+        DAC_STAT |= DAC_STAT_DDUDR1;
+    }
+}
+
+/*!
+    \brief      enable DAC interrupt(DAC DMA underrun interrupt)
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_interrupt_enable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_CTL |= DAC_CTL_DDUDRIE0;
+    } else {
+        DAC_CTL |= DAC_CTL_DDUDRIE1;
+    }
+}
+
+/*!
+    \brief      disable DAC interrupt(DAC DMA underrun interrupt)
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_interrupt_disable(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_CTL &= ~DAC_CTL_DDUDRIE0;
+    } else {
+        DAC_CTL &= ~DAC_CTL_DDUDRIE1;
+    }
+}
+
+/*!
+    \brief      get the specified DAC interrupt flag (DAC DMA underrun interrupt flag)
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus dac_interrupt_flag_get(uint32_t dac_periph)
+{
+    FlagStatus temp_flag = RESET;
+    uint32_t ddudr_flag = 0U, ddudrie_flag = 0U;
+
+    if(DAC0 == dac_periph) {
+        /* check the DMA underrun flag and DAC DMA underrun interrupt enable flag */
+        ddudr_flag = DAC_STAT & DAC_STAT_DDUDR0;
+        ddudrie_flag = DAC_CTL & DAC_CTL_DDUDRIE0;
+        if((RESET != ddudr_flag) && (RESET != ddudrie_flag)) {
+            temp_flag = SET;
+        }
+    } else {
+        /* check the DMA underrun flag and DAC DMA underrun interrupt enable flag */
+        ddudr_flag = DAC_STAT & DAC_STAT_DDUDR1;
+        ddudrie_flag = DAC_CTL & DAC_CTL_DDUDRIE1;
+        if((RESET != ddudr_flag) && (RESET != ddudrie_flag)) {
+            temp_flag = SET;
+        }
+    }
+    return temp_flag;
+}
+
+/*!
+    \brief      clear the specified DAC interrupt flag (DAC DMA underrun interrupt flag)
+    \param[in]  dac_periph: DACx(x = 0,1)
+    \param[out] none
+    \retval     none
+*/
+void dac_interrupt_flag_clear(uint32_t dac_periph)
+{
+    if(DAC0 == dac_periph) {
+        DAC_STAT |= DAC_STAT_DDUDR0;
+    } else {
+        DAC_STAT |= DAC_STAT_DDUDR1;
+    }
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_dbg.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_dbg.c
@@ -1,0 +1,183 @@
+/*!
+    \file    gd32f4xx_dbg.c
+    \brief   DBG driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_dbg.h"
+
+#define DBG_RESET_VAL       0x00000000U
+
+/*!
+    \brief    deinitialize the DBG
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dbg_deinit(void)
+{
+    DBG_CTL0 = DBG_RESET_VAL;
+    DBG_CTL1 = DBG_RESET_VAL;
+}
+
+/*!
+    \brief    read DBG_ID code register
+    \param[in]  none
+    \param[out] none
+    \retval     DBG_ID code
+*/
+uint32_t dbg_id_get(void)
+{
+    return DBG_ID;
+}
+
+/*!
+    \brief    enable low power behavior when the mcu is in debug mode
+    \param[in]  dbg_low_power:
+                this parameter can be any combination of the following values:
+      \arg        DBG_LOW_POWER_SLEEP: keep debugger connection during sleep mode
+      \arg        DBG_LOW_POWER_DEEPSLEEP: keep debugger connection during deepsleep mode
+      \arg        DBG_LOW_POWER_STANDBY: keep debugger connection during standby mode
+    \param[out] none
+    \retval     none
+*/
+void dbg_low_power_enable(uint32_t dbg_low_power)
+{
+    DBG_CTL0 |= dbg_low_power;
+}
+
+/*!
+    \brief    disable low power behavior when the mcu is in debug mode
+    \param[in]  dbg_low_power:
+                this parameter can be any combination of the following values:
+      \arg        DBG_LOW_POWER_SLEEP: donot keep debugger connection during sleep mode
+      \arg        DBG_LOW_POWER_DEEPSLEEP: donot keep debugger connection during deepsleep mode
+      \arg        DBG_LOW_POWER_STANDBY: donot keep debugger connection during standby mode
+    \param[out] none
+    \retval     none
+*/
+void dbg_low_power_disable(uint32_t dbg_low_power)
+{
+    DBG_CTL0 &= ~dbg_low_power;
+}
+
+/*!
+    \brief    enable peripheral behavior when the mcu is in debug mode
+    \param[in]  dbg_periph: dbg_periph_enum
+                only one parameter can be selected which is shown as below:
+      \arg        DBG_TIMER1_HOLD: hold TIMER1 counter when core is halted
+      \arg        DBG_TIMER2_HOLD: hold TIMER2 counter when core is halted
+      \arg        DBG_TIMER3_HOLD: hold TIMER3 counter when core is halted
+      \arg        DBG_TIMER4_HOLD: hold TIMER4 counter when core is halted
+      \arg        DBG_TIMER5_HOLD: hold TIMER5 counter when core is halted
+      \arg        DBG_TIMER6_HOLD: hold TIMER6 counter when core is halted
+      \arg        DBG_TIMER11_HOLD: hold TIMER11 counter when core is halted
+      \arg        DBG_TIMER12_HOLD: hold TIMER12 counter when core is halted
+      \arg        DBG_TIMER13_HOLD: hold TIMER13 counter when core is halted
+      \arg        DBG_RTC_HOLD: hold RTC calendar and wakeup counter when core is halted
+      \arg        DBG_WWDGT_HOLD: debug WWDGT kept when core is halted
+      \arg        DBG_FWDGT_HOLD: debug FWDGT kept when core is halted
+      \arg        DBG_I2C0_HOLD: hold I2C0 smbus when core is halted
+      \arg        DBG_I2C1_HOLD: hold I2C1 smbus when core is halted
+      \arg        DBG_I2C2_HOLD: hold I2C2 smbus when core is halted
+      \arg        DBG_CAN0_HOLD: debug CAN0 kept when core is halted
+      \arg        DBG_CAN1_HOLD: debug CAN1 kept when core is halted
+      \arg        DBG_TIMER0_HOLD: hold TIMER0 counter when core is halted
+      \arg        DBG_TIMER7_HOLD: hold TIMER7 counter when core is halted
+      \arg        DBG_TIMER8_HOLD: hold TIMER8 counter when core is halted
+      \arg        DBG_TIMER9_HOLD: hold TIMER9 counter when core is halted
+      \arg        DBG_TIMER10_HOLD: hold TIMER10 counter when core is halted
+    \retval     none
+*/
+void dbg_periph_enable(dbg_periph_enum dbg_periph)
+{
+    DBG_REG_VAL(dbg_periph) |= BIT(DBG_BIT_POS(dbg_periph));
+}
+
+/*!
+    \brief    disable peripheral behavior when the mcu is in debug mode
+    \param[in]  dbg_periph: dbg_periph_enum
+                only one parameter can be selected which is shown as below:
+      \arg        DBG_TIMER1_HOLD: hold TIMER1 counter when core is halted
+      \arg        DBG_TIMER2_HOLD: hold TIMER2 counter when core is halted
+      \arg        DBG_TIMER3_HOLD: hold TIMER3 counter when core is halted
+      \arg        DBG_TIMER4_HOLD: hold TIMER4 counter when core is halted
+      \arg        DBG_TIMER5_HOLD: hold TIMER5 counter when core is halted
+      \arg        DBG_TIMER6_HOLD: hold TIMER6 counter when core is halted
+      \arg        DBG_TIMER11_HOLD: hold TIMER11 counter when core is halted
+      \arg        DBG_TIMER12_HOLD: hold TIMER12 counter when core is halted
+      \arg        DBG_TIMER13_HOLD: hold TIMER13 counter when core is halted
+      \arg        DBG_RTC_HOLD: hold RTC calendar and wakeup counter when core is halted
+      \arg        DBG_WWDGT_HOLD: debug WWDGT kept when core is halted
+      \arg        DBG_FWDGT_HOLD: debug FWDGT kept when core is halted
+      \arg        DBG_I2C0_HOLD: hold I2C0 smbus when core is halted
+      \arg        DBG_I2C1_HOLD: hold I2C1 smbus when core is halted
+      \arg        DBG_I2C2_HOLD: hold I2C2 smbus when core is halted
+      \arg        DBG_CAN0_HOLD: debug CAN0 kept when core is halted
+      \arg        DBG_CAN1_HOLD: debug CAN1 kept when core is halted
+      \arg        DBG_TIMER0_HOLD: hold TIMER0 counter when core is halted
+      \arg        DBG_TIMER7_HOLD: hold TIMER7 counter when core is halted
+      \arg        DBG_TIMER8_HOLD: hold TIMER8 counter when core is halted
+      \arg        DBG_TIMER9_HOLD: hold TIMER9 counter when core is halted
+      \arg        DBG_TIMER10_HOLD: hold TIMER10 counter when core is halted
+    \param[out] none
+    \retval     none
+*/
+void dbg_periph_disable(dbg_periph_enum dbg_periph)
+{
+    DBG_REG_VAL(dbg_periph) &= ~BIT(DBG_BIT_POS(dbg_periph));
+}
+
+/*!
+    \brief    enable trace pin assignment
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dbg_trace_pin_enable(void)
+{
+    DBG_CTL0 |= DBG_CTL0_TRACE_IOEN;
+}
+
+/*!
+    \brief    disable trace pin assignment
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dbg_trace_pin_disable(void)
+{
+    DBG_CTL0 &= ~DBG_CTL0_TRACE_IOEN;
+}
+

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_dci.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_dci.c
@@ -1,0 +1,346 @@
+/*!
+    \file    gd32f4xx_dci.c
+    \brief   DCI driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_dci.h"
+
+/*!
+    \brief    DCI deinit
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dci_deinit(void)
+{
+    rcu_periph_reset_enable(RCU_DCIRST);
+    rcu_periph_reset_disable(RCU_DCIRST);
+}
+
+/*!
+    \brief    initialize DCI registers
+    \param[in]  dci_struct: DCI parameter initialization structure
+                members of the structure and the member values are shown as below:
+                capture_mode    : DCI_CAPTURE_MODE_CONTINUOUS, DCI_CAPTURE_MODE_SNAPSHOT
+                colck_polarity  : DCI_CK_POLARITY_FALLING, DCI_CK_POLARITY_RISING
+                hsync_polarity  : DCI_HSYNC_POLARITY_LOW, DCI_HSYNC_POLARITY_HIGH
+                vsync_polarity  : DCI_VSYNC_POLARITY_LOW, DCI_VSYNC_POLARITY_HIGH
+                frame_rate      : DCI_FRAME_RATE_ALL, DCI_FRAME_RATE_1_2, DCI_FRAME_RATE_1_4
+                interface_format: DCI_INTERFACE_FORMAT_8BITS, DCI_INTERFACE_FORMAT_10BITS,
+                                      DCI_INTERFACE_FORMAT_12BITS, DCI_INTERFACE_FORMAT_14BITS
+    \param[out] none
+    \retval     none
+*/
+void dci_init(dci_parameter_struct *dci_struct)
+{
+    uint32_t reg = 0U;
+    /* disable capture function and DCI */
+    DCI_CTL &= ~(DCI_CTL_CAP | DCI_CTL_DCIEN);
+    /* configure DCI parameter */
+    reg |= dci_struct->capture_mode;
+    reg |= dci_struct->clock_polarity;
+    reg |= dci_struct->hsync_polarity;
+    reg |= dci_struct->vsync_polarity;
+    reg |= dci_struct->frame_rate;
+    reg |= dci_struct->interface_format;
+
+    DCI_CTL = reg;
+}
+
+/*!
+    \brief    enable DCI function
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dci_enable(void)
+{
+    DCI_CTL |= DCI_CTL_DCIEN;
+}
+
+/*!
+    \brief    disable DCI function
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dci_disable(void)
+{
+    DCI_CTL &= ~DCI_CTL_DCIEN;
+}
+
+/*!
+    \brief    enable DCI capture
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dci_capture_enable(void)
+{
+    DCI_CTL |= DCI_CTL_CAP;
+}
+
+/*!
+    \brief    disable DCI capture
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dci_capture_disable(void)
+{
+    DCI_CTL &= ~DCI_CTL_CAP;
+}
+
+/*!
+    \brief    enable DCI jpeg mode
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dci_jpeg_enable(void)
+{
+    DCI_CTL |= DCI_CTL_JM;
+}
+
+/*!
+    \brief    disable DCI jpeg mode
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dci_jpeg_disable(void)
+{
+    DCI_CTL &= ~DCI_CTL_JM;
+}
+
+/*!
+    \brief    enable cropping window function
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dci_crop_window_enable(void)
+{
+    DCI_CTL |= DCI_CTL_WDEN;
+}
+
+/*!
+    \brief    disable cropping window function
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dci_crop_window_disable(void)
+{
+    DCI_CTL &= ~DCI_CTL_WDEN;
+}
+
+/*!
+    \brief    configure DCI cropping window
+    \param[in]  start_x: window horizontal start position
+    \param[in]  start_y: window vertical start position
+    \param[in]  size_width: window horizontal size
+    \param[in]  size_height: window vertical size
+    \param[out] none
+    \retval     none
+*/
+void dci_crop_window_config(uint16_t start_x, uint16_t start_y, uint16_t size_width, uint16_t size_height)
+{
+    DCI_CWSPOS = ((uint32_t)start_x | ((uint32_t)start_y << 16));
+    DCI_CWSZ = ((uint32_t)size_width | ((uint32_t)size_height << 16));
+}
+
+/*!
+    \brief    enable embedded synchronous mode
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dci_embedded_sync_enable(void)
+{
+    DCI_CTL |= DCI_CTL_ESM;
+}
+
+/*!
+    \brief    disble embedded synchronous mode
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void dci_embedded_sync_disable(void)
+{
+    DCI_CTL &= ~DCI_CTL_ESM;
+}
+/*!
+    \brief    config synchronous codes in embedded synchronous mode
+    \param[in]  frame_start: frame start code in embedded synchronous mode
+    \param[in]  line_start: line start code in embedded synchronous mode
+    \param[in]  line_end: line end code in embedded synchronous mode
+    \param[in]  frame_end: frame end code in embedded synchronous mode
+    \param[out] none
+    \retval     none
+*/
+void dci_sync_codes_config(uint8_t frame_start, uint8_t line_start, uint8_t line_end, uint8_t frame_end)
+{
+    DCI_SC = ((uint32_t)frame_start | ((uint32_t)line_start << 8) | ((uint32_t)line_end << 16) | ((uint32_t)frame_end << 24));
+}
+
+/*!
+    \brief    config synchronous codes unmask in embedded synchronous mode
+    \param[in]  frame_start: frame start code unmask bits in embedded synchronous mode
+    \param[in]  line_start: line start code unmask bits in embedded synchronous mode
+    \param[in]  line_end: line end code unmask bits in embedded synchronous mode
+    \param[in]  frame_end: frame end code unmask bits in embedded synchronous mode
+    \param[out] none
+    \retval     none
+*/
+void dci_sync_codes_unmask_config(uint8_t frame_start, uint8_t line_start, uint8_t line_end, uint8_t frame_end)
+{
+    DCI_SCUMSK = ((uint32_t)frame_start | ((uint32_t)line_start << 8) | ((uint32_t)line_end << 16) | ((uint32_t)frame_end << 24));
+}
+
+/*!
+    \brief    read DCI data register
+    \param[in]  none
+    \param[out] none
+    \retval     data
+*/
+uint32_t dci_data_read(void)
+{
+    return DCI_DATA;
+}
+
+/*!
+    \brief    get specified flag
+    \param[in]  flag:
+      \arg         DCI_FLAG_HS: HS line status
+      \arg         DCI_FLAG_VS: VS line status
+      \arg         DCI_FLAG_FV:FIFO valid
+      \arg         DCI_FLAG_EF: end of frame flag
+      \arg         DCI_FLAG_OVR: FIFO overrun flag
+      \arg         DCI_FLAG_ESE: embedded synchronous error flag
+      \arg         DCI_FLAG_VSYNC: vsync flag
+      \arg         DCI_FLAG_EL: end of line flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus dci_flag_get(uint32_t flag)
+{
+    uint32_t stat = 0U;
+
+    if(flag >> 31) {
+        /* get flag status from DCI_STAT1 register */
+        stat = DCI_STAT1;
+    } else {
+        /* get flag status from DCI_STAT0 register */
+        stat = DCI_STAT0;
+    }
+
+    if(flag & stat) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    enable specified DCI interrupt
+    \param[in]  interrupt:
+      \arg         DCI_INT_EF: end of frame interrupt
+      \arg         DCI_INT_OVR: FIFO overrun interrupt
+      \arg         DCI_INT_ESE: embedded synchronous error interrupt
+      \arg         DCI_INT_VSYNC: vsync interrupt
+      \arg         DCI_INT_EL: end of line interrupt
+    \param[out] none
+    \retval     none
+*/
+void dci_interrupt_enable(uint32_t interrupt)
+{
+    DCI_INTEN |= interrupt;
+}
+
+/*!
+    \brief    disable specified DCI interrupt
+    \param[in]  interrupt:
+      \arg         DCI_INT_EF: end of frame interrupt
+      \arg         DCI_INT_OVR: FIFO overrun interrupt
+      \arg         DCI_INT_ESE: embedded synchronous error interrupt
+      \arg         DCI_INT_VSYNC: vsync interrupt
+      \arg         DCI_INT_EL: end of line interrupt
+    \param[out] none
+    \retval     none
+*/
+void dci_interrupt_disable(uint32_t interrupt)
+{
+    DCI_INTEN &= ~interrupt;
+}
+
+/*!
+    \brief    clear specified interrupt flag
+    \param[in]  int_flag:
+      \arg         DCI_INT_EF: end of frame interrupt
+      \arg         DCI_INT_OVR: FIFO overrun interrupt
+      \arg         DCI_INT_ESE: embedded synchronous error interrupt
+      \arg         DCI_INT_VSYNC: vsync interrupt
+      \arg         DCI_INT_EL: end of line interrupt
+    \param[out] none
+    \retval     none
+*/
+void dci_interrupt_flag_clear(uint32_t int_flag)
+{
+    DCI_INTC |= int_flag;
+}
+
+/*!
+    \brief    get specified interrupt flag
+    \param[in]  int_flag:
+      \arg         DCI_INT_FLAG_EF: end of frame interrupt flag
+      \arg         DCI_INT_FLAG_OVR: FIFO overrun interrupt flag
+      \arg         DCI_INT_FLAG_ESE: embedded synchronous error interrupt flag
+      \arg         DCI_INT_FLAG_VSYNC: vsync interrupt flag
+      \arg         DCI_INT_FLAG_EL: end of line interrupt flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus dci_interrupt_flag_get(uint32_t int_flag)
+{
+    if(RESET == (DCI_INTF & int_flag)) {
+        return RESET;
+    } else {
+        return SET;
+    }
+}
+
+

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_dma.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_dma.c
@@ -1,0 +1,904 @@
+/*!
+    \file    gd32f4xx_dma.c
+    \brief   DMA driver
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_dma.h"
+
+/*  DMA register bit offset */
+#define CHXCTL_PERIEN_OFFSET            ((uint32_t)25U)
+
+/*!
+    \brief    deinitialize DMA a channel registers
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel is deinitialized
+      \arg        DMA_CHx(x=0..7)
+    \param[out] none
+    \retval     none
+*/
+void dma_deinit(uint32_t dma_periph, dma_channel_enum channelx)
+{
+    /* disable DMA a channel */
+    DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_CHEN;
+    /* reset DMA channel registers */
+    DMA_CHCTL(dma_periph, channelx) = DMA_CHCTL_RESET_VALUE;
+    DMA_CHCNT(dma_periph, channelx) = DMA_CHCNT_RESET_VALUE;
+    DMA_CHPADDR(dma_periph, channelx) = DMA_CHPADDR_RESET_VALUE;
+    DMA_CHM0ADDR(dma_periph, channelx) = DMA_CHMADDR_RESET_VALUE;
+    DMA_CHM1ADDR(dma_periph, channelx) = DMA_CHMADDR_RESET_VALUE;
+    DMA_CHFCTL(dma_periph, channelx) = DMA_CHFCTL_RESET_VALUE;
+    if(channelx < DMA_CH4) {
+        DMA_INTC0(dma_periph) |= DMA_FLAG_ADD(DMA_CHINTF_RESET_VALUE, channelx);
+    } else {
+        channelx -= (dma_channel_enum)4;
+        DMA_INTC1(dma_periph) |= DMA_FLAG_ADD(DMA_CHINTF_RESET_VALUE, channelx);
+    }
+}
+
+/*!
+    \brief    initialize the DMA single data mode parameters struct with the default values
+    \param[in]  init_struct: the initialization data needed to initialize DMA channel
+    \param[out] none
+    \retval     none
+*/
+void dma_single_data_para_struct_init(dma_single_data_parameter_struct *init_struct)
+{
+    /* set the DMA struct with the default values */
+    init_struct->periph_addr         = 0U;
+    init_struct->periph_inc          = DMA_PERIPH_INCREASE_DISABLE;
+    init_struct->memory0_addr        = 0U;
+    init_struct->memory_inc          = DMA_MEMORY_INCREASE_DISABLE;
+    init_struct->periph_memory_width = 0U;
+    init_struct->circular_mode       = DMA_CIRCULAR_MODE_DISABLE;
+    init_struct->direction           = DMA_PERIPH_TO_MEMORY;
+    init_struct->number              = 0U;
+    init_struct->priority            = DMA_PRIORITY_LOW;
+}
+
+/*!
+    \brief    initialize the DMA multi data mode parameters struct with the default values
+    \param[in]  init_struct: the initialization data needed to initialize DMA channel
+    \param[out] none
+    \retval     none
+*/
+void dma_multi_data_para_struct_init(dma_multi_data_parameter_struct *init_struct)
+{
+    /* set the DMA struct with the default values */
+    init_struct->periph_addr         = 0U;
+    init_struct->periph_width        = 0U;
+    init_struct->periph_inc          = DMA_PERIPH_INCREASE_DISABLE;
+    init_struct->memory0_addr        = 0U;
+    init_struct->memory_width        = 0U;
+    init_struct->memory_inc          = DMA_MEMORY_INCREASE_DISABLE;
+    init_struct->memory_burst_width  = 0U;
+    init_struct->periph_burst_width  = 0U;
+    init_struct->circular_mode       = DMA_CIRCULAR_MODE_DISABLE;
+    init_struct->direction           = DMA_PERIPH_TO_MEMORY;
+    init_struct->number              = 0U;
+    init_struct->priority            = DMA_PRIORITY_LOW;
+}
+
+/*!
+    \brief    initialize DMA single data mode
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel is initialized
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  init_struct: the data needed to initialize DMA single data mode
+                  periph_addr: peripheral base address
+                  periph_inc: DMA_PERIPH_INCREASE_ENABLE,DMA_PERIPH_INCREASE_DISABLE,DMA_PERIPH_INCREASE_FIX
+                  memory0_addr: memory base address
+                  memory_inc: DMA_MEMORY_INCREASE_ENABLE,DMA_MEMORY_INCREASE_DISABLE
+                  periph_memory_width: DMA_PERIPH_WIDTH_8BIT,DMA_PERIPH_WIDTH_16BIT,DMA_PERIPH_WIDTH_32BIT
+                  circular_mode: DMA_CIRCULAR_MODE_ENABLE,DMA_CIRCULAR_MODE_DISABLE
+                  direction: DMA_PERIPH_TO_MEMORY,DMA_MEMORY_TO_PERIPH,DMA_MEMORY_TO_MEMORY
+                  number: the number of remaining data to be transferred by the DMA
+                  priority: DMA_PRIORITY_LOW,DMA_PRIORITY_MEDIUM,DMA_PRIORITY_HIGH,DMA_PRIORITY_ULTRA_HIGH
+    \param[out] none
+    \retval     none
+*/
+void dma_single_data_mode_init(uint32_t dma_periph, dma_channel_enum channelx, dma_single_data_parameter_struct *init_struct)
+{
+    uint32_t ctl;
+
+    /* select single data mode */
+    DMA_CHFCTL(dma_periph, channelx) &= ~DMA_CHXFCTL_MDMEN;
+
+    /* configure peripheral base address */
+    DMA_CHPADDR(dma_periph, channelx) = init_struct->periph_addr;
+
+    /* configure memory base address */
+    DMA_CHM0ADDR(dma_periph, channelx) = init_struct->memory0_addr;
+
+    /* configure the number of remaining data to be transferred */
+    DMA_CHCNT(dma_periph, channelx) = init_struct->number;
+
+    /* configure peripheral and memory transfer width,channel priotity,transfer mode */
+    ctl = DMA_CHCTL(dma_periph, channelx);
+    ctl &= ~(DMA_CHXCTL_PWIDTH | DMA_CHXCTL_MWIDTH | DMA_CHXCTL_PRIO | DMA_CHXCTL_TM);
+    ctl |= (init_struct->periph_memory_width | (init_struct->periph_memory_width << 2) | init_struct->priority | init_struct->direction);
+    DMA_CHCTL(dma_periph, channelx) = ctl;
+
+    /* configure peripheral increasing mode */
+    if(DMA_PERIPH_INCREASE_ENABLE == init_struct->periph_inc) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PNAGA;
+    } else if(DMA_PERIPH_INCREASE_DISABLE == init_struct->periph_inc) {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_PNAGA;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PAIF;
+    }
+
+    /* configure memory increasing mode */
+    if(DMA_MEMORY_INCREASE_ENABLE == init_struct->memory_inc) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_MNAGA;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_MNAGA;
+    }
+
+    /* configure DMA circular mode */
+    if(DMA_CIRCULAR_MODE_ENABLE == init_struct->circular_mode) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_CMEN;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_CMEN;
+    }
+}
+
+/*!
+    \brief    initialize DMA multi data mode
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel is initialized
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  dma_multi_data_parameter_struct: the data needed to initialize DMA multi data mode
+                  periph_addr: peripheral base address
+                  periph_width: DMA_PERIPH_WIDTH_8BIT,DMA_PERIPH_WIDTH_16BIT,DMA_PERIPH_WIDTH_32BIT
+                  periph_inc: DMA_PERIPH_INCREASE_ENABLE,DMA_PERIPH_INCREASE_DISABLE,DMA_PERIPH_INCREASE_FIX
+                  memory0_addr: memory0 base address
+                  memory_width: DMA_MEMORY_WIDTH_8BIT,DMA_MEMORY_WIDTH_16BIT,DMA_MEMORY_WIDTH_32BIT
+                  memory_inc: DMA_MEMORY_INCREASE_ENABLE,DMA_MEMORY_INCREASE_DISABLE
+                  memory_burst_width: DMA_MEMORY_BURST_SINGLE,DMA_MEMORY_BURST_4_BEAT,DMA_MEMORY_BURST_8_BEAT,DMA_MEMORY_BURST_16_BEAT
+                  periph_burst_width: DMA_PERIPH_BURST_SINGLE,DMA_PERIPH_BURST_4_BEAT,DMA_PERIPH_BURST_8_BEAT,DMA_PERIPH_BURST_16_BEAT
+                  critical_value: DMA_FIFO_1_WORD,DMA_FIFO_2_WORD,DMA_FIFO_3_WORD,DMA_FIFO_4_WORD
+                  circular_mode: DMA_CIRCULAR_MODE_ENABLE,DMA_CIRCULAR_MODE_DISABLE
+                  direction: DMA_PERIPH_TO_MEMORY,DMA_MEMORY_TO_PERIPH,DMA_MEMORY_TO_MEMORY
+                  number: the number of remaining data to be transferred by the DMA
+                  priority: DMA_PRIORITY_LOW,DMA_PRIORITY_MEDIUM,DMA_PRIORITY_HIGH,DMA_PRIORITY_ULTRA_HIGH
+    \param[out] none
+    \retval     none
+*/
+void dma_multi_data_mode_init(uint32_t dma_periph, dma_channel_enum channelx, dma_multi_data_parameter_struct *init_struct)
+{
+    uint32_t ctl;
+
+    /* select multi data mode and configure FIFO critical value */
+    DMA_CHFCTL(dma_periph, channelx) |= (DMA_CHXFCTL_MDMEN | init_struct->critical_value);
+
+    /* configure peripheral base address */
+    DMA_CHPADDR(dma_periph, channelx) = init_struct->periph_addr;
+
+    /* configure memory base address */
+    DMA_CHM0ADDR(dma_periph, channelx) = init_struct->memory0_addr;
+
+    /* configure the number of remaining data to be transferred */
+    DMA_CHCNT(dma_periph, channelx) = init_struct->number;
+
+    /* configure peripheral and memory transfer width,channel priotity,transfer mode,peripheral and memory burst transfer width */
+    ctl = DMA_CHCTL(dma_periph, channelx);
+    ctl &= ~(DMA_CHXCTL_PWIDTH | DMA_CHXCTL_MWIDTH | DMA_CHXCTL_PRIO | DMA_CHXCTL_TM | DMA_CHXCTL_PBURST | DMA_CHXCTL_MBURST);
+    ctl |= (init_struct->periph_width | (init_struct->memory_width) | init_struct->priority | init_struct->direction | init_struct->memory_burst_width |
+            init_struct->periph_burst_width);
+    DMA_CHCTL(dma_periph, channelx) = ctl;
+
+    /* configure peripheral increasing mode */
+    if(DMA_PERIPH_INCREASE_ENABLE == init_struct->periph_inc) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PNAGA;
+    } else if(DMA_PERIPH_INCREASE_DISABLE == init_struct->periph_inc) {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_PNAGA;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PAIF;
+    }
+
+    /* configure memory increasing mode */
+    if(DMA_MEMORY_INCREASE_ENABLE == init_struct->memory_inc) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_MNAGA;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_MNAGA;
+    }
+
+    /* configure DMA circular mode */
+    if(DMA_CIRCULAR_MODE_ENABLE == init_struct->circular_mode) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_CMEN;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_CMEN;
+    }
+}
+
+/*!
+    \brief    set DMA peripheral base address
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel to set peripheral base address
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  address: peripheral base address
+    \param[out] none
+    \retval     none
+*/
+void dma_periph_address_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t address)
+{
+    DMA_CHPADDR(dma_periph, channelx) = address;
+}
+
+/*!
+    \brief    set DMA Memory0 base address
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel to set Memory base address
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  memory_flag: DMA_MEMORY_x(x=0,1)
+    \param[in]  address: Memory base address
+    \param[out] none
+    \retval     none
+*/
+void dma_memory_address_config(uint32_t dma_periph, dma_channel_enum channelx, uint8_t memory_flag, uint32_t address)
+{
+    if(memory_flag) {
+        DMA_CHM1ADDR(dma_periph, channelx) = address;
+    } else {
+        DMA_CHM0ADDR(dma_periph, channelx) = address;
+    }
+}
+
+/*!
+    \brief    set the number of remaining data to be transferred by the DMA
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel to set number
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  number: the number of remaining data to be transferred by the DMA
+    \param[out] none
+    \retval     none
+*/
+void dma_transfer_number_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t number)
+{
+    DMA_CHCNT(dma_periph, channelx) = number;
+}
+
+/*!
+    \brief    get the number of remaining data to be transferred by the DMA
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel to set number
+      \arg        DMA_CHx(x=0..7)
+    \param[out] none
+    \retval     uint32_t: the number of remaining data to be transferred by the DMA
+*/
+uint32_t dma_transfer_number_get(uint32_t dma_periph, dma_channel_enum channelx)
+{
+    return (uint32_t)DMA_CHCNT(dma_periph, channelx);
+}
+
+/*!
+    \brief    configure priority level of DMA channel
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  priority: priority Level of this channel
+                only one parameter can be selected which is shown as below:
+      \arg        DMA_PRIORITY_LOW: low priority
+      \arg        DMA_PRIORITY_MEDIUM: medium priority
+      \arg        DMA_PRIORITY_HIGH: high priority
+      \arg        DMA_PRIORITY_ULTRA_HIGH: ultra high priority
+    \param[out] none
+    \retval     none
+*/
+void dma_priority_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t priority)
+{
+    uint32_t ctl;
+    /* acquire DMA_CHxCTL register */
+    ctl = DMA_CHCTL(dma_periph, channelx);
+    /* assign regiser */
+    ctl &= ~DMA_CHXCTL_PRIO;
+    ctl |= priority;
+    DMA_CHCTL(dma_periph, channelx) = ctl;
+}
+
+/*!
+    \brief    configure transfer burst beats of memory
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  mbeat: transfer burst beats
+      \arg        DMA_MEMORY_BURST_SINGLE: memory transfer single burst
+      \arg        DMA_MEMORY_BURST_4_BEAT: memory transfer 4-beat burst
+      \arg        DMA_MEMORY_BURST_8_BEAT: memory transfer 8-beat burst
+      \arg        DMA_MEMORY_BURST_16_BEAT: memory transfer 16-beat burst
+    \param[out] none
+    \retval     none
+*/
+void dma_memory_burst_beats_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t mbeat)
+{
+    uint32_t ctl;
+    /* acquire DMA_CHxCTL register */
+    ctl = DMA_CHCTL(dma_periph, channelx);
+    /* assign regiser */
+    ctl &= ~DMA_CHXCTL_MBURST;
+    ctl |= mbeat;
+    DMA_CHCTL(dma_periph, channelx) = ctl;
+}
+
+/*!
+    \brief    configure transfer burst beats of peripheral
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  pbeat: transfer burst beats
+                only one parameter can be selected which is shown as below:
+      \arg        DMA_PERIPH_BURST_SINGLE: peripheral transfer single burst
+      \arg        DMA_PERIPH_BURST_4_BEAT: peripheral transfer 4-beat burst
+      \arg        DMA_PERIPH_BURST_8_BEAT: peripheral transfer 8-beat burst
+      \arg        DMA_PERIPH_BURST_16_BEAT: peripheral transfer 16-beat burst
+    \param[out] none
+    \retval     none
+*/
+void dma_periph_burst_beats_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t pbeat)
+{
+    uint32_t ctl;
+    /* acquire DMA_CHxCTL register */
+    ctl = DMA_CHCTL(dma_periph, channelx);
+    /* assign regiser */
+    ctl &= ~DMA_CHXCTL_PBURST;
+    ctl |= pbeat;
+    DMA_CHCTL(dma_periph, channelx) = ctl;
+}
+
+/*!
+    \brief    configure transfer data size of memory
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  msize: transfer data size of memory
+                only one parameter can be selected which is shown as below:
+      \arg        DMA_MEMORY_WIDTH_8BIT: transfer data size of memory is 8-bit
+      \arg        DMA_MEMORY_WIDTH_16BIT: transfer data size of memory is 16-bit
+      \arg        DMA_MEMORY_WIDTH_32BIT: transfer data size of memory is 32-bit
+    \param[out] none
+    \retval     none
+*/
+void dma_memory_width_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t msize)
+{
+    uint32_t ctl;
+    /* acquire DMA_CHxCTL register */
+    ctl = DMA_CHCTL(dma_periph, channelx);
+    /* assign regiser */
+    ctl &= ~DMA_CHXCTL_MWIDTH;
+    ctl |= msize;
+    DMA_CHCTL(dma_periph, channelx) = ctl;
+}
+
+/*!
+    \brief    configure transfer data size of peripheral
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  msize: transfer data size of peripheral
+                only one parameter can be selected which is shown as below:
+      \arg        DMA_PERIPHERAL_WIDTH_8BIT: transfer data size of peripheral is 8-bit
+      \arg        DMA_PERIPHERAL_WIDTH_16BIT: transfer data size of peripheral is 16-bit
+      \arg        DMA_PERIPHERAL_WIDTH_32BIT: transfer data size of peripheral is 32-bit
+    \param[out] none
+    \retval     none
+*/
+void dma_periph_width_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t psize)
+{
+    uint32_t ctl;
+    /* acquire DMA_CHxCTL register */
+    ctl = DMA_CHCTL(dma_periph, channelx);
+    /* assign regiser */
+    ctl &= ~DMA_CHXCTL_PWIDTH;
+    ctl |= psize;
+    DMA_CHCTL(dma_periph, channelx) = ctl;
+}
+
+/*!
+    \brief    configure memory address generation generation_algorithm
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  generation_algorithm: the address generation algorithm
+                only one parameter can be selected which is shown as below:
+      \arg        DMA_MEMORY_INCREASE_ENABLE: next address of memory is increasing address mode
+      \arg        DMA_MEMORY_INCREASE_DISABLE: next address of memory is fixed address mode
+    \param[out] none
+    \retval     none
+*/
+void dma_memory_address_generation_config(uint32_t dma_periph, dma_channel_enum channelx, uint8_t generation_algorithm)
+{
+    if(DMA_MEMORY_INCREASE_ENABLE == generation_algorithm) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_MNAGA;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_MNAGA;
+    }
+}
+
+/*!
+    \brief    configure peripheral address generation_algorithm
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  generation_algorithm: the address generation algorithm
+                only one parameter can be selected which is shown as below:
+      \arg        DMA_PERIPH_INCREASE_ENABLE: next address of peripheral is increasing address mode
+      \arg        DMA_PERIPH_INCREASE_DISABLE: next address of peripheral is fixed address mode
+      \arg        DMA_PERIPH_INCREASE_FIX: increasing steps of peripheral address is fixed
+    \param[out] none
+    \retval     none
+*/
+void dma_peripheral_address_generation_config(uint32_t dma_periph, dma_channel_enum channelx, uint8_t generation_algorithm)
+{
+    if(DMA_PERIPH_INCREASE_ENABLE == generation_algorithm) {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PNAGA;
+    } else if(DMA_PERIPH_INCREASE_DISABLE == generation_algorithm) {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_PNAGA;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PNAGA;
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_PAIF;
+    }
+}
+
+/*!
+    \brief    enable DMA circulation mode
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[out] none
+    \retval     none
+*/
+void dma_circulation_enable(uint32_t dma_periph, dma_channel_enum channelx)
+{
+    DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_CMEN;
+}
+
+/*!
+    \brief    disable DMA circulation mode
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[out] none
+    \retval     none
+*/
+void dma_circulation_disable(uint32_t dma_periph, dma_channel_enum channelx)
+{
+    DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_CMEN;
+}
+
+/*!
+    \brief    enable DMA channel
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[out] none
+    \retval     none
+*/
+void dma_channel_enable(uint32_t dma_periph, dma_channel_enum channelx)
+{
+    DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_CHEN;
+}
+
+/*!
+    \brief    disable DMA channel
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[out] none
+    \retval     none
+*/
+void dma_channel_disable(uint32_t dma_periph, dma_channel_enum channelx)
+{
+    DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_CHEN;
+}
+
+/*!
+    \brief    configure the direction of  data transfer on the channel
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  direction: specify the direction of  data transfer
+                only one parameter can be selected which is shown as below:
+      \arg        DMA_PERIPH_TO_MEMORY: read from peripheral and write to memory
+      \arg        DMA_MEMORY_TO_PERIPH: read from memory and write to peripheral
+      \arg        DMA_MEMORY_TO_MEMORY: read from memory and write to memory
+    \param[out] none
+    \retval     none
+*/
+void dma_transfer_direction_config(uint32_t dma_periph, dma_channel_enum channelx, uint8_t direction)
+{
+    uint32_t ctl;
+    /* acquire DMA_CHxCTL register */
+    ctl = DMA_CHCTL(dma_periph, channelx);
+    /* assign regiser */
+    ctl &= ~DMA_CHXCTL_TM;
+    ctl |= direction;
+
+    DMA_CHCTL(dma_periph, channelx) = ctl;
+}
+
+/*!
+    \brief    DMA switch buffer mode config
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  memory1_addr: memory1 base address
+    \param[in]  memory_select: DMA_MEMORY_0 or DMA_MEMORY_1
+    \param[out] none
+    \retval     none
+*/
+void dma_switch_buffer_mode_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t memory1_addr, uint32_t memory_select)
+{
+    /* configure memory1 base address */
+    DMA_CHM1ADDR(dma_periph, channelx) = memory1_addr;
+
+    if(DMA_MEMORY_0 == memory_select) {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_MBS;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_MBS;
+    }
+}
+
+/*!
+    \brief    DMA using memory get
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[out] none
+    \retval     the using memory
+*/
+uint32_t dma_using_memory_get(uint32_t dma_periph, dma_channel_enum channelx)
+{
+    if((DMA_CHCTL(dma_periph, channelx)) & DMA_CHXCTL_MBS) {
+        return DMA_MEMORY_1;
+    } else {
+        return DMA_MEMORY_0;
+    }
+}
+
+/*!
+    \brief    DMA channel peripheral select
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  sub_periph: specify DMA channel peripheral
+      \arg        DMA_SUBPERIx(x=0..7)
+    \param[out] none
+    \retval     none
+*/
+void dma_channel_subperipheral_select(uint32_t dma_periph, dma_channel_enum channelx, dma_subperipheral_enum sub_periph)
+{
+    uint32_t ctl;
+    /* acquire DMA_CHxCTL register */
+    ctl = DMA_CHCTL(dma_periph, channelx);
+    /* assign regiser */
+    ctl &= ~DMA_CHXCTL_PERIEN;
+    ctl |= ((uint32_t)sub_periph << CHXCTL_PERIEN_OFFSET);
+
+    DMA_CHCTL(dma_periph, channelx) = ctl;
+}
+
+/*!
+    \brief    DMA flow controller configure
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  controller: specify DMA flow controler
+                only one parameter can be selected which is shown as below:
+      \arg        DMA_FLOW_CONTROLLER_DMA: DMA is the flow controller
+      \arg        DMA_FLOW_CONTROLLER_PERI: peripheral is the flow controller
+    \param[out] none
+    \retval     none
+*/
+void dma_flow_controller_config(uint32_t dma_periph, dma_channel_enum channelx, uint32_t controller)
+{
+    if(DMA_FLOW_CONTROLLER_DMA == controller) {
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_TFCS;
+    } else {
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_TFCS;
+    }
+}
+
+/*!
+    \brief    DMA switch buffer mode enable
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  newvalue: ENABLE or DISABLE
+    \param[out] none
+    \retval     none
+*/
+void dma_switch_buffer_mode_enable(uint32_t dma_periph, dma_channel_enum channelx, ControlStatus newvalue)
+{
+    if(ENABLE == newvalue) {
+        /* switch buffer mode enable */
+        DMA_CHCTL(dma_periph, channelx) |= DMA_CHXCTL_SBMEN;
+    } else {
+        /* switch buffer mode disable */
+        DMA_CHCTL(dma_periph, channelx) &= ~DMA_CHXCTL_SBMEN;
+    }
+}
+
+/*!
+    \brief    DMA FIFO status get
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[out] none
+    \retval     the using memory
+*/
+uint32_t dma_fifo_status_get(uint32_t dma_periph, dma_channel_enum channelx)
+{
+    return (DMA_CHFCTL(dma_periph, channelx) & DMA_CHXFCTL_FCNT);
+}
+
+/*!
+    \brief    get DMA flag is set or not
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel to get flag
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  flag: specify get which flag
+                only one parameter can be selected which is shown as below:
+      \arg        DMA_FLAG_FEE: FIFO error and exception flag
+      \arg        DMA_FLAG_SDE: single data mode exception flag
+      \arg        DMA_FLAG_TAE: transfer access error flag
+      \arg        DMA_FLAG_HTF: half transfer finish flag
+      \arg        DMA_FLAG_FTF: full transger finish flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus dma_flag_get(uint32_t dma_periph, dma_channel_enum channelx, uint32_t flag)
+{
+    if(channelx < DMA_CH4) {
+        if(DMA_INTF0(dma_periph) & DMA_FLAG_ADD(flag, channelx)) {
+            return SET;
+        } else {
+            return RESET;
+        }
+    } else {
+        channelx -= (dma_channel_enum)4;
+        if(DMA_INTF1(dma_periph) & DMA_FLAG_ADD(flag, channelx)) {
+            return SET;
+        } else {
+            return RESET;
+        }
+    }
+}
+
+/*!
+    \brief    clear DMA a channel flag
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel to get flag
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  flag: specify get which flag
+                only one parameter can be selected which is shown as below:
+      \arg        DMA_FLAG_FEE: FIFO error and exception flag
+      \arg        DMA_FLAG_SDE: single data mode exception flag
+      \arg        DMA_FLAG_TAE: transfer access error flag
+      \arg        DMA_FLAG_HTF: half transfer finish flag
+      \arg        DMA_FLAG_FTF: full transger finish flag
+    \param[out] none
+    \retval     none
+*/
+void dma_flag_clear(uint32_t dma_periph, dma_channel_enum channelx, uint32_t flag)
+{
+    if(channelx < DMA_CH4) {
+        DMA_INTC0(dma_periph) |= DMA_FLAG_ADD(flag, channelx);
+    } else {
+        channelx -= (dma_channel_enum)4;
+        DMA_INTC1(dma_periph) |= DMA_FLAG_ADD(flag, channelx);
+    }
+}
+
+/*!
+    \brief    enable DMA interrupt
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  source: specify which interrupt to enbale
+                only one parameters can be selected which are shown as below:
+      \arg        DMA_CHXCTL_SDEIE: single data mode exception interrupt enable
+      \arg        DMA_CHXCTL_TAEIE: tranfer access error interrupt enable
+      \arg        DMA_CHXCTL_HTFIE: half transfer finish interrupt enable
+      \arg        DMA_CHXCTL_FTFIE: full transfer finish interrupt enable
+      \arg        DMA_CHXFCTL_FEEIE: FIFO exception interrupt enable
+    \param[out] none
+    \retval     none
+*/
+void dma_interrupt_enable(uint32_t dma_periph, dma_channel_enum channelx, uint32_t source)
+{
+    if(DMA_CHXFCTL_FEEIE != source) {
+        DMA_CHCTL(dma_periph, channelx) |= source;
+    } else {
+        DMA_CHFCTL(dma_periph, channelx) |= source;
+    }
+}
+
+/*!
+    \brief    disable DMA interrupt
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  source: specify which interrupt to disbale
+                only one parameters can be selected which are shown as below:
+      \arg        DMA_CHXCTL_SDEIE: single data mode exception interrupt enable
+      \arg        DMA_CHXCTL_TAEIE: tranfer access error interrupt enable
+      \arg        DMA_CHXCTL_HTFIE: half transfer finish interrupt enable
+      \arg        DMA_CHXCTL_FTFIE: full transfer finish interrupt enable
+      \arg        DMA_CHXFCTL_FEEIE: FIFO exception interrupt enable
+    \param[out] none
+    \retval     none
+*/
+void dma_interrupt_disable(uint32_t dma_periph, dma_channel_enum channelx, uint32_t source)
+{
+    if(DMA_CHXFCTL_FEEIE != source) {
+        DMA_CHCTL(dma_periph, channelx) &= ~source;
+    } else {
+        DMA_CHFCTL(dma_periph, channelx) &= ~source;
+    }
+}
+
+/*!
+    \brief    get DMA interrupt flag is set or not
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel to get interrupt flag
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  interrupt: specify get which flag
+                only one parameter can be selected which is shown as below:
+      \arg        DMA_INT_FLAG_FEE: FIFO error and exception flag
+      \arg        DMA_INT_FLAG_SDE: single data mode exception flag
+      \arg        DMA_INT_FLAG_TAE: transfer access error flag
+      \arg        DMA_INT_FLAG_HTF: half transfer finish flag
+      \arg        DMA_INT_FLAG_FTF: full transger finish flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus dma_interrupt_flag_get(uint32_t dma_periph, dma_channel_enum channelx, uint32_t interrupt)
+{
+    uint32_t interrupt_enable = 0U, interrupt_flag = 0U;
+    dma_channel_enum channel_flag_offset = channelx;
+    if(channelx < DMA_CH4) {
+        switch(interrupt) {
+        case DMA_INTF_FEEIF:
+            interrupt_flag = DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt, channelx);
+            interrupt_enable = DMA_CHFCTL(dma_periph, channelx) & DMA_CHXFCTL_FEEIE;
+            break;
+        case DMA_INTF_SDEIF:
+            interrupt_flag = DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt, channelx);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_SDEIE;
+            break;
+        case DMA_INTF_TAEIF:
+            interrupt_flag = DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt, channelx);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_TAEIE;
+            break;
+        case DMA_INTF_HTFIF:
+            interrupt_flag = DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt, channelx);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_HTFIE;
+            break;
+        case DMA_INTF_FTFIF:
+            interrupt_flag = (DMA_INTF0(dma_periph) & DMA_FLAG_ADD(interrupt, channelx));
+            interrupt_enable = (DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_FTFIE);
+            break;
+        default:
+            break;
+        }
+    } else {
+        channel_flag_offset -= (dma_channel_enum)4;
+        switch(interrupt) {
+        case DMA_INTF_FEEIF:
+            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt, channel_flag_offset);
+            interrupt_enable = DMA_CHFCTL(dma_periph, channelx) & DMA_CHXFCTL_FEEIE;
+            break;
+        case DMA_INTF_SDEIF:
+            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt, channel_flag_offset);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_SDEIE;
+            break;
+        case DMA_INTF_TAEIF:
+            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt, channel_flag_offset);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_TAEIE;
+            break;
+        case DMA_INTF_HTFIF:
+            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt, channel_flag_offset);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_HTFIE;
+            break;
+        case DMA_INTF_FTFIF:
+            interrupt_flag = DMA_INTF1(dma_periph) & DMA_FLAG_ADD(interrupt, channel_flag_offset);
+            interrupt_enable = DMA_CHCTL(dma_periph, channelx) & DMA_CHXCTL_FTFIE;
+            break;
+        default:
+            break;
+        }
+    }
+
+    if(interrupt_flag && interrupt_enable) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    clear DMA a channel interrupt flag
+    \param[in]  dma_periph: DMAx(x=0,1)
+      \arg        DMAx(x=0,1)
+    \param[in]  channelx: specify which DMA channel to clear interrupt flag
+      \arg        DMA_CHx(x=0..7)
+    \param[in]  interrupt: specify get which flag
+                only one parameter can be selected which is shown as below:
+      \arg        DMA_INT_FLAG_FEE: FIFO error and exception flag
+      \arg        DMA_INT_FLAG_SDE: single data mode exception flag
+      \arg        DMA_INT_FLAG_TAE: transfer access error flag
+      \arg        DMA_INT_FLAG_HTF: half transfer finish flag
+      \arg        DMA_INT_FLAG_FTF: full transger finish flag
+    \param[out] none
+    \retval     none
+*/
+void dma_interrupt_flag_clear(uint32_t dma_periph, dma_channel_enum channelx, uint32_t interrupt)
+{
+    if(channelx < DMA_CH4) {
+        DMA_INTC0(dma_periph) |= DMA_FLAG_ADD(interrupt, channelx);
+    } else {
+        channelx -= (dma_channel_enum)4;
+        DMA_INTC1(dma_periph) |= DMA_FLAG_ADD(interrupt, channelx);
+    }
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_enet.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_enet.c
@@ -1,0 +1,3510 @@
+/*!
+    \file    gd32f4xx_enet.c
+    \brief   ENET driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_enet.h"
+
+#if defined   (__CC_ARM)                                    /*!< ARM compiler */
+__align(4)
+enet_descriptors_struct  rxdesc_tab[ENET_RXBUF_NUM];        /*!< ENET RxDMA descriptor */
+__align(4)
+enet_descriptors_struct  txdesc_tab[ENET_TXBUF_NUM];        /*!< ENET TxDMA descriptor */
+__align(4)
+uint8_t rx_buff[ENET_RXBUF_NUM][ENET_RXBUF_SIZE];           /*!< ENET receive buffer */
+__align(4)
+uint8_t tx_buff[ENET_TXBUF_NUM][ENET_TXBUF_SIZE];           /*!< ENET transmit buffer */
+
+#elif defined ( __ICCARM__ )                                /*!< IAR compiler */
+#pragma data_alignment=4
+enet_descriptors_struct  rxdesc_tab[ENET_RXBUF_NUM];        /*!< ENET RxDMA descriptor */
+#pragma data_alignment=4
+enet_descriptors_struct  txdesc_tab[ENET_TXBUF_NUM];        /*!< ENET TxDMA descriptor */
+#pragma data_alignment=4
+uint8_t rx_buff[ENET_RXBUF_NUM][ENET_RXBUF_SIZE];           /*!< ENET receive buffer */
+#pragma data_alignment=4
+uint8_t tx_buff[ENET_TXBUF_NUM][ENET_TXBUF_SIZE];           /*!< ENET transmit buffer */
+
+#elif defined (__GNUC__)        /* GNU Compiler */
+enet_descriptors_struct  rxdesc_tab[ENET_RXBUF_NUM] __attribute__((aligned(4)));          /*!< ENET RxDMA descriptor */
+enet_descriptors_struct  txdesc_tab[ENET_TXBUF_NUM] __attribute__((aligned(4)));          /*!< ENET TxDMA descriptor */
+uint8_t rx_buff[ENET_RXBUF_NUM][ENET_RXBUF_SIZE] __attribute__((aligned(4)));             /*!< ENET receive buffer */
+uint8_t tx_buff[ENET_TXBUF_NUM][ENET_TXBUF_SIZE] __attribute__((aligned(4)));             /*!< ENET transmit buffer */
+
+#endif /* __CC_ARM */
+
+/* global transmit and receive descriptors pointers */
+enet_descriptors_struct  *dma_current_txdesc;
+enet_descriptors_struct  *dma_current_rxdesc;
+
+/* structure pointer of ptp descriptor for normal mode */
+enet_descriptors_struct  *dma_current_ptp_txdesc = NULL;
+enet_descriptors_struct  *dma_current_ptp_rxdesc = NULL;
+
+/* init structure parameters for ENET initialization */
+static enet_initpara_struct enet_initpara = {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0};
+static uint32_t enet_unknow_err = 0U;
+/* array of register offset for debug information get */
+static const uint16_t enet_reg_tab[] = {
+    0x0000, 0x0004, 0x0008, 0x000C, 0x0010, 0x0014, 0x0018, 0x001C, 0x0028, 0x002C, 0x0034,
+    0x0038, 0x003C, 0x0040, 0x0044, 0x0048, 0x004C, 0x0050, 0x0054, 0x0058, 0x005C, 0x1080,
+
+    0x0100, 0x0104, 0x0108, 0x010C, 0x0110, 0x014C, 0x0150, 0x0168, 0x0194, 0x0198, 0x01C4,
+
+    0x0700, 0x0704, 0x0708, 0x070C, 0x0710, 0x0714, 0x0718, 0x071C, 0x0720, 0x0728, 0x072C,
+
+    0x1000, 0x1004, 0x1008, 0x100C, 0x1010, 0x1014, 0x1018, 0x101C, 0x1020, 0x1024, 0x1048,
+    0x104C, 0x1050, 0x1054
+};
+
+/* initialize ENET peripheral with generally concerned parameters, call it by enet_init() */
+static void enet_default_init(void);
+#ifdef USE_DELAY
+/* user can provide more timing precise _ENET_DELAY_ function */
+#define _ENET_DELAY_                              delay_ms
+#else
+/* insert a delay time */
+static void enet_delay(uint32_t ncount);
+/* default _ENET_DELAY_ function with less precise timing */
+#define _ENET_DELAY_                              enet_delay
+#endif
+
+
+/*!
+    \brief    deinitialize the ENET, and reset structure parameters for ENET initialization
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_deinit(void)
+{
+    rcu_periph_reset_enable(RCU_ENETRST);
+    rcu_periph_reset_disable(RCU_ENETRST);
+    enet_initpara_reset();
+}
+
+/*!
+    \brief    configure the parameters which are usually less cared for initialization
+                note -- this function must be called before enet_init(), otherwise
+                configuration will be no effect
+    \param[in]  option: different function option, which is related to several parameters, refer to enet_option_enum
+                only one parameter can be selected which is shown as below
+      \arg        FORWARD_OPTION: choose to configure the frame forward related parameters
+      \arg        DMABUS_OPTION: choose to configure the DMA bus mode related parameters
+      \arg        DMA_MAXBURST_OPTION: choose to configure the DMA max burst related parameters
+      \arg        DMA_ARBITRATION_OPTION: choose to configure the DMA arbitration related parameters
+      \arg        STORE_OPTION: choose to configure the store forward mode related parameters
+      \arg        DMA_OPTION: choose to configure the DMA descriptor related parameters
+      \arg        VLAN_OPTION: choose to configure vlan related parameters
+      \arg        FLOWCTL_OPTION: choose to configure flow control related parameters
+      \arg        HASHH_OPTION: choose to configure hash high
+      \arg        HASHL_OPTION: choose to configure hash low
+      \arg        FILTER_OPTION: choose to configure frame filter related parameters
+      \arg        HALFDUPLEX_OPTION: choose to configure halfduplex mode related parameters
+      \arg        TIMER_OPTION: choose to configure time counter related parameters
+      \arg        INTERFRAMEGAP_OPTION: choose to configure the inter frame gap related parameters
+    \param[in]  para: the related parameters according to the option
+                all the related parameters should be configured which are shown as below
+                      FORWARD_OPTION related parameters:
+                      -  ENET_AUTO_PADCRC_DROP_ENABLE/ ENET_AUTO_PADCRC_DROP_DISABLE ;
+                      -  ENET_TYPEFRAME_CRC_DROP_ENABLE/ ENET_TYPEFRAME_CRC_DROP_DISABLE ;
+                      -  ENET_FORWARD_ERRFRAMES_ENABLE/ ENET_FORWARD_ERRFRAMES_DISABLE ;
+                      -  ENET_FORWARD_UNDERSZ_GOODFRAMES_ENABLE/ ENET_FORWARD_UNDERSZ_GOODFRAMES_DISABLE .
+                      DMABUS_OPTION related parameters:
+                      -  ENET_ADDRESS_ALIGN_ENABLE/ ENET_ADDRESS_ALIGN_DISABLE ;
+                      -  ENET_FIXED_BURST_ENABLE/ ENET_FIXED_BURST_DISABLE ;
+                      -  ENET_MIXED_BURST_ENABLE/ ENET_MIXED_BURST_DISABLE ;
+                      DMA_MAXBURST_OPTION related parameters:
+                      -  ENET_RXDP_1BEAT/ ENET_RXDP_2BEAT/ ENET_RXDP_4BEAT/
+                         ENET_RXDP_8BEAT/ ENET_RXDP_16BEAT/ ENET_RXDP_32BEAT/
+                         ENET_RXDP_4xPGBL_4BEAT/ ENET_RXDP_4xPGBL_8BEAT/
+                         ENET_RXDP_4xPGBL_16BEAT/ ENET_RXDP_4xPGBL_32BEAT/
+                         ENET_RXDP_4xPGBL_64BEAT/ ENET_RXDP_4xPGBL_128BEAT ;
+                      -  ENET_PGBL_1BEAT/ ENET_PGBL_2BEAT/ ENET_PGBL_4BEAT/
+                         ENET_PGBL_8BEAT/ ENET_PGBL_16BEAT/ ENET_PGBL_32BEAT/
+                         ENET_PGBL_4xPGBL_4BEAT/ ENET_PGBL_4xPGBL_8BEAT/
+                         ENET_PGBL_4xPGBL_16BEAT/ ENET_PGBL_4xPGBL_32BEAT/
+                         ENET_PGBL_4xPGBL_64BEAT/ ENET_PGBL_4xPGBL_128BEAT ;
+                      -  ENET_RXTX_DIFFERENT_PGBL/ ENET_RXTX_SAME_PGBL ;
+                      DMA_ARBITRATION_OPTION related parameters:
+                      -  ENET_ARBITRATION_RXPRIORTX
+                      -  ENET_ARBITRATION_RXTX_1_1/ ENET_ARBITRATION_RXTX_2_1/
+                         ENET_ARBITRATION_RXTX_3_1/ ENET_ARBITRATION_RXTX_4_1/.
+                      STORE_OPTION related parameters:
+                      -  ENET_RX_MODE_STOREFORWARD/ ENET_RX_MODE_CUTTHROUGH ;
+                      -  ENET_TX_MODE_STOREFORWARD/ ENET_TX_MODE_CUTTHROUGH ;
+                      -  ENET_RX_THRESHOLD_64BYTES/ ENET_RX_THRESHOLD_32BYTES/
+                         ENET_RX_THRESHOLD_96BYTES/ ENET_RX_THRESHOLD_128BYTES ;
+                      -  ENET_TX_THRESHOLD_64BYTES/ ENET_TX_THRESHOLD_128BYTES/
+                         ENET_TX_THRESHOLD_192BYTES/ ENET_TX_THRESHOLD_256BYTES/
+                         ENET_TX_THRESHOLD_40BYTES/ ENET_TX_THRESHOLD_32BYTES/
+                         ENET_TX_THRESHOLD_24BYTES/ ENET_TX_THRESHOLD_16BYTES .
+                      DMA_OPTION related parameters:
+                      -  ENET_FLUSH_RXFRAME_ENABLE/ ENET_FLUSH_RXFRAME_DISABLE ;
+                      -  ENET_SECONDFRAME_OPT_ENABLE/ ENET_SECONDFRAME_OPT_DISABLE ;
+                      -  ENET_ENHANCED_DESCRIPTOR/ ENET_NORMAL_DESCRIPTOR .
+                      VLAN_OPTION related parameters:
+                      -  ENET_VLANTAGCOMPARISON_12BIT/ ENET_VLANTAGCOMPARISON_16BIT ;
+                      -  MAC_VLT_VLTI(regval) .
+                      FLOWCTL_OPTION related parameters:
+                      -  MAC_FCTL_PTM(regval) ;
+                      -  ENET_ZERO_QUANTA_PAUSE_ENABLE/ ENET_ZERO_QUANTA_PAUSE_DISABLE ;
+                      -  ENET_PAUSETIME_MINUS4/ ENET_PAUSETIME_MINUS28/
+                         ENET_PAUSETIME_MINUS144/ENET_PAUSETIME_MINUS256 ;
+                      -  ENET_MAC0_AND_UNIQUE_ADDRESS_PAUSEDETECT/ ENET_UNIQUE_PAUSEDETECT ;
+                      -  ENET_RX_FLOWCONTROL_ENABLE/ ENET_RX_FLOWCONTROL_DISABLE ;
+                      -  ENET_TX_FLOWCONTROL_ENABLE/ ENET_TX_FLOWCONTROL_DISABLE ;
+                      -  ENET_ACTIVE_THRESHOLD_256BYTES/ ENET_ACTIVE_THRESHOLD_512BYTES ;
+                      -  ENET_ACTIVE_THRESHOLD_768BYTES/ ENET_ACTIVE_THRESHOLD_1024BYTES ;
+                      -  ENET_ACTIVE_THRESHOLD_1280BYTES/ ENET_ACTIVE_THRESHOLD_1536BYTES ;
+                      -  ENET_ACTIVE_THRESHOLD_1792BYTES ;
+                      -  ENET_DEACTIVE_THRESHOLD_256BYTES/ ENET_DEACTIVE_THRESHOLD_512BYTES ;
+                      -  ENET_DEACTIVE_THRESHOLD_768BYTES/ ENET_DEACTIVE_THRESHOLD_1024BYTES ;
+                      -  ENET_DEACTIVE_THRESHOLD_1280BYTES/ ENET_DEACTIVE_THRESHOLD_1536BYTES ;
+                      -  ENET_DEACTIVE_THRESHOLD_1792BYTES .
+                      HASHH_OPTION related parameters:
+                      -  0x0~0xFFFF FFFFU
+                      HASHL_OPTION related parameters:
+                      -  0x0~0xFFFF FFFFU
+                      FILTER_OPTION related parameters:
+                      -  ENET_SRC_FILTER_NORMAL_ENABLE/ ENET_SRC_FILTER_INVERSE_ENABLE/
+                         ENET_SRC_FILTER_DISABLE ;
+                      -  ENET_DEST_FILTER_INVERSE_ENABLE/ ENET_DEST_FILTER_INVERSE_DISABLE ;
+                      -  ENET_MULTICAST_FILTER_HASH_OR_PERFECT/ ENET_MULTICAST_FILTER_HASH/
+                         ENET_MULTICAST_FILTER_PERFECT/ ENET_MULTICAST_FILTER_NONE ;
+                      -  ENET_UNICAST_FILTER_EITHER/ ENET_UNICAST_FILTER_HASH/
+                         ENET_UNICAST_FILTER_PERFECT ;
+                      -  ENET_PCFRM_PREVENT_ALL/ ENET_PCFRM_PREVENT_PAUSEFRAME/
+                         ENET_PCFRM_FORWARD_ALL/ ENET_PCFRM_FORWARD_FILTERED .
+                      HALFDUPLEX_OPTION related parameters:
+                      -  ENET_CARRIERSENSE_ENABLE/ ENET_CARRIERSENSE_DISABLE ;
+                      -  ENET_RECEIVEOWN_ENABLE/ ENET_RECEIVEOWN_DISABLE ;
+                      -  ENET_RETRYTRANSMISSION_ENABLE/ ENET_RETRYTRANSMISSION_DISABLE ;
+                      -  ENET_BACKOFFLIMIT_10/ ENET_BACKOFFLIMIT_8/
+                         ENET_BACKOFFLIMIT_4/ ENET_BACKOFFLIMIT_1 ;
+                      -  ENET_DEFERRALCHECK_ENABLE/ ENET_DEFERRALCHECK_DISABLE .
+                      TIMER_OPTION related parameters:
+                      -  ENET_WATCHDOG_ENABLE/ ENET_WATCHDOG_DISABLE ;
+                      -  ENET_JABBER_ENABLE/ ENET_JABBER_DISABLE ;
+                      INTERFRAMEGAP_OPTION related parameters:
+                      -  ENET_INTERFRAMEGAP_96BIT/ ENET_INTERFRAMEGAP_88BIT/
+                         ENET_INTERFRAMEGAP_80BIT/ ENET_INTERFRAMEGAP_72BIT/
+                         ENET_INTERFRAMEGAP_64BIT/ ENET_INTERFRAMEGAP_56BIT/
+                         ENET_INTERFRAMEGAP_48BIT/ ENET_INTERFRAMEGAP_40BIT .
+    \param[out] none
+    \retval     none
+*/
+void enet_initpara_config(enet_option_enum option, uint32_t para)
+{
+    switch(option) {
+    case FORWARD_OPTION:
+        /* choose to configure forward_frame, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)FORWARD_OPTION;
+        enet_initpara.forward_frame = para;
+        break;
+    case DMABUS_OPTION:
+        /* choose to configure dmabus_mode, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)DMABUS_OPTION;
+        enet_initpara.dmabus_mode = para;
+        break;
+    case DMA_MAXBURST_OPTION:
+        /* choose to configure dma_maxburst, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)DMA_MAXBURST_OPTION;
+        enet_initpara.dma_maxburst = para;
+        break;
+    case DMA_ARBITRATION_OPTION:
+        /* choose to configure dma_arbitration, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)DMA_ARBITRATION_OPTION;
+        enet_initpara.dma_arbitration = para;
+        break;
+    case STORE_OPTION:
+        /* choose to configure store_forward_mode, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)STORE_OPTION;
+        enet_initpara.store_forward_mode = para;
+        break;
+    case DMA_OPTION:
+        /* choose to configure dma_function, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)DMA_OPTION;
+
+#ifndef SELECT_DESCRIPTORS_ENHANCED_MODE
+        para &= ~ENET_ENHANCED_DESCRIPTOR;
+#endif /* SELECT_DESCRIPTORS_ENHANCED_MODE */
+
+        enet_initpara.dma_function = para;
+        break;
+    case VLAN_OPTION:
+        /* choose to configure vlan_config, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)VLAN_OPTION;
+        enet_initpara.vlan_config = para;
+        break;
+    case FLOWCTL_OPTION:
+        /* choose to configure flow_control, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)FLOWCTL_OPTION;
+        enet_initpara.flow_control = para;
+        break;
+    case HASHH_OPTION:
+        /* choose to configure hashtable_high, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)HASHH_OPTION;
+        enet_initpara.hashtable_high = para;
+        break;
+    case HASHL_OPTION:
+        /* choose to configure hashtable_low, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)HASHL_OPTION;
+        enet_initpara.hashtable_low = para;
+        break;
+    case FILTER_OPTION:
+        /* choose to configure framesfilter_mode, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)FILTER_OPTION;
+        enet_initpara.framesfilter_mode = para;
+        break;
+    case HALFDUPLEX_OPTION:
+        /* choose to configure halfduplex_param, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)HALFDUPLEX_OPTION;
+        enet_initpara.halfduplex_param = para;
+        break;
+    case TIMER_OPTION:
+        /* choose to configure timer_config, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)TIMER_OPTION;
+        enet_initpara.timer_config = para;
+        break;
+    case INTERFRAMEGAP_OPTION:
+        /* choose to configure interframegap, and save the configuration parameters */
+        enet_initpara.option_enable |= (uint32_t)INTERFRAMEGAP_OPTION;
+        enet_initpara.interframegap = para;
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief    initialize ENET peripheral with generally concerned parameters and the less cared
+                parameters
+    \param[in]  mediamode: PHY mode and mac loopback configurations, refer to enet_mediamode_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_AUTO_NEGOTIATION: PHY auto negotiation
+      \arg        ENET_100M_FULLDUPLEX: 100Mbit/s, full-duplex
+      \arg        ENET_100M_HALFDUPLEX: 100Mbit/s, half-duplex
+      \arg        ENET_10M_FULLDUPLEX: 10Mbit/s, full-duplex
+      \arg        ENET_10M_HALFDUPLEX: 10Mbit/s, half-duplex
+      \arg        ENET_LOOPBACKMODE: MAC in loopback mode at the MII
+    \param[in]  checksum: IP frame checksum offload function, refer to enet_mediamode_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_NO_AUTOCHECKSUM: disable IP frame checksum function
+      \arg        ENET_AUTOCHECKSUM_DROP_FAILFRAMES: enable IP frame checksum function
+      \arg        ENET_AUTOCHECKSUM_ACCEPT_FAILFRAMES: enable IP frame checksum function, and the received frame
+                                                       with only payload error but no other errors will not be dropped
+    \param[in]  recept: frame filter function, refer to enet_frmrecept_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_PROMISCUOUS_MODE: promiscuous mode enabled
+      \arg        ENET_RECEIVEALL: all received frame are forwarded to application
+      \arg        ENET_BROADCAST_FRAMES_PASS: the address filters pass all received broadcast frames
+      \arg        ENET_BROADCAST_FRAMES_DROP: the address filters filter all incoming broadcast frames
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus enet_init(enet_mediamode_enum mediamode, enet_chksumconf_enum checksum, enet_frmrecept_enum recept)
+{
+    uint32_t reg_value = 0U, reg_temp = 0U, temp = 0U;
+    uint32_t media_temp = 0U;
+    uint32_t timeout = 0U;
+    uint16_t phy_value = 0U;
+    ErrStatus phy_state = ERROR, enet_state = ERROR;
+
+    /* PHY interface configuration, configure SMI clock and reset PHY chip */
+    if(ERROR == enet_phy_config()) {
+        _ENET_DELAY_(PHY_RESETDELAY);
+        if(ERROR == enet_phy_config()) {
+            return enet_state;
+        }
+    }
+    /* initialize ENET peripheral with generally concerned parameters */
+    enet_default_init();
+
+    /* 1st, configure mediamode */
+    media_temp = (uint32_t)mediamode;
+    /* if is PHY auto negotiation */
+    if((uint32_t)ENET_AUTO_NEGOTIATION == media_temp) {
+        /* wait for PHY_LINKED_STATUS bit be set */
+        do {
+            enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_REG_BSR, &phy_value);
+            phy_value &= PHY_LINKED_STATUS;
+            timeout++;
+        } while((RESET == phy_value) && (timeout < PHY_READ_TO));
+        /* return ERROR due to timeout */
+        if(PHY_READ_TO == timeout) {
+            return enet_state;
+        }
+        /* reset timeout counter */
+        timeout = 0U;
+
+        /* enable auto-negotiation */
+        phy_value = PHY_AUTONEGOTIATION;
+        phy_state = enet_phy_write_read(ENET_PHY_WRITE, PHY_ADDRESS, PHY_REG_BCR, &phy_value);
+        if(!phy_state) {
+            /* return ERROR due to write timeout */
+            return enet_state;
+        }
+
+        /* wait for the PHY_AUTONEGO_COMPLETE bit be set */
+        do {
+            enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_REG_BSR, &phy_value);
+            phy_value &= PHY_AUTONEGO_COMPLETE;
+            timeout++;
+        } while((RESET == phy_value) && (timeout < (uint32_t)PHY_READ_TO));
+        /* return ERROR due to timeout */
+        if(PHY_READ_TO == timeout) {
+            return enet_state;
+        }
+        /* reset timeout counter */
+        timeout = 0U;
+
+        /* read the result of the auto-negotiation */
+        enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_SR, &phy_value);
+        /* configure the duplex mode of MAC following the auto-negotiation result */
+        if((uint16_t)RESET != (phy_value & PHY_DUPLEX_STATUS)) {
+            media_temp = ENET_MODE_FULLDUPLEX;
+        } else {
+            media_temp = ENET_MODE_HALFDUPLEX;
+        }
+        /* configure the communication speed of MAC following the auto-negotiation result */
+        if((uint16_t)RESET != (phy_value & PHY_SPEED_STATUS)) {
+            media_temp |= ENET_SPEEDMODE_10M;
+        } else {
+            media_temp |= ENET_SPEEDMODE_100M;
+        }
+    } else {
+        phy_value = (uint16_t)((media_temp & ENET_MAC_CFG_DPM) >> 3);
+        phy_value |= (uint16_t)((media_temp & ENET_MAC_CFG_SPD) >> 1);
+        phy_state = enet_phy_write_read(ENET_PHY_WRITE, PHY_ADDRESS, PHY_REG_BCR, &phy_value);
+        if(!phy_state) {
+            /* return ERROR due to write timeout */
+            return enet_state;
+        }
+        /* PHY configuration need some time */
+        _ENET_DELAY_(PHY_CONFIGDELAY);
+    }
+    /* after configuring the PHY, use mediamode to configure registers */
+    reg_value = ENET_MAC_CFG;
+    /* configure ENET_MAC_CFG register */
+    reg_value &= (~(ENET_MAC_CFG_SPD | ENET_MAC_CFG_DPM | ENET_MAC_CFG_LBM));
+    reg_value |= media_temp;
+    ENET_MAC_CFG = reg_value;
+
+
+    /* 2st, configure checksum */
+    if(RESET != ((uint32_t)checksum & ENET_CHECKSUMOFFLOAD_ENABLE)) {
+        ENET_MAC_CFG |= ENET_CHECKSUMOFFLOAD_ENABLE;
+
+        reg_value = ENET_DMA_CTL;
+        /* configure ENET_DMA_CTL register */
+        reg_value &= ~ENET_DMA_CTL_DTCERFD;
+        reg_value |= ((uint32_t)checksum & ENET_DMA_CTL_DTCERFD);
+        ENET_DMA_CTL = reg_value;
+    }
+
+    /* 3rd, configure recept */
+    ENET_MAC_FRMF |= (uint32_t)recept;
+
+    /* 4th, configure different function options */
+    /* configure forward_frame related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)FORWARD_OPTION)) {
+        reg_temp = enet_initpara.forward_frame;
+
+        reg_value = ENET_MAC_CFG;
+        temp = reg_temp;
+        /* configure ENET_MAC_CFG register */
+        reg_value &= (~(ENET_MAC_CFG_TFCD | ENET_MAC_CFG_APCD));
+        temp &= (ENET_MAC_CFG_TFCD | ENET_MAC_CFG_APCD);
+        reg_value |= temp;
+        ENET_MAC_CFG = reg_value;
+
+        reg_value = ENET_DMA_CTL;
+        temp = reg_temp;
+        /* configure ENET_DMA_CTL register */
+        reg_value &= (~(ENET_DMA_CTL_FERF | ENET_DMA_CTL_FUF));
+        temp &= ((ENET_DMA_CTL_FERF | ENET_DMA_CTL_FUF) << 2);
+        reg_value |= (temp >> 2);
+        ENET_DMA_CTL = reg_value;
+    }
+
+    /* configure dmabus_mode related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)DMABUS_OPTION)) {
+        temp = enet_initpara.dmabus_mode;
+
+        reg_value = ENET_DMA_BCTL;
+        /* configure ENET_DMA_BCTL register */
+        reg_value &= ~(ENET_DMA_BCTL_AA | ENET_DMA_BCTL_FB \
+                       | ENET_DMA_BCTL_FPBL | ENET_DMA_BCTL_MB);
+        reg_value |= temp;
+        ENET_DMA_BCTL = reg_value;
+    }
+
+    /* configure dma_maxburst related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)DMA_MAXBURST_OPTION)) {
+        temp = enet_initpara.dma_maxburst;
+
+        reg_value = ENET_DMA_BCTL;
+        /* configure ENET_DMA_BCTL register */
+        reg_value &= ~(ENET_DMA_BCTL_RXDP | ENET_DMA_BCTL_PGBL | ENET_DMA_BCTL_UIP);
+        reg_value |= temp;
+        ENET_DMA_BCTL = reg_value;
+    }
+
+    /* configure dma_arbitration related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)DMA_ARBITRATION_OPTION)) {
+        temp = enet_initpara.dma_arbitration;
+
+        reg_value = ENET_DMA_BCTL;
+        /* configure ENET_DMA_BCTL register */
+        reg_value &= ~(ENET_DMA_BCTL_RTPR | ENET_DMA_BCTL_DAB);
+        reg_value |= temp;
+        ENET_DMA_BCTL = reg_value;
+    }
+
+    /* configure store_forward_mode related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)STORE_OPTION)) {
+        temp = enet_initpara.store_forward_mode;
+
+        reg_value = ENET_DMA_CTL;
+        /* configure ENET_DMA_CTL register */
+        reg_value &= ~(ENET_DMA_CTL_RSFD | ENET_DMA_CTL_TSFD | ENET_DMA_CTL_RTHC | ENET_DMA_CTL_TTHC);
+        reg_value |= temp;
+        ENET_DMA_CTL = reg_value;
+    }
+
+    /* configure dma_function related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)DMA_OPTION)) {
+        reg_temp = enet_initpara.dma_function;
+
+        reg_value = ENET_DMA_CTL;
+        temp = reg_temp;
+        /* configure ENET_DMA_CTL register */
+        reg_value &= (~(ENET_DMA_CTL_DAFRF | ENET_DMA_CTL_OSF));
+        temp &= (ENET_DMA_CTL_DAFRF | ENET_DMA_CTL_OSF);
+        reg_value |= temp;
+        ENET_DMA_CTL = reg_value;
+
+        reg_value = ENET_DMA_BCTL;
+        temp = reg_temp;
+        /* configure ENET_DMA_BCTL register */
+        reg_value &= (~ENET_DMA_BCTL_DFM);
+        temp &= ENET_DMA_BCTL_DFM;
+        reg_value |= temp;
+        ENET_DMA_BCTL = reg_value;
+    }
+
+    /* configure vlan_config related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)VLAN_OPTION)) {
+        reg_temp = enet_initpara.vlan_config;
+
+        reg_value = ENET_MAC_VLT;
+        /* configure ENET_MAC_VLT register */
+        reg_value &= ~(ENET_MAC_VLT_VLTI | ENET_MAC_VLT_VLTC);
+        reg_value |= reg_temp;
+        ENET_MAC_VLT = reg_value;
+    }
+
+    /* configure flow_control related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)FLOWCTL_OPTION)) {
+        reg_temp = enet_initpara.flow_control;
+
+        reg_value = ENET_MAC_FCTL;
+        temp = reg_temp;
+        /* configure ENET_MAC_FCTL register */
+        reg_value &= ~(ENET_MAC_FCTL_PTM | ENET_MAC_FCTL_DZQP | ENET_MAC_FCTL_PLTS \
+                       | ENET_MAC_FCTL_UPFDT | ENET_MAC_FCTL_RFCEN | ENET_MAC_FCTL_TFCEN);
+        temp &= (ENET_MAC_FCTL_PTM | ENET_MAC_FCTL_DZQP | ENET_MAC_FCTL_PLTS \
+                 | ENET_MAC_FCTL_UPFDT | ENET_MAC_FCTL_RFCEN | ENET_MAC_FCTL_TFCEN);
+        reg_value |= temp;
+        ENET_MAC_FCTL = reg_value;
+
+        reg_value = ENET_MAC_FCTH;
+        temp = reg_temp;
+        /* configure ENET_MAC_FCTH register */
+        reg_value &= ~(ENET_MAC_FCTH_RFA | ENET_MAC_FCTH_RFD);
+        temp &= ((ENET_MAC_FCTH_RFA | ENET_MAC_FCTH_RFD) << 8);
+        reg_value |= (temp >> 8);
+        ENET_MAC_FCTH = reg_value;
+    }
+
+    /* configure hashtable_high related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)HASHH_OPTION)) {
+        ENET_MAC_HLH = enet_initpara.hashtable_high;
+    }
+
+    /* configure hashtable_low related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)HASHL_OPTION)) {
+        ENET_MAC_HLL = enet_initpara.hashtable_low;
+    }
+
+    /* configure framesfilter_mode related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)FILTER_OPTION)) {
+        reg_temp = enet_initpara.framesfilter_mode;
+
+        reg_value = ENET_MAC_FRMF;
+        /* configure ENET_MAC_FRMF register */
+        reg_value &= ~(ENET_MAC_FRMF_SAFLT | ENET_MAC_FRMF_SAIFLT | ENET_MAC_FRMF_DAIFLT \
+                       | ENET_MAC_FRMF_HMF | ENET_MAC_FRMF_HPFLT | ENET_MAC_FRMF_MFD \
+                       | ENET_MAC_FRMF_HUF | ENET_MAC_FRMF_PCFRM);
+        reg_value |= reg_temp;
+        ENET_MAC_FRMF = reg_value;
+    }
+
+    /* configure halfduplex_param related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)HALFDUPLEX_OPTION)) {
+        reg_temp = enet_initpara.halfduplex_param;
+
+        reg_value = ENET_MAC_CFG;
+        /* configure ENET_MAC_CFG register */
+        reg_value &= ~(ENET_MAC_CFG_CSD | ENET_MAC_CFG_ROD | ENET_MAC_CFG_RTD \
+                       | ENET_MAC_CFG_BOL | ENET_MAC_CFG_DFC);
+        reg_value |= reg_temp;
+        ENET_MAC_CFG = reg_value;
+    }
+
+    /* configure timer_config related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)TIMER_OPTION)) {
+        reg_temp = enet_initpara.timer_config;
+
+        reg_value = ENET_MAC_CFG;
+        /* configure ENET_MAC_CFG register */
+        reg_value &= ~(ENET_MAC_CFG_WDD | ENET_MAC_CFG_JBD);
+        reg_value |= reg_temp;
+        ENET_MAC_CFG = reg_value;
+    }
+
+    /* configure interframegap related registers */
+    if(RESET != (enet_initpara.option_enable & (uint32_t)INTERFRAMEGAP_OPTION)) {
+        reg_temp = enet_initpara.interframegap;
+
+        reg_value = ENET_MAC_CFG;
+        /* configure ENET_MAC_CFG register */
+        reg_value &= ~ENET_MAC_CFG_IGBS;
+        reg_value |= reg_temp;
+        ENET_MAC_CFG = reg_value;
+    }
+
+    enet_state = SUCCESS;
+    return enet_state;
+}
+
+/*!
+    \brief    reset all core internal registers located in CLK_TX and CLK_RX
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus enet_software_reset(void)
+{
+    uint32_t timeout = 0U;
+    ErrStatus enet_state = ERROR;
+    uint32_t dma_flag;
+
+    /* reset all core internal registers located in CLK_TX and CLK_RX */
+    ENET_DMA_BCTL |= ENET_DMA_BCTL_SWR;
+
+    /* wait for reset operation complete */
+    do {
+        dma_flag = (ENET_DMA_BCTL & ENET_DMA_BCTL_SWR);
+        timeout++;
+    } while((RESET != dma_flag) && (ENET_DELAY_TO != timeout));
+
+    /* reset operation complete */
+    if(RESET == (ENET_DMA_BCTL & ENET_DMA_BCTL_SWR)) {
+        enet_state = SUCCESS;
+    }
+
+    return enet_state;
+}
+
+/*!
+    \brief    check receive frame valid and return frame size
+    \param[in]  none
+    \param[out] none
+    \retval     size of received frame: 0x0 - 0x3FFF
+*/
+uint32_t enet_rxframe_size_get(void)
+{
+    uint32_t size = 0U;
+    uint32_t status;
+
+    /* get rdes0 information of current RxDMA descriptor */
+    status = dma_current_rxdesc->status;
+
+    /* if the desciptor is owned by DMA */
+    if((uint32_t)RESET != (status & ENET_RDES0_DAV)) {
+        return 0U;
+    }
+
+    /* if has any error, or the frame uses two or more descriptors */
+    if((((uint32_t)RESET) != (status & ENET_RDES0_ERRS)) ||
+            (((uint32_t)RESET) == (status & ENET_RDES0_LDES)) ||
+            (((uint32_t)RESET) == (status & ENET_RDES0_FDES))) {
+        /* drop current receive frame */
+        enet_rxframe_drop();
+
+        return 1U;
+    }
+#ifdef SELECT_DESCRIPTORS_ENHANCED_MODE
+    /* if is an ethernet-type frame, and IP frame payload error occurred */
+    if(((uint32_t)RESET) != (dma_current_rxdesc->status & ENET_RDES0_FRMT) &&
+            ((uint32_t)RESET) != (dma_current_rxdesc->extended_status & ENET_RDES4_IPPLDERR)) {
+        /* drop current receive frame */
+        enet_rxframe_drop();
+
+        return 1U;
+    }
+#else
+    /* if is an ethernet-type frame, and IP frame payload error occurred */
+    if((((uint32_t)RESET) != (status & ENET_RDES0_FRMT)) &&
+            (((uint32_t)RESET) != (status & ENET_RDES0_PCERR))) {
+        /* drop current receive frame */
+        enet_rxframe_drop();
+
+        return 1U;
+    }
+#endif
+    /* if CPU owns current descriptor, no error occured, the frame uses only one descriptor */
+    if((((uint32_t)RESET) == (status & ENET_RDES0_DAV)) &&
+            (((uint32_t)RESET) == (status & ENET_RDES0_ERRS)) &&
+            (((uint32_t)RESET) != (status & ENET_RDES0_LDES)) &&
+            (((uint32_t)RESET) != (status & ENET_RDES0_FDES))) {
+        /* get the size of the received data including CRC */
+        size = GET_RDES0_FRML(status);
+        /* substract the CRC size */
+        size = size - 4U;
+
+        /* if is a type frame, and CRC is not included in forwarding frame */
+        if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (status & ENET_RDES0_FRMT))) {
+            size = size + 4U;
+        }
+    } else {
+        enet_unknow_err++;
+        enet_rxframe_drop();
+
+        return 1U;
+    }
+
+    /* return packet size */
+    return size;
+}
+
+/*!
+    \brief    initialize the DMA Tx/Rx descriptors's parameters in chain mode
+    \param[in]  direction: the descriptors which users want to init, refer to enet_dmadirection_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_DMA_TX: DMA Tx descriptors
+      \arg        ENET_DMA_RX: DMA Rx descriptors
+    \param[out] none
+    \retval     none
+*/
+void enet_descriptors_chain_init(enet_dmadirection_enum direction)
+{
+    uint32_t num = 0U, count = 0U, maxsize = 0U;
+    uint32_t desc_status = 0U, desc_bufsize = 0U;
+    enet_descriptors_struct *desc, *desc_tab;
+    uint8_t *buf;
+
+    /* if want to initialize DMA Tx descriptors */
+    if(ENET_DMA_TX == direction) {
+        /* save a copy of the DMA Tx descriptors */
+        desc_tab = txdesc_tab;
+        buf = &tx_buff[0][0];
+        count = ENET_TXBUF_NUM;
+        maxsize = ENET_TXBUF_SIZE;
+
+        /* select chain mode */
+        desc_status = ENET_TDES0_TCHM;
+
+        /* configure DMA Tx descriptor table address register */
+        ENET_DMA_TDTADDR = (uint32_t)desc_tab;
+        dma_current_txdesc = desc_tab;
+    } else {
+        /* if want to initialize DMA Rx descriptors */
+        /* save a copy of the DMA Rx descriptors */
+        desc_tab = rxdesc_tab;
+        buf = &rx_buff[0][0];
+        count = ENET_RXBUF_NUM;
+        maxsize = ENET_RXBUF_SIZE;
+
+        /* enable receiving */
+        desc_status = ENET_RDES0_DAV;
+        /* select receive chained mode and set buffer1 size */
+        desc_bufsize = ENET_RDES1_RCHM | (uint32_t)ENET_RXBUF_SIZE;
+
+        /* configure DMA Rx descriptor table address register */
+        ENET_DMA_RDTADDR = (uint32_t)desc_tab;
+        dma_current_rxdesc = desc_tab;
+    }
+    dma_current_ptp_rxdesc = NULL;
+    dma_current_ptp_txdesc = NULL;
+
+    /* configure each descriptor */
+    for(num = 0U; num < count; num++) {
+        /* get the pointer to the next descriptor of the descriptor table */
+        desc = desc_tab + num;
+
+        /* configure descriptors */
+        desc->status = desc_status;
+        desc->control_buffer_size = desc_bufsize;
+        desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);
+
+        /* if is not the last descriptor */
+        if(num < (count - 1U)) {
+            /* configure the next descriptor address */
+            desc->buffer2_next_desc_addr = (uint32_t)(desc_tab + num + 1U);
+        } else {
+            /* when it is the last descriptor, the next descriptor address
+            equals to first descriptor address in descriptor table */
+            desc->buffer2_next_desc_addr = (uint32_t) desc_tab;
+        }
+    }
+}
+
+/*!
+    \brief    initialize the DMA Tx/Rx descriptors's parameters in ring mode
+    \param[in]  direction: the descriptors which users want to init, refer to enet_dmadirection_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_DMA_TX: DMA Tx descriptors
+      \arg        ENET_DMA_RX: DMA Rx descriptors
+    \param[out] none
+    \retval     none
+*/
+void enet_descriptors_ring_init(enet_dmadirection_enum direction)
+{
+    uint32_t num = 0U, count = 0U, maxsize = 0U;
+    uint32_t desc_status = 0U, desc_bufsize = 0U;
+    enet_descriptors_struct *desc;
+    enet_descriptors_struct *desc_tab;
+    uint8_t *buf;
+
+    /* configure descriptor skip length */
+    ENET_DMA_BCTL &= ~ENET_DMA_BCTL_DPSL;
+    ENET_DMA_BCTL |= DMA_BCTL_DPSL(0);
+
+    /* if want to initialize DMA Tx descriptors */
+    if(ENET_DMA_TX == direction) {
+        /* save a copy of the DMA Tx descriptors */
+        desc_tab = txdesc_tab;
+        buf = &tx_buff[0][0];
+        count = ENET_TXBUF_NUM;
+        maxsize = ENET_TXBUF_SIZE;
+
+        /* configure DMA Tx descriptor table address register */
+        ENET_DMA_TDTADDR = (uint32_t)desc_tab;
+        dma_current_txdesc = desc_tab;
+    } else {
+        /* if want to initialize DMA Rx descriptors */
+        /* save a copy of the DMA Rx descriptors */
+        desc_tab = rxdesc_tab;
+        buf = &rx_buff[0][0];
+        count = ENET_RXBUF_NUM;
+        maxsize = ENET_RXBUF_SIZE;
+
+        /* enable receiving */
+        desc_status = ENET_RDES0_DAV;
+        /* set buffer1 size */
+        desc_bufsize = ENET_RXBUF_SIZE;
+
+        /* configure DMA Rx descriptor table address register */
+        ENET_DMA_RDTADDR = (uint32_t)desc_tab;
+        dma_current_rxdesc = desc_tab;
+    }
+    dma_current_ptp_rxdesc = NULL;
+    dma_current_ptp_txdesc = NULL;
+
+    /* configure each descriptor */
+    for(num = 0U; num < count; num++) {
+        /* get the pointer to the next descriptor of the descriptor table */
+        desc = desc_tab + num;
+
+        /* configure descriptors */
+        desc->status = desc_status;
+        desc->control_buffer_size = desc_bufsize;
+        desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);
+
+        /* when it is the last descriptor */
+        if(num == (count - 1U)) {
+            if(ENET_DMA_TX == direction) {
+                /* configure transmit end of ring mode */
+                desc->status |= ENET_TDES0_TERM;
+            } else {
+                /* configure receive end of ring mode */
+                desc->control_buffer_size |= ENET_RDES1_RERM;
+            }
+        }
+    }
+}
+
+/*!
+    \brief    handle current received frame data to application buffer
+    \param[in]  bufsize: the size of buffer which is the parameter in function
+    \param[out] buffer: pointer to the received frame data
+                note -- if the input is NULL, user should copy data in application by himself
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus enet_frame_receive(uint8_t *buffer, uint32_t bufsize)
+{
+    uint32_t offset = 0U, size = 0U;
+
+    /* the descriptor is busy due to own by the DMA */
+    if((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_DAV)) {
+        return ERROR;
+    }
+
+
+    /* if buffer pointer is null, indicates that users has copied data in application */
+    if(NULL != buffer) {
+        /* if no error occurs, and the frame uses only one descriptor */
+        if((((uint32_t)RESET) == (dma_current_rxdesc->status & ENET_RDES0_ERRS)) &&
+                (((uint32_t)RESET) != (dma_current_rxdesc->status & ENET_RDES0_LDES)) &&
+                (((uint32_t)RESET) != (dma_current_rxdesc->status & ENET_RDES0_FDES))) {
+            /* get the frame length except CRC */
+            size = GET_RDES0_FRML(dma_current_rxdesc->status);
+            size = size - 4U;
+
+            /* if is a type frame, and CRC is not included in forwarding frame */
+            if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (dma_current_rxdesc->status & ENET_RDES0_FRMT))) {
+                size = size + 4U;
+            }
+
+            /* to avoid situation that the frame size exceeds the buffer length */
+            if(size > bufsize) {
+                return ERROR;
+            }
+
+            /* copy data from Rx buffer to application buffer */
+            for(offset = 0U; offset < size; offset++) {
+                (*(buffer + offset)) = (*(__IO uint8_t *)(uint32_t)((dma_current_rxdesc->buffer1_addr) + offset));
+            }
+
+        } else {
+            /* return ERROR */
+            return ERROR;
+        }
+    }
+    /* enable reception, descriptor is owned by DMA */
+    dma_current_rxdesc->status = ENET_RDES0_DAV;
+
+    /* check Rx buffer unavailable flag status */
+    if((uint32_t)RESET != (ENET_DMA_STAT & ENET_DMA_STAT_RBU)) {
+        /* clear RBU flag */
+        ENET_DMA_STAT = ENET_DMA_STAT_RBU;
+        /* resume DMA reception by writing to the RPEN register*/
+        ENET_DMA_RPEN = 0U;
+    }
+
+    /* update the current RxDMA descriptor pointer to the next decriptor in RxDMA decriptor table */
+    /* chained mode */
+    if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RCHM)) {
+        dma_current_rxdesc = (enet_descriptors_struct *)(dma_current_rxdesc->buffer2_next_desc_addr);
+    } else {
+        /* ring mode */
+        if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RERM)) {
+            /* if is the last descriptor in table, the next descriptor is the table header */
+            dma_current_rxdesc = (enet_descriptors_struct *)(ENET_DMA_RDTADDR);
+        } else {
+            /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
+            dma_current_rxdesc = (enet_descriptors_struct *)(uint32_t)((uint32_t)dma_current_rxdesc + ETH_DMARXDESC_SIZE + (GET_DMA_BCTL_DPSL(ENET_DMA_BCTL)));
+        }
+    }
+
+    return SUCCESS;
+}
+
+/*!
+    \brief    handle application buffer data to transmit it
+    \param[in]  buffer: pointer to the frame data to be transmitted,
+                note -- if the input is NULL, user should handle the data in application by himself
+    \param[in]  length: the length of frame data to be transmitted
+    \param[out] none
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus enet_frame_transmit(uint8_t *buffer, uint32_t length)
+{
+    uint32_t offset = 0U;
+    uint32_t dma_tbu_flag, dma_tu_flag;
+
+    /* the descriptor is busy due to own by the DMA */
+    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_DAV)) {
+        return ERROR;
+    }
+
+    /* only frame length no more than ENET_MAX_FRAME_SIZE is allowed */
+    if(length > ENET_MAX_FRAME_SIZE) {
+        return ERROR;
+    }
+
+    /* if buffer pointer is null, indicates that users has handled data in application */
+    if(NULL != buffer) {
+        /* copy frame data from application buffer to Tx buffer */
+        for(offset = 0U; offset < length; offset++) {
+            (*(__IO uint8_t *)(uint32_t)((dma_current_txdesc->buffer1_addr) + offset)) = (*(buffer + offset));
+        }
+    }
+
+    /* set the frame length */
+    dma_current_txdesc->control_buffer_size = length;
+    /* set the segment of frame, frame is transmitted in one descriptor */
+    dma_current_txdesc->status |= ENET_TDES0_LSG | ENET_TDES0_FSG;
+    /* enable the DMA transmission */
+    dma_current_txdesc->status |= ENET_TDES0_DAV;
+
+    /* check Tx buffer unavailable flag status */
+    dma_tbu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TBU);
+    dma_tu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TU);
+
+    if((RESET != dma_tbu_flag) || (RESET != dma_tu_flag)) {
+        /* clear TBU and TU flag */
+        ENET_DMA_STAT = (dma_tbu_flag | dma_tu_flag);
+        /* resume DMA transmission by writing to the TPEN register*/
+        ENET_DMA_TPEN = 0U;
+    }
+
+    /* update the current TxDMA descriptor pointer to the next decriptor in TxDMA decriptor table*/
+    /* chained mode */
+    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TCHM)) {
+        dma_current_txdesc = (enet_descriptors_struct *)(dma_current_txdesc->buffer2_next_desc_addr);
+    } else {
+        /* ring mode */
+        if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TERM)) {
+            /* if is the last descriptor in table, the next descriptor is the table header */
+            dma_current_txdesc = (enet_descriptors_struct *)(ENET_DMA_TDTADDR);
+        } else {
+            /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
+            dma_current_txdesc = (enet_descriptors_struct *)(uint32_t)((uint32_t)dma_current_txdesc + ETH_DMATXDESC_SIZE + (GET_DMA_BCTL_DPSL(ENET_DMA_BCTL)));
+        }
+    }
+
+    return SUCCESS;
+}
+
+/*!
+    \brief    configure the transmit IP frame checksum offload calculation and insertion
+    \param[in]  desc: the descriptor pointer which users want to configure, refer to enet_descriptors_struct
+    \param[in]  checksum: IP frame checksum configuration
+                only one parameter can be selected which is shown as below
+      \arg        ENET_CHECKSUM_DISABLE: checksum insertion disabled
+      \arg        ENET_CHECKSUM_IPV4HEADER: only IP header checksum calculation and insertion are enabled
+      \arg        ENET_CHECKSUM_TCPUDPICMP_SEGMENT: TCP/UDP/ICMP checksum insertion calculated but pseudo-header
+      \arg        ENET_CHECKSUM_TCPUDPICMP_FULL: TCP/UDP/ICMP checksum insertion fully calculated
+    \param[out] none
+    \retval     none
+*/
+void enet_transmit_checksum_config(enet_descriptors_struct *desc, uint32_t checksum)
+{
+    desc->status &= ~ENET_TDES0_CM;
+    desc->status |= checksum;
+}
+
+/*!
+    \brief    ENET Tx and Rx function enable (include MAC and DMA module)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_enable(void)
+{
+    enet_tx_enable();
+    enet_rx_enable();
+}
+
+/*!
+    \brief    ENET Tx and Rx function disable (include MAC and DMA module)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_disable(void)
+{
+    enet_tx_disable();
+    enet_rx_disable();
+}
+
+/*!
+    \brief    configure MAC address
+    \param[in]  mac_addr: select which MAC address will be set, refer to enet_macaddress_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_MAC_ADDRESS0: set MAC address 0 filter
+      \arg        ENET_MAC_ADDRESS1: set MAC address 1 filter
+      \arg        ENET_MAC_ADDRESS2: set MAC address 2 filter
+      \arg        ENET_MAC_ADDRESS3: set MAC address 3 filter
+    \param[in]  paddr: the buffer pointer which stores the MAC address
+                  (little-ending store, such as MAC address is aa:bb:cc:dd:ee:22, the buffer is {22, ee, dd, cc, bb, aa})
+    \param[out] none
+    \retval     none
+*/
+void enet_mac_address_set(enet_macaddress_enum mac_addr, uint8_t paddr[])
+{
+    REG32(ENET_ADDRH_BASE + (uint32_t)mac_addr) = ENET_SET_MACADDRH(paddr);
+    REG32(ENET_ADDRL_BASE + (uint32_t)mac_addr) = ENET_SET_MACADDRL(paddr);
+}
+
+/*!
+    \brief    get MAC address
+    \param[in]  mac_addr: select which MAC address will be get, refer to enet_macaddress_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_MAC_ADDRESS0: get MAC address 0 filter
+      \arg        ENET_MAC_ADDRESS1: get MAC address 1 filter
+      \arg        ENET_MAC_ADDRESS2: get MAC address 2 filter
+      \arg        ENET_MAC_ADDRESS3: get MAC address 3 filter
+    \param[out] paddr: the buffer pointer which is stored the MAC address
+                  (little-ending store, such as mac address is aa:bb:cc:dd:ee:22, the buffer is {22, ee, dd, cc, bb, aa})
+    \retval     none
+*/
+void enet_mac_address_get(enet_macaddress_enum mac_addr, uint8_t paddr[])
+{
+    paddr[0] = ENET_GET_MACADDR(mac_addr, 0U);
+    paddr[1] = ENET_GET_MACADDR(mac_addr, 1U);
+    paddr[2] = ENET_GET_MACADDR(mac_addr, 2U);
+    paddr[3] = ENET_GET_MACADDR(mac_addr, 3U);
+    paddr[4] = ENET_GET_MACADDR(mac_addr, 4U);
+    paddr[5] = ENET_GET_MACADDR(mac_addr, 5U);
+}
+
+/*!
+    \brief    get the ENET MAC/MSC/PTP/DMA status flag
+    \param[in]  enet_flag: ENET status flag, refer to enet_flag_enum,
+                only one parameter can be selected which is shown as below
+      \arg        ENET_MAC_FLAG_MPKR: magic packet received flag
+      \arg        ENET_MAC_FLAG_WUFR: wakeup frame received flag
+      \arg        ENET_MAC_FLAG_FLOWCONTROL: flow control status flag
+      \arg        ENET_MAC_FLAG_WUM: WUM status flag
+      \arg        ENET_MAC_FLAG_MSC: MSC status flag
+      \arg        ENET_MAC_FLAG_MSCR: MSC receive status flag
+      \arg        ENET_MAC_FLAG_MSCT: MSC transmit status flag
+      \arg        ENET_MAC_FLAG_TMST: time stamp trigger status flag
+      \arg        ENET_PTP_FLAG_TSSCO: timestamp second counter overflow flag
+      \arg        ENET_PTP_FLAG_TTM: target time match flag
+      \arg        ENET_MSC_FLAG_RFCE: received frames CRC error flag
+      \arg        ENET_MSC_FLAG_RFAE: received frames alignment error flag
+      \arg        ENET_MSC_FLAG_RGUF: received good unicast frames flag
+      \arg        ENET_MSC_FLAG_TGFSC: transmitted good frames single collision flag
+      \arg        ENET_MSC_FLAG_TGFMSC: transmitted good frames more single collision flag
+      \arg        ENET_MSC_FLAG_TGF: transmitted good frames flag
+      \arg        ENET_DMA_FLAG_TS: transmit status flag
+      \arg        ENET_DMA_FLAG_TPS: transmit process stopped status flag
+      \arg        ENET_DMA_FLAG_TBU: transmit buffer unavailable status flag
+      \arg        ENET_DMA_FLAG_TJT: transmit jabber timeout status flag
+      \arg        ENET_DMA_FLAG_RO: receive overflow status flag
+      \arg        ENET_DMA_FLAG_TU: transmit underflow status flag
+      \arg        ENET_DMA_FLAG_RS: receive status flag
+      \arg        ENET_DMA_FLAG_RBU: receive buffer unavailable status flag
+      \arg        ENET_DMA_FLAG_RPS: receive process stopped status flag
+      \arg        ENET_DMA_FLAG_RWT: receive watchdog timeout status flag
+      \arg        ENET_DMA_FLAG_ET: early transmit status flag
+      \arg        ENET_DMA_FLAG_FBE: fatal bus error status flag
+      \arg        ENET_DMA_FLAG_ER: early receive status flag
+      \arg        ENET_DMA_FLAG_AI: abnormal interrupt summary flag
+      \arg        ENET_DMA_FLAG_NI: normal interrupt summary flag
+      \arg        ENET_DMA_FLAG_EB_DMA_ERROR: DMA error flag
+      \arg        ENET_DMA_FLAG_EB_TRANSFER_ERROR: transfer error flag
+      \arg        ENET_DMA_FLAG_EB_ACCESS_ERROR: access error flag
+      \arg        ENET_DMA_FLAG_MSC: MSC status flag
+      \arg        ENET_DMA_FLAG_WUM: WUM status flag
+      \arg        ENET_DMA_FLAG_TST: timestamp trigger status flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus enet_flag_get(enet_flag_enum enet_flag)
+{
+    if(RESET != (ENET_REG_VAL(enet_flag) & BIT(ENET_BIT_POS(enet_flag)))) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    clear the ENET DMA status flag
+    \param[in]  enet_flag: ENET DMA flag clear, refer to enet_flag_clear_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_DMA_FLAG_TS_CLR: transmit status flag clear
+      \arg        ENET_DMA_FLAG_TPS_CLR: transmit process stopped status flag clear
+      \arg        ENET_DMA_FLAG_TBU_CLR: transmit buffer unavailable status flag clear
+      \arg        ENET_DMA_FLAG_TJT_CLR: transmit jabber timeout status flag clear
+      \arg        ENET_DMA_FLAG_RO_CLR: receive overflow status flag clear
+      \arg        ENET_DMA_FLAG_TU_CLR: transmit underflow status flag clear
+      \arg        ENET_DMA_FLAG_RS_CLR: receive status flag clear
+      \arg        ENET_DMA_FLAG_RBU_CLR: receive buffer unavailable status flag clear
+      \arg        ENET_DMA_FLAG_RPS_CLR: receive process stopped status flag clear
+      \arg        ENET_DMA_FLAG_RWT_CLR: receive watchdog timeout status flag clear
+      \arg        ENET_DMA_FLAG_ET_CLR: early transmit status flag clear
+      \arg        ENET_DMA_FLAG_FBE_CLR: fatal bus error status flag clear
+      \arg        ENET_DMA_FLAG_ER_CLR: early receive status flag clear
+      \arg        ENET_DMA_FLAG_AI_CLR: abnormal interrupt summary flag clear
+      \arg        ENET_DMA_FLAG_NI_CLR: normal interrupt summary flag clear
+    \param[out] none
+    \retval     none
+*/
+void enet_flag_clear(enet_flag_clear_enum enet_flag)
+{
+    /* write 1 to the corresponding bit in ENET_DMA_STAT, to clear it */
+    ENET_REG_VAL(enet_flag) = BIT(ENET_BIT_POS(enet_flag));
+}
+
+/*!
+    \brief    enable ENET MAC/MSC/DMA interrupt
+    \param[in]  enet_int: ENET interrupt,, refer to enet_int_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_MAC_INT_WUMIM: WUM interrupt mask
+      \arg        ENET_MAC_INT_TMSTIM: timestamp trigger interrupt mask
+      \arg        ENET_MSC_INT_RFCEIM: received frame CRC error interrupt mask
+      \arg        ENET_MSC_INT_RFAEIM: received frames alignment error interrupt mask
+      \arg        ENET_MSC_INT_RGUFIM: received good unicast frames interrupt mask
+      \arg        ENET_MSC_INT_TGFSCIM: transmitted good frames single collision interrupt mask
+      \arg        ENET_MSC_INT_TGFMSCIM: transmitted good frames more single collision interrupt mask
+      \arg        ENET_MSC_INT_TGFIM: transmitted good frames interrupt mask
+      \arg        ENET_DMA_INT_TIE: transmit interrupt enable
+      \arg        ENET_DMA_INT_TPSIE: transmit process stopped interrupt enable
+      \arg        ENET_DMA_INT_TBUIE: transmit buffer unavailable interrupt enable
+      \arg        ENET_DMA_INT_TJTIE: transmit jabber timeout interrupt enable
+      \arg        ENET_DMA_INT_ROIE: receive overflow interrupt enable
+      \arg        ENET_DMA_INT_TUIE: transmit underflow interrupt enable
+      \arg        ENET_DMA_INT_RIE: receive interrupt enable
+      \arg        ENET_DMA_INT_RBUIE: receive buffer unavailable interrupt enable
+      \arg        ENET_DMA_INT_RPSIE: receive process stopped interrupt enable
+      \arg        ENET_DMA_INT_RWTIE: receive watchdog timeout interrupt enable
+      \arg        ENET_DMA_INT_ETIE: early transmit interrupt enable
+      \arg        ENET_DMA_INT_FBEIE: fatal bus error interrupt enable
+      \arg        ENET_DMA_INT_ERIE: early receive interrupt enable
+      \arg        ENET_DMA_INT_AIE: abnormal interrupt summary enable
+      \arg        ENET_DMA_INT_NIE: normal interrupt summary enable
+    \param[out] none
+    \retval     none
+*/
+void enet_interrupt_enable(enet_int_enum enet_int)
+{
+    if(DMA_INTEN_REG_OFFSET == ((uint32_t)enet_int >> 6)) {
+        /* ENET_DMA_INTEN register interrupt */
+        ENET_REG_VAL(enet_int) |= BIT(ENET_BIT_POS(enet_int));
+    } else {
+        /* other INTMSK register interrupt */
+        ENET_REG_VAL(enet_int) &= ~BIT(ENET_BIT_POS(enet_int));
+    }
+}
+
+/*!
+    \brief    disable ENET MAC/MSC/DMA interrupt
+    \param[in]  enet_int: ENET interrupt, refer to enet_int_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_MAC_INT_WUMIM: WUM interrupt mask
+      \arg        ENET_MAC_INT_TMSTIM: timestamp trigger interrupt mask
+      \arg        ENET_MSC_INT_RFCEIM: received frame CRC error interrupt mask
+      \arg        ENET_MSC_INT_RFAEIM: received frames alignment error interrupt mask
+      \arg        ENET_MSC_INT_RGUFIM: received good unicast frames interrupt mask
+      \arg        ENET_MSC_INT_TGFSCIM: transmitted good frames single collision interrupt mask
+      \arg        ENET_MSC_INT_TGFMSCIM: transmitted good frames more single collision interrupt mask
+      \arg        ENET_MSC_INT_TGFIM: transmitted good frames interrupt mask
+      \arg        ENET_DMA_INT_TIE: transmit interrupt enable
+      \arg        ENET_DMA_INT_TPSIE: transmit process stopped interrupt enable
+      \arg        ENET_DMA_INT_TBUIE: transmit buffer unavailable interrupt enable
+      \arg        ENET_DMA_INT_TJTIE: transmit jabber timeout interrupt enable
+      \arg        ENET_DMA_INT_ROIE: receive overflow interrupt enable
+      \arg        ENET_DMA_INT_TUIE: transmit underflow interrupt enable
+      \arg        ENET_DMA_INT_RIE: receive interrupt enable
+      \arg        ENET_DMA_INT_RBUIE: receive buffer unavailable interrupt enable
+      \arg        ENET_DMA_INT_RPSIE: receive process stopped interrupt enable
+      \arg        ENET_DMA_INT_RWTIE: receive watchdog timeout interrupt enable
+      \arg        ENET_DMA_INT_ETIE: early transmit interrupt enable
+      \arg        ENET_DMA_INT_FBEIE: fatal bus error interrupt enable
+      \arg        ENET_DMA_INT_ERIE: early receive interrupt enable
+      \arg        ENET_DMA_INT_AIE: abnormal interrupt summary enable
+      \arg        ENET_DMA_INT_NIE: normal interrupt summary enable
+    \param[out] none
+    \retval     none
+*/
+void enet_interrupt_disable(enet_int_enum enet_int)
+{
+    if(DMA_INTEN_REG_OFFSET == ((uint32_t)enet_int >> 6)) {
+        /* ENET_DMA_INTEN register interrupt */
+        ENET_REG_VAL(enet_int) &= ~BIT(ENET_BIT_POS(enet_int));
+    } else {
+        /* other INTMSK register interrupt */
+        ENET_REG_VAL(enet_int) |= BIT(ENET_BIT_POS(enet_int));
+    }
+}
+
+/*!
+    \brief    get ENET MAC/MSC/DMA interrupt flag
+    \param[in]  int_flag: ENET interrupt flag, refer to enet_int_flag_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_MAC_INT_FLAG_WUM: WUM status flag
+      \arg        ENET_MAC_INT_FLAG_MSC: MSC status flag
+      \arg        ENET_MAC_INT_FLAG_MSCR: MSC receive status flag
+      \arg        ENET_MAC_INT_FLAG_MSCT: MSC transmit status flag
+      \arg        ENET_MAC_INT_FLAG_TMST: time stamp trigger status flag
+      \arg        ENET_MSC_INT_FLAG_RFCE: received frames CRC error flag
+      \arg        ENET_MSC_INT_FLAG_RFAE: received frames alignment error flag
+      \arg        ENET_MSC_INT_FLAG_RGUF: received good unicast frames flag
+      \arg        ENET_MSC_INT_FLAG_TGFSC: transmitted good frames single collision flag
+      \arg        ENET_MSC_INT_FLAG_TGFMSC: transmitted good frames more single collision flag
+      \arg        ENET_MSC_INT_FLAG_TGF: transmitted good frames flag
+      \arg        ENET_DMA_INT_FLAG_TS: transmit status flag
+      \arg        ENET_DMA_INT_FLAG_TPS: transmit process stopped status flag
+      \arg        ENET_DMA_INT_FLAG_TBU: transmit buffer unavailable status flag
+      \arg        ENET_DMA_INT_FLAG_TJT: transmit jabber timeout status flag
+      \arg        ENET_DMA_INT_FLAG_RO: receive overflow status flag
+      \arg        ENET_DMA_INT_FLAG_TU: transmit underflow status flag
+      \arg        ENET_DMA_INT_FLAG_RS: receive status flag
+      \arg        ENET_DMA_INT_FLAG_RBU: receive buffer unavailable status flag
+      \arg        ENET_DMA_INT_FLAG_RPS: receive process stopped status flag
+      \arg        ENET_DMA_INT_FLAG_RWT: receive watchdog timeout status flag
+      \arg        ENET_DMA_INT_FLAG_ET: early transmit status flag
+      \arg        ENET_DMA_INT_FLAG_FBE: fatal bus error status flag
+      \arg        ENET_DMA_INT_FLAG_ER: early receive status flag
+      \arg        ENET_DMA_INT_FLAG_AI: abnormal interrupt summary flag
+      \arg        ENET_DMA_INT_FLAG_NI: normal interrupt summary flag
+      \arg        ENET_DMA_INT_FLAG_MSC: MSC status flag
+      \arg        ENET_DMA_INT_FLAG_WUM: WUM status flag
+      \arg        ENET_DMA_INT_FLAG_TST: timestamp trigger status flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus enet_interrupt_flag_get(enet_int_flag_enum int_flag)
+{
+    if(RESET != (ENET_REG_VAL(int_flag) & BIT(ENET_BIT_POS(int_flag)))) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    clear ENET DMA interrupt flag
+    \param[in]  int_flag_clear: clear ENET interrupt flag, refer to enet_int_flag_clear_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_DMA_INT_FLAG_TS_CLR: transmit status flag
+      \arg        ENET_DMA_INT_FLAG_TPS_CLR: transmit process stopped status flag
+      \arg        ENET_DMA_INT_FLAG_TBU_CLR: transmit buffer unavailable status flag
+      \arg        ENET_DMA_INT_FLAG_TJT_CLR: transmit jabber timeout status flag
+      \arg        ENET_DMA_INT_FLAG_RO_CLR: receive overflow status flag
+      \arg        ENET_DMA_INT_FLAG_TU_CLR: transmit underflow status flag
+      \arg        ENET_DMA_INT_FLAG_RS_CLR: receive status flag
+      \arg        ENET_DMA_INT_FLAG_RBU_CLR: receive buffer unavailable status flag
+      \arg        ENET_DMA_INT_FLAG_RPS_CLR: receive process stopped status flag
+      \arg        ENET_DMA_INT_FLAG_RWT_CLR: receive watchdog timeout status flag
+      \arg        ENET_DMA_INT_FLAG_ET_CLR: early transmit status flag
+      \arg        ENET_DMA_INT_FLAG_FBE_CLR: fatal bus error status flag
+      \arg        ENET_DMA_INT_FLAG_ER_CLR: early receive status flag
+      \arg        ENET_DMA_INT_FLAG_AI_CLR: abnormal interrupt summary flag
+      \arg        ENET_DMA_INT_FLAG_NI_CLR: normal interrupt summary flag
+    \param[out] none
+    \retval     none
+*/
+void enet_interrupt_flag_clear(enet_int_flag_clear_enum int_flag_clear)
+{
+    /* write 1 to the corresponding bit in ENET_DMA_STAT, to clear it */
+    ENET_REG_VAL(int_flag_clear) = BIT(ENET_BIT_POS(int_flag_clear));
+}
+
+/*!
+    \brief    ENET Tx function enable (include MAC and DMA module)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_tx_enable(void)
+{
+    ENET_MAC_CFG |= ENET_MAC_CFG_TEN;
+    enet_txfifo_flush();
+    ENET_DMA_CTL |= ENET_DMA_CTL_STE;
+}
+
+/*!
+    \brief    ENET Tx function disable (include MAC and DMA module)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_tx_disable(void)
+{
+    ENET_DMA_CTL &= ~ENET_DMA_CTL_STE;
+    enet_txfifo_flush();
+    ENET_MAC_CFG &= ~ENET_MAC_CFG_TEN;
+}
+
+/*!
+    \brief    ENET Rx function enable (include MAC and DMA module)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_rx_enable(void)
+{
+    ENET_MAC_CFG |= ENET_MAC_CFG_REN;
+    ENET_DMA_CTL |= ENET_DMA_CTL_SRE;
+}
+
+/*!
+    \brief    ENET Rx function disable (include MAC and DMA module)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_rx_disable(void)
+{
+    ENET_DMA_CTL &= ~ENET_DMA_CTL_SRE;
+    ENET_MAC_CFG &= ~ENET_MAC_CFG_REN;
+}
+
+/*!
+    \brief    put registers value into the application buffer
+    \param[in]  type: register type which will be get, refer to enet_registers_type_enum,
+                only one parameter can be selected which is shown as below
+      \arg        ALL_MAC_REG: get the registers within the offset scope between ENET_MAC_CFG and ENET_MAC_FCTH
+      \arg        ALL_MSC_REG: get the registers within the offset scope between ENET_MSC_CTL and ENET_MSC_RGUFCNT
+      \arg        ALL_PTP_REG: get the registers within the offset scope between ENET_PTP_TSCTL and ENET_PTP_PPSCTL
+      \arg        ALL_DMA_REG: get the registers within the offset scope between ENET_DMA_BCTL and ENET_DMA_CRBADDR
+    \param[in]  num: the number of registers that the user want to get
+    \param[out] preg: the application buffer pointer for storing the register value
+    \retval     none
+*/
+void enet_registers_get(enet_registers_type_enum type, uint32_t *preg, uint32_t num)
+{
+    uint32_t offset = 0U, max = 0U, limit = 0U;
+
+    offset = (uint32_t)type;
+    max = (uint32_t)type + num;
+    limit = sizeof(enet_reg_tab) / sizeof(uint16_t);
+
+    /* prevent element in this array is out of range */
+    if(max > limit) {
+        max = limit;
+    }
+
+    for(; offset < max; offset++) {
+        /* get value of the corresponding register */
+        *preg = REG32((ENET) + enet_reg_tab[offset]);
+        preg++;
+    }
+}
+
+/*!
+    \brief    get the enet debug status from the debug register
+    \param[in]  mac_debug: enet debug status
+                only one parameter can be selected which is shown as below
+      \arg        ENET_MAC_RECEIVER_NOT_IDLE: MAC receiver is not in idle state
+      \arg        ENET_RX_ASYNCHRONOUS_FIFO_STATE: Rx asynchronous FIFO status
+      \arg        ENET_RXFIFO_WRITING: RxFIFO is doing write operation
+      \arg        ENET_RXFIFO_READ_STATUS: RxFIFO read operation status
+      \arg        ENET_RXFIFO_STATE: RxFIFO state
+      \arg        ENET_MAC_TRANSMITTER_NOT_IDLE: MAC transmitter is not in idle state
+      \arg        ENET_MAC_TRANSMITTER_STATUS: status of MAC transmitter
+      \arg        ENET_PAUSE_CONDITION_STATUS: pause condition status
+      \arg        ENET_TXFIFO_READ_STATUS: TxFIFO read operation status
+      \arg        ENET_TXFIFO_WRITING: TxFIFO is doing write operation
+      \arg        ENET_TXFIFO_NOT_EMPTY: TxFIFO is not empty
+      \arg        ENET_TXFIFO_FULL: TxFIFO is full
+    \param[out] none
+    \retval     value of the status users want to get
+*/
+uint32_t enet_debug_status_get(uint32_t mac_debug)
+{
+    uint32_t temp_state = 0U;
+
+    switch(mac_debug) {
+    case ENET_RX_ASYNCHRONOUS_FIFO_STATE:
+        temp_state = GET_MAC_DBG_RXAFS(ENET_MAC_DBG);
+        break;
+    case ENET_RXFIFO_READ_STATUS:
+        temp_state = GET_MAC_DBG_RXFRS(ENET_MAC_DBG);
+        break;
+    case ENET_RXFIFO_STATE:
+        temp_state = GET_MAC_DBG_RXFS(ENET_MAC_DBG);
+        break;
+    case ENET_MAC_TRANSMITTER_STATUS:
+        temp_state = GET_MAC_DBG_SOMT(ENET_MAC_DBG);
+        break;
+    case ENET_TXFIFO_READ_STATUS:
+        temp_state = GET_MAC_DBG_TXFRS(ENET_MAC_DBG);
+        break;
+    default:
+        if(RESET != (ENET_MAC_DBG & mac_debug)) {
+            temp_state = 0x1U;
+        }
+        break;
+    }
+    return temp_state;
+}
+
+/*!
+    \brief    enable the MAC address filter
+    \param[in]  mac_addr: select which MAC address will be enable, refer to enet_macaddress_enum
+      \arg        ENET_MAC_ADDRESS1: enable MAC address 1 filter
+      \arg        ENET_MAC_ADDRESS2: enable MAC address 2 filter
+      \arg        ENET_MAC_ADDRESS3: enable MAC address 3 filter
+    \param[out] none
+    \retval     none
+*/
+void enet_address_filter_enable(enet_macaddress_enum mac_addr)
+{
+    REG32(ENET_ADDRH_BASE + mac_addr) |= ENET_MAC_ADDR1H_AFE;
+}
+
+/*!
+    \brief    disable the MAC address filter
+    \param[in]  mac_addr: select which MAC address will be disable, refer to enet_macaddress_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_MAC_ADDRESS1: disable MAC address 1 filter
+      \arg        ENET_MAC_ADDRESS2: disable MAC address 2 filter
+      \arg        ENET_MAC_ADDRESS3: disable MAC address 3 filter
+    \param[out] none
+    \retval     none
+*/
+void enet_address_filter_disable(enet_macaddress_enum mac_addr)
+{
+    REG32(ENET_ADDRH_BASE + mac_addr) &= ~ENET_MAC_ADDR1H_AFE;
+}
+
+/*!
+    \brief    configure the MAC address filter
+    \param[in]  mac_addr: select which MAC address will be configured, refer to enet_macaddress_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_MAC_ADDRESS1: configure MAC address 1 filter
+      \arg        ENET_MAC_ADDRESS2: configure MAC address 2 filter
+      \arg        ENET_MAC_ADDRESS3: configure MAC address 3 filter
+    \param[in]  addr_mask: select which MAC address bytes will be mask
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_ADDRESS_MASK_BYTE0: mask ENET_MAC_ADDR1L[7:0] bits
+      \arg        ENET_ADDRESS_MASK_BYTE1: mask ENET_MAC_ADDR1L[15:8] bits
+      \arg        ENET_ADDRESS_MASK_BYTE2: mask ENET_MAC_ADDR1L[23:16] bits
+      \arg        ENET_ADDRESS_MASK_BYTE3: mask ENET_MAC_ADDR1L [31:24] bits
+      \arg        ENET_ADDRESS_MASK_BYTE4: mask ENET_MAC_ADDR1H [7:0] bits
+      \arg        ENET_ADDRESS_MASK_BYTE5: mask ENET_MAC_ADDR1H [15:8] bits
+    \param[in]  filter_type: select which MAC address filter type will be selected
+                only one parameter can be selected which is shown as below
+      \arg        ENET_ADDRESS_FILTER_SA: The MAC address is used to compared with the SA field of the received frame
+      \arg        ENET_ADDRESS_FILTER_DA: The MAC address is used to compared with the DA field of the received frame
+    \param[out] none
+    \retval     none
+*/
+void enet_address_filter_config(enet_macaddress_enum mac_addr, uint32_t addr_mask, uint32_t filter_type)
+{
+    uint32_t reg;
+
+    /* get the address filter register value which is to be configured */
+    reg = REG32(ENET_ADDRH_BASE + mac_addr);
+
+    /* clear and configure the address filter register */
+    reg &= ~(ENET_MAC_ADDR1H_MB | ENET_MAC_ADDR1H_SAF);
+    reg |= (addr_mask | filter_type);
+    REG32(ENET_ADDRH_BASE + mac_addr) = reg;
+}
+
+/*!
+    \brief    PHY interface configuration (configure SMI clock and reset PHY chip)
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus enet_phy_config(void)
+{
+    uint32_t ahbclk;
+    uint32_t reg;
+    uint16_t phy_value;
+    ErrStatus enet_state = ERROR;
+
+    /* clear the previous MDC clock */
+    reg = ENET_MAC_PHY_CTL;
+    reg &= ~ENET_MAC_PHY_CTL_CLR;
+
+    /* get the HCLK frequency */
+    ahbclk = rcu_clock_freq_get(CK_AHB);
+
+    /* configure MDC clock according to HCLK frequency range */
+    if(ENET_RANGE(ahbclk, 20000000U, 35000000U)) {
+        reg |= ENET_MDC_HCLK_DIV16;
+    } else if(ENET_RANGE(ahbclk, 35000000U, 60000000U)) {
+        reg |= ENET_MDC_HCLK_DIV26;
+    } else if(ENET_RANGE(ahbclk, 60000000U, 100000000U)) {
+        reg |= ENET_MDC_HCLK_DIV42;
+    } else if(ENET_RANGE(ahbclk, 100000000U, 150000000U)) {
+        reg |= ENET_MDC_HCLK_DIV62;
+    } else if((ENET_RANGE(ahbclk, 150000000U, 240000000U)) || (240000000U == ahbclk)) {
+        reg |= ENET_MDC_HCLK_DIV102;
+    } else {
+        return enet_state;
+    }
+    ENET_MAC_PHY_CTL = reg;
+
+    /* reset PHY */
+    phy_value = PHY_RESET;
+    if(ERROR == (enet_phy_write_read(ENET_PHY_WRITE, PHY_ADDRESS, PHY_REG_BCR, &phy_value))) {
+        return enet_state;
+    }
+    /* PHY reset need some time */
+    _ENET_DELAY_(ENET_DELAY_TO);
+
+    /* check whether PHY reset is complete */
+    if(ERROR == (enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_REG_BCR, &phy_value))) {
+        return enet_state;
+    }
+
+    /* PHY reset complete */
+    if(RESET == (phy_value & PHY_RESET)) {
+        enet_state = SUCCESS;
+    }
+
+    return enet_state;
+}
+
+/*!
+    \brief    write to / read from a PHY register
+    \param[in]  direction: only one parameter can be selected which is shown as below, refer to enet_phydirection_enum
+      \arg        ENET_PHY_WRITE: write data to phy register
+      \arg        ENET_PHY_READ:  read data from phy register
+    \param[in]  phy_address: 0x0000 - 0x001F
+    \param[in]  phy_reg: 0x0000 - 0x001F
+    \param[in]  pvalue: the value will be written to the PHY register in ENET_PHY_WRITE direction
+    \param[out] pvalue: the value will be read from the PHY register in ENET_PHY_READ direction
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus enet_phy_write_read(enet_phydirection_enum direction, uint16_t phy_address, uint16_t phy_reg, uint16_t *pvalue)
+{
+    uint32_t reg, phy_flag;
+    uint32_t timeout = 0U;
+    ErrStatus enet_state = ERROR;
+
+    /* configure ENET_MAC_PHY_CTL with write/read operation */
+    reg = ENET_MAC_PHY_CTL;
+    reg &= ~(ENET_MAC_PHY_CTL_PB | ENET_MAC_PHY_CTL_PW | ENET_MAC_PHY_CTL_PR | ENET_MAC_PHY_CTL_PA);
+    reg |= (direction | MAC_PHY_CTL_PR(phy_reg) | MAC_PHY_CTL_PA(phy_address) | ENET_MAC_PHY_CTL_PB);
+
+    /* if do the write operation, write value to the register */
+    if(ENET_PHY_WRITE == direction) {
+        ENET_MAC_PHY_DATA = *pvalue;
+    }
+
+    /* do PHY write/read operation, and wait the operation complete  */
+    ENET_MAC_PHY_CTL = reg;
+    do {
+        phy_flag = (ENET_MAC_PHY_CTL & ENET_MAC_PHY_CTL_PB);
+        timeout++;
+    } while((RESET != phy_flag) && (ENET_DELAY_TO != timeout));
+
+    /* write/read operation complete */
+    if(RESET == (ENET_MAC_PHY_CTL & ENET_MAC_PHY_CTL_PB)) {
+        enet_state = SUCCESS;
+    }
+
+    /* if do the read operation, get value from the register */
+    if(ENET_PHY_READ == direction) {
+        *pvalue = (uint16_t)ENET_MAC_PHY_DATA;
+    }
+
+    return enet_state;
+}
+
+/*!
+    \brief    enable the loopback function of PHY chip
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus enet_phyloopback_enable(void)
+{
+    uint16_t temp_phy = 0U;
+    ErrStatus phy_state = ERROR;
+
+    /* get the PHY configuration to update it */
+    enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_REG_BCR, &temp_phy);
+
+    /* enable the PHY loopback mode */
+    temp_phy |= PHY_LOOPBACK;
+
+    /* update the PHY control register with the new configuration */
+    phy_state = enet_phy_write_read(ENET_PHY_WRITE, PHY_ADDRESS, PHY_REG_BCR, &temp_phy);
+
+    return phy_state;
+}
+
+/*!
+    \brief    disable the loopback function of PHY chip
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus enet_phyloopback_disable(void)
+{
+    uint16_t temp_phy = 0U;
+    ErrStatus phy_state = ERROR;
+
+    /* get the PHY configuration to update it */
+    enet_phy_write_read(ENET_PHY_READ, PHY_ADDRESS, PHY_REG_BCR, &temp_phy);
+
+    /* disable the PHY loopback mode */
+    temp_phy &= (uint16_t)~PHY_LOOPBACK;
+
+    /* update the PHY control register with the new configuration */
+    phy_state = enet_phy_write_read(ENET_PHY_WRITE, PHY_ADDRESS, PHY_REG_BCR, &temp_phy);
+
+    return phy_state;
+}
+
+/*!
+    \brief    enable ENET forward feature
+    \param[in]  feature: the feature of ENET forward mode
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_AUTO_PADCRC_DROP: the function of the MAC strips the Pad/FCS field on received frames
+      \arg        ENET_TYPEFRAME_CRC_DROP: the function that FCS field(last 4 bytes) of frame will be dropped before forwarding
+      \arg        ENET_FORWARD_ERRFRAMES: the function that all frame received with error except runt error are forwarded to memory
+      \arg        ENET_FORWARD_UNDERSZ_GOODFRAMES: the function that forwarding undersized good frames
+    \param[out] none
+    \retval     none
+*/
+void enet_forward_feature_enable(uint32_t feature)
+{
+    uint32_t mask;
+
+    mask = (feature & (~(ENET_FORWARD_ERRFRAMES | ENET_FORWARD_UNDERSZ_GOODFRAMES)));
+    ENET_MAC_CFG |= mask;
+
+    mask = (feature & (~(ENET_AUTO_PADCRC_DROP | ENET_TYPEFRAME_CRC_DROP)));
+    ENET_DMA_CTL |= (mask >> 2);
+}
+
+/*!
+    \brief    disable ENET forward feature
+    \param[in]  feature: the feature of ENET forward mode
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_AUTO_PADCRC_DROP: the function of the MAC strips the Pad/FCS field on received frames
+      \arg        ENET_TYPEFRAME_CRC_DROP: the function that FCS field(last 4 bytes) of frame will be dropped before forwarding
+      \arg        ENET_FORWARD_ERRFRAMES: the function that all frame received with error except runt error are forwarded to memory
+      \arg        ENET_FORWARD_UNDERSZ_GOODFRAMES: the function that forwarding undersized good frames
+    \param[out] none
+    \retval     none
+*/
+void enet_forward_feature_disable(uint32_t feature)
+{
+    uint32_t mask;
+
+    mask = (feature & (~(ENET_FORWARD_ERRFRAMES | ENET_FORWARD_UNDERSZ_GOODFRAMES)));
+    ENET_MAC_CFG &= ~mask;
+
+    mask = (feature & (~(ENET_AUTO_PADCRC_DROP | ENET_TYPEFRAME_CRC_DROP)));
+    ENET_DMA_CTL &= ~(mask >> 2);
+}
+
+/*!
+    \brief      enable ENET fliter feature
+    \param[in]  feature: the feature of ENET fliter mode
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_SRC_FILTER: filter source address function
+      \arg        ENET_SRC_FILTER_INVERSE: inverse source address filtering result function
+      \arg        ENET_DEST_FILTER_INVERSE: inverse DA filtering result function
+      \arg        ENET_MULTICAST_FILTER_PASS: pass all multicast frames function
+      \arg        ENET_MULTICAST_FILTER_HASH_MODE: HASH multicast filter function
+      \arg        ENET_UNICAST_FILTER_HASH_MODE: HASH unicast filter function
+      \arg        ENET_FILTER_MODE_EITHER: HASH or perfect filter function
+    \param[out] none
+    \retval     none
+*/
+void enet_fliter_feature_enable(uint32_t feature)
+{
+    ENET_MAC_FRMF |= feature;
+}
+
+/*!
+    \brief    disable ENET fliter feature
+    \param[in]  feature: the feature of ENET fliter mode
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_SRC_FILTER: filter source address function
+      \arg        ENET_SRC_FILTER_INVERSE: inverse source address filtering result function
+      \arg        ENET_DEST_FILTER_INVERSE: inverse DA filtering result function
+      \arg        ENET_MULTICAST_FILTER_PASS: pass all multicast frames function
+      \arg        ENET_MULTICAST_FILTER_HASH_MODE: HASH multicast filter function
+      \arg        ENET_UNICAST_FILTER_HASH_MODE: HASH unicast filter function
+      \arg        ENET_FILTER_MODE_EITHER: HASH or perfect filter function
+    \param[out] none
+    \retval     none
+*/
+void enet_fliter_feature_disable(uint32_t feature)
+{
+    ENET_MAC_FRMF &= ~feature;
+}
+
+/*!
+    \brief    generate the pause frame, ENET will send pause frame after enable transmit flow control
+                this function only use in full-dulex mode
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus enet_pauseframe_generate(void)
+{
+    ErrStatus enet_state = ERROR;
+    uint32_t temp = 0U;
+
+    /* in full-duplex mode, must make sure this bit is 0 before writing register */
+    temp = ENET_MAC_FCTL & ENET_MAC_FCTL_FLCBBKPA;
+    if(RESET == temp) {
+        ENET_MAC_FCTL |= ENET_MAC_FCTL_FLCBBKPA;
+        enet_state = SUCCESS;
+    }
+    return enet_state;
+}
+
+/*!
+    \brief    configure the pause frame detect type
+    \param[in]  detect: pause frame detect type
+                only one parameter can be selected which is shown as below
+      \arg        ENET_MAC0_AND_UNIQUE_ADDRESS_PAUSEDETECT: besides the unique multicast address, MAC can also
+                                                            use the MAC0 address to detecting pause frame
+      \arg        ENET_UNIQUE_PAUSEDETECT: only the unique multicast address for pause frame which is specified
+                                           in IEEE802.3 can be detected
+    \param[out] none
+    \retval     none
+*/
+void enet_pauseframe_detect_config(uint32_t detect)
+{
+    ENET_MAC_FCTL &= ~ENET_MAC_FCTL_UPFDT;
+    ENET_MAC_FCTL |= detect;
+}
+
+/*!
+    \brief    configure the pause frame parameters
+    \param[in]  pausetime: pause time in transmit pause control frame
+    \param[in]  pause_threshold: the threshold of the pause timer for retransmitting frames automatically
+                this value must make sure to be less than configured pause time
+                only one parameter can be selected which is shown as below
+      \arg        ENET_PAUSETIME_MINUS4: pause time minus 4 slot times
+      \arg        ENET_PAUSETIME_MINUS28: pause time minus 28 slot times
+      \arg        ENET_PAUSETIME_MINUS144: pause time minus 144 slot times
+      \arg        ENET_PAUSETIME_MINUS256: pause time minus 256 slot times
+    \param[out] none
+    \retval     none
+*/
+void enet_pauseframe_config(uint32_t pausetime, uint32_t pause_threshold)
+{
+    ENET_MAC_FCTL &= ~(ENET_MAC_FCTL_PTM | ENET_MAC_FCTL_PLTS);
+    ENET_MAC_FCTL |= (MAC_FCTL_PTM(pausetime) | pause_threshold);
+}
+
+/*!
+    \brief    configure the threshold of the flow control(deactive and active threshold)
+    \param[in]  deactive: the threshold of the deactive flow control
+                this value should always be less than active flow control value
+                only one parameter can be selected which is shown as below
+      \arg        ENET_DEACTIVE_THRESHOLD_256BYTES: threshold level is 256 bytes
+      \arg        ENET_DEACTIVE_THRESHOLD_512BYTES: threshold level is 512 bytes
+      \arg        ENET_DEACTIVE_THRESHOLD_768BYTES: threshold level is 768 bytes
+      \arg        ENET_DEACTIVE_THRESHOLD_1024BYTES: threshold level is 1024 bytes
+      \arg        ENET_DEACTIVE_THRESHOLD_1280BYTES: threshold level is 1280 bytes
+      \arg        ENET_DEACTIVE_THRESHOLD_1536BYTES: threshold level is 1536 bytes
+      \arg        ENET_DEACTIVE_THRESHOLD_1792BYTES: threshold level is 1792 bytes
+    \param[in]  active: the threshold of the active flow control
+                only one parameter can be selected which is shown as below
+      \arg        ENET_ACTIVE_THRESHOLD_256BYTES: threshold level is 256 bytes
+      \arg        ENET_ACTIVE_THRESHOLD_512BYTES: threshold level is 512 bytes
+      \arg        ENET_ACTIVE_THRESHOLD_768BYTES: threshold level is 768 bytes
+      \arg        ENET_ACTIVE_THRESHOLD_1024BYTES: threshold level is 1024 bytes
+      \arg        ENET_ACTIVE_THRESHOLD_1280BYTES: threshold level is 1280 bytes
+      \arg        ENET_ACTIVE_THRESHOLD_1536BYTES: threshold level is 1536 bytes
+      \arg        ENET_ACTIVE_THRESHOLD_1792BYTES: threshold level is 1792 bytes
+    \param[out] none
+    \retval     none
+*/
+void enet_flowcontrol_threshold_config(uint32_t deactive, uint32_t active)
+{
+    ENET_MAC_FCTH = ((deactive | active) >> 8);
+}
+
+/*!
+    \brief    enable ENET flow control feature
+    \param[in]  feature: the feature of ENET flow control mode
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_ZERO_QUANTA_PAUSE: the automatic zero-quanta generation function
+      \arg        ENET_TX_FLOWCONTROL: the flow control operation in the MAC
+      \arg        ENET_RX_FLOWCONTROL: decoding function for the received pause frame and process it
+      \arg        ENET_BACK_PRESSURE: back pressure operation in the MAC(only use in half-dulex mode)
+    \param[out] none
+    \retval     none
+*/
+void enet_flowcontrol_feature_enable(uint32_t feature)
+{
+    if(RESET != (feature & ENET_ZERO_QUANTA_PAUSE)) {
+        ENET_MAC_FCTL &= ~ENET_ZERO_QUANTA_PAUSE;
+    }
+    feature &= ~ENET_ZERO_QUANTA_PAUSE;
+    ENET_MAC_FCTL |= feature;
+}
+
+/*!
+    \brief    disable ENET flow control feature
+    \param[in]  feature: the feature of ENET flow control mode
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_ZERO_QUANTA_PAUSE: the automatic zero-quanta generation function
+      \arg        ENET_TX_FLOWCONTROL: the flow control operation in the MAC
+      \arg        ENET_RX_FLOWCONTROL: decoding function for the received pause frame and process it
+      \arg        ENET_BACK_PRESSURE: back pressure operation in the MAC(only use in half-dulex mode)
+    \param[out] none
+    \retval     none
+*/
+void enet_flowcontrol_feature_disable(uint32_t feature)
+{
+    if(RESET != (feature & ENET_ZERO_QUANTA_PAUSE)) {
+        ENET_MAC_FCTL |= ENET_ZERO_QUANTA_PAUSE;
+    }
+    feature &= ~ENET_ZERO_QUANTA_PAUSE;
+    ENET_MAC_FCTL &= ~feature;
+}
+
+/*!
+    \brief    get the dma transmit/receive process state
+    \param[in]  direction: choose the direction of dma process which users want to check, refer to enet_dmadirection_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_DMA_TX: dma transmit process
+      \arg        ENET_DMA_RX: dma receive process
+    \param[out] none
+    \retval     state of dma process, the value range shows below:
+                  ENET_RX_STATE_STOPPED, ENET_RX_STATE_FETCHING, ENET_RX_STATE_WAITING,
+                  ENET_RX_STATE_SUSPENDED, ENET_RX_STATE_CLOSING, ENET_RX_STATE_QUEUING,
+                  ENET_TX_STATE_STOPPED, ENET_TX_STATE_FETCHING, ENET_TX_STATE_WAITING,
+                  ENET_TX_STATE_READING, ENET_TX_STATE_SUSPENDED, ENET_TX_STATE_CLOSING
+*/
+uint32_t enet_dmaprocess_state_get(enet_dmadirection_enum direction)
+{
+    uint32_t reval;
+    reval = (uint32_t)(ENET_DMA_STAT & (uint32_t)direction);
+    return reval;
+}
+
+/*!
+    \brief    poll the DMA transmission/reception enable by writing any value to the
+                ENET_DMA_TPEN/ENET_DMA_RPEN register, this will make the DMA to resume transmission/reception
+    \param[in]  direction: choose the direction of DMA process which users want to resume, refer to enet_dmadirection_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_DMA_TX: DMA transmit process
+      \arg        ENET_DMA_RX: DMA receive process
+    \param[out] none
+    \retval     none
+*/
+void enet_dmaprocess_resume(enet_dmadirection_enum direction)
+{
+    if(ENET_DMA_TX == direction) {
+        ENET_DMA_TPEN = 0U;
+    } else {
+        ENET_DMA_RPEN = 0U;
+    }
+}
+
+/*!
+    \brief    check and recover the Rx process
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_rxprocess_check_recovery(void)
+{
+    uint32_t status;
+
+    /* get DAV information of current RxDMA descriptor */
+    status = dma_current_rxdesc->status;
+    status &= ENET_RDES0_DAV;
+
+    /* if current descriptor is owned by DMA, but the descriptor address mismatches with
+    receive descriptor address pointer updated by RxDMA controller */
+    if((ENET_DMA_CRDADDR != ((uint32_t)dma_current_rxdesc)) &&
+            (ENET_RDES0_DAV == status)) {
+        dma_current_rxdesc = (enet_descriptors_struct *)ENET_DMA_CRDADDR;
+    }
+}
+
+/*!
+    \brief    flush the ENET transmit FIFO, and wait until the flush operation completes
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus enet_txfifo_flush(void)
+{
+    uint32_t flush_state;
+    uint32_t timeout = 0U;
+    ErrStatus enet_state = ERROR;
+
+    /* set the FTF bit for flushing transmit FIFO */
+    ENET_DMA_CTL |= ENET_DMA_CTL_FTF;
+    /* wait until the flush operation completes */
+    do {
+        flush_state = ENET_DMA_CTL & ENET_DMA_CTL_FTF;
+        timeout++;
+    } while((RESET != flush_state) && (timeout < ENET_DELAY_TO));
+    /* return ERROR due to timeout */
+    if(RESET == flush_state) {
+        enet_state = SUCCESS;
+    }
+
+    return  enet_state;
+}
+
+/*!
+    \brief    get the transmit/receive address of current descriptor, or current buffer, or descriptor table
+    \param[in]  addr_get: choose the address which users want to get, refer to enet_desc_reg_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_RX_DESC_TABLE: the start address of the receive descriptor table
+      \arg        ENET_RX_CURRENT_DESC: the start descriptor address of the current receive descriptor read by
+                                        the RxDMA controller
+      \arg        ENET_RX_CURRENT_BUFFER: the current receive buffer address being read by the RxDMA controller
+      \arg        ENET_TX_DESC_TABLE: the start address of the transmit descriptor table
+      \arg        ENET_TX_CURRENT_DESC: the start descriptor address of the current transmit descriptor read by
+                                        the TxDMA controller
+      \arg        ENET_TX_CURRENT_BUFFER: the current transmit buffer address being read by the TxDMA controller
+    \param[out] none
+    \retval     address value
+*/
+uint32_t enet_current_desc_address_get(enet_desc_reg_enum addr_get)
+{
+    uint32_t reval = 0U;
+
+    reval = REG32((ENET) + (uint32_t)addr_get);
+    return reval;
+}
+
+/*!
+    \brief    get the Tx or Rx descriptor information
+    \param[in]  desc: the descriptor pointer which users want to get information
+    \param[in]  info_get: the descriptor information type which is selected, refer to enet_descstate_enum
+                only one parameter can be selected which is shown as below
+      \arg        RXDESC_BUFFER_1_SIZE: receive buffer 1 size
+      \arg        RXDESC_BUFFER_2_SIZE: receive buffer 2 size
+      \arg        RXDESC_FRAME_LENGTH: the byte length of the received frame that was transferred to the buffer
+      \arg        TXDESC_COLLISION_COUNT: the number of collisions occurred before the frame was transmitted
+      \arg        RXDESC_BUFFER_1_ADDR: the buffer1 address of the Rx frame
+      \arg        TXDESC_BUFFER_1_ADDR: the buffer1 address of the Tx frame
+    \param[out] none
+    \retval     descriptor information, if value is 0xFFFFFFFFU, means the false input parameter
+*/
+uint32_t enet_desc_information_get(enet_descriptors_struct *desc, enet_descstate_enum info_get)
+{
+    uint32_t reval = 0xFFFFFFFFU;
+
+    switch(info_get) {
+    case RXDESC_BUFFER_1_SIZE:
+        reval = GET_RDES1_RB1S(desc->control_buffer_size);
+        break;
+    case RXDESC_BUFFER_2_SIZE:
+        reval = GET_RDES1_RB2S(desc->control_buffer_size);
+        break;
+    case RXDESC_FRAME_LENGTH:
+        reval = GET_RDES0_FRML(desc->status);
+        if(reval > 4U) {
+            reval = reval - 4U;
+
+            /* if is a type frame, and CRC is not included in forwarding frame */
+            if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (desc->status & ENET_RDES0_FRMT))) {
+                reval = reval + 4U;
+            }
+        } else {
+            reval = 0U;
+        }
+
+        break;
+    case RXDESC_BUFFER_1_ADDR:
+        reval = desc->buffer1_addr;
+        break;
+    case TXDESC_BUFFER_1_ADDR:
+        reval = desc->buffer1_addr;
+        break;
+    case TXDESC_COLLISION_COUNT:
+        reval = GET_TDES0_COCNT(desc->status);
+        break;
+    default:
+        break;
+    }
+    return reval;
+}
+
+/*!
+    \brief    get the number of missed frames during receiving
+    \param[in]  none
+    \param[out] rxfifo_drop: pointer to the number of frames dropped by RxFIFO
+    \param[out] rxdma_drop: pointer to the number of frames missed by the RxDMA controller
+    \retval     none
+*/
+void enet_missed_frame_counter_get(uint32_t *rxfifo_drop, uint32_t *rxdma_drop)
+{
+    uint32_t temp_counter = 0U;
+
+    temp_counter = ENET_DMA_MFBOCNT;
+    *rxfifo_drop = GET_DMA_MFBOCNT_MSFA(temp_counter);
+    *rxdma_drop = GET_DMA_MFBOCNT_MSFC(temp_counter);
+}
+
+/*!
+    \brief    get the bit flag of ENET DMA descriptor
+    \param[in]  desc: the descriptor pointer which users want to get flag
+    \param[in]  desc_flag: the bit flag of ENET DMA descriptor
+                only one parameter can be selected which is shown as below
+      \arg        ENET_TDES0_DB: deferred
+      \arg        ENET_TDES0_UFE: underflow error
+      \arg        ENET_TDES0_EXD: excessive deferral
+      \arg        ENET_TDES0_VFRM: VLAN frame
+      \arg        ENET_TDES0_ECO: excessive collision
+      \arg        ENET_TDES0_LCO: late collision
+      \arg        ENET_TDES0_NCA: no carrier
+      \arg        ENET_TDES0_LCA: loss of carrier
+      \arg        ENET_TDES0_IPPE: IP payload error
+      \arg        ENET_TDES0_FRMF: frame flushed
+      \arg        ENET_TDES0_JT: jabber timeout
+      \arg        ENET_TDES0_ES: error summary
+      \arg        ENET_TDES0_IPHE: IP header error
+      \arg        ENET_TDES0_TTMSS: transmit timestamp status
+      \arg        ENET_TDES0_TCHM: the second address chained mode
+      \arg        ENET_TDES0_TERM: transmit end of ring mode
+      \arg        ENET_TDES0_TTSEN: transmit timestamp function enable
+      \arg        ENET_TDES0_DPAD: disable adding pad
+      \arg        ENET_TDES0_DCRC: disable CRC
+      \arg        ENET_TDES0_FSG: first segment
+      \arg        ENET_TDES0_LSG: last segment
+      \arg        ENET_TDES0_INTC: interrupt on completion
+      \arg        ENET_TDES0_DAV: DAV bit
+
+      \arg        ENET_RDES0_PCERR: payload checksum error
+      \arg        ENET_RDES0_EXSV: extended status valid
+      \arg        ENET_RDES0_CERR: CRC error
+      \arg        ENET_RDES0_DBERR: dribble bit error
+      \arg        ENET_RDES0_RERR: receive error
+      \arg        ENET_RDES0_RWDT: receive watchdog timeout
+      \arg        ENET_RDES0_FRMT: frame type
+      \arg        ENET_RDES0_LCO: late collision
+      \arg        ENET_RDES0_IPHERR: IP frame header error
+      \arg        ENET_RDES0_TSV: timestamp valid
+      \arg        ENET_RDES0_LDES: last descriptor
+      \arg        ENET_RDES0_FDES: first descriptor
+      \arg        ENET_RDES0_VTAG: VLAN tag
+      \arg        ENET_RDES0_OERR: overflow error
+      \arg        ENET_RDES0_LERR: length error
+      \arg        ENET_RDES0_SAFF: SA filter fail
+      \arg        ENET_RDES0_DERR: descriptor error
+      \arg        ENET_RDES0_ERRS: error summary
+      \arg        ENET_RDES0_DAFF: destination address filter fail
+      \arg        ENET_RDES0_DAV: descriptor available
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus enet_desc_flag_get(enet_descriptors_struct *desc, uint32_t desc_flag)
+{
+    FlagStatus enet_flag = RESET;
+
+    if((uint32_t)RESET != (desc->status & desc_flag)) {
+        enet_flag = SET;
+    }
+
+    return enet_flag;
+}
+
+/*!
+    \brief    set the bit flag of ENET DMA descriptor
+    \param[in]  desc: the descriptor pointer which users want to set flag
+    \param[in]  desc_flag: the bit flag of ENET DMA descriptor
+                only one parameter can be selected which is shown as below
+      \arg        ENET_TDES0_VFRM: VLAN frame
+      \arg        ENET_TDES0_FRMF: frame flushed
+      \arg        ENET_TDES0_TCHM: the second address chained mode
+      \arg        ENET_TDES0_TERM: transmit end of ring mode
+      \arg        ENET_TDES0_TTSEN: transmit timestamp function enable
+      \arg        ENET_TDES0_DPAD: disable adding pad
+      \arg        ENET_TDES0_DCRC: disable CRC
+      \arg        ENET_TDES0_FSG: first segment
+      \arg        ENET_TDES0_LSG: last segment
+      \arg        ENET_TDES0_INTC: interrupt on completion
+      \arg        ENET_TDES0_DAV: DAV bit
+      \arg        ENET_RDES0_DAV: descriptor available
+    \param[out] none
+    \retval     none
+*/
+void enet_desc_flag_set(enet_descriptors_struct *desc, uint32_t desc_flag)
+{
+    desc->status |= desc_flag;
+}
+
+/*!
+    \brief    clear the bit flag of ENET DMA descriptor
+    \param[in]  desc: the descriptor pointer which users want to clear flag
+    \param[in]  desc_flag: the bit flag of ENET DMA descriptor
+                only one parameter can be selected which is shown as below
+      \arg        ENET_TDES0_VFRM: VLAN frame
+      \arg        ENET_TDES0_FRMF: frame flushed
+      \arg        ENET_TDES0_TCHM: the second address chained mode
+      \arg        ENET_TDES0_TERM: transmit end of ring mode
+      \arg        ENET_TDES0_TTSEN: transmit timestamp function enable
+      \arg        ENET_TDES0_DPAD: disable adding pad
+      \arg        ENET_TDES0_DCRC: disable CRC
+      \arg        ENET_TDES0_FSG: first segment
+      \arg        ENET_TDES0_LSG: last segment
+      \arg        ENET_TDES0_INTC: interrupt on completion
+      \arg        ENET_TDES0_DAV: DAV bit
+      \arg        ENET_RDES0_DAV: descriptor available
+    \param[out] none
+    \retval     none
+*/
+void enet_desc_flag_clear(enet_descriptors_struct *desc, uint32_t desc_flag)
+{
+    desc->status &= ~desc_flag;
+}
+
+/*!
+    \brief    when receiving completed, set RS bit in ENET_DMA_STAT register will immediately set
+    \param[in]  desc: the descriptor pointer which users want to configure
+    \param[out] none
+    \retval     none
+*/
+void enet_rx_desc_immediate_receive_complete_interrupt(enet_descriptors_struct *desc)
+{
+    desc->control_buffer_size &= ~ENET_RDES1_DINTC;
+}
+
+/*!
+    \brief    when receiving completed, set RS bit in ENET_DMA_STAT register will is set after a configurable delay time
+    \param[in]  desc: the descriptor pointer which users want to configure
+    \param[in]  delay_time: delay a time of 256*delay_time HCLK(0x00000000 - 0x000000FF)
+    \param[out] none
+    \retval     none
+*/
+void enet_rx_desc_delay_receive_complete_interrupt(enet_descriptors_struct *desc, uint32_t delay_time)
+{
+    desc->control_buffer_size |= ENET_RDES1_DINTC;
+    ENET_DMA_RSWDC = DMA_RSWDC_WDCFRS(delay_time);
+}
+
+/*!
+    \brief    drop current receive frame
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_rxframe_drop(void)
+{
+    /* enable reception, descriptor is owned by DMA */
+    dma_current_rxdesc->status = ENET_RDES0_DAV;
+
+    /* chained mode */
+    if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RCHM)) {
+        if(NULL != dma_current_ptp_rxdesc) {
+            dma_current_rxdesc = (enet_descriptors_struct *)(dma_current_ptp_rxdesc->buffer2_next_desc_addr);
+            /* if it is the last ptp descriptor */
+            if(0U != dma_current_ptp_rxdesc->status) {
+                /* pointer back to the first ptp descriptor address in the desc_ptptab list address */
+                dma_current_ptp_rxdesc = (enet_descriptors_struct *)(dma_current_ptp_rxdesc->status);
+            } else {
+                /* ponter to the next ptp descriptor */
+                dma_current_ptp_rxdesc++;
+            }
+        } else {
+            dma_current_rxdesc = (enet_descriptors_struct *)(dma_current_rxdesc->buffer2_next_desc_addr);
+        }
+
+    } else {
+        /* ring mode */
+        if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RERM)) {
+            /* if is the last descriptor in table, the next descriptor is the table header */
+            dma_current_rxdesc = (enet_descriptors_struct *)(ENET_DMA_RDTADDR);
+            if(NULL != dma_current_ptp_rxdesc) {
+                dma_current_ptp_rxdesc = (enet_descriptors_struct *)(dma_current_ptp_rxdesc->status);
+            }
+        } else {
+            /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
+            dma_current_rxdesc = (enet_descriptors_struct *)(uint32_t)((uint32_t)dma_current_rxdesc + ETH_DMARXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));
+            if(NULL != dma_current_ptp_rxdesc) {
+                dma_current_ptp_rxdesc++;
+            }
+        }
+    }
+}
+
+/*!
+    \brief    enable DMA feature
+    \param[in]  feature: the feature of DMA mode
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_NO_FLUSH_RXFRAME: RxDMA does not flushes frames function
+      \arg        ENET_SECONDFRAME_OPT: TxDMA controller operate on second frame function
+    \param[out] none
+    \retval     none
+*/
+void enet_dma_feature_enable(uint32_t feature)
+{
+    ENET_DMA_CTL |= feature;
+}
+
+/*!
+    \brief    disable DMA feature
+    \param[in]  feature: the feature of DMA mode
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_NO_FLUSH_RXFRAME: RxDMA does not flushes frames function
+      \arg        ENET_SECONDFRAME_OPT: TxDMA controller operate on second frame function
+    \param[out] none
+    \retval     none
+*/
+void enet_dma_feature_disable(uint32_t feature)
+{
+    ENET_DMA_CTL &= ~feature;
+}
+
+#ifdef SELECT_DESCRIPTORS_ENHANCED_MODE
+/*!
+    \brief    get the bit of extended status flag in ENET DMA descriptor
+    \param[in]  desc: the descriptor pointer which users want to get the extended status flag
+    \param[in]  desc_status: the extended status want to get
+                only one parameter can be selected which is shown as below
+      \arg        ENET_RDES4_IPPLDT: IP frame payload type
+      \arg        ENET_RDES4_IPHERR: IP frame header error
+      \arg        ENET_RDES4_IPPLDERR: IP frame payload error
+      \arg        ENET_RDES4_IPCKSB: IP frame checksum bypassed
+      \arg        ENET_RDES4_IPF4: IP frame in version 4
+      \arg        ENET_RDES4_IPF6: IP frame in version 6
+      \arg        ENET_RDES4_PTPMT: PTP message type
+      \arg        ENET_RDES4_PTPOEF: PTP on ethernet frame
+      \arg        ENET_RDES4_PTPVF: PTP version format
+    \param[out] none
+    \retval     value of extended status
+*/
+uint32_t enet_rx_desc_enhanced_status_get(enet_descriptors_struct *desc, uint32_t desc_status)
+{
+    uint32_t reval = 0xFFFFFFFFU;
+
+    switch(desc_status) {
+    case ENET_RDES4_IPPLDT:
+        reval = GET_RDES4_IPPLDT(desc->extended_status);
+        break;
+    case ENET_RDES4_PTPMT:
+        reval = GET_RDES4_PTPMT(desc->extended_status);
+        break;
+    default:
+        if((uint32_t)RESET != (desc->extended_status & desc_status)) {
+            reval = 1U;
+        } else {
+            reval = 0U;
+        }
+    }
+
+    return reval;
+}
+
+/*!
+    \brief    configure descriptor to work in enhanced mode
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_desc_select_enhanced_mode(void)
+{
+    ENET_DMA_BCTL |= ENET_DMA_BCTL_DFM;
+}
+
+/*!
+    \brief    initialize the DMA Tx/Rx descriptors's parameters in enhanced chain mode with ptp function
+    \param[in]  direction: the descriptors which users want to init, refer to enet_dmadirection_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_DMA_TX: DMA Tx descriptors
+      \arg        ENET_DMA_RX: DMA Rx descriptors
+    \param[out] none
+    \retval     none
+*/
+void enet_ptp_enhanced_descriptors_chain_init(enet_dmadirection_enum direction)
+{
+    uint32_t num = 0U, count = 0U, maxsize = 0U;
+    uint32_t desc_status = 0U, desc_bufsize = 0U;
+    enet_descriptors_struct *desc, *desc_tab;
+    uint8_t *buf;
+
+    /* if want to initialize DMA Tx descriptors */
+    if(ENET_DMA_TX == direction) {
+        /* save a copy of the DMA Tx descriptors */
+        desc_tab = txdesc_tab;
+        buf = &tx_buff[0][0];
+        count = ENET_TXBUF_NUM;
+        maxsize = ENET_TXBUF_SIZE;
+
+        /* select chain mode, and enable transmit timestamp function */
+        desc_status = ENET_TDES0_TCHM | ENET_TDES0_TTSEN;
+
+        /* configure DMA Tx descriptor table address register */
+        ENET_DMA_TDTADDR = (uint32_t)desc_tab;
+        dma_current_txdesc = desc_tab;
+    } else {
+        /* if want to initialize DMA Rx descriptors */
+        /* save a copy of the DMA Rx descriptors */
+        desc_tab = rxdesc_tab;
+        buf = &rx_buff[0][0];
+        count = ENET_RXBUF_NUM;
+        maxsize = ENET_RXBUF_SIZE;
+
+        /* enable receiving */
+        desc_status = ENET_RDES0_DAV;
+        /* select receive chained mode and set buffer1 size */
+        desc_bufsize = ENET_RDES1_RCHM | (uint32_t)ENET_RXBUF_SIZE;
+
+        /* configure DMA Rx descriptor table address register */
+        ENET_DMA_RDTADDR = (uint32_t)desc_tab;
+        dma_current_rxdesc = desc_tab;
+    }
+
+    /* configuration each descriptor */
+    for(num = 0U; num < count; num++) {
+        /* get the pointer to the next descriptor of the descriptor table */
+        desc = desc_tab + num;
+
+        /* configure descriptors */
+        desc->status = desc_status;
+        desc->control_buffer_size = desc_bufsize;
+        desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);
+
+        /* if is not the last descriptor */
+        if(num < (count - 1U)) {
+            /* configure the next descriptor address */
+            desc->buffer2_next_desc_addr = (uint32_t)(desc_tab + num + 1U);
+        } else {
+            /* when it is the last descriptor, the next descriptor address
+            equals to first descriptor address in descriptor table */
+            desc->buffer2_next_desc_addr = (uint32_t)desc_tab;
+        }
+    }
+}
+
+/*!
+    \brief    initialize the DMA Tx/Rx descriptors's parameters in enhanced ring mode with ptp function
+    \param[in]  direction: the descriptors which users want to init, refer to enet_dmadirection_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_DMA_TX: DMA Tx descriptors
+      \arg        ENET_DMA_RX: DMA Rx descriptors
+    \param[out] none
+    \retval     none
+*/
+void enet_ptp_enhanced_descriptors_ring_init(enet_dmadirection_enum direction)
+{
+    uint32_t num = 0U, count = 0U, maxsize = 0U;
+    uint32_t desc_status = 0U, desc_bufsize = 0U;
+    enet_descriptors_struct *desc;
+    enet_descriptors_struct *desc_tab;
+    uint8_t *buf;
+
+    /* configure descriptor skip length */
+    ENET_DMA_BCTL &= ~ENET_DMA_BCTL_DPSL;
+    ENET_DMA_BCTL |= DMA_BCTL_DPSL(0);
+
+    /* if want to initialize DMA Tx descriptors */
+    if(ENET_DMA_TX == direction) {
+        /* save a copy of the DMA Tx descriptors */
+        desc_tab = txdesc_tab;
+        buf = &tx_buff[0][0];
+        count = ENET_TXBUF_NUM;
+        maxsize = ENET_TXBUF_SIZE;
+
+        /* select ring mode, and enable transmit timestamp function */
+        desc_status = ENET_TDES0_TTSEN;
+
+        /* configure DMA Tx descriptor table address register */
+        ENET_DMA_TDTADDR = (uint32_t)desc_tab;
+        dma_current_txdesc = desc_tab;
+    } else {
+        /* if want to initialize DMA Rx descriptors */
+        /* save a copy of the DMA Rx descriptors */
+        desc_tab = rxdesc_tab;
+        buf = &rx_buff[0][0];
+        count = ENET_RXBUF_NUM;
+        maxsize = ENET_RXBUF_SIZE;
+
+        /* enable receiving */
+        desc_status = ENET_RDES0_DAV;
+        /* set buffer1 size */
+        desc_bufsize = ENET_RXBUF_SIZE;
+
+        /* configure DMA Rx descriptor table address register */
+        ENET_DMA_RDTADDR = (uint32_t)desc_tab;
+        dma_current_rxdesc = desc_tab;
+    }
+
+    /* configure each descriptor */
+    for(num = 0U; num < count; num++) {
+        /* get the pointer to the next descriptor of the descriptor table */
+        desc = desc_tab + num;
+
+        /* configure descriptors */
+        desc->status = desc_status;
+        desc->control_buffer_size = desc_bufsize;
+        desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);
+
+        /* when it is the last descriptor */
+        if(num == (count - 1U)) {
+            if(ENET_DMA_TX == direction) {
+                /* configure transmit end of ring mode */
+                desc->status |= ENET_TDES0_TERM;
+            } else {
+                /* configure receive end of ring mode */
+                desc->control_buffer_size |= ENET_RDES1_RERM;
+            }
+        }
+    }
+}
+
+/*!
+    \brief    receive a packet data with timestamp values to application buffer, when the DMA is in enhanced mode
+    \param[in]  bufsize: the size of buffer which is the parameter in function
+    \param[out] buffer: pointer to the application buffer
+                note -- if the input is NULL, user should copy data in application by himself
+    \param[out] timestamp: pointer to the table which stores the timestamp high and low
+                note -- if the input is NULL, timestamp is ignored
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus enet_ptpframe_receive_enhanced_mode(uint8_t *buffer, uint32_t bufsize, uint32_t timestamp[])
+{
+    uint32_t offset = 0U, size = 0U;
+    uint32_t timeout = 0U;
+    uint32_t rdes0_tsv_flag;
+
+    /* the descriptor is busy due to own by the DMA */
+    if((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_DAV)) {
+        return ERROR;
+    }
+
+    /* if buffer pointer is null, indicates that users has copied data in application */
+    if(NULL != buffer) {
+        /* if no error occurs, and the frame uses only one descriptor */
+        if(((uint32_t)RESET == (dma_current_rxdesc->status & ENET_RDES0_ERRS)) &&
+                ((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_LDES)) &&
+                ((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_FDES))) {
+            /* get the frame length except CRC */
+            size = GET_RDES0_FRML(dma_current_rxdesc->status) - 4U;
+
+            /* if is a type frame, and CRC is not included in forwarding frame */
+            if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (dma_current_rxdesc->status & ENET_RDES0_FRMT))) {
+                size = size + 4U;
+            }
+
+            /* to avoid situation that the frame size exceeds the buffer length */
+            if(size > bufsize) {
+                return ERROR;
+            }
+
+            /* copy data from Rx buffer to application buffer */
+            for(offset = 0; offset < size; offset++) {
+                (*(buffer + offset)) = (*(__IO uint8_t *)((dma_current_rxdesc->buffer1_addr) + offset));
+            }
+        } else {
+            return ERROR;
+        }
+    }
+
+    /* if timestamp pointer is null, indicates that users don't care timestamp in application */
+    if(NULL != timestamp) {
+        /* wait for ENET_RDES0_TSV flag to be set, the timestamp value is taken and
+        write to the RDES6 and RDES7 */
+        do {
+            rdes0_tsv_flag = (dma_current_rxdesc->status & ENET_RDES0_TSV);
+            timeout++;
+        } while((RESET == rdes0_tsv_flag) && (timeout < ENET_DELAY_TO));
+
+        /* return ERROR due to timeout */
+        if(ENET_DELAY_TO == timeout) {
+            return ERROR;
+        }
+
+        /* clear the ENET_RDES0_TSV flag */
+        dma_current_rxdesc->status &= ~ENET_RDES0_TSV;
+        /* get the timestamp value of the received frame */
+        timestamp[0] = dma_current_rxdesc->timestamp_low;
+        timestamp[1] = dma_current_rxdesc->timestamp_high;
+    }
+
+    /* enable reception, descriptor is owned by DMA */
+    dma_current_rxdesc->status = ENET_RDES0_DAV;
+
+    /* check Rx buffer unavailable flag status */
+    if((uint32_t)RESET != (ENET_DMA_STAT & ENET_DMA_STAT_RBU)) {
+        /* Clear RBU flag */
+        ENET_DMA_STAT = ENET_DMA_STAT_RBU;
+        /* resume DMA reception by writing to the RPEN register*/
+        ENET_DMA_RPEN = 0;
+    }
+
+    /* update the current RxDMA descriptor pointer to the next decriptor in RxDMA decriptor table */
+    /* chained mode */
+    if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RCHM)) {
+        dma_current_rxdesc = (enet_descriptors_struct *)(dma_current_rxdesc->buffer2_next_desc_addr);
+    } else {
+        /* ring mode */
+        if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RERM)) {
+            /* if is the last descriptor in table, the next descriptor is the table header */
+            dma_current_rxdesc = (enet_descriptors_struct *)(ENET_DMA_RDTADDR);
+        } else {
+            /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
+            dma_current_rxdesc = (enet_descriptors_struct *)((uint32_t)dma_current_rxdesc + ETH_DMARXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));
+        }
+    }
+
+    return SUCCESS;
+}
+
+/*!
+    \brief    send data with timestamp values in application buffer as a transmit packet, when the DMA is in enhanced mode
+    \param[in]  buffer: pointer on the application buffer
+                note -- if the input is NULL, user should copy data in application by himself
+    \param[in]  length: the length of frame data to be transmitted
+    \param[out] timestamp: pointer to the table which stores the timestamp high and low
+                note -- if the input is NULL, timestamp is ignored
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus enet_ptpframe_transmit_enhanced_mode(uint8_t *buffer, uint32_t length, uint32_t timestamp[])
+{
+    uint32_t offset = 0;
+    uint32_t dma_tbu_flag, dma_tu_flag;
+    uint32_t tdes0_ttmss_flag;
+    uint32_t timeout = 0;
+
+    /* the descriptor is busy due to own by the DMA */
+    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_DAV)) {
+        return ERROR;
+    }
+
+    /* only frame length no more than ENET_MAX_FRAME_SIZE is allowed */
+    if(length > ENET_MAX_FRAME_SIZE) {
+        return ERROR;
+    }
+
+    /* if buffer pointer is null, indicates that users has handled data in application */
+    if(NULL != buffer) {
+        /* copy frame data from application buffer to Tx buffer */
+        for(offset = 0; offset < length; offset++) {
+            (*(__IO uint8_t *)((dma_current_txdesc->buffer1_addr) + offset)) = (*(buffer + offset));
+        }
+    }
+    /* set the frame length */
+    dma_current_txdesc->control_buffer_size = length;
+    /* set the segment of frame, frame is transmitted in one descriptor */
+    dma_current_txdesc->status |= ENET_TDES0_LSG | ENET_TDES0_FSG;
+    /* enable the DMA transmission */
+    dma_current_txdesc->status |= ENET_TDES0_DAV;
+
+    /* check Tx buffer unavailable flag status */
+    dma_tbu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TBU);
+    dma_tu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TU);
+
+    if((RESET != dma_tbu_flag) || (RESET != dma_tu_flag)) {
+        /* Clear TBU and TU flag */
+        ENET_DMA_STAT = (dma_tbu_flag | dma_tu_flag);
+        /* resume DMA transmission by writing to the TPEN register*/
+        ENET_DMA_TPEN = 0;
+    }
+
+    /* if timestamp pointer is null, indicates that users don't care timestamp in application */
+    if(NULL != timestamp) {
+        /* wait for ENET_TDES0_TTMSS flag to be set, a timestamp was captured */
+        do {
+            tdes0_ttmss_flag = (dma_current_txdesc->status & ENET_TDES0_TTMSS);
+            timeout++;
+        } while((RESET == tdes0_ttmss_flag) && (timeout < ENET_DELAY_TO));
+
+        /* return ERROR due to timeout */
+        if(ENET_DELAY_TO == timeout) {
+            return ERROR;
+        }
+
+        /* clear the ENET_TDES0_TTMSS flag */
+        dma_current_txdesc->status &= ~ENET_TDES0_TTMSS;
+        /* get the timestamp value of the transmit frame */
+        timestamp[0] = dma_current_txdesc->timestamp_low;
+        timestamp[1] = dma_current_txdesc->timestamp_high;
+    }
+
+    /* update the current TxDMA descriptor pointer to the next decriptor in TxDMA decriptor table*/
+    /* chained mode */
+    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TCHM)) {
+        dma_current_txdesc = (enet_descriptors_struct *)(dma_current_txdesc->buffer2_next_desc_addr);
+    } else {
+        /* ring mode */
+        if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TERM)) {
+            /* if is the last descriptor in table, the next descriptor is the table header */
+            dma_current_txdesc = (enet_descriptors_struct *)(ENET_DMA_TDTADDR);
+        } else {
+            /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
+            dma_current_txdesc = (enet_descriptors_struct *)((uint32_t)dma_current_txdesc + ETH_DMATXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));
+        }
+    }
+
+    return SUCCESS;
+}
+
+#else
+
+/*!
+    \brief    configure descriptor to work in normal mode
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_desc_select_normal_mode(void)
+{
+    ENET_DMA_BCTL &= ~ENET_DMA_BCTL_DFM;
+}
+
+/*!
+    \brief    initialize the DMA Tx/Rx descriptors's parameters in normal chain mode with PTP function
+    \param[in]  direction: the descriptors which users want to init, refer to enet_dmadirection_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_DMA_TX: DMA Tx descriptors
+      \arg        ENET_DMA_RX: DMA Rx descriptors
+    \param[in]  desc_ptptab: pointer to the first descriptor address of PTP Rx descriptor table
+    \param[out] none
+    \retval     none
+*/
+void enet_ptp_normal_descriptors_chain_init(enet_dmadirection_enum direction, enet_descriptors_struct *desc_ptptab)
+{
+    uint32_t num = 0U, count = 0U, maxsize = 0U;
+    uint32_t desc_status = 0U, desc_bufsize = 0U;
+    enet_descriptors_struct *desc, *desc_tab;
+    uint8_t *buf;
+
+    /* if want to initialize DMA Tx descriptors */
+    if(ENET_DMA_TX == direction) {
+        /* save a copy of the DMA Tx descriptors */
+        desc_tab = txdesc_tab;
+        buf = &tx_buff[0][0];
+        count = ENET_TXBUF_NUM;
+        maxsize = ENET_TXBUF_SIZE;
+
+        /* select chain mode, and enable transmit timestamp function */
+        desc_status = ENET_TDES0_TCHM | ENET_TDES0_TTSEN;
+
+        /* configure DMA Tx descriptor table address register */
+        ENET_DMA_TDTADDR = (uint32_t)desc_tab;
+        dma_current_txdesc = desc_tab;
+        dma_current_ptp_txdesc = desc_ptptab;
+    } else {
+        /* if want to initialize DMA Rx descriptors */
+        /* save a copy of the DMA Rx descriptors */
+        desc_tab = rxdesc_tab;
+        buf = &rx_buff[0][0];
+        count = ENET_RXBUF_NUM;
+        maxsize = ENET_RXBUF_SIZE;
+
+        /* enable receiving */
+        desc_status = ENET_RDES0_DAV;
+        /* select receive chained mode and set buffer1 size */
+        desc_bufsize = ENET_RDES1_RCHM | (uint32_t)ENET_RXBUF_SIZE;
+
+        /* configure DMA Rx descriptor table address register */
+        ENET_DMA_RDTADDR = (uint32_t)desc_tab;
+        dma_current_rxdesc = desc_tab;
+        dma_current_ptp_rxdesc = desc_ptptab;
+    }
+
+    /* configure each descriptor */
+    for(num = 0U; num < count; num++) {
+        /* get the pointer to the next descriptor of the descriptor table */
+        desc = desc_tab + num;
+
+        /* configure descriptors */
+        desc->status = desc_status;
+        desc->control_buffer_size = desc_bufsize;
+        desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);
+
+        /* if is not the last descriptor */
+        if(num < (count - 1U)) {
+            /* configure the next descriptor address */
+            desc->buffer2_next_desc_addr = (uint32_t)(desc_tab + num + 1U);
+        } else {
+            /* when it is the last descriptor, the next descriptor address
+            equals to first descriptor address in descriptor table */
+            desc->buffer2_next_desc_addr = (uint32_t)desc_tab;
+        }
+        /* set desc_ptptab equal to desc_tab */
+        (&desc_ptptab[num])->buffer1_addr = desc->buffer1_addr;
+        (&desc_ptptab[num])->buffer2_next_desc_addr = desc->buffer2_next_desc_addr;
+    }
+    /* when it is the last ptp descriptor, preserve the first descriptor
+    address of desc_ptptab in ptp descriptor status */
+    (&desc_ptptab[num - 1U])->status = (uint32_t)desc_ptptab;
+}
+
+/*!
+    \brief    initialize the DMA Tx/Rx descriptors's parameters in normal ring mode with PTP function
+    \param[in]  direction: the descriptors which users want to init, refer to enet_dmadirection_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_DMA_TX: DMA Tx descriptors
+      \arg        ENET_DMA_RX: DMA Rx descriptors
+    \param[in]  desc_ptptab: pointer to the first descriptor address of PTP Rx descriptor table
+    \param[out] none
+    \retval     none
+*/
+void enet_ptp_normal_descriptors_ring_init(enet_dmadirection_enum direction, enet_descriptors_struct *desc_ptptab)
+{
+    uint32_t num = 0U, count = 0U, maxsize = 0U;
+    uint32_t desc_status = 0U, desc_bufsize = 0U;
+    enet_descriptors_struct *desc, *desc_tab;
+    uint8_t *buf;
+
+    /* configure descriptor skip length */
+    ENET_DMA_BCTL &= ~ENET_DMA_BCTL_DPSL;
+    ENET_DMA_BCTL |= DMA_BCTL_DPSL(0);
+
+    /* if want to initialize DMA Tx descriptors */
+    if(ENET_DMA_TX == direction) {
+        /* save a copy of the DMA Tx descriptors */
+        desc_tab = txdesc_tab;
+        buf = &tx_buff[0][0];
+        count = ENET_TXBUF_NUM;
+        maxsize = ENET_TXBUF_SIZE;
+
+        /* select ring mode, and enable transmit timestamp function */
+        desc_status = ENET_TDES0_TTSEN;
+
+        /* configure DMA Tx descriptor table address register */
+        ENET_DMA_TDTADDR = (uint32_t)desc_tab;
+        dma_current_txdesc = desc_tab;
+        dma_current_ptp_txdesc = desc_ptptab;
+    } else {
+        /* if want to initialize DMA Rx descriptors */
+        /* save a copy of the DMA Rx descriptors */
+        desc_tab = rxdesc_tab;
+        buf = &rx_buff[0][0];
+        count = ENET_RXBUF_NUM;
+        maxsize = ENET_RXBUF_SIZE;
+
+        /* enable receiving */
+        desc_status = ENET_RDES0_DAV;
+        /* select receive ring mode and set buffer1 size */
+        desc_bufsize = (uint32_t)ENET_RXBUF_SIZE;
+
+        /* configure DMA Rx descriptor table address register */
+        ENET_DMA_RDTADDR = (uint32_t)desc_tab;
+        dma_current_rxdesc = desc_tab;
+        dma_current_ptp_rxdesc = desc_ptptab;
+    }
+
+    /* configure each descriptor */
+    for(num = 0U; num < count; num++) {
+        /* get the pointer to the next descriptor of the descriptor table */
+        desc = desc_tab + num;
+
+        /* configure descriptors */
+        desc->status = desc_status;
+        desc->control_buffer_size = desc_bufsize;
+        desc->buffer1_addr = (uint32_t)(&buf[num * maxsize]);
+
+        /* when it is the last descriptor */
+        if(num == (count - 1U)) {
+            if(ENET_DMA_TX == direction) {
+                /* configure transmit end of ring mode */
+                desc->status |= ENET_TDES0_TERM;
+            } else {
+                /* configure receive end of ring mode */
+                desc->control_buffer_size |= ENET_RDES1_RERM;
+            }
+        }
+        /* set desc_ptptab equal to desc_tab */
+        (&desc_ptptab[num])->buffer1_addr = desc->buffer1_addr;
+        (&desc_ptptab[num])->buffer2_next_desc_addr = desc->buffer2_next_desc_addr;
+    }
+    /* when it is the last ptp descriptor, preserve the first descriptor
+    address of desc_ptptab in ptp descriptor status */
+    (&desc_ptptab[num - 1U])->status = (uint32_t)desc_ptptab;
+}
+
+/*!
+    \brief    receive a packet data with timestamp values to application buffer, when the DMA is in normal mode
+    \param[in]  bufsize: the size of buffer which is the parameter in function
+    \param[out] buffer: pointer to the application buffer
+                note -- if the input is NULL, user should copy data in application by himself
+    \param[out] timestamp: pointer to the table which stores the timestamp high and low
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus enet_ptpframe_receive_normal_mode(uint8_t *buffer, uint32_t bufsize, uint32_t timestamp[])
+{
+    uint32_t offset = 0U, size = 0U;
+
+    /* the descriptor is busy due to own by the DMA */
+    if((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_DAV)) {
+        return ERROR;
+    }
+
+    /* if buffer pointer is null, indicates that users has copied data in application */
+    if(NULL != buffer) {
+        /* if no error occurs, and the frame uses only one descriptor */
+        if(((uint32_t)RESET == (dma_current_rxdesc->status & ENET_RDES0_ERRS)) &&
+                ((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_LDES)) &&
+                ((uint32_t)RESET != (dma_current_rxdesc->status & ENET_RDES0_FDES))) {
+
+            /* get the frame length except CRC */
+            size = GET_RDES0_FRML(dma_current_rxdesc->status) - 4U;
+            /* if is a type frame, and CRC is not included in forwarding frame */
+            if((RESET != (ENET_MAC_CFG & ENET_MAC_CFG_TFCD)) && (RESET != (dma_current_rxdesc->status & ENET_RDES0_FRMT))) {
+                size = size + 4U;
+            }
+
+            /* to avoid situation that the frame size exceeds the buffer length */
+            if(size > bufsize) {
+                return ERROR;
+            }
+
+            /* copy data from Rx buffer to application buffer */
+            for(offset = 0U; offset < size; offset++) {
+                (*(buffer + offset)) = (*(__IO uint8_t *)(uint32_t)((dma_current_ptp_rxdesc->buffer1_addr) + offset));
+            }
+
+        } else {
+            return ERROR;
+        }
+    }
+    /* copy timestamp value from Rx descriptor to application array */
+    timestamp[0] = dma_current_rxdesc->buffer1_addr;
+    timestamp[1] = dma_current_rxdesc->buffer2_next_desc_addr;
+
+    dma_current_rxdesc->buffer1_addr = dma_current_ptp_rxdesc ->buffer1_addr ;
+    dma_current_rxdesc->buffer2_next_desc_addr = dma_current_ptp_rxdesc ->buffer2_next_desc_addr;
+
+    /* enable reception, descriptor is owned by DMA */
+    dma_current_rxdesc->status = ENET_RDES0_DAV;
+
+    /* check Rx buffer unavailable flag status */
+    if((uint32_t)RESET != (ENET_DMA_STAT & ENET_DMA_STAT_RBU)) {
+        /* clear RBU flag */
+        ENET_DMA_STAT = ENET_DMA_STAT_RBU;
+        /* resume DMA reception by writing to the RPEN register*/
+        ENET_DMA_RPEN = 0U;
+    }
+
+
+    /* update the current RxDMA descriptor pointer to the next decriptor in RxDMA decriptor table */
+    /* chained mode */
+    if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RCHM)) {
+        dma_current_rxdesc = (enet_descriptors_struct *)(dma_current_ptp_rxdesc->buffer2_next_desc_addr);
+        /* if it is the last ptp descriptor */
+        if(0U != dma_current_ptp_rxdesc->status) {
+            /* pointer back to the first ptp descriptor address in the desc_ptptab list address */
+            dma_current_ptp_rxdesc = (enet_descriptors_struct *)(dma_current_ptp_rxdesc->status);
+        } else {
+            /* ponter to the next ptp descriptor */
+            dma_current_ptp_rxdesc++;
+        }
+    } else {
+        /* ring mode */
+        if((uint32_t)RESET != (dma_current_rxdesc->control_buffer_size & ENET_RDES1_RERM)) {
+            /* if is the last descriptor in table, the next descriptor is the table header */
+            dma_current_rxdesc = (enet_descriptors_struct *)(ENET_DMA_RDTADDR);
+            /* RDES2 and RDES3 will not be covered by buffer address, so do not need to preserve a new table,
+            use the same table with RxDMA descriptor */
+            dma_current_ptp_rxdesc = (enet_descriptors_struct *)(dma_current_ptp_rxdesc->status);
+        } else {
+            /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
+            dma_current_rxdesc = (enet_descriptors_struct *)(uint32_t)((uint32_t)dma_current_rxdesc + ETH_DMARXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));
+            dma_current_ptp_rxdesc ++;
+        }
+    }
+
+    return SUCCESS;
+}
+
+/*!
+    \brief    send data with timestamp values in application buffer as a transmit packet, when the DMA is in normal mode
+    \param[in]  buffer: pointer on the application buffer
+                note -- if the input is NULL, user should copy data in application by himself
+    \param[in]  length: the length of frame data to be transmitted
+    \param[out] timestamp: pointer to the table which stores the timestamp high and low
+                note -- if the input is NULL, timestamp is ignored
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus enet_ptpframe_transmit_normal_mode(uint8_t *buffer, uint32_t length, uint32_t timestamp[])
+{
+    uint32_t offset = 0U, timeout = 0U;
+    uint32_t dma_tbu_flag, dma_tu_flag, tdes0_ttmss_flag;
+
+    /* the descriptor is busy due to own by the DMA */
+    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_DAV)) {
+        return ERROR;
+    }
+
+    /* only frame length no more than ENET_MAX_FRAME_SIZE is allowed */
+    if(length > ENET_MAX_FRAME_SIZE) {
+        return ERROR;
+    }
+
+    /* if buffer pointer is null, indicates that users has handled data in application */
+    if(NULL != buffer) {
+        /* copy frame data from application buffer to Tx buffer */
+        for(offset = 0U; offset < length; offset++) {
+            (*(__IO uint8_t *)(uint32_t)((dma_current_ptp_txdesc->buffer1_addr) + offset)) = (*(buffer + offset));
+        }
+    }
+    /* set the frame length */
+    dma_current_txdesc->control_buffer_size = (length & (uint32_t)0x1FFF);
+    /* set the segment of frame, frame is transmitted in one descriptor */
+    dma_current_txdesc->status |= ENET_TDES0_LSG | ENET_TDES0_FSG;
+    /* enable the DMA transmission */
+    dma_current_txdesc->status |= ENET_TDES0_DAV;
+
+    /* check Tx buffer unavailable flag status */
+    dma_tbu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TBU);
+    dma_tu_flag = (ENET_DMA_STAT & ENET_DMA_STAT_TU);
+
+    if((RESET != dma_tbu_flag) || (RESET != dma_tu_flag)) {
+        /* clear TBU and TU flag */
+        ENET_DMA_STAT = (dma_tbu_flag | dma_tu_flag);
+        /* resume DMA transmission by writing to the TPEN register*/
+        ENET_DMA_TPEN = 0U;
+    }
+
+    /* if timestamp pointer is null, indicates that users don't care timestamp in application */
+    if(NULL != timestamp) {
+        /* wait for ENET_TDES0_TTMSS flag to be set, a timestamp was captured */
+        do {
+            tdes0_ttmss_flag = (dma_current_txdesc->status & ENET_TDES0_TTMSS);
+            timeout++;
+        } while((RESET == tdes0_ttmss_flag) && (timeout < ENET_DELAY_TO));
+
+        /* return ERROR due to timeout */
+        if(ENET_DELAY_TO == timeout) {
+            return ERROR;
+        }
+
+        /* clear the ENET_TDES0_TTMSS flag */
+        dma_current_txdesc->status &= ~ENET_TDES0_TTMSS;
+        /* get the timestamp value of the transmit frame */
+        timestamp[0] = dma_current_txdesc->buffer1_addr;
+        timestamp[1] = dma_current_txdesc->buffer2_next_desc_addr;
+    }
+    dma_current_txdesc->buffer1_addr = dma_current_ptp_txdesc ->buffer1_addr ;
+    dma_current_txdesc->buffer2_next_desc_addr = dma_current_ptp_txdesc ->buffer2_next_desc_addr;
+
+    /* update the current TxDMA descriptor pointer to the next decriptor in TxDMA decriptor table */
+    /* chained mode */
+    if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TCHM)) {
+        dma_current_txdesc = (enet_descriptors_struct *)(dma_current_ptp_txdesc->buffer2_next_desc_addr);
+        /* if it is the last ptp descriptor */
+        if(0U != dma_current_ptp_txdesc->status) {
+            /* pointer back to the first ptp descriptor address in the desc_ptptab list address */
+            dma_current_ptp_txdesc = (enet_descriptors_struct *)(dma_current_ptp_txdesc->status);
+        } else {
+            /* ponter to the next ptp descriptor */
+            dma_current_ptp_txdesc++;
+        }
+    } else {
+        /* ring mode */
+        if((uint32_t)RESET != (dma_current_txdesc->status & ENET_TDES0_TERM)) {
+            /* if is the last descriptor in table, the next descriptor is the table header */
+            dma_current_txdesc = (enet_descriptors_struct *)(ENET_DMA_TDTADDR);
+            /* TDES2 and TDES3 will not be covered by buffer address, so do not need to preserve a new table,
+            use the same table with TxDMA descriptor */
+            dma_current_ptp_txdesc = (enet_descriptors_struct *)(dma_current_ptp_txdesc->status);
+        } else {
+            /* the next descriptor is the current address, add the descriptor size, and descriptor skip length */
+            dma_current_txdesc = (enet_descriptors_struct *)(uint32_t)((uint32_t)dma_current_txdesc + ETH_DMATXDESC_SIZE + GET_DMA_BCTL_DPSL(ENET_DMA_BCTL));
+            dma_current_ptp_txdesc ++;
+        }
+    }
+    return SUCCESS;
+}
+
+#endif /* SELECT_DESCRIPTORS_ENHANCED_MODE */
+
+/*!
+    \brief    wakeup frame filter register pointer reset
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_wum_filter_register_pointer_reset(void)
+{
+    ENET_MAC_WUM |= ENET_MAC_WUM_WUFFRPR;
+}
+
+/*!
+    \brief    set the remote wakeup frame registers
+    \param[in]  pdata: pointer to buffer data which is written to remote wakeup frame registers (8 words total)
+    \param[out] none
+    \retval     none
+*/
+void enet_wum_filter_config(uint32_t pdata[])
+{
+    uint32_t num = 0U;
+
+    /* configure ENET_MAC_RWFF register */
+    for(num = 0U; num < ETH_WAKEUP_REGISTER_LENGTH; num++) {
+        ENET_MAC_RWFF = pdata[num];
+    }
+}
+
+/*!
+    \brief    enable wakeup management features
+    \param[in]  feature: the wake up type which is selected
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_WUM_POWER_DOWN: power down mode
+      \arg        ENET_WUM_MAGIC_PACKET_FRAME: enable a wakeup event due to magic packet reception
+      \arg        ENET_WUM_WAKE_UP_FRAME: enable a wakeup event due to wakeup frame reception
+      \arg        ENET_WUM_GLOBAL_UNICAST: any received unicast frame passed filter is considered to be a wakeup frame
+    \param[out] none
+    \retval     none
+*/
+void enet_wum_feature_enable(uint32_t feature)
+{
+    ENET_MAC_WUM |= feature;
+}
+
+/*!
+    \brief    disable wakeup management features
+    \param[in]  feature: the wake up type which is selected
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_WUM_MAGIC_PACKET_FRAME: enable a wakeup event due to magic packet reception
+      \arg        ENET_WUM_WAKE_UP_FRAME: enable a wakeup event due to wakeup frame reception
+      \arg        ENET_WUM_GLOBAL_UNICAST: any received unicast frame passed filter is considered to be a wakeup frame
+    \param[out] none
+    \retval     none
+*/
+void enet_wum_feature_disable(uint32_t feature)
+{
+    ENET_MAC_WUM &= (~feature);
+}
+
+/*!
+    \brief    reset the MAC statistics counters
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_msc_counters_reset(void)
+{
+    /* reset all counters */
+    ENET_MSC_CTL |= ENET_MSC_CTL_CTR;
+}
+
+/*!
+    \brief    enable the MAC statistics counter features
+    \param[in]  feature: the feature of MAC statistics counter
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_MSC_COUNTER_STOP_ROLLOVER: counter stop rollover
+      \arg        ENET_MSC_RESET_ON_READ: reset on read
+      \arg        ENET_MSC_COUNTERS_FREEZE: MSC counter freeze
+    \param[out] none
+    \retval     none
+*/
+void enet_msc_feature_enable(uint32_t feature)
+{
+    ENET_MSC_CTL |= feature;
+}
+
+/*!
+    \brief    disable the MAC statistics counter features
+    \param[in]  feature: the feature of MAC statistics counter
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_MSC_COUNTER_STOP_ROLLOVER: counter stop rollover
+      \arg        ENET_MSC_RESET_ON_READ: reset on read
+      \arg        ENET_MSC_COUNTERS_FREEZE: MSC counter freeze
+    \param[out] none
+    \retval     none
+*/
+void enet_msc_feature_disable(uint32_t feature)
+{
+    ENET_MSC_CTL &= (~feature);
+}
+
+/*!
+    \brief    configure MAC statistics counters preset mode
+    \param[in]  mode: MSC counters preset mode, refer to enet_msc_preset_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_MSC_PRESET_NONE: do not preset MSC counter
+      \arg        ENET_MSC_PRESET_HALF: preset all MSC counters to almost-half(0x7FFF FFF0) value
+      \arg        ENET_MSC_PRESET_FULL: preset all MSC counters to almost-full(0xFFFF FFF0) value
+    \param[out] none
+    \retval     none
+*/
+void enet_msc_counters_preset_config(enet_msc_preset_enum mode)
+{
+    ENET_MSC_CTL &= ENET_MSC_PRESET_MASK;
+    ENET_MSC_CTL |= (uint32_t)mode;
+}
+
+/*!
+    \brief    get MAC statistics counter
+    \param[in]  counter: MSC counters which is selected, refer to enet_msc_counter_enum
+                only one parameter can be selected which is shown as below
+      \arg        ENET_MSC_TX_SCCNT: MSC transmitted good frames after a single collision counter
+      \arg        ENET_MSC_TX_MSCCNT: MSC transmitted good frames after more than a single collision counter
+      \arg        ENET_MSC_TX_TGFCNT: MSC transmitted good frames counter
+      \arg        ENET_MSC_RX_RFCECNT: MSC received frames with CRC error counter
+      \arg        ENET_MSC_RX_RFAECNT: MSC received frames with alignment error counter
+      \arg        ENET_MSC_RX_RGUFCNT: MSC received good unicast frames counter
+    \param[out] none
+    \retval     the MSC counter value
+*/
+uint32_t enet_msc_counters_get(enet_msc_counter_enum counter)
+{
+    uint32_t reval;
+
+    reval = REG32((ENET + (uint32_t)counter));
+
+    return reval;
+}
+
+/*!
+    \brief    enable the PTP features
+    \param[in]  feature: the feature of ENET PTP mode
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_RXTX_TIMESTAMP: timestamp function for transmit and receive frames
+      \arg        ENET_PTP_TIMESTAMP_INT: timestamp interrupt trigger
+      \arg        ENET_ALL_RX_TIMESTAMP: all received frames are taken snapshot
+      \arg        ENET_NONTYPE_FRAME_SNAPSHOT: take snapshot when received non type frame
+      \arg        ENET_IPV6_FRAME_SNAPSHOT: take snapshot for IPv6 frame
+      \arg        ENET_IPV4_FRAME_SNAPSHOT: take snapshot for IPv4 frame
+      \arg        ENET_PTP_FRAME_USE_MACADDRESS_FILTER: use MAC address1-3 to filter the PTP frame
+    \param[out] none
+    \retval     none
+*/
+void enet_ptp_feature_enable(uint32_t feature)
+{
+    ENET_PTP_TSCTL |= feature;
+}
+
+/*!
+    \brief    disable the PTP features
+    \param[in]  feature: the feature of ENET PTP mode
+                one or more parameters can be selected which are shown as below
+      \arg        ENET_RXTX_TIMESTAMP: timestamp function for transmit and receive frames
+      \arg        ENET_PTP_TIMESTAMP_INT: timestamp interrupt trigger
+      \arg        ENET_ALL_RX_TIMESTAMP: all received frames are taken snapshot
+      \arg        ENET_NONTYPE_FRAME_SNAPSHOT: take snapshot when received non type frame
+      \arg        ENET_IPV6_FRAME_SNAPSHOT: take snapshot for IPv6 frame
+      \arg        ENET_IPV4_FRAME_SNAPSHOT: take snapshot for IPv4 frame
+      \arg        ENET_PTP_FRAME_USE_MACADDRESS_FILTER: use MAC address1-3 to filter the PTP frame
+    \param[out] none
+    \retval     none
+*/
+void enet_ptp_feature_disable(uint32_t feature)
+{
+    ENET_PTP_TSCTL &= ~feature;
+}
+
+/*!
+    \brief    configure the PTP timestamp function
+    \param[in]  func: the function of PTP timestamp
+                only one parameter can be selected which is shown as below
+      \arg        ENET_CKNT_ORDINARY: type of ordinary clock node type for timestamp
+      \arg        ENET_CKNT_BOUNDARY: type of boundary clock node type for timestamp
+      \arg        ENET_CKNT_END_TO_END: type of end-to-end transparent clock node type for timestamp
+      \arg        ENET_CKNT_PEER_TO_PEER: type of peer-to-peer transparent clock node type for timestamp
+      \arg        ENET_PTP_ADDEND_UPDATE: addend register update
+      \arg        ENET_PTP_SYSTIME_UPDATE: timestamp update
+      \arg        ENET_PTP_SYSTIME_INIT: timestamp initialize
+      \arg        ENET_PTP_FINEMODE: the system timestamp uses the fine method for updating
+      \arg        ENET_PTP_COARSEMODE: the system timestamp uses the coarse method for updating
+      \arg        ENET_SUBSECOND_DIGITAL_ROLLOVER: digital rollover mode
+      \arg        ENET_SUBSECOND_BINARY_ROLLOVER: binary rollover mode
+      \arg        ENET_SNOOPING_PTP_VERSION_2: version 2
+      \arg        ENET_SNOOPING_PTP_VERSION_1: version 1
+      \arg        ENET_EVENT_TYPE_MESSAGES_SNAPSHOT: only event type messages are taken snapshot
+      \arg        ENET_ALL_TYPE_MESSAGES_SNAPSHOT: all type messages are taken snapshot except announce,
+                                                   management and signaling message
+      \arg        ENET_MASTER_NODE_MESSAGE_SNAPSHOT: snapshot is only take for master node message
+      \arg        ENET_SLAVE_NODE_MESSAGE_SNAPSHOT: snapshot is only taken for slave node message
+    \param[out] none
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus enet_ptp_timestamp_function_config(enet_ptp_function_enum func)
+{
+    uint32_t temp_config = 0U, temp_state = 0U;
+    uint32_t timeout = 0U;
+    ErrStatus enet_state = SUCCESS;
+
+    switch(func) {
+    case ENET_CKNT_ORDINARY:
+    case ENET_CKNT_BOUNDARY:
+    case ENET_CKNT_END_TO_END:
+    case ENET_CKNT_PEER_TO_PEER:
+        ENET_PTP_TSCTL &= ~ENET_PTP_TSCTL_CKNT;
+        ENET_PTP_TSCTL |= (uint32_t)func;
+        break;
+    case ENET_PTP_ADDEND_UPDATE:
+        /* this bit must be read as zero before application set it */
+        do {
+            temp_state = ENET_PTP_TSCTL & ENET_PTP_TSCTL_TMSARU;
+            timeout++;
+        } while((RESET != temp_state) && (timeout < ENET_DELAY_TO));
+        /* return ERROR due to timeout */
+        if(ENET_DELAY_TO == timeout) {
+            enet_state = ERROR;
+        } else {
+            ENET_PTP_TSCTL |= ENET_PTP_TSCTL_TMSARU;
+        }
+        break;
+    case ENET_PTP_SYSTIME_UPDATE:
+        /* both the TMSSTU and TMSSTI bits must be read as zero before application set this bit */
+        do {
+            temp_state = ENET_PTP_TSCTL & (ENET_PTP_TSCTL_TMSSTU | ENET_PTP_TSCTL_TMSSTI);
+            timeout++;
+        } while((RESET != temp_state) && (timeout < ENET_DELAY_TO));
+        /* return ERROR due to timeout */
+        if(ENET_DELAY_TO == timeout) {
+            enet_state = ERROR;
+        } else {
+            ENET_PTP_TSCTL |= ENET_PTP_TSCTL_TMSSTU;
+        }
+        break;
+    case ENET_PTP_SYSTIME_INIT:
+        /* this bit must be read as zero before application set it */
+        do {
+            temp_state = ENET_PTP_TSCTL & ENET_PTP_TSCTL_TMSSTI;
+            timeout++;
+        } while((RESET != temp_state) && (timeout < ENET_DELAY_TO));
+        /* return ERROR due to timeout */
+        if(ENET_DELAY_TO == timeout) {
+            enet_state = ERROR;
+        } else {
+            ENET_PTP_TSCTL |= ENET_PTP_TSCTL_TMSSTI;
+        }
+        break;
+    default:
+        temp_config = (uint32_t)func & (~BIT(31));
+        if(RESET != ((uint32_t)func & BIT(31))) {
+            ENET_PTP_TSCTL |= temp_config;
+        } else {
+            ENET_PTP_TSCTL &= ~temp_config;
+        }
+        break;
+    }
+
+    return enet_state;
+}
+
+/*!
+    \brief    configure system time subsecond increment value
+    \param[in]  subsecond: the value will be added to the subsecond value of system time(0x00000000 - 0x000000FF)
+    \param[out] none
+    \retval     none
+*/
+void enet_ptp_subsecond_increment_config(uint32_t subsecond)
+{
+    ENET_PTP_SSINC = PTP_SSINC_STMSSI(subsecond);
+}
+
+/*!
+    \brief    adjusting the clock frequency only in fine update mode
+    \param[in]  add: the value will be added to the accumulator register to achieve time synchronization
+    \param[out] none
+    \retval     none
+*/
+void enet_ptp_timestamp_addend_config(uint32_t add)
+{
+    ENET_PTP_TSADDEND = add;
+}
+
+/*!
+    \brief    initialize or add/subtract to second of the system time
+    \param[in]  sign: timestamp update positive or negative sign
+                only one parameter can be selected which is shown as below
+      \arg        ENET_PTP_ADD_TO_TIME: timestamp update value is added to system time
+      \arg        ENET_PTP_SUBSTRACT_FROM_TIME: timestamp update value is subtracted from system time
+    \param[in]  second: initializing or adding/subtracting to second of the system time
+    \param[in]  subsecond: the current subsecond of the system time
+                with 0.46 ns accuracy if required accuracy is 20 ns
+    \param[out] none
+    \retval     none
+*/
+void enet_ptp_timestamp_update_config(uint32_t sign, uint32_t second, uint32_t subsecond)
+{
+    ENET_PTP_TSUH = second;
+    ENET_PTP_TSUL = sign | PTP_TSUL_TMSUSS(subsecond);
+}
+
+/*!
+    \brief    configure the expected target time
+    \param[in]  second: the expected target second time
+    \param[in]  nanosecond: the expected target nanosecond time (signed)
+    \param[out] none
+    \retval     none
+*/
+void enet_ptp_expected_time_config(uint32_t second, uint32_t nanosecond)
+{
+    ENET_PTP_ETH = second;
+    ENET_PTP_ETL = nanosecond;
+}
+
+/*!
+    \brief    get the current system time
+    \param[in]  none
+    \param[out] systime_struct: pointer to a enet_ptp_systime_struct structure which contains
+                parameters of PTP system time
+                members of the structure and the member values are shown as below:
+                  second: 0x0 - 0xFFFF FFFF
+                  subsecond: 0x0 - 0x7FFF FFFF
+                  sign: ENET_PTP_TIME_POSITIVE, ENET_PTP_TIME_NEGATIVE
+    \retval     none
+*/
+void enet_ptp_system_time_get(enet_ptp_systime_struct *systime_struct)
+{
+    uint32_t temp_sec = 0U, temp_subs = 0U;
+
+    /* get the value of sysytem time registers */
+    temp_sec = (uint32_t)ENET_PTP_TSH;
+    temp_subs = (uint32_t)ENET_PTP_TSL;
+
+    /* get sysytem time and construct the enet_ptp_systime_struct structure */
+    systime_struct->second = temp_sec;
+    systime_struct->subsecond = GET_PTP_TSL_STMSS(temp_subs);
+    systime_struct->sign = GET_PTP_TSL_STS(temp_subs);
+}
+
+/*!
+    \brief    configure the PPS output frequency
+    \param[in]  freq: PPS output frequency
+                only one parameter can be selected which is shown as below
+      \arg        ENET_PPSOFC_1HZ: PPS output 1Hz frequency
+      \arg        ENET_PPSOFC_2HZ: PPS output 2Hz frequency
+      \arg        ENET_PPSOFC_4HZ: PPS output 4Hz frequency
+      \arg        ENET_PPSOFC_8HZ: PPS output 8Hz frequency
+      \arg        ENET_PPSOFC_16HZ: PPS output 16Hz frequency
+      \arg        ENET_PPSOFC_32HZ: PPS output 32Hz frequency
+      \arg        ENET_PPSOFC_64HZ: PPS output 64Hz frequency
+      \arg        ENET_PPSOFC_128HZ: PPS output 128Hz frequency
+      \arg        ENET_PPSOFC_256HZ: PPS output 256Hz frequency
+      \arg        ENET_PPSOFC_512HZ: PPS output 512Hz frequency
+      \arg        ENET_PPSOFC_1024HZ: PPS output 1024Hz frequency
+      \arg        ENET_PPSOFC_2048HZ: PPS output 2048Hz frequency
+      \arg        ENET_PPSOFC_4096HZ: PPS output 4096Hz frequency
+      \arg        ENET_PPSOFC_8192HZ: PPS output 8192Hz frequency
+      \arg        ENET_PPSOFC_16384HZ: PPS output 16384Hz frequency
+      \arg        ENET_PPSOFC_32768HZ: PPS output 32768Hz frequency
+    \param[out] none
+    \retval     none
+*/
+void enet_ptp_pps_output_frequency_config(uint32_t freq)
+{
+    ENET_PTP_PPSCTL = freq;
+}
+
+/*!
+    \brief    reset the ENET initpara struct, call it before using enet_initpara_config()
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void enet_initpara_reset(void)
+{
+    enet_initpara.option_enable = 0U;
+    enet_initpara.forward_frame = 0U;
+    enet_initpara.dmabus_mode = 0U;
+    enet_initpara.dma_maxburst = 0U;
+    enet_initpara.dma_arbitration = 0U;
+    enet_initpara.store_forward_mode = 0U;
+    enet_initpara.dma_function = 0U;
+    enet_initpara.vlan_config = 0U;
+    enet_initpara.flow_control = 0U;
+    enet_initpara.hashtable_high = 0U;
+    enet_initpara.hashtable_low = 0U;
+    enet_initpara.framesfilter_mode = 0U;
+    enet_initpara.halfduplex_param = 0U;
+    enet_initpara.timer_config = 0U;
+    enet_initpara.interframegap = 0U;
+}
+
+/*!
+    \brief    initialize ENET peripheral with generally concerned parameters, call it by enet_init()
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+static void enet_default_init(void)
+{
+    uint32_t reg_value = 0U;
+
+    /* MAC */
+    /* configure ENET_MAC_CFG register */
+    reg_value = ENET_MAC_CFG;
+    reg_value &= MAC_CFG_MASK;
+    reg_value |= ENET_WATCHDOG_ENABLE | ENET_JABBER_ENABLE | ENET_INTERFRAMEGAP_96BIT \
+                 | ENET_SPEEDMODE_10M | ENET_MODE_HALFDUPLEX | ENET_LOOPBACKMODE_DISABLE \
+                 | ENET_CARRIERSENSE_ENABLE | ENET_RECEIVEOWN_ENABLE \
+                 | ENET_RETRYTRANSMISSION_ENABLE | ENET_BACKOFFLIMIT_10 \
+                 | ENET_DEFERRALCHECK_DISABLE \
+                 | ENET_TYPEFRAME_CRC_DROP_DISABLE \
+                 | ENET_AUTO_PADCRC_DROP_DISABLE \
+                 | ENET_CHECKSUMOFFLOAD_DISABLE;
+    ENET_MAC_CFG = reg_value;
+
+    /* configure ENET_MAC_FRMF register */
+    ENET_MAC_FRMF = ENET_SRC_FILTER_DISABLE | ENET_DEST_FILTER_INVERSE_DISABLE \
+                    | ENET_MULTICAST_FILTER_PERFECT | ENET_UNICAST_FILTER_PERFECT \
+                    | ENET_PCFRM_PREVENT_ALL | ENET_BROADCASTFRAMES_ENABLE \
+                    | ENET_PROMISCUOUS_DISABLE | ENET_RX_FILTER_ENABLE;
+
+    /* configure ENET_MAC_HLH, ENET_MAC_HLL register */
+    ENET_MAC_HLH = 0x0U;
+
+    ENET_MAC_HLL = 0x0U;
+
+    /* configure ENET_MAC_FCTL, ENET_MAC_FCTH register */
+    reg_value = ENET_MAC_FCTL;
+    reg_value &= MAC_FCTL_MASK;
+    reg_value |= MAC_FCTL_PTM(0) | ENET_ZERO_QUANTA_PAUSE_DISABLE \
+                 | ENET_PAUSETIME_MINUS4 | ENET_UNIQUE_PAUSEDETECT \
+                 | ENET_RX_FLOWCONTROL_DISABLE | ENET_TX_FLOWCONTROL_DISABLE;
+    ENET_MAC_FCTL = reg_value;
+
+    /* configure ENET_MAC_VLT register */
+    ENET_MAC_VLT = ENET_VLANTAGCOMPARISON_16BIT | MAC_VLT_VLTI(0);
+
+    /* DMA */
+    /* configure ENET_DMA_CTL register */
+    reg_value = ENET_DMA_CTL;
+    reg_value &= DMA_CTL_MASK;
+    reg_value |= ENET_TCPIP_CKSUMERROR_DROP | ENET_RX_MODE_STOREFORWARD \
+                 | ENET_FLUSH_RXFRAME_ENABLE | ENET_TX_MODE_STOREFORWARD \
+                 | ENET_TX_THRESHOLD_64BYTES | ENET_RX_THRESHOLD_64BYTES \
+                 | ENET_SECONDFRAME_OPT_DISABLE;
+    ENET_DMA_CTL = reg_value;
+
+    /* configure ENET_DMA_BCTL register */
+    reg_value = ENET_DMA_BCTL;
+    reg_value &= DMA_BCTL_MASK;
+    reg_value = ENET_ADDRESS_ALIGN_ENABLE | ENET_ARBITRATION_RXTX_2_1 \
+                | ENET_RXDP_32BEAT | ENET_PGBL_32BEAT | ENET_RXTX_DIFFERENT_PGBL \
+                | ENET_FIXED_BURST_ENABLE | ENET_MIXED_BURST_DISABLE \
+                | ENET_NORMAL_DESCRIPTOR;
+    ENET_DMA_BCTL = reg_value;
+}
+
+#ifndef USE_DELAY
+/*!
+    \brief    insert a delay time
+    \param[in]  ncount: specifies the delay time length
+    \param[out] none
+    \param[out] none
+*/
+static void enet_delay(uint32_t ncount)
+{
+    __IO uint32_t delay_time = 0U;
+
+    for(delay_time = ncount; delay_time != 0U; delay_time--) {
+    }
+}
+#endif /* USE_DELAY */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_exmc.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_exmc.c
@@ -1,0 +1,1252 @@
+/*!
+    \file    gd32f4xx_exmc.c
+    \brief   EXMC driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+    \version 2022-06-08, V3.0.1, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_exmc.h"
+
+/* EXMC bank0 register reset value */
+#define BANK0_SNCTL_RESET                 ((uint32_t)0x000030DAU)
+#define BANK0_SNTCFG_RESET                ((uint32_t)0x0FFFFFFFU)
+#define BANK0_SNWTCFG_RESET               ((uint32_t)0x0FFFFFFFU)
+
+/* EXMC bank1/2 register reset mask */
+#define BANK1_2_NPCTL_RESET               ((uint32_t)0x00000008U)
+#define BANK1_2_NPINTEN_RESET             ((uint32_t)0x00000042U)
+#define BANK1_2_NPCTCFG_RESET             ((uint32_t)0xFFFFFFFFU)
+#define BANK1_2_NPATCFG_RESET             ((uint32_t)0xFFFFFFFFU)
+
+/* EXMC bank3 register reset mask */
+#define BANK3_NPCTL_RESET                 ((uint32_t)0x00000008U)
+#define BANK3_NPINTEN_RESET               ((uint32_t)0x00000040U)
+#define BANK3_NPCTCFG_RESET               ((uint32_t)0xFFFFFFFFU)
+#define BANK3_NPATCFG_RESET               ((uint32_t)0xFFFFFFFFU)
+#define BANK3_PIOTCFG3_RESET              ((uint32_t)0xFFFFFFFFU)
+
+/* EXMC SDRAM device register reset mask */
+#define SDRAM_DEVICE_SDCTL_RESET          ((uint32_t)0x000002D0U)
+#define SDRAM_DEVICE_SDTCFG_RESET         ((uint32_t)0x0FFFFFFFU)
+#define SDRAM_DEVICE_SDCMD_RESET          ((uint32_t)0x00000000U)
+#define SDRAM_DEVICE_SDARI_RESET          ((uint32_t)0x00000000U)
+#define SDRAM_DEVICE_SDSTAT_RESET         ((uint32_t)0x00000000U)
+#define SDRAM_DEVICE_SDRSCTL_RESET        ((uint32_t)0x00000000U)
+
+/* EXMC bank0 SQPI-PSRAM register reset mask */
+#define BANK0_SQPI_SINIT_RESET            ((uint32_t)0x18010000U)
+#define BANK0_SQPI_SRCMD_RESET            ((uint32_t)0x00000000U)
+#define BANK0_SQPI_SWCMD_RESET            ((uint32_t)0x00000000U)
+#define BANK0_SQPI_SIDL_RESET             ((uint32_t)0x00000000U)
+#define BANK0_SQPI_SIDH_RESET             ((uint32_t)0x00000000U)
+
+/* EXMC register bit offset */
+#define SNCTL_NRMUX_OFFSET                ((uint32_t)1U)
+#define SNCTL_SBRSTEN_OFFSET              ((uint32_t)8U)
+#define SNCTL_WRAPEN_OFFSET               ((uint32_t)10U)
+#define SNCTL_WREN_OFFSET                 ((uint32_t)12U)
+#define SNCTL_NRWTEN_OFFSET               ((uint32_t)13U)
+#define SNCTL_EXMODEN_OFFSET              ((uint32_t)14U)
+#define SNCTL_ASYNCWAIT_OFFSET            ((uint32_t)15U)
+
+#define SNTCFG_AHLD_OFFSET                ((uint32_t)4U)
+#define SNTCFG_DSET_OFFSET                ((uint32_t)8U)
+#define SNTCFG_BUSLAT_OFFSET              ((uint32_t)16U)
+
+#define NPCTL_NDWTEN_OFFSET               ((uint32_t)1U)
+#define NPCTL_ECCEN_OFFSET                ((uint32_t)6U)
+
+#define NPCTCFG_COMWAIT_OFFSET            ((uint32_t)8U)
+#define NPCTCFG_COMHLD_OFFSET             ((uint32_t)16U)
+#define NPCTCFG_COMHIZ_OFFSET             ((uint32_t)24U)
+
+#define NPATCFG_ATTWAIT_OFFSET            ((uint32_t)8U)
+#define NPATCFG_ATTHLD_OFFSET             ((uint32_t)16U)
+#define NPATCFG_ATTHIZ_OFFSET             ((uint32_t)24U)
+
+#define PIOTCFG_IOWAIT_OFFSET             ((uint32_t)8U)
+#define PIOTCFG_IOHLD_OFFSET              ((uint32_t)16U)
+#define PIOTCFG_IOHIZ_OFFSET              ((uint32_t)24U)
+
+#define SDCTL_WPEN_OFFSET                 ((uint32_t)9U)
+#define SDCTL_BRSTRD_OFFSET               ((uint32_t)12U)
+
+#define SDTCFG_XSRD_OFFSET                ((uint32_t)4U)
+#define SDTCFG_RASD_OFFSET                ((uint32_t)8U)
+#define SDTCFG_ARFD_OFFSET                ((uint32_t)12U)
+#define SDTCFG_WRD_OFFSET                 ((uint32_t)16U)
+#define SDTCFG_RPD_OFFSET                 ((uint32_t)20U)
+#define SDTCFG_RCD_OFFSET                 ((uint32_t)24U)
+
+#define SDCMD_NARF_OFFSET                 ((uint32_t)5U)
+#define SDCMD_MRC_OFFSET                  ((uint32_t)9U)
+
+#define SDARI_ARINTV_OFFSET               ((uint32_t)1U)
+
+#define SDSTAT_STA0_OFFSET                ((uint32_t)1U)
+#define SDSTAT_STA1_OFFSET                ((uint32_t)3U)
+
+#define SRCMD_RWAITCYCLE_OFFSET           ((uint32_t)16U)
+#define SWCMD_WWAITCYCLE_OFFSET           ((uint32_t)16U)
+
+#define INTEN_INTS_OFFSET                 ((uint32_t)3U)
+
+/*!
+    \brief      deinitialize EXMC NOR/SRAM region
+    \param[in]  exmc_norsram_region: select the region of bank0
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANK0_NORSRAM_REGIONx(x=0..3)
+    \param[out] none
+    \retval     none
+*/
+void exmc_norsram_deinit(uint32_t exmc_norsram_region)
+{
+    /* reset the registers */
+    EXMC_SNCTL(exmc_norsram_region) = BANK0_SNCTL_RESET;
+    EXMC_SNTCFG(exmc_norsram_region) = BANK0_SNTCFG_RESET;
+    EXMC_SNWTCFG(exmc_norsram_region) = BANK0_SNWTCFG_RESET;
+}
+
+/*!
+    \brief      initialize exmc_norsram_parameter_struct with the default values
+    \param[in]  none
+    \param[out] exmc_norsram_init_struct: the initialized struct exmc_norsram_parameter_struct pointer
+    \retval     none
+*/
+void exmc_norsram_struct_para_init(exmc_norsram_parameter_struct *exmc_norsram_init_struct)
+{
+    /* configure the structure with default values */
+    exmc_norsram_init_struct->norsram_region = EXMC_BANK0_NORSRAM_REGION0;
+    exmc_norsram_init_struct->address_data_mux = ENABLE;
+    exmc_norsram_init_struct->memory_type = EXMC_MEMORY_TYPE_SRAM;
+    exmc_norsram_init_struct->databus_width = EXMC_NOR_DATABUS_WIDTH_8B;
+    exmc_norsram_init_struct->burst_mode = DISABLE;
+    exmc_norsram_init_struct->nwait_polarity = EXMC_NWAIT_POLARITY_LOW;
+    exmc_norsram_init_struct->wrap_burst_mode = DISABLE;
+    exmc_norsram_init_struct->nwait_config = EXMC_NWAIT_CONFIG_BEFORE;
+    exmc_norsram_init_struct->memory_write = ENABLE;
+    exmc_norsram_init_struct->nwait_signal = ENABLE;
+    exmc_norsram_init_struct->extended_mode = DISABLE;
+    exmc_norsram_init_struct->asyn_wait = DISABLE;
+    exmc_norsram_init_struct->write_mode = EXMC_ASYN_WRITE;
+
+    /* configure read/write timing */
+    exmc_norsram_init_struct->read_write_timing->asyn_address_setuptime = 0xFU;
+    exmc_norsram_init_struct->read_write_timing->asyn_address_holdtime = 0xFU;
+    exmc_norsram_init_struct->read_write_timing->asyn_data_setuptime = 0xFFU;
+    exmc_norsram_init_struct->read_write_timing->bus_latency = 0xFU;
+    exmc_norsram_init_struct->read_write_timing->syn_clk_division = EXMC_SYN_CLOCK_RATIO_16_CLK;
+    exmc_norsram_init_struct->read_write_timing->syn_data_latency = EXMC_DATALAT_17_CLK;
+    exmc_norsram_init_struct->read_write_timing->asyn_access_mode = EXMC_ACCESS_MODE_A;
+
+    /* configure write timing, when extended mode is used */
+    exmc_norsram_init_struct->write_timing->asyn_address_setuptime = 0xFU;
+    exmc_norsram_init_struct->write_timing->asyn_address_holdtime = 0xFU;
+    exmc_norsram_init_struct->write_timing->asyn_data_setuptime = 0xFFU;
+    exmc_norsram_init_struct->write_timing->bus_latency = 0xFU;
+    exmc_norsram_init_struct->write_timing->asyn_access_mode = EXMC_ACCESS_MODE_A;
+}
+
+/*!
+    \brief      initialize EXMC NOR/SRAM region
+    \param[in]  exmc_norsram_parameter_struct: configure the EXMC NOR/SRAM parameter
+                  norsram_region: EXMC_BANK0_NORSRAM_REGIONx, x=0..3
+                  write_mode: EXMC_ASYN_WRITE, EXMC_SYN_WRITE
+                  extended_mode: ENABLE or DISABLE
+                  asyn_wait: ENABLE or DISABLE
+                  nwait_signal: ENABLE or DISABLE
+                  memory_write: ENABLE or DISABLE
+                  nwait_config: EXMC_NWAIT_CONFIG_BEFORE, EXMC_NWAIT_CONFIG_DURING
+                  wrap_burst_mode: ENABLE or DISABLE
+                  nwait_polarity: EXMC_NWAIT_POLARITY_LOW, EXMC_NWAIT_POLARITY_HIGH
+                  burst_mode: ENABLE or DISABLE
+                  databus_width: EXMC_NOR_DATABUS_WIDTH_8B, EXMC_NOR_DATABUS_WIDTH_16B
+                  memory_type: EXMC_MEMORY_TYPE_SRAM, EXMC_MEMORY_TYPE_PSRAM, EXMC_MEMORY_TYPE_NOR
+                  address_data_mux: ENABLE or DISABLE
+                  read_write_timing: struct exmc_norsram_timing_parameter_struct set the time
+                    asyn_access_mode: EXMC_ACCESS_MODE_A, EXMC_ACCESS_MODE_B, EXMC_ACCESS_MODE_C, EXMC_ACCESS_MODE_D
+                    syn_data_latency: EXMC_DATALAT_x_CLK, x=2..17
+                    syn_clk_division: EXMC_SYN_CLOCK_RATIO_DISABLE, EXMC_SYN_CLOCK_RATIO_x_CLK, x=2..16
+                    bus_latency: 0x0U~0xFU
+                    asyn_data_setuptime: 0x01U~0xFFU
+                    asyn_address_holdtime: 0x1U~0xFU
+                    asyn_address_setuptime: 0x0U~0xFU
+                  write_timing: struct exmc_norsram_timing_parameter_struct set the time
+                    asyn_access_mode: EXMC_ACCESS_MODE_A, EXMC_ACCESS_MODE_B, EXMC_ACCESS_MODE_C, EXMC_ACCESS_MODE_D
+                    syn_data_latency: EXMC_DATALAT_x_CLK, x=2..17
+                    syn_clk_division: EXMC_SYN_CLOCK_RATIO_x_CLK, x=2..16
+                    bus_latency: 0x0U~0xFU
+                    asyn_data_setuptime: 0x01U~0xFFU
+                    asyn_address_holdtime: 0x1U~0xFU
+                    asyn_address_setuptime: 0x0U~0xFU
+    \param[out] none
+    \retval     none
+*/
+void exmc_norsram_init(exmc_norsram_parameter_struct *exmc_norsram_init_struct)
+{
+    uint32_t snctl = 0x00000000U, sntcfg = 0x00000000U, snwtcfg = 0x00000000U;
+
+    /* get the register value */
+    snctl = EXMC_SNCTL(exmc_norsram_init_struct->norsram_region);
+
+    /* clear relative bits */
+    snctl &= ((uint32_t)~(EXMC_SNCTL_NREN | EXMC_SNCTL_NRTP | EXMC_SNCTL_NRW | EXMC_SNCTL_SBRSTEN |
+                          EXMC_SNCTL_NRWTPOL | EXMC_SNCTL_WRAPEN | EXMC_SNCTL_NRWTCFG | EXMC_SNCTL_WEN |
+                          EXMC_SNCTL_NRWTEN | EXMC_SNCTL_EXMODEN | EXMC_SNCTL_ASYNCWTEN | EXMC_SNCTL_SYNCWR |
+                          EXMC_SNCTL_NRMUX));
+
+    /* configure control bits */
+    snctl |= (uint32_t)(exmc_norsram_init_struct->address_data_mux << SNCTL_NRMUX_OFFSET) |
+             exmc_norsram_init_struct->memory_type |
+             exmc_norsram_init_struct->databus_width |
+             (exmc_norsram_init_struct->burst_mode << SNCTL_SBRSTEN_OFFSET) |
+             exmc_norsram_init_struct->nwait_polarity |
+             (exmc_norsram_init_struct->wrap_burst_mode << SNCTL_WRAPEN_OFFSET) |
+             exmc_norsram_init_struct->nwait_config |
+             (exmc_norsram_init_struct->memory_write << SNCTL_WREN_OFFSET) |
+             (exmc_norsram_init_struct->nwait_signal << SNCTL_NRWTEN_OFFSET) |
+             (exmc_norsram_init_struct->extended_mode << SNCTL_EXMODEN_OFFSET) |
+             (exmc_norsram_init_struct->asyn_wait << SNCTL_ASYNCWAIT_OFFSET) |
+             exmc_norsram_init_struct->write_mode;
+
+    /* configure timing */
+    sntcfg = (uint32_t)exmc_norsram_init_struct->read_write_timing->asyn_address_setuptime |
+             (exmc_norsram_init_struct->read_write_timing->asyn_address_holdtime << SNTCFG_AHLD_OFFSET) |
+             (exmc_norsram_init_struct->read_write_timing->asyn_data_setuptime << SNTCFG_DSET_OFFSET) |
+             (exmc_norsram_init_struct->read_write_timing->bus_latency << SNTCFG_BUSLAT_OFFSET) |
+             exmc_norsram_init_struct->read_write_timing->syn_clk_division |
+             exmc_norsram_init_struct->read_write_timing->syn_data_latency |
+             exmc_norsram_init_struct->read_write_timing->asyn_access_mode;
+
+    /* enable nor flash access */
+    if(EXMC_MEMORY_TYPE_NOR == exmc_norsram_init_struct->memory_type) {
+        snctl |= (uint32_t)EXMC_SNCTL_NREN;
+    }
+
+    /* configure extended mode */
+    if(ENABLE == exmc_norsram_init_struct->extended_mode) {
+        snwtcfg = (uint32_t)exmc_norsram_init_struct->write_timing->asyn_address_setuptime |
+                  (exmc_norsram_init_struct->write_timing->asyn_address_holdtime << SNTCFG_AHLD_OFFSET) |
+                  (exmc_norsram_init_struct->write_timing->asyn_data_setuptime << SNTCFG_DSET_OFFSET) |
+                  (exmc_norsram_init_struct->write_timing->bus_latency << SNTCFG_BUSLAT_OFFSET) |
+                  exmc_norsram_init_struct->write_timing->asyn_access_mode;
+    } else {
+        snwtcfg = BANK0_SNWTCFG_RESET;
+    }
+
+    /* configure the registers */
+    EXMC_SNCTL(exmc_norsram_init_struct->norsram_region) = snctl;
+    EXMC_SNTCFG(exmc_norsram_init_struct->norsram_region) = sntcfg;
+    EXMC_SNWTCFG(exmc_norsram_init_struct->norsram_region) = snwtcfg;
+}
+
+/*!
+    \brief      enable EXMC NOR/PSRAM bank region
+    \param[in]  exmc_norsram_region: specify the region of NOR/PSRAM bank
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANK0_NORSRAM_REGIONx(x=0..3)
+    \param[out] none
+    \retval     none
+*/
+void exmc_norsram_enable(uint32_t exmc_norsram_region)
+{
+    EXMC_SNCTL(exmc_norsram_region) |= (uint32_t)EXMC_SNCTL_NRBKEN;
+}
+
+/*!
+    \brief      disable EXMC NOR/PSRAM bank region
+    \param[in]  exmc_norsram_region: specify the region of NOR/PSRAM Bank
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANK0_NORSRAM_REGIONx(x=0..3)
+    \param[out] none
+    \retval     none
+*/
+void exmc_norsram_disable(uint32_t exmc_norsram_region)
+{
+    EXMC_SNCTL(exmc_norsram_region) &= ~(uint32_t)EXMC_SNCTL_NRBKEN;
+}
+
+/*!
+    \brief      deinitialize EXMC NAND bank
+    \param[in]  exmc_nand_bank: select the bank of NAND
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANKx_NAND(x=1..2)
+    \param[out] none
+    \retval     none
+*/
+void exmc_nand_deinit(uint32_t exmc_nand_bank)
+{
+    /* EXMC_BANK1_NAND or EXMC_BANK2_NAND */
+    EXMC_NPCTL(exmc_nand_bank) = BANK1_2_NPCTL_RESET;
+    EXMC_NPINTEN(exmc_nand_bank) = BANK1_2_NPINTEN_RESET;
+    EXMC_NPCTCFG(exmc_nand_bank) = BANK1_2_NPCTCFG_RESET;
+    EXMC_NPATCFG(exmc_nand_bank) = BANK1_2_NPATCFG_RESET;
+}
+
+/*!
+    \brief      initialize exmc_norsram_parameter_struct with the default values
+    \param[in]  none
+    \param[out] the initialized struct exmc_norsram_parameter_struct pointer
+    \retval     none
+*/
+void exmc_nand_struct_para_init(exmc_nand_parameter_struct *exmc_nand_init_struct)
+{
+    /* configure the structure with default values */
+    exmc_nand_init_struct->nand_bank = EXMC_BANK1_NAND;
+    exmc_nand_init_struct->wait_feature = DISABLE;
+    exmc_nand_init_struct->databus_width = EXMC_NAND_DATABUS_WIDTH_8B;
+    exmc_nand_init_struct->ecc_logic = DISABLE;
+    exmc_nand_init_struct->ecc_size = EXMC_ECC_SIZE_256BYTES;
+    exmc_nand_init_struct->ctr_latency = 0x0U;
+    exmc_nand_init_struct->atr_latency = 0x0U;
+    exmc_nand_init_struct->common_space_timing->setuptime = 0xFCU;
+    exmc_nand_init_struct->common_space_timing->waittime = 0xFCU;
+    exmc_nand_init_struct->common_space_timing->holdtime = 0xFCU;
+    exmc_nand_init_struct->common_space_timing->databus_hiztime = 0xFCU;
+    exmc_nand_init_struct->attribute_space_timing->setuptime = 0xFCU;
+    exmc_nand_init_struct->attribute_space_timing->waittime = 0xFCU;
+    exmc_nand_init_struct->attribute_space_timing->holdtime = 0xFCU;
+    exmc_nand_init_struct->attribute_space_timing->databus_hiztime = 0xFCU;
+}
+
+/*!
+    \brief      initialize EXMC NAND bank
+    \param[in]  exmc_nand_parameter_struct: configure the EXMC NAND parameter
+                  nand_bank: EXMC_BANK1_NAND,EXMC_BANK2_NAND
+                  ecc_size: EXMC_ECC_SIZE_xBYTES,x=256,512,1024,2048,4096
+                  atr_latency: EXMC_ALE_RE_DELAY_x_HCLK,x=1..16
+                  ctr_latency: EXMC_CLE_RE_DELAY_x_HCLK,x=1..16
+                  ecc_logic: ENABLE or DISABLE
+                  databus_width: EXMC_NAND_DATABUS_WIDTH_8B,EXMC_NAND_DATABUS_WIDTH_16B
+                  wait_feature: ENABLE or DISABLE
+                  common_space_timing: struct exmc_nand_pccard_timing_parameter_struct set the time
+                    databus_hiztime: 0x01U~0xFFU
+                    holdtime: 0x01U~0xFEU
+                    waittime: 0x02U~0xFFU
+                    setuptime: 0x01U~0xFFU
+                  attribute_space_timing: struct exmc_nand_pccard_timing_parameter_struct set the time
+                    databus_hiztime: 0x00U~0xFEU
+                    holdtime: 0x01U~0xFEU
+                    waittime: 0x02U~0xFFU
+                    setuptime: 0x01U~0xFFU
+    \param[out] none
+    \retval     none
+*/
+void exmc_nand_init(exmc_nand_parameter_struct *exmc_nand_init_struct)
+{
+    uint32_t npctl = 0x00000000U, npctcfg = 0x00000000U, npatcfg = 0x00000000U;
+
+    npctl = (uint32_t)(exmc_nand_init_struct->wait_feature << NPCTL_NDWTEN_OFFSET) |
+            EXMC_NPCTL_NDTP |
+            exmc_nand_init_struct->databus_width |
+            (exmc_nand_init_struct->ecc_logic << NPCTL_ECCEN_OFFSET) |
+            exmc_nand_init_struct->ecc_size |
+            exmc_nand_init_struct->ctr_latency |
+            exmc_nand_init_struct->atr_latency;
+
+    npctcfg = (uint32_t)((exmc_nand_init_struct->common_space_timing->setuptime - 1U) & EXMC_NPCTCFG_COMSET) |
+              (((exmc_nand_init_struct->common_space_timing->waittime - 1U) << NPCTCFG_COMWAIT_OFFSET) & EXMC_NPCTCFG_COMWAIT) |
+              ((exmc_nand_init_struct->common_space_timing->holdtime << NPCTCFG_COMHLD_OFFSET) & EXMC_NPCTCFG_COMHLD) |
+              (((exmc_nand_init_struct->common_space_timing->databus_hiztime - 1U) << NPCTCFG_COMHIZ_OFFSET) & EXMC_NPCTCFG_COMHIZ);
+
+    npatcfg = (uint32_t)((exmc_nand_init_struct->attribute_space_timing->setuptime - 1U) & EXMC_NPATCFG_ATTSET) |
+              (((exmc_nand_init_struct->attribute_space_timing->waittime - 1U) << NPATCFG_ATTWAIT_OFFSET) & EXMC_NPATCFG_ATTWAIT) |
+              ((exmc_nand_init_struct->attribute_space_timing->holdtime << NPATCFG_ATTHLD_OFFSET) & EXMC_NPATCFG_ATTHLD) |
+              ((exmc_nand_init_struct->attribute_space_timing->databus_hiztime << NPATCFG_ATTHIZ_OFFSET) & EXMC_NPATCFG_ATTHIZ);
+
+    /* initialize EXMC_BANK1_NAND or EXMC_BANK2_NAND */
+    EXMC_NPCTL(exmc_nand_init_struct->nand_bank) = npctl;
+    EXMC_NPCTCFG(exmc_nand_init_struct->nand_bank) = npctcfg;
+    EXMC_NPATCFG(exmc_nand_init_struct->nand_bank) = npatcfg;
+}
+
+/*!
+    \brief      enable NAND bank
+    \param[in]  exmc_nand_bank: specify the NAND bank
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANKx_NAND(x=1,2)
+    \param[out] none
+    \retval     none
+*/
+void exmc_nand_enable(uint32_t exmc_nand_bank)
+{
+    EXMC_NPCTL(exmc_nand_bank) |= EXMC_NPCTL_NDBKEN;
+}
+
+/*!
+    \brief      disable NAND bank
+    \param[in]  exmc_nand_bank: specify the NAND bank
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANKx_NAND(x=1,2)
+    \param[out] none
+    \retval     none
+*/
+void exmc_nand_disable(uint32_t exmc_nand_bank)
+{
+    EXMC_NPCTL(exmc_nand_bank) &= ~EXMC_NPCTL_NDBKEN;
+}
+
+/*!
+    \brief      deinitialize EXMC PC card bank
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void exmc_pccard_deinit(void)
+{
+    /* EXMC_BANK3_PCCARD */
+    EXMC_NPCTL3 = BANK3_NPCTL_RESET;
+    EXMC_NPINTEN3 = BANK3_NPINTEN_RESET;
+    EXMC_NPCTCFG3 = BANK3_NPCTCFG_RESET;
+    EXMC_NPATCFG3 = BANK3_NPATCFG_RESET;
+    EXMC_PIOTCFG3 = BANK3_PIOTCFG3_RESET;
+}
+
+/*!
+    \brief      initialize exmc_pccard_parameter_struct with the default values
+    \param[in]  none
+    \param[out] the initialized struct exmc_pccard_parameter_struct pointer
+    \retval     none
+*/
+void exmc_pccard_struct_para_init(exmc_pccard_parameter_struct *exmc_pccard_init_struct)
+{
+    /* configure the structure with default values */
+    exmc_pccard_init_struct->wait_feature = DISABLE;
+    exmc_pccard_init_struct->ctr_latency = 0x0U;
+    exmc_pccard_init_struct->atr_latency = 0x0U;
+    exmc_pccard_init_struct->common_space_timing->setuptime = 0xFCU;
+    exmc_pccard_init_struct->common_space_timing->waittime = 0xFCU;
+    exmc_pccard_init_struct->common_space_timing->holdtime = 0xFCU;
+    exmc_pccard_init_struct->common_space_timing->databus_hiztime = 0xFCU;
+    exmc_pccard_init_struct->attribute_space_timing->setuptime = 0xFCU;
+    exmc_pccard_init_struct->attribute_space_timing->waittime = 0xFCU;
+    exmc_pccard_init_struct->attribute_space_timing->holdtime = 0xFCU;
+    exmc_pccard_init_struct->attribute_space_timing->databus_hiztime = 0xFCU;
+    exmc_pccard_init_struct->io_space_timing->setuptime = 0xFCU;
+    exmc_pccard_init_struct->io_space_timing->waittime = 0xFCU;
+    exmc_pccard_init_struct->io_space_timing->holdtime = 0xFCU;
+    exmc_pccard_init_struct->io_space_timing->databus_hiztime = 0xFCU;
+}
+
+/*!
+    \brief      initialize EXMC PC card bank
+    \param[in]  exmc_pccard_parameter_struct: configure the EXMC NAND parameter
+                  atr_latency: EXMC_ALE_RE_DELAY_x_HCLK,x=1..16
+                  ctr_latency: EXMC_CLE_RE_DELAY_x_HCLK,x=1..16
+                  wait_feature: ENABLE or DISABLE
+                  common_space_timing: struct exmc_nand_pccard_timing_parameter_struct set the time
+                    databus_hiztime: 0x01U~0xFFU
+                    holdtime: 0x01U~0xFEU
+                    waittime: 0x02U~0xFFU
+                    setuptime: 0x01U~0xFFU
+                  attribute_space_timing: struct exmc_nand_pccard_timing_parameter_struct set the time
+                    databus_hiztime: 0x00U~0xFEU
+                    holdtime: 0x01U~0xFEU
+                    waittime: 0x02U~0xFFU
+                    setuptime: 0x01U~0xFFU
+                  io_space_timing: exmc_nand_pccard_timing_parameter_struct set the time
+                    databus_hiztime: 0x00U~0xFFU
+                    holdtime: 0x01U~0xFFU
+                    waittime: 0x02U~0x100U
+                    setuptime: 0x01U~0x100U
+    \param[out] none
+    \retval     none
+*/
+void exmc_pccard_init(exmc_pccard_parameter_struct *exmc_pccard_init_struct)
+{
+    /* configure the EXMC bank3 PC card control register */
+    EXMC_NPCTL3 = (uint32_t)(exmc_pccard_init_struct->wait_feature << NPCTL_NDWTEN_OFFSET) |
+                  EXMC_NAND_DATABUS_WIDTH_16B |
+                  exmc_pccard_init_struct->ctr_latency |
+                  exmc_pccard_init_struct->atr_latency ;
+
+    /* configure the EXMC bank3 PC card common space timing configuration register */
+    EXMC_NPCTCFG3 = (uint32_t)((exmc_pccard_init_struct->common_space_timing->setuptime - 1U) & EXMC_NPCTCFG_COMSET) |
+                    (((exmc_pccard_init_struct->common_space_timing->waittime - 1U) << NPCTCFG_COMWAIT_OFFSET) & EXMC_NPCTCFG_COMWAIT) |
+                    ((exmc_pccard_init_struct->common_space_timing->holdtime << NPCTCFG_COMHLD_OFFSET) & EXMC_NPCTCFG_COMHLD) |
+                    (((exmc_pccard_init_struct->common_space_timing->databus_hiztime - 1U) << NPCTCFG_COMHIZ_OFFSET) & EXMC_NPCTCFG_COMHIZ);
+
+    /* configure the EXMC bank3 PC card attribute space timing configuration register */
+    EXMC_NPATCFG3 = (uint32_t)((exmc_pccard_init_struct->attribute_space_timing->setuptime - 1U) & EXMC_NPATCFG_ATTSET) |
+                    (((exmc_pccard_init_struct->attribute_space_timing->waittime - 1U) << NPATCFG_ATTWAIT_OFFSET) & EXMC_NPATCFG_ATTWAIT) |
+                    ((exmc_pccard_init_struct->attribute_space_timing->holdtime << NPATCFG_ATTHLD_OFFSET) & EXMC_NPATCFG_ATTHLD) |
+                    ((exmc_pccard_init_struct->attribute_space_timing->databus_hiztime << NPATCFG_ATTHIZ_OFFSET) & EXMC_NPATCFG_ATTHIZ);
+
+    /* configure the EXMC bank3 PC card io space timing configuration register */
+    EXMC_PIOTCFG3 = (uint32_t)((exmc_pccard_init_struct->io_space_timing->setuptime - 1U) & EXMC_PIOTCFG3_IOSET) |
+                    (((exmc_pccard_init_struct->io_space_timing->waittime - 1U) << PIOTCFG_IOWAIT_OFFSET) & EXMC_PIOTCFG3_IOWAIT) |
+                    ((exmc_pccard_init_struct->io_space_timing->holdtime << PIOTCFG_IOHLD_OFFSET) & EXMC_PIOTCFG3_IOHLD) |
+                    ((exmc_pccard_init_struct->io_space_timing->databus_hiztime << PIOTCFG_IOHIZ_OFFSET) & EXMC_PIOTCFG3_IOHIZ);
+}
+
+/*!
+    \brief      enable PC Card Bank
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void exmc_pccard_enable(void)
+{
+    EXMC_NPCTL3 |= EXMC_NPCTL_NDBKEN;
+}
+
+/*!
+    \brief      disable PC Card Bank
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void exmc_pccard_disable(void)
+{
+    EXMC_NPCTL3 &= ~EXMC_NPCTL_NDBKEN;
+}
+
+/*!
+    \brief      deinitialize EXMC SDRAM device
+   \param[in]   exmc_sdram_device: select the SRAM device
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_SDRAM_DEVICEx(x=0, 1)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void exmc_sdram_deinit(uint32_t exmc_sdram_device)
+{
+    /* reset SDRAM registers */
+    EXMC_SDCTL(exmc_sdram_device) = SDRAM_DEVICE_SDCTL_RESET;
+    EXMC_SDTCFG(exmc_sdram_device) = SDRAM_DEVICE_SDTCFG_RESET;
+    EXMC_SDCMD = SDRAM_DEVICE_SDCMD_RESET;
+    EXMC_SDARI = SDRAM_DEVICE_SDARI_RESET;
+    EXMC_SDRSCTL = SDRAM_DEVICE_SDRSCTL_RESET;
+}
+
+/*!
+    \brief      initialize exmc_sdram_parameter_struct with the default values
+    \param[in]  none
+    \param[out] the initialized struct exmc_pccard_parameter_struct pointer
+    \retval     none
+*/
+void exmc_sdram_struct_para_init(exmc_sdram_parameter_struct *exmc_sdram_init_struct)
+{
+    /* configure the structure with default values */
+    exmc_sdram_init_struct->sdram_device = EXMC_SDRAM_DEVICE0;
+    exmc_sdram_init_struct->column_address_width = EXMC_SDRAM_COW_ADDRESS_8;
+    exmc_sdram_init_struct->row_address_width = EXMC_SDRAM_ROW_ADDRESS_11;
+    exmc_sdram_init_struct->data_width = EXMC_SDRAM_DATABUS_WIDTH_16B;
+    exmc_sdram_init_struct->internal_bank_number = EXMC_SDRAM_4_INTER_BANK;
+    exmc_sdram_init_struct->cas_latency = EXMC_CAS_LATENCY_1_SDCLK;
+    exmc_sdram_init_struct->write_protection = ENABLE;
+    exmc_sdram_init_struct->sdclock_config = EXMC_SDCLK_DISABLE;
+    exmc_sdram_init_struct->burst_read_switch = DISABLE;
+    exmc_sdram_init_struct->pipeline_read_delay = EXMC_PIPELINE_DELAY_0_HCLK;
+
+    exmc_sdram_init_struct->timing->load_mode_register_delay = 16U;
+    exmc_sdram_init_struct->timing->exit_selfrefresh_delay = 16U;
+    exmc_sdram_init_struct->timing->row_address_select_delay = 16U;
+    exmc_sdram_init_struct->timing->auto_refresh_delay = 16U;
+    exmc_sdram_init_struct->timing->write_recovery_delay = 16U;
+    exmc_sdram_init_struct->timing->row_precharge_delay = 16U;
+    exmc_sdram_init_struct->timing->row_to_column_delay = 16U;
+}
+
+/*!
+    \brief      initialize EXMC SDRAM device
+    \param[in]  exmc_sdram_parameter_struct: configure the EXMC SDRAM parameter
+                  sdram_device: EXMC_SDRAM_DEVICE0,EXMC_SDRAM_DEVICE1
+                  pipeline_read_delay: EXMC_PIPELINE_DELAY_x_HCLK,x=0..2
+                  burst_read_switch: ENABLE or DISABLE
+                  sdclock_config: EXMC_SDCLK_DISABLE,EXMC_SDCLK_PERIODS_2_HCLK,EXMC_SDCLK_PERIODS_3_HCLK
+                  write_protection: ENABLE or DISABLE
+                  cas_latency: EXMC_CAS_LATENCY_x_SDCLK,x=1..3
+                  internal_bank_number: EXMC_SDRAM_2_INTER_BANK,EXMC_SDRAM_4_INTER_BANK
+                  data_width: EXMC_SDRAM_DATABUS_WIDTH_8B,EXMC_SDRAM_DATABUS_WIDTH_16B,EXMC_SDRAM_DATABUS_WIDTH_32B
+                  row_address_width: EXMC_SDRAM_ROW_ADDRESS_x,x=11..13
+                  column_address_width: EXMC_SDRAM_COW_ADDRESS_x,x=8..11
+                  timing: exmc_sdram_timing_parameter_struct set the time
+                    row_to_column_delay: 1U~16U
+                    row_precharge_delay: 1U~16U
+                    write_recovery_delay: 1U~16U
+                    auto_refresh_delay: 1U~16U
+                    row_address_select_delay: 1U~16U
+                    exit_selfrefresh_delay: 1U~16U
+                    load_mode_register_delay: 1U~16U
+    \param[out] none
+    \retval     none
+*/
+void exmc_sdram_init(exmc_sdram_parameter_struct *exmc_sdram_init_struct)
+{
+    uint32_t sdctl0, sdctl1, sdtcfg0, sdtcfg1;
+
+    /* configure EXMC_SDCTL0 or EXMC_SDCTL1 */
+    if(EXMC_SDRAM_DEVICE0 == exmc_sdram_init_struct->sdram_device) {
+        /* configure EXMC_SDCTL0 */
+        EXMC_SDCTL(EXMC_SDRAM_DEVICE0)  = (uint32_t)(exmc_sdram_init_struct->column_address_width |
+                                                     exmc_sdram_init_struct->row_address_width |
+                                                     exmc_sdram_init_struct->data_width |
+                                                     exmc_sdram_init_struct->internal_bank_number |
+                                                     exmc_sdram_init_struct->cas_latency |
+                                                    (exmc_sdram_init_struct->write_protection << SDCTL_WPEN_OFFSET) |
+                                                     exmc_sdram_init_struct->sdclock_config |
+                                                    (exmc_sdram_init_struct->burst_read_switch << SDCTL_BRSTRD_OFFSET) | 
+                                                     exmc_sdram_init_struct->pipeline_read_delay);
+        
+        /* configure EXMC_SDTCFG0 */
+        EXMC_SDTCFG(EXMC_SDRAM_DEVICE0) = (uint32_t)((exmc_sdram_init_struct->timing->load_mode_register_delay) - 1U) |
+                                          (((exmc_sdram_init_struct->timing->exit_selfrefresh_delay) - 1U) << SDTCFG_XSRD_OFFSET) |
+                                          (((exmc_sdram_init_struct->timing->row_address_select_delay) - 1U) << SDTCFG_RASD_OFFSET) |
+                                          (((exmc_sdram_init_struct->timing->auto_refresh_delay) - 1U) << SDTCFG_ARFD_OFFSET) |
+                                          (((exmc_sdram_init_struct->timing->write_recovery_delay) - 1U) << SDTCFG_WRD_OFFSET) |
+                                          (((exmc_sdram_init_struct->timing->row_precharge_delay) - 1U) << SDTCFG_RPD_OFFSET) |
+                                          (((exmc_sdram_init_struct->timing->row_to_column_delay) - 1U) << SDTCFG_RCD_OFFSET);
+    } else {
+        /* configure EXMC_SDCTL0 and EXMC_SDCTL1 */
+        /* some bits in the EXMC_SDCTL1 register are reserved */
+        sdctl0 = EXMC_SDCTL(EXMC_SDRAM_DEVICE0) & (~(EXMC_SDCTL_PIPED | EXMC_SDCTL_BRSTRD | EXMC_SDCTL_SDCLK));
+
+        sdctl0 |= (uint32_t)(exmc_sdram_init_struct->sdclock_config |
+                             (exmc_sdram_init_struct->burst_read_switch << SDCTL_BRSTRD_OFFSET) | 
+                             exmc_sdram_init_struct->pipeline_read_delay);
+        
+        sdctl1 = (uint32_t)(exmc_sdram_init_struct->column_address_width |
+                            exmc_sdram_init_struct->row_address_width |
+                            exmc_sdram_init_struct->data_width |
+                            exmc_sdram_init_struct->internal_bank_number |
+                            exmc_sdram_init_struct->cas_latency |
+                            (exmc_sdram_init_struct->write_protection << SDCTL_WPEN_OFFSET));
+
+        EXMC_SDCTL(EXMC_SDRAM_DEVICE0) = sdctl0;
+        EXMC_SDCTL(EXMC_SDRAM_DEVICE1) = sdctl1;
+
+        /* configure EXMC_SDTCFG0 and EXMC_SDTCFG1 */
+        /* some bits in the EXMC_SDTCFG1 register are reserved */
+        sdtcfg0 = EXMC_SDTCFG(EXMC_SDRAM_DEVICE0) & (~(EXMC_SDTCFG_RPD | EXMC_SDTCFG_WRD | EXMC_SDTCFG_ARFD));
+
+        sdtcfg0 |= (uint32_t)((((exmc_sdram_init_struct->timing->auto_refresh_delay) - 1U) << SDTCFG_ARFD_OFFSET) |
+                              (((exmc_sdram_init_struct->timing->row_precharge_delay) - 1U) << SDTCFG_RPD_OFFSET) |
+                              (((exmc_sdram_init_struct->timing->write_recovery_delay) - 1U) << SDTCFG_WRD_OFFSET));
+
+        sdtcfg1 = (uint32_t)(((exmc_sdram_init_struct->timing->load_mode_register_delay) - 1U) |
+                            (((exmc_sdram_init_struct->timing->exit_selfrefresh_delay) - 1U) << SDTCFG_XSRD_OFFSET) |
+                            (((exmc_sdram_init_struct->timing->row_address_select_delay) - 1U) << SDTCFG_RASD_OFFSET) |
+                            (((exmc_sdram_init_struct->timing->row_to_column_delay) - 1U) << SDTCFG_RCD_OFFSET));
+
+        EXMC_SDTCFG(EXMC_SDRAM_DEVICE0) = sdtcfg0;
+        EXMC_SDTCFG(EXMC_SDRAM_DEVICE1) = sdtcfg1;
+    }
+}
+
+/*!
+    \brief      initialize exmc_sdram_struct_command_para_init with the default values
+    \param[in]  none
+    \param[out] the initialized struct exmc_sdram_struct_command_para_init pointer
+    \retval     none
+*/
+void exmc_sdram_struct_command_para_init(exmc_sdram_command_parameter_struct *exmc_sdram_command_init_struct)
+{
+    /* configure the structure with default value */
+    exmc_sdram_command_init_struct->mode_register_content = 0U;
+    exmc_sdram_command_init_struct->auto_refresh_number = EXMC_SDRAM_AUTO_REFLESH_1_SDCLK;
+    exmc_sdram_command_init_struct->bank_select = EXMC_SDRAM_DEVICE0_SELECT;
+    exmc_sdram_command_init_struct->command = EXMC_SDRAM_NORMAL_OPERATION;
+}
+
+/*!
+    \brief      deinitialize exmc SQPIPSRAM
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void exmc_sqpipsram_deinit(void)
+{
+    /* reset the registers */
+    EXMC_SINIT = BANK0_SQPI_SINIT_RESET;
+    EXMC_SRCMD = BANK0_SQPI_SRCMD_RESET;
+    EXMC_SWCMD = BANK0_SQPI_SWCMD_RESET;
+    EXMC_SIDL = BANK0_SQPI_SIDL_RESET;
+    EXMC_SIDH = BANK0_SQPI_SIDH_RESET;
+}
+
+/*!
+    \brief      initialize exmc_sqpipsram_parameter_struct with the default values
+    \param[in]  the struct exmc_sqpipsram_parameter_struct pointer
+    \param[out] none
+    \retval     none
+*/
+void exmc_sqpipsram_struct_para_init(exmc_sqpipsram_parameter_struct *exmc_sqpipsram_init_struct)
+{
+    /* configure the structure with default values */
+    exmc_sqpipsram_init_struct->sample_polarity = EXMC_SQPIPSRAM_SAMPLE_RISING_EDGE;
+    exmc_sqpipsram_init_struct->id_length = EXMC_SQPIPSRAM_ID_LENGTH_64B;
+    exmc_sqpipsram_init_struct->address_bits = EXMC_SQPIPSRAM_ADDR_LENGTH_24B;
+    exmc_sqpipsram_init_struct->command_bits = EXMC_SQPIPSRAM_COMMAND_LENGTH_8B;
+}
+
+/*!
+    \brief      initialize EXMC SQPIPSRAM
+    \param[in]  exmc_sqpipsram_parameter_struct: configure the EXMC SQPIPSRAM parameter
+                  sample_polarity: EXMC_SQPIPSRAM_SAMPLE_RISING_EDGE,EXMC_SQPIPSRAM_SAMPLE_FALLING_EDGE
+                  id_length: EXMC_SQPIPSRAM_ID_LENGTH_xB,x=8,16,32,64
+                  address_bits: EXMC_SQPIPSRAM_ADDR_LENGTH_xB,x=1..26
+                  command_bits: EXMC_SQPIPSRAM_COMMAND_LENGTH_xB,x=4,8,16
+    \param[out] none
+    \retval     none
+*/
+void exmc_sqpipsram_init(exmc_sqpipsram_parameter_struct *exmc_sqpipsram_init_struct)
+{
+    /* initialize SQPI controller */
+    EXMC_SINIT = (uint32_t)exmc_sqpipsram_init_struct->sample_polarity |
+                 exmc_sqpipsram_init_struct->id_length |
+                 exmc_sqpipsram_init_struct->address_bits |
+                 exmc_sqpipsram_init_struct->command_bits;
+}
+
+/*!
+    \brief      configure consecutive clock
+    \param[in]  clock_mode: specify when the clock is generated
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_CLOCK_SYN_MODE: the clock is generated only during synchronous access
+      \arg        EXMC_CLOCK_UNCONDITIONALLY: the clock is generated unconditionally
+    \param[out] none
+    \retval     none
+*/
+void exmc_norsram_consecutive_clock_config(uint32_t clock_mode)
+{
+    if(EXMC_CLOCK_UNCONDITIONALLY == clock_mode) {
+        EXMC_SNCTL(EXMC_BANK0_NORSRAM_REGION0) |= EXMC_CLOCK_UNCONDITIONALLY;
+    } else {
+        EXMC_SNCTL(EXMC_BANK0_NORSRAM_REGION0) &= ~EXMC_CLOCK_UNCONDITIONALLY;
+    }
+}
+
+/*!
+    \brief      configure CRAM page size
+    \param[in]  exmc_norsram_region: select the region of bank0
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANK0_NORSRAM_REGIONx(x=0..3)
+    \param[in]  page_size: CRAM page size
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_CRAM_AUTO_SPLIT: the clock is generated only during synchronous access
+      \arg        EXMC_CRAM_PAGE_SIZE_128_BYTES: page size is 128 bytes
+      \arg        EXMC_CRAM_PAGE_SIZE_256_BYTES: page size is 256 bytes
+      \arg        EXMC_CRAM_PAGE_SIZE_512_BYTES: page size is 512 bytes
+      \arg        EXMC_CRAM_PAGE_SIZE_1024_BYTES: page size is 1024 bytes
+    \param[out] none
+    \retval     none
+*/
+void exmc_norsram_page_size_config(uint32_t exmc_norsram_region, uint32_t page_size)
+{
+    /* reset the bits */
+    EXMC_SNCTL(exmc_norsram_region) &= ~EXMC_SNCTL_CPS;
+
+    /* set the CPS bits */
+    EXMC_SNCTL(exmc_norsram_region) |= page_size;
+}
+
+/*!
+    \brief      enable or disable the EXMC NAND ECC function
+    \param[in]  exmc_nand_bank: specify the NAND bank
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANKx_NAND(x=1,2)
+    \param[in]  newvalue: ENABLE or DISABLE
+    \param[out] none
+    \retval     none
+*/
+void exmc_nand_ecc_config(uint32_t exmc_nand_bank, ControlStatus newvalue)
+{
+    if(ENABLE == newvalue) {
+        /* enable the selected NAND bank ECC function */
+        EXMC_NPCTL(exmc_nand_bank) |= EXMC_NPCTL_ECCEN;
+    } else {
+        /* disable the selected NAND bank ECC function */
+        EXMC_NPCTL(exmc_nand_bank) &= ~EXMC_NPCTL_ECCEN;
+    }
+}
+
+/*!
+    \brief      get the EXMC ECC value
+    \param[in]  exmc_nand_bank: specify the NAND bank
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANKx_NAND(x=1,2)
+    \param[out] none
+    \retval     the error correction code(ECC) value
+*/
+uint32_t exmc_ecc_get(uint32_t exmc_nand_bank)
+{
+    return(EXMC_NECC(exmc_nand_bank));
+}
+
+/*!
+    \brief      enable or disable read sample
+    \param[in]  newvalue: ENABLE or DISABLE
+    \param[out] none
+    \retval     none
+*/
+void exmc_sdram_readsample_enable(ControlStatus newvalue)
+{
+    if(ENABLE == newvalue) {
+        EXMC_SDRSCTL |=  EXMC_SDRSCTL_RSEN;
+    } else {
+        EXMC_SDRSCTL &= (uint32_t)(~EXMC_SDRSCTL_RSEN);
+    }
+}
+
+/*!
+    \brief      configure the delayed sample clock of read data
+    \param[in]  delay_cell: SDRAM the delayed sample clock of read data
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_SDRAM_x_DELAY_CELL(x=0..15)
+    \param[in]  extra_hclk: sample cycle of read data
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_SDRAM_READSAMPLE_x_EXTRAHCLK(x=0,1)
+    \param[out] none
+    \retval     none
+*/
+void exmc_sdram_readsample_config(uint32_t delay_cell, uint32_t extra_hclk)
+{
+    uint32_t sdrsctl = 0U;
+
+    /* reset the bits */
+    sdrsctl = EXMC_SDRSCTL & (~(EXMC_SDRSCTL_SDSC | EXMC_SDRSCTL_SSCR));
+    /* set the bits */
+    sdrsctl |= (uint32_t)(delay_cell | extra_hclk);
+    EXMC_SDRSCTL = sdrsctl;
+}
+
+/*!
+    \brief      configure the SDRAM memory command
+    \param[in]  exmc_sdram_command_init_struct: initialize EXMC SDRAM command
+                  mode_register_content:
+                  auto_refresh_number: EXMC_SDRAM_AUTO_REFLESH_x_SDCLK, x=1..15
+                  bank_select: EXMC_SDRAM_DEVICE0_SELECT, EXMC_SDRAM_DEVICE1_SELECT, EXMC_SDRAM_DEVICE0_1_SELECT
+                  command: EXMC_SDRAM_NORMAL_OPERATION, EXMC_SDRAM_CLOCK_ENABLE, EXMC_SDRAM_PRECHARGE_ALL,
+                           EXMC_SDRAM_AUTO_REFRESH, EXMC_SDRAM_LOAD_MODE_REGISTER, EXMC_SDRAM_SELF_REFRESH,
+                           EXMC_SDRAM_POWERDOWN_ENTRY
+    \param[out] none
+    \retval     none
+*/
+void exmc_sdram_command_config(exmc_sdram_command_parameter_struct *exmc_sdram_command_init_struct)
+{
+    /* configure command register */
+    EXMC_SDCMD = (uint32_t)((exmc_sdram_command_init_struct->command) |
+                            (exmc_sdram_command_init_struct->bank_select) |
+                            ((exmc_sdram_command_init_struct->auto_refresh_number)) |
+                            ((exmc_sdram_command_init_struct->mode_register_content) << SDCMD_MRC_OFFSET));
+}
+
+/*!
+    \brief      set auto-refresh interval
+    \param[in]  exmc_count: the number SDRAM clock cycles unit between two successive auto-refresh commands, 0x0000~0x1FFF
+    \param[out] none
+    \retval     none
+*/
+void exmc_sdram_refresh_count_set(uint32_t exmc_count)
+{
+    uint32_t sdari;
+    sdari = EXMC_SDARI & (~EXMC_SDARI_ARINTV);
+    EXMC_SDARI = sdari | (uint32_t)((exmc_count << SDARI_ARINTV_OFFSET) & EXMC_SDARI_ARINTV);
+}
+
+/*!
+    \brief      set the number of successive auto-refresh command
+    \param[in]  exmc_number: the number of successive Auto-refresh cycles will be send, 1~15
+    \param[out] none
+    \retval     none
+*/
+void exmc_sdram_autorefresh_number_set(uint32_t exmc_number)
+{
+    uint32_t sdcmd;
+    sdcmd = EXMC_SDCMD & (~EXMC_SDCMD_NARF);
+    EXMC_SDCMD = sdcmd | (uint32_t)((exmc_number << SDCMD_NARF_OFFSET) & EXMC_SDCMD_NARF) ;
+}
+
+/*!
+    \brief      configure the write protection function
+    \param[in]  exmc_sdram_device: specify the SDRAM device
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_SDRAM_DEVICEx(x=0,1)
+    \param[in]  newvalue: ENABLE or DISABLE
+    \param[out] none
+    \retval     none
+*/
+void exmc_sdram_write_protection_config(uint32_t exmc_sdram_device, ControlStatus newvalue)
+{
+    if(ENABLE == newvalue) {
+        EXMC_SDCTL(exmc_sdram_device) |= (uint32_t)EXMC_SDCTL_WPEN;
+    } else {
+        EXMC_SDCTL(exmc_sdram_device) &= ~((uint32_t)EXMC_SDCTL_WPEN);
+    }
+
+}
+
+/*!
+    \brief      get the status of SDRAM device0 or device1
+    \param[in]  exmc_sdram_device: specify the SDRAM device
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_SDRAM_DEVICEx(x=0,1)
+    \param[out] none
+    \retval     the status of SDRAM device
+*/
+uint32_t exmc_sdram_bankstatus_get(uint32_t exmc_sdram_device)
+{
+    uint32_t sdstat = 0U;
+
+    if(EXMC_SDRAM_DEVICE0 == exmc_sdram_device) {
+        sdstat = ((uint32_t)(EXMC_SDSTAT & EXMC_SDSDAT_STA0) >> SDSTAT_STA0_OFFSET);
+    } else {
+        sdstat = ((uint32_t)(EXMC_SDSTAT & EXMC_SDSDAT_STA1) >> SDSTAT_STA1_OFFSET);
+    }
+
+    return sdstat;
+}
+
+/*!
+    \brief      set the read command
+    \param[in]  read_command_mode: configure SPI PSRAM read command mode
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_SQPIPSRAM_READ_MODE_DISABLE: not SPI mode
+      \arg        EXMC_SQPIPSRAM_READ_MODE_SPI: SPI mode
+      \arg        EXMC_SQPIPSRAM_READ_MODE_SQPI: SQPI mode
+      \arg        EXMC_SQPIPSRAM_READ_MODE_QPI: QPI mode
+    \param[in]  read_wait_cycle: wait cycle number after address phase,0..15
+    \param[in]  read_command_code: read command for AHB read transfer
+    \param[out] none
+    \retval     none
+*/
+void exmc_sqpipsram_read_command_set(uint32_t read_command_mode, uint32_t read_wait_cycle, uint32_t read_command_code)
+{
+    uint32_t srcmd;
+
+    srcmd = (uint32_t) read_command_mode |
+            ((read_wait_cycle << SRCMD_RWAITCYCLE_OFFSET) & EXMC_SRCMD_RWAITCYCLE) |
+            ((read_command_code & EXMC_SRCMD_RCMD));
+    EXMC_SRCMD = srcmd;
+}
+
+/*!
+    \brief      set the write command
+    \param[in]  write_command_mode: configure SPI PSRAM write command mode
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_SQPIPSRAM_WRITE_MODE_DISABLE: not SPI mode
+      \arg        EXMC_SQPIPSRAM_WRITE_MODE_SPI: SPI mode
+      \arg        EXMC_SQPIPSRAM_WRITE_MODE_SQPI: SQPI mode
+      \arg        EXMC_SQPIPSRAM_WRITE_MODE_QPI: QPI mode
+    \param[in]  write_wait_cycle: wait cycle number after address phase,0..15
+    \param[in]  write_command_code: read command for AHB read transfer
+    \param[out] none
+    \retval     none
+*/
+void exmc_sqpipsram_write_command_set(uint32_t write_command_mode, uint32_t write_wait_cycle, uint32_t write_command_code)
+{
+    uint32_t swcmd;
+
+    swcmd = (uint32_t) write_command_mode |
+            ((write_wait_cycle << SWCMD_WWAITCYCLE_OFFSET) & EXMC_SWCMD_WWAITCYCLE) |
+            ((write_command_code & EXMC_SWCMD_WCMD));
+    EXMC_SWCMD = swcmd;
+}
+
+/*!
+    \brief      send SPI read ID command
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void exmc_sqpipsram_read_id_command_send(void)
+{
+    EXMC_SRCMD |= EXMC_SRCMD_RDID;
+}
+
+/*!
+    \brief      send SPI special command which does not have address and data phase
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void exmc_sqpipsram_write_cmd_send(void)
+{
+    EXMC_SWCMD |= EXMC_SWCMD_SC;
+}
+
+/*!
+    \brief      get the EXMC SPI ID low data
+    \param[in]  none
+    \param[out] none
+    \retval     the ID low data
+*/
+uint32_t exmc_sqpipsram_low_id_get(void)
+{
+    return (EXMC_SIDL);
+}
+
+/*!
+    \brief      get the EXMC SPI ID high data
+    \param[in]  none
+    \param[out] none
+    \retval     the ID high data
+*/
+uint32_t exmc_sqpipsram_high_id_get(void)
+{
+    return (EXMC_SIDH);
+}
+
+/*!
+    \brief      get the bit value of EXMC send write command bit or read ID command
+    \param[in]  send_command_flag: the send command flag
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_SEND_COMMAND_FLAG_RDID: EXMC_SRCMD_RDID flag bit
+      \arg        EXMC_SEND_COMMAND_FLAG_SC: EXMC_SWCMD_SC flag bit
+    \param[out] none
+    \retval     the new value of send command flag
+*/
+FlagStatus exmc_sqpipsram_send_command_state_get(uint32_t send_command_flag)
+{
+    uint32_t flag = 0x00000000U;
+
+    if(EXMC_SEND_COMMAND_FLAG_RDID == send_command_flag) {
+        flag = EXMC_SRCMD;
+    } else if(EXMC_SEND_COMMAND_FLAG_SC == send_command_flag) {
+        flag = EXMC_SWCMD;
+    } else {
+    }
+
+    if(flag & send_command_flag) {
+        /* flag is set */
+        return SET;
+    } else {
+        /* flag is reset */
+        return RESET;
+    }
+}
+
+/*!
+    \brief      enable EXMC interrupt
+    \param[in]  exmc_bank: specify the NAND bank,PC card bank or SDRAM device
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANK1_NAND: the NAND bank1
+      \arg        EXMC_BANK2_NAND: the NAND bank2
+      \arg        EXMC_BANK3_PCCARD: the PC card bank
+      \arg        EXMC_SDRAM_DEVICE0: the SDRAM device0
+      \arg        EXMC_SDRAM_DEVICE1: the SDRAM device1
+    \param[in]  interrupt: specify EXMC interrupt flag
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_NAND_PCCARD_INT_FLAG_RISE: rising edge interrupt and flag
+      \arg        EXMC_NAND_PCCARD_INT_FLAG_LEVEL: high-level interrupt and flag
+      \arg        EXMC_NAND_PCCARD_INT_FLAG_FALL: falling edge interrupt and flag
+      \arg        EXMC_SDRAM_INT_FLAG_REFRESH: refresh error interrupt and flag
+    \param[out] none
+    \retval     none
+*/
+void exmc_interrupt_enable(uint32_t exmc_bank, uint32_t interrupt)
+{
+    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)) {
+        /* NAND bank1,bank2 or PC card bank3 */
+        EXMC_NPINTEN(exmc_bank) |= interrupt;
+    } else {
+        /* SDRAM device0 or device1 */
+        EXMC_SDARI |= EXMC_SDARI_REIE;
+    }
+}
+
+/*!
+    \brief      disable EXMC interrupt
+    \param[in]  exmc_bank: specify the NAND bank , PC card bank or SDRAM device
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANK1_NAND: the NAND bank1
+      \arg        EXMC_BANK2_NAND: the NAND bank2
+      \arg        EXMC_BANK3_PCCARD: the PC card bank
+      \arg        EXMC_SDRAM_DEVICE0: the SDRAM device0
+      \arg        EXMC_SDRAM_DEVICE1: the SDRAM device1
+    \param[in]  interrupt: specify EXMC interrupt flag
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_NAND_PCCARD_INT_FLAG_RISE: rising edge interrupt and flag
+      \arg        EXMC_NAND_PCCARD_INT_FLAG_LEVEL: high-level interrupt and flag
+      \arg        EXMC_NAND_PCCARD_INT_FLAG_FALL: falling edge interrupt and flag
+      \arg        EXMC_SDRAM_INT_FLAG_REFRESH: refresh error interrupt and flag
+    \param[out] none
+    \retval     none
+*/
+void exmc_interrupt_disable(uint32_t exmc_bank, uint32_t interrupt)
+{
+    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)) {
+        /* NAND bank1,bank2 or PC card bank3 */
+        EXMC_NPINTEN(exmc_bank) &= ~interrupt;
+    } else {
+        /* SDRAM device0 or device1 */
+        EXMC_SDARI &= ~EXMC_SDARI_REIE;
+    }
+}
+
+/*!
+    \brief      get EXMC flag status
+    \param[in]  exmc_bank: specify the NAND bank , PC card bank or SDRAM device
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANK1_NAND: the NAND bank1
+      \arg        EXMC_BANK2_NAND: the NAND bank2
+      \arg        EXMC_BANK3_PCCARD: the PC Card bank
+      \arg        EXMC_SDRAM_DEVICE0: the SDRAM device0
+      \arg        EXMC_SDRAM_DEVICE1: the SDRAM device1
+    \param[in]  flag: EXMC status and flag
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_NAND_PCCARD_FLAG_RISE: interrupt rising edge status
+      \arg        EXMC_NAND_PCCARD_FLAG_LEVEL: interrupt high-level status
+      \arg        EXMC_NAND_PCCARD_FLAG_FALL: interrupt falling edge status
+      \arg        EXMC_NAND_PCCARD_FLAG_FIFOE: FIFO empty flag
+      \arg        EXMC_SDRAM_FLAG_REFRESH: refresh error interrupt flag
+      \arg        EXMC_SDRAM_FLAG_NREADY: not ready status
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus exmc_flag_get(uint32_t exmc_bank, uint32_t flag)
+{
+    uint32_t status = 0x00000000U;
+
+    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)) {
+        /* NAND bank1,bank2 or PC card bank3 */
+        status = EXMC_NPINTEN(exmc_bank);
+    } else {
+        /* SDRAM device0 or device1 */
+        status = EXMC_SDSTAT;
+    }
+
+    if((status & flag) != (uint32_t)flag) {
+        /* flag is reset */
+        return RESET;
+    } else {
+        /* flag is set */
+        return SET;
+    }
+}
+
+/*!
+    \brief      clear EXMC flag status
+    \param[in]  exmc_bank: specify the NAND bank , PCCARD bank or SDRAM device
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANK1_NAND: the NAND bank1
+      \arg        EXMC_BANK2_NAND: the NAND bank2
+      \arg        EXMC_BANK3_PCCARD: the PC card bank
+      \arg        EXMC_SDRAM_DEVICE0: the SDRAM device0
+      \arg        EXMC_SDRAM_DEVICE1: the SDRAM device1
+    \param[in]  flag: EXMC status and flag
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_NAND_PCCARD_FLAG_RISE: interrupt rising edge status
+      \arg        EXMC_NAND_PCCARD_FLAG_LEVEL: interrupt high-level status
+      \arg        EXMC_NAND_PCCARD_FLAG_FALL: interrupt falling edge status
+      \arg        EXMC_NAND_PCCARD_FLAG_FIFOE: FIFO empty flag
+      \arg        EXMC_SDRAM_FLAG_REFRESH: refresh error interrupt flag
+      \arg        EXMC_SDRAM_FLAG_NREADY: not ready status
+    \param[out] none
+    \retval     none
+*/
+void exmc_flag_clear(uint32_t exmc_bank, uint32_t flag)
+{
+    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)) {
+        /* NAND bank1,bank2 or PC card bank3 */
+        EXMC_NPINTEN(exmc_bank) &= ~flag;
+    } else {
+        /* SDRAM device0 or device1 */
+        EXMC_SDSTAT &= ~flag;
+    }
+}
+
+/*!
+    \brief      get EXMC interrupt flag
+    \param[in]  exmc_bank: specify the NAND bank , PC card bank or SDRAM device
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANK1_NAND: the NAND bank1
+      \arg        EXMC_BANK2_NAND: the NAND bank2
+      \arg        EXMC_BANK3_PCCARD: the PC card bank
+      \arg        EXMC_SDRAM_DEVICE0: the SDRAM device0
+      \arg        EXMC_SDRAM_DEVICE1: the SDRAM device1
+    \param[in]  interrupt: EXMC interrupt flag
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_NAND_PCCARD_INT_FLAG_RISE: rising edge interrupt and flag
+      \arg        EXMC_NAND_PCCARD_INT_FLAG_LEVEL: high-level interrupt and flag
+      \arg        EXMC_NAND_PCCARD_INT_FLAG_FALL: falling edge interrupt and flag
+      \arg        EXMC_SDRAM_INT_FLAG_REFRESH: refresh error interrupt and flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus exmc_interrupt_flag_get(uint32_t exmc_bank, uint32_t interrupt)
+{
+    uint32_t status = 0x00000000U, interrupt_enable = 0x00000000U, interrupt_state = 0x00000000U;
+
+    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)) {
+        /* NAND bank1,bank2 or PC card bank3 */
+        status = EXMC_NPINTEN(exmc_bank);
+        interrupt_state = (status & (interrupt >> INTEN_INTS_OFFSET));
+    } else {
+        /* SDRAM device0 or device1 */
+        status = EXMC_SDARI;
+        interrupt_state = (EXMC_SDSTAT & EXMC_SDSDAT_REIF);
+    }
+
+    interrupt_enable = (status & interrupt);
+
+    if((interrupt_enable) && (interrupt_state)) {
+        /* interrupt flag is set */
+        return SET;
+    } else {
+        /* interrupt flag is reset */
+        return RESET;
+    }
+}
+
+/*!
+    \brief      clear EXMC interrupt flag
+    \param[in]  exmc_bank: specify the NAND bank , PC card bank or SDRAM device
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_BANK1_NAND: the NAND bank1
+      \arg        EXMC_BANK2_NAND: the NAND bank2
+      \arg        EXMC_BANK3_PCCARD: the PC card bank
+      \arg        EXMC_SDRAM_DEVICE0: the SDRAM device0
+      \arg        EXMC_SDRAM_DEVICE1: the SDRAM device1
+    \param[in]  interrupt: EXMC interrupt flag
+                only one parameter can be selected which is shown as below:
+      \arg        EXMC_NAND_PCCARD_INT_FLAG_RISE: rising edge interrupt and flag
+      \arg        EXMC_NAND_PCCARD_INT_FLAG_LEVEL: high-level interrupt and flag
+      \arg        EXMC_NAND_PCCARD_INT_FLAG_FALL: falling edge interrupt and flag
+      \arg        EXMC_SDRAM_INT_FLAG_REFRESH: refresh error interrupt and flag
+    \param[out] none
+    \retval     none
+*/
+void exmc_interrupt_flag_clear(uint32_t exmc_bank, uint32_t interrupt)
+{
+    if((EXMC_BANK1_NAND == exmc_bank) || (EXMC_BANK2_NAND == exmc_bank) || (EXMC_BANK3_PCCARD == exmc_bank)) {
+        /* NAND bank1,bank2 or PC card bank3 */
+        EXMC_NPINTEN(exmc_bank) &= ~(interrupt >> INTEN_INTS_OFFSET);
+    } else {
+        /* SDRAM device0 or device1 */
+        EXMC_SDARI |= EXMC_SDARI_REC;
+    }
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_exti.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_exti.c
@@ -1,0 +1,256 @@
+/*!
+    \file    gd32f4xx_exti.c
+    \brief   EXTI driver
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_exti.h"
+
+/*!
+    \brief    deinitialize the EXTI
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void exti_deinit(void)
+{
+    /* reset the value of all the EXTI registers */
+    EXTI_INTEN = (uint32_t)0x00000000U;
+    EXTI_EVEN  = (uint32_t)0x00000000U;
+    EXTI_RTEN  = (uint32_t)0x00000000U;
+    EXTI_FTEN  = (uint32_t)0x00000000U;
+    EXTI_SWIEV = (uint32_t)0x00000000U;
+}
+
+/*!
+    \brief    initialize the EXTI
+    \param[in]  linex: EXTI line number, refer to exti_line_enum
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_x (x=0..22): EXTI line x
+    \param[in]  mode: interrupt or event mode, refer to exti_mode_enum
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_INTERRUPT: interrupt mode
+      \arg        EXTI_EVENT: event mode
+    \param[in]  trig_type: interrupt trigger type, refer to exti_trig_type_enum
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_TRIG_RISING: rising edge trigger
+      \arg        EXTI_TRIG_FALLING: falling trigger
+      \arg        EXTI_TRIG_BOTH: rising and falling trigger
+      \arg        EXTI_TRIG_NONE: without rising edge or falling edge trigger
+    \param[out] none
+    \retval     none
+*/
+void exti_init(exti_line_enum linex, \
+               exti_mode_enum mode, \
+               exti_trig_type_enum trig_type)
+{
+    /* reset the EXTI line x */
+    EXTI_INTEN &= ~(uint32_t)linex;
+    EXTI_EVEN &= ~(uint32_t)linex;
+    EXTI_RTEN &= ~(uint32_t)linex;
+    EXTI_FTEN &= ~(uint32_t)linex;
+
+    /* set the EXTI mode and enable the interrupts or events from EXTI line x */
+    switch(mode) {
+    case EXTI_INTERRUPT:
+        EXTI_INTEN |= (uint32_t)linex;
+        break;
+    case EXTI_EVENT:
+        EXTI_EVEN |= (uint32_t)linex;
+        break;
+    default:
+        break;
+    }
+
+    /* set the EXTI trigger type */
+    switch(trig_type) {
+    case EXTI_TRIG_RISING:
+        EXTI_RTEN |= (uint32_t)linex;
+        EXTI_FTEN &= ~(uint32_t)linex;
+        break;
+    case EXTI_TRIG_FALLING:
+        EXTI_RTEN &= ~(uint32_t)linex;
+        EXTI_FTEN |= (uint32_t)linex;
+        break;
+    case EXTI_TRIG_BOTH:
+        EXTI_RTEN |= (uint32_t)linex;
+        EXTI_FTEN |= (uint32_t)linex;
+        break;
+    case EXTI_TRIG_NONE:
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief    enable the interrupts from EXTI line x
+    \param[in]  linex: EXTI line number, refer to exti_line_enum
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_x (x=0..22): EXTI line x
+    \param[out] none
+    \retval     none
+*/
+void exti_interrupt_enable(exti_line_enum linex)
+{
+    EXTI_INTEN |= (uint32_t)linex;
+}
+
+/*!
+    \brief    disable the interrupt from EXTI line x
+    \param[in]  linex: EXTI line number, refer to exti_line_enum
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_x (x=0..22): EXTI line x
+    \param[out] none
+    \retval     none
+*/
+void exti_interrupt_disable(exti_line_enum linex)
+{
+    EXTI_INTEN &= ~(uint32_t)linex;
+}
+
+/*!
+    \brief    enable the events from EXTI line x
+    \param[in]  linex: EXTI line number, refer to exti_line_enum
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_x (x=0..22): EXTI line x
+    \param[out] none
+    \retval     none
+*/
+void exti_event_enable(exti_line_enum linex)
+{
+    EXTI_EVEN |= (uint32_t)linex;
+}
+
+/*!
+    \brief    disable the events from EXTI line x
+    \param[in]  linex: EXTI line number, refer to exti_line_enum
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_x (x=0..22): EXTI line x
+    \param[out] none
+    \retval     none
+*/
+void exti_event_disable(exti_line_enum linex)
+{
+    EXTI_EVEN &= ~(uint32_t)linex;
+}
+
+/*!
+    \brief    enable EXTI software interrupt event
+    \param[in]  linex: EXTI line number, refer to exti_line_enum
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_x (x=0..22): EXTI line x
+    \param[out] none
+    \retval     none
+*/
+void exti_software_interrupt_enable(exti_line_enum linex)
+{
+    EXTI_SWIEV |= (uint32_t)linex;
+}
+
+/*!
+    \brief    disable EXTI software interrupt event
+    \param[in]  linex: EXTI line number, refer to exti_line_enum
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_x (x=0..22): EXTI line x
+    \param[out] none
+    \retval     none
+*/
+void exti_software_interrupt_disable(exti_line_enum linex)
+{
+    EXTI_SWIEV &= ~(uint32_t)linex;
+}
+
+/*!
+    \brief    get EXTI lines flag
+    \param[in]  linex: EXTI line number, refer to exti_line_enum
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_x (x=0..22): EXTI line x
+    \param[out] none
+    \retval     FlagStatus: status of flag (RESET or SET)
+*/
+FlagStatus exti_flag_get(exti_line_enum linex)
+{
+    if(RESET != (EXTI_PD & (uint32_t)linex)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    clear EXTI lines pending flag
+    \param[in]  linex: EXTI line number, refer to exti_line_enum
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_x (x=0..22): EXTI line x
+    \param[out] none
+    \retval     none
+*/
+void exti_flag_clear(exti_line_enum linex)
+{
+    EXTI_PD = (uint32_t)linex;
+}
+
+/*!
+    \brief    get EXTI lines flag when the interrupt flag is set
+    \param[in]  linex: EXTI line number, refer to exti_line_enum
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_x (x=0..22): EXTI line x
+    \param[out] none
+    \retval     FlagStatus: status of flag (RESET or SET)
+*/
+FlagStatus exti_interrupt_flag_get(exti_line_enum linex)
+{
+    uint32_t flag_left, flag_right;
+
+    flag_left = EXTI_PD & (uint32_t)linex;
+    flag_right = EXTI_INTEN & (uint32_t)linex;
+
+    if((RESET != flag_left) && (RESET != flag_right)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    clear EXTI lines pending flag
+    \param[in]  linex: EXTI line number, refer to exti_line_enum
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_x (x=0..22): EXTI line x
+    \param[out] none
+    \retval     none
+*/
+void exti_interrupt_flag_clear(exti_line_enum linex)
+{
+    EXTI_PD = (uint32_t)linex;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_fmc.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_fmc.c
@@ -1,0 +1,1052 @@
+/*!
+    \file    gd32f4xx_fmc.c
+    \brief   FMC driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+
+#include "gd32f4xx_fmc.h"
+
+/*!
+    \brief    set the FMC wait state counter
+    \param[in]  wscnt: wait state counter value
+                only one parameter can be selected which is shown as below:
+      \arg        WS_WSCNT_0: FMC 0 wait
+      \arg        WS_WSCNT_1: FMC 1 wait
+      \arg        WS_WSCNT_2: FMC 2 wait
+      \arg        WS_WSCNT_3: FMC 3 wait
+      \arg        WS_WSCNT_4: FMC 4 wait
+      \arg        WS_WSCNT_5: FMC 5 wait
+      \arg        WS_WSCNT_6: FMC 6 wait
+      \arg        WS_WSCNT_7: FMC 7 wait
+      \arg        WS_WSCNT_8: FMC 8 wait
+      \arg        WS_WSCNT_9: FMC 9 wait
+      \arg        WS_WSCNT_10: FMC 10 wait
+      \arg        WS_WSCNT_11: FMC 11 wait
+      \arg        WS_WSCNT_12: FMC 12 wait
+      \arg        WS_WSCNT_13: FMC 13 wait
+      \arg        WS_WSCNT_14: FMC 14 wait
+      \arg        WS_WSCNT_15: FMC 15 wait
+    \param[out] none
+    \retval     none
+*/
+void fmc_wscnt_set(uint32_t wscnt)
+{
+    uint32_t reg;
+
+    reg = FMC_WS;
+    /* set the wait state counter value */
+    reg &= ~FMC_WC_WSCNT;
+    FMC_WS = (reg | wscnt);
+}
+
+/*!
+    \brief    unlock the main FMC operation
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void fmc_unlock(void)
+{
+    if((RESET != (FMC_CTL & FMC_CTL_LK))) {
+        /* write the FMC key */
+        FMC_KEY = UNLOCK_KEY0;
+        FMC_KEY = UNLOCK_KEY1;
+    }
+}
+
+/*!
+    \brief    lock the main FMC operation
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void fmc_lock(void)
+{
+    /* set the LK bit*/
+    FMC_CTL |= FMC_CTL_LK;
+}
+
+#if defined (GD32F425) || defined (GD32F427) || defined (GD32F470)
+
+/*!
+    \brief      FMC erase page
+    \param[in]  page_addr: the page address to be erased.
+    \param[out] none
+    \retval     state of FMC
+      \arg        FMC_READY: the operation has been completed
+      \arg        FMC_BUSY: the operation is in progress
+      \arg        FMC_RDDERR: read D-bus protection error
+      \arg        FMC_PGSERR: program sequence error
+      \arg        FMC_PGMERR: program size not match error
+      \arg        FMC_WPERR: erase/program protection error
+      \arg        FMC_OPERR: operation error
+      \arg        FMC_TOERR: timeout error
+*/
+fmc_state_enum fmc_page_erase(uint32_t page_addr)
+{
+    fmc_state_enum fmc_state = FMC_READY;
+
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        /* unlock page erase operation */
+        FMC_PEKEY = UNLOCK_PE_KEY;
+
+        /* start page erase */
+        FMC_PECFG = FMC_PE_EN | page_addr;
+        FMC_CTL &= ~FMC_CTL_SN;
+        FMC_CTL |= FMC_CTL_SER;
+        FMC_CTL |= FMC_CTL_START;
+
+        /* wait for the FMC ready */
+        fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+        FMC_PECFG &= ~FMC_PE_EN;
+        FMC_CTL &= ~FMC_CTL_SER;
+    }
+
+    /* return the FMC state */
+    return fmc_state;
+}
+
+#endif
+
+/*!
+    \brief    FMC erase sector
+    \param[in]  fmc_sector: select the sector to erase
+                only one parameter can be selected which is shown as below:
+      \arg        CTL_SECTOR_NUMBER_0: sector 0
+      \arg        CTL_SECTOR_NUMBER_1: sector 1
+      \arg        CTL_SECTOR_NUMBER_2: sector 2
+      \arg        CTL_SECTOR_NUMBER_3: sector 3
+      \arg        CTL_SECTOR_NUMBER_4: sector 4
+      \arg        CTL_SECTOR_NUMBER_5: sector 5
+      \arg        CTL_SECTOR_NUMBER_6: sector 6
+      \arg        CTL_SECTOR_NUMBER_7: sector 7
+      \arg        CTL_SECTOR_NUMBER_8: sector 8
+      \arg        CTL_SECTOR_NUMBER_9: sector 9
+      \arg        CTL_SECTOR_NUMBER_10: sector 10
+      \arg        CTL_SECTOR_NUMBER_11: sector 11
+      \arg        CTL_SECTOR_NUMBER_12: sector 12
+      \arg        CTL_SECTOR_NUMBER_13: sector 13
+      \arg        CTL_SECTOR_NUMBER_14: sector 14
+      \arg        CTL_SECTOR_NUMBER_15: sector 15
+      \arg        CTL_SECTOR_NUMBER_16: sector 16
+      \arg        CTL_SECTOR_NUMBER_17: sector 17
+      \arg        CTL_SECTOR_NUMBER_18: sector 18
+      \arg        CTL_SECTOR_NUMBER_19: sector 19
+      \arg        CTL_SECTOR_NUMBER_20: sector 20
+      \arg        CTL_SECTOR_NUMBER_21: sector 21
+      \arg        CTL_SECTOR_NUMBER_22: sector 22
+      \arg        CTL_SECTOR_NUMBER_23: sector 23
+      \arg        CTL_SECTOR_NUMBER_24: sector 24
+      \arg        CTL_SECTOR_NUMBER_25: sector 25
+      \arg        CTL_SECTOR_NUMBER_26: sector 26
+      \arg        CTL_SECTOR_NUMBER_27: sector 27
+    \param[out] none
+    \retval     state of FMC
+      \arg        FMC_READY: the operation has been completed
+      \arg        FMC_BUSY: the operation is in progress
+      \arg        FMC_RDDERR: read D-bus protection error
+      \arg        FMC_PGSERR: program sequence error
+      \arg        FMC_PGMERR: program size not match error
+      \arg        FMC_WPERR: erase/program protection error
+      \arg        FMC_OPERR: operation error
+      \arg        FMC_TOERR: timeout error
+*/
+fmc_state_enum fmc_sector_erase(uint32_t fmc_sector)
+{
+    fmc_state_enum fmc_state = FMC_READY;
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        /* start sector erase */
+        FMC_CTL &= ~FMC_CTL_SN;
+        FMC_CTL |= (FMC_CTL_SER | fmc_sector);
+        FMC_CTL |= FMC_CTL_START;
+
+        /* wait for the FMC ready */
+        fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+        /* reset the SER bit */
+        FMC_CTL &= (~FMC_CTL_SER);
+        FMC_CTL &= ~FMC_CTL_SN;
+    }
+
+    /* return the FMC state */
+    return fmc_state;
+}
+
+/*!
+    \brief    FMC erase whole chip
+    \param[in]  none
+    \param[out] none
+    \retval     state of FMC
+      \arg        FMC_READY: the operation has been completed
+      \arg        FMC_BUSY: the operation is in progress
+      \arg        FMC_RDDERR: read D-bus protection error
+      \arg        FMC_PGSERR: program sequence error
+      \arg        FMC_PGMERR: program size not match error
+      \arg        FMC_WPERR: erase/program protection error
+      \arg        FMC_OPERR: operation error
+      \arg        FMC_TOERR: timeout error
+*/
+fmc_state_enum fmc_mass_erase(void)
+{
+    fmc_state_enum fmc_state = FMC_READY;
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        /* start whole chip erase */
+        FMC_CTL |= (FMC_CTL_MER0 | FMC_CTL_MER1);
+        FMC_CTL |= FMC_CTL_START;
+
+        /* wait for the FMC ready */
+        fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+        /* reset the MER bits */
+        FMC_CTL &= ~(FMC_CTL_MER0 | FMC_CTL_MER1);
+    }
+
+    /* return the fmc state */
+    return fmc_state;
+}
+
+/*!
+    \brief    FMC erase whole bank0
+    \param[in]  none
+    \param[out] none
+    \retval     state of FMC
+      \arg        FMC_READY: the operation has been completed
+      \arg        FMC_BUSY: the operation is in progress
+      \arg        FMC_RDDERR: read D-bus protection error
+      \arg        FMC_PGSERR: program sequence error
+      \arg        FMC_PGMERR: program size not match error
+      \arg        FMC_WPERR: erase/program protection error
+      \arg        FMC_OPERR: operation error
+      \arg        FMC_TOERR: timeout error
+*/
+fmc_state_enum fmc_bank0_erase(void)
+{
+    fmc_state_enum fmc_state = FMC_READY;
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        /* start FMC bank0 erase */
+        FMC_CTL |= FMC_CTL_MER0;
+        FMC_CTL |= FMC_CTL_START;
+
+        /* wait for the FMC ready */
+        fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+        /* reset the MER0 bit */
+        FMC_CTL &= (~FMC_CTL_MER0);
+    }
+
+    /* return the fmc state */
+    return fmc_state;
+}
+
+/*!
+    \brief    FMC erase whole bank1
+    \param[in]  none
+    \param[out] none
+    \retval     state of FMC
+      \arg        FMC_READY: the operation has been completed
+      \arg        FMC_BUSY: the operation is in progress
+      \arg        FMC_RDDERR: read D-bus protection error
+      \arg        FMC_PGSERR: program sequence error
+      \arg        FMC_PGMERR: program size not match error
+      \arg        FMC_WPERR: erase/program protection error
+      \arg        FMC_OPERR: operation error
+      \arg        FMC_TOERR: timeout error
+*/
+fmc_state_enum fmc_bank1_erase(void)
+{
+    fmc_state_enum fmc_state = FMC_READY;
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        /* start FMC bank1 erase */
+        FMC_CTL |= FMC_CTL_MER1;
+        FMC_CTL |= FMC_CTL_START;
+
+        /* wait for the FMC ready */
+        fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+        /* reset the MER1 bit */
+        FMC_CTL &= (~FMC_CTL_MER1);
+    }
+
+    /* return the fmc state */
+    return fmc_state;
+}
+
+/*!
+    \brief    program a word at the corresponding address
+    \param[in]  address: address to program
+    \param[in]  data: word to program(0x00000000 - 0xFFFFFFFF)
+    \param[out] none
+    \retval     state of FMC
+      \arg        FMC_READY: the operation has been completed
+      \arg        FMC_BUSY: the operation is in progress
+      \arg        FMC_RDDERR: read D-bus protection error
+      \arg        FMC_PGSERR: program sequence error
+      \arg        FMC_PGMERR: program size not match error
+      \arg        FMC_WPERR: erase/program protection error
+      \arg        FMC_OPERR: operation error
+      \arg        FMC_TOERR: timeout error
+*/
+fmc_state_enum fmc_word_program(uint32_t address, uint32_t data)
+{
+    fmc_state_enum fmc_state = FMC_READY;
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        /* set the PG bit to start program */
+        FMC_CTL &= ~FMC_CTL_PSZ;
+        FMC_CTL |= CTL_PSZ_WORD;
+        FMC_CTL |= FMC_CTL_PG;
+
+        REG32(address) = data;
+
+        /* wait for the FMC ready */
+        fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+        /* reset the PG bit */
+        FMC_CTL &= ~FMC_CTL_PG;
+    }
+
+    /* return the FMC state */
+    return fmc_state;
+}
+
+/*!
+    \brief    program a half word at the corresponding address
+    \param[in]  address: address to program
+    \param[in]  data: halfword to program(0x0000 - 0xFFFF)
+    \param[out] none
+    \retval     state of FMC
+      \arg        FMC_READY: the operation has been completed
+      \arg        FMC_BUSY: the operation is in progress
+      \arg        FMC_RDDERR: read D-bus protection error
+      \arg        FMC_PGSERR: program sequence error
+      \arg        FMC_PGMERR: program size not match error
+      \arg        FMC_WPERR: erase/program protection error
+      \arg        FMC_OPERR: operation error
+      \arg        FMC_TOERR: timeout error
+*/
+fmc_state_enum fmc_halfword_program(uint32_t address, uint16_t data)
+{
+    fmc_state_enum fmc_state = FMC_READY;
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        /* set the PG bit to start program */
+        FMC_CTL &= ~FMC_CTL_PSZ;
+        FMC_CTL |= CTL_PSZ_HALF_WORD;
+        FMC_CTL |= FMC_CTL_PG;
+
+        REG16(address) = data;
+
+        /* wait for the FMC ready */
+        fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+        /* reset the PG bit */
+        FMC_CTL &= ~FMC_CTL_PG;
+    }
+
+    /* return the FMC state */
+    return fmc_state;
+}
+
+/*!
+    \brief    program a byte at the corresponding address
+    \param[in]  address: address to program
+    \param[in]  data: byte to program(0x00 - 0xFF)
+    \param[out] none
+    \retval     state of FMC
+      \arg        FMC_READY: the operation has been completed
+      \arg        FMC_BUSY: the operation is in progress
+      \arg        FMC_RDDERR: read D-bus protection error
+      \arg        FMC_PGSERR: program sequence error
+      \arg        FMC_PGMERR: program size not match error
+      \arg        FMC_WPERR: erase/program protection error
+      \arg        FMC_OPERR: operation error
+      \arg        FMC_TOERR: timeout error
+*/
+fmc_state_enum fmc_byte_program(uint32_t address, uint8_t data)
+{
+    fmc_state_enum fmc_state = FMC_READY;
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        /* set the PG bit to start program */
+        FMC_CTL &= ~FMC_CTL_PSZ;
+        FMC_CTL |= CTL_PSZ_BYTE;
+        FMC_CTL |= FMC_CTL_PG;
+
+        REG8(address) = data;
+
+        /* wait for the FMC ready */
+        fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+        /* reset the PG bit */
+        FMC_CTL &= ~FMC_CTL_PG;
+    }
+
+    /* return the FMC state */
+    return fmc_state;
+}
+
+/*!
+    \brief    unlock the option byte operation
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ob_unlock(void)
+{
+    if(RESET != (FMC_OBCTL0 & FMC_OBCTL0_OB_LK)) {
+        /* write the FMC key */
+        FMC_OBKEY = OB_UNLOCK_KEY0;
+        FMC_OBKEY = OB_UNLOCK_KEY1;
+    }
+}
+
+/*!
+    \brief    lock the option byte operation
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ob_lock(void)
+{
+    /* reset the OB_LK bit */
+    FMC_OBCTL0 |= FMC_OBCTL0_OB_LK;
+}
+
+/*!
+    \brief    send option byte change command
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ob_start(void)
+{
+    /* set the OB_START bit in OBCTL0 register */
+    FMC_OBCTL0 |= FMC_OBCTL0_OB_START;
+}
+
+/*!
+    \brief    erase option byte
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ob_erase(void)
+{
+    uint32_t reg, reg1;
+    fmc_state_enum fmc_state = FMC_READY;
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+    reg = FMC_OBCTL0;
+    reg1 = FMC_OBCTL1;
+
+    if(FMC_READY == fmc_state) {
+
+        /* reset the OB_FWDGT, OB_DEEPSLEEP and OB_STDBY, set according to ob_fwdgt ,ob_deepsleep and ob_stdby */
+        reg |= (FMC_OBCTL0_NWDG_HW | FMC_OBCTL0_NRST_DPSLP | FMC_OBCTL0_NRST_STDBY);
+        /* reset the BOR level */
+        reg |= FMC_OBCTL0_BOR_TH;
+        /* reset option byte boot bank value */
+        reg &= ~FMC_OBCTL0_BB;
+        /* reset option byte dbs value */
+        reg &= ~FMC_OBCTL0_DBS;
+
+        /* reset drp and wp value */
+        reg |= FMC_OBCTL0_WP0;
+        reg &= (~FMC_OBCTL0_DRP);
+        FMC_OBCTL0 = reg;
+
+        reg1 |= FMC_OBCTL1_WP1;
+        FMC_OBCTL1 = reg1;
+
+        FMC_OBCTL0 = reg;
+    }
+}
+
+/*!
+    \brief    enable write protection
+    \param[in]  ob_wp: specify sector to be write protected
+                one or more parameters can be selected which are shown as below:
+      \arg        OB_WP_x(x=0..22):sector x(x = 0,1,2...22)
+      \arg        OB_WP_23_27: sector23~27
+      \arg        OB_WP_ALL: all sector
+    \param[out] none
+    \retval     SUCCESS or ERROR
+*/
+ErrStatus ob_write_protection_enable(uint32_t ob_wp)
+{
+    uint32_t reg0 = FMC_OBCTL0;
+    uint32_t reg1 = FMC_OBCTL1;
+    fmc_state_enum fmc_state = FMC_READY;
+    if(RESET != (FMC_OBCTL0 & FMC_OBCTL0_DRP)) {
+        return ERROR;
+    }
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        reg0 &= (~((uint32_t)ob_wp << 16U));
+        reg1 &= (~(ob_wp & 0xFFFF0000U));
+        FMC_OBCTL0 = reg0;
+        FMC_OBCTL1 = reg1;
+
+        return SUCCESS;
+    } else {
+        return ERROR;
+    }
+}
+
+/*!
+    \brief    disable write protection
+    \param[in]  ob_wp: specify sector to be write protected
+                one or more parameters can be selected which are shown as below:
+      \arg        OB_WP_x(x=0..22):sector x(x = 0,1,2...22)
+      \arg        OB_WP_23_27: sector23~27
+      \arg        OB_WP_ALL: all sector
+    \param[out] none
+    \retval     SUCCESS or ERROR
+*/
+ErrStatus ob_write_protection_disable(uint32_t ob_wp)
+{
+    uint32_t reg0 = FMC_OBCTL0;
+    uint32_t reg1 = FMC_OBCTL1;
+    fmc_state_enum fmc_state = FMC_READY;
+    if(RESET != (FMC_OBCTL0 & FMC_OBCTL0_DRP)) {
+        return ERROR;
+    }
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        reg0 |= ((uint32_t)ob_wp << 16U);
+        reg1 |= (ob_wp & 0xFFFF0000U);
+        FMC_OBCTL0 = reg0;
+        FMC_OBCTL1 = reg1;
+
+        return SUCCESS;
+    } else {
+        return ERROR;
+    }
+}
+
+/*!
+    \brief    enable erase/program protection and D-bus read protection
+    \param[in]  ob_drp: enable the WPx bits used as erase/program protection and D-bus read protection of each sector
+                one or more parameters can be selected which are shown as below:
+      \arg        OB_DRP_x(x=0..22): sector x(x = 0,1,2...22)
+      \arg        OB_DRP_23_27: sector23~27
+      \arg        OB_DRP_ALL: all sector
+    \param[out] none
+    \retval     none
+*/
+void ob_drp_enable(uint32_t ob_drp)
+{
+    uint32_t reg0 = FMC_OBCTL0;
+    uint32_t reg1 = FMC_OBCTL1;
+    fmc_state_enum fmc_state = FMC_READY;
+    uint32_t drp_state = FMC_OBCTL0 & FMC_OBCTL0_DRP;
+    uint32_t wp0_state = FMC_OBCTL0 & FMC_OBCTL0_WP0;
+    uint32_t wp1_state = FMC_OBCTL1 & FMC_OBCTL1_WP1;
+
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        if(RESET == drp_state) {
+            reg0 &= ~FMC_OBCTL0_WP0;
+            reg1 &= ~FMC_OBCTL1_WP1;
+        }
+        reg0 |= ((uint32_t)ob_drp << 16U);
+        reg0 |= FMC_OBCTL0_DRP;
+        reg1 |= ((uint32_t)ob_drp & 0xFFFF0000U);
+
+        FMC_OBCTL0 = reg0;
+        FMC_OBCTL1 = reg1;
+    }
+}
+
+/*!
+    \brief    disable erase/program protection and D-bus read protection
+    \param[in]  ob_drp: disable the WPx bits used as erase/program protection and D-bus read protection of each sector
+                one or more parameters can be selected which are shown as below:
+      \arg        OB_DRP_x(x=0..22): sector x(x = 0,1,2...22)
+      \arg        OB_DRP_23_27: sector23~27
+      \arg        OB_DRP_ALL: all sector
+    \param[out] none
+    \retval     none
+*/
+void ob_drp_disable(void)
+{
+    uint32_t reg0 = FMC_OBCTL0;
+    uint32_t reg1 = FMC_OBCTL1;
+    fmc_state_enum fmc_state = FMC_READY;
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        if(((uint8_t)(reg0 >> 8U)) == (uint8_t)FMC_NSPC) {
+            /* security protection should be set as low level protection before disable D-BUS read protection */
+            reg0 &= ~FMC_OBCTL0_SPC;
+            reg0 |= ((uint32_t)FMC_LSPC << 8U);
+            FMC_OBCTL0 = reg0;
+            /* set the OB_START bit in OBCTL0 register */
+            FMC_OBCTL0 |= FMC_OBCTL0_OB_START;
+        }
+
+        /* it is necessary to disable the security protection at the same time when D-BUS read protection is disabled */
+        reg0 &= ~FMC_OBCTL0_SPC;
+        reg0 |= ((uint32_t)FMC_NSPC << 8U);
+        reg0 |= FMC_OBCTL0_WP0;
+        reg0 &= (~FMC_OBCTL0_DRP);
+        FMC_OBCTL0 = reg0;
+
+        reg1 |= FMC_OBCTL1_WP1;
+        FMC_OBCTL1 = reg1;
+
+    }
+}
+
+/*!
+    \brief    configure security protection level
+    \param[in]  ob_spc: specify security protection level
+                only one parameter can be selected which is shown as below:
+      \arg        FMC_NSPC: no security protection
+      \arg        FMC_LSPC: low security protection
+      \arg        FMC_HSPC: high security protection
+    \param[out] none
+    \retval     none
+*/
+void ob_security_protection_config(uint8_t ob_spc)
+{
+    fmc_state_enum fmc_state = FMC_READY;
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        uint32_t reg;
+
+        reg = FMC_OBCTL0;
+        /* reset the OBCTL0_SPC, set according to ob_spc */
+        reg &= ~FMC_OBCTL0_SPC;
+        reg |= ((uint32_t)ob_spc << 8U);
+        FMC_OBCTL0 = reg;
+    }
+}
+
+/*!
+    \brief    program the FMC user option byte
+    \param[in]  ob_fwdgt: option byte watchdog value
+                only one parameter can be selected which is shown as below:
+      \arg        OB_FWDGT_SW: software free watchdog
+      \arg        OB_FWDGT_HW: hardware free watchdog
+    \param[in]  ob_deepsleep: option byte deepsleep reset value
+                only one parameter can be selected which is shown as below:
+      \arg        OB_DEEPSLEEP_NRST: no reset when entering deepsleep mode
+      \arg        OB_DEEPSLEEP_RST: generate a reset instead of entering deepsleep mode
+    \param[in]  ob_stdby:option byte standby reset value
+                only one parameter can be selected which is shown as below:
+      \arg        OB_STDBY_NRST: no reset when entering standby mode
+      \arg        OB_STDBY_RST: generate a reset instead of entering standby mode
+    \param[out] none
+    \retval     none
+*/
+void ob_user_write(uint32_t ob_fwdgt, uint32_t ob_deepsleep, uint32_t ob_stdby)
+{
+    fmc_state_enum fmc_state = FMC_READY;
+
+    /* wait for the FMC ready */
+    fmc_state = fmc_ready_wait(FMC_TIMEOUT_COUNT);
+
+    if(FMC_READY == fmc_state) {
+        uint32_t reg;
+
+        reg = FMC_OBCTL0;
+        /* reset the OB_FWDGT, OB_DEEPSLEEP and OB_STDBY, set according to ob_fwdgt ,ob_deepsleep and ob_stdby */
+        reg &= ~(FMC_OBCTL0_NWDG_HW | FMC_OBCTL0_NRST_DPSLP | FMC_OBCTL0_NRST_STDBY);
+        FMC_OBCTL0 = (reg | ob_fwdgt | ob_deepsleep | ob_stdby);
+    }
+}
+
+/*!
+    \brief    program the option byte BOR threshold value
+    \param[in]  ob_bor_th: user option byte
+                only one parameter can be selected which is shown as below:
+      \arg        OB_BOR_TH_VALUE3: BOR threshold value 3
+      \arg        OB_BOR_TH_VALUE2: BOR threshold value 2
+      \arg        OB_BOR_TH_VALUE1: BOR threshold value 1
+      \arg        OB_BOR_TH_OFF: no BOR function
+    \param[out] none
+    \retval     none
+*/
+void ob_user_bor_threshold(uint32_t ob_bor_th)
+{
+    uint32_t reg;
+
+    reg = FMC_OBCTL0;
+    /* set the BOR level */
+    reg &= ~FMC_OBCTL0_BOR_TH;
+    FMC_OBCTL0 = (reg | ob_bor_th);
+}
+
+/*!
+    \brief    configure the option byte boot bank value
+    \param[in]  boot_mode: specifies the option byte boot bank value
+                only one parameter can be selected which is shown as below:
+      \arg        OB_BB_DISABLE: boot from bank0
+      \arg        OB_BB_ENABLE: boot from bank1 or bank0 if bank1 is void
+    \param[out] none
+    \retval     none
+*/
+void ob_boot_mode_config(uint32_t boot_mode)
+{
+    uint32_t reg;
+
+    reg = FMC_OBCTL0;
+    /* set option byte boot bank value */
+    reg &= ~FMC_OBCTL0_BB;
+    FMC_OBCTL0 = (reg | boot_mode);
+}
+
+/*!
+    \brief    get the FMC user option byte
+    \param[in]  none
+    \param[out] none
+    \retval     the FMC user option byte values: ob_fwdgt(Bit0), ob_deepsleep(Bit1), ob_stdby(Bit2)
+*/
+uint8_t ob_user_get(void)
+{
+    return (uint8_t)((uint8_t)(FMC_OBCTL0 >> 5U) & 0x07U);
+}
+
+/*!
+    \brief    get the FMC option byte write protection
+    \param[in]  none
+    \param[out] none
+    \retval     the FMC write protection option byte value
+*/
+uint16_t ob_write_protection0_get(void)
+{
+    /* return the FMC write protection option byte value */
+    return (uint16_t)(((uint16_t)(FMC_OBCTL0 >> 16U)) & 0x0FFFU);
+}
+
+/*!
+    \brief    get the FMC option byte write protection
+    \param[in]  none
+    \param[out] none
+    \retval     the FMC write protection option byte value
+*/
+uint16_t ob_write_protection1_get(void)
+{
+    /* return the the FMC write protection option byte value */
+    return (uint16_t)(((uint16_t)(FMC_OBCTL1 >> 16U)) & 0x0FFFU);
+}
+
+/*!
+    \brief    get the FMC erase/program protection and D-bus read protection option bytes value
+    \param[in]  none
+    \param[out] none
+    \retval     the FMC erase/program protection and D-bus read protection option bytes value
+*/
+uint16_t ob_drp0_get(void)
+{
+    /* return the FMC erase/program protection and D-bus read protection option bytes value */
+    if(FMC_OBCTL0 & FMC_OBCTL0_DRP) {
+        return (uint16_t)(((uint16_t)(FMC_OBCTL0 >> 16U)) & 0x0FFFU);
+    } else {
+        return 0xF000U;
+    }
+}
+
+/*!
+    \brief    get the FMC erase/program protection and D-bus read protection option bytes value
+    \param[in]  none
+    \param[out] none
+    \retval     the FMC erase/program protection and D-bus read protection option bytes value
+*/
+uint16_t ob_drp1_get(void)
+{
+    /* return the FMC erase/program protection and D-bus read protection option bytes value */
+    if(FMC_OBCTL0 & FMC_OBCTL0_DRP) {
+        return (uint16_t)(((uint16_t)(FMC_OBCTL1 >> 16U)) & 0x0FFFU);
+    } else {
+        return 0xF000U;
+    }
+}
+
+/*!
+    \brief    get option byte security protection code value
+    \param[in]  none
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus ob_spc_get(void)
+{
+    FlagStatus spc_state = RESET;
+
+    if(((uint8_t)(FMC_OBCTL0 >> 8U)) != FMC_NSPC) {
+        spc_state = SET;
+    } else {
+        spc_state = RESET;
+    }
+    return spc_state;
+}
+
+/*!
+    \brief    get the FMC option byte BOR threshold value
+    \param[in]  none
+    \param[out] none
+    \retval     the FMC BOR threshold value:OB_BOR_TH_OFF,OB_BOR_TH_VALUE1,OB_BOR_TH_VALUE2,OB_BOR_TH_VALUE3
+*/
+uint8_t ob_user_bor_threshold_get(void)
+{
+    /* return the FMC BOR threshold value */
+    return (uint8_t)((uint8_t)FMC_OBCTL0 & 0x0CU);
+}
+
+/*!
+    \brief    get flag set or reset
+    \param[in]  fmc_flag: check FMC flag
+                only one parameter can be selected which is shown as below:
+      \arg        FMC_FLAG_BUSY: FMC busy flag bit
+      \arg        FMC_FLAG_RDDERR: FMC read D-bus protection error flag bit
+      \arg        FMC_FLAG_PGSERR: FMC program sequence error flag bit
+      \arg        FMC_FLAG_PGMERR: FMC program size not match error flag bit
+      \arg        FMC_FLAG_WPERR: FMC Erase/Program protection error flag bit
+      \arg        FMC_FLAG_OPERR: FMC operation error flag bit
+      \arg        FMC_FLAG_END: FMC end of operation flag bit
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus fmc_flag_get(uint32_t fmc_flag)
+{
+    if(FMC_STAT & fmc_flag) {
+        return SET;
+    }
+    /* return the state of corresponding FMC flag */
+    return RESET;
+}
+
+/*!
+    \brief    clear the FMC pending flag
+    \param[in]  FMC_flag: clear FMC flag
+                only one parameter can be selected which is shown as below:
+      \arg        FMC_FLAG_RDDERR: FMC read D-bus protection error flag bit
+      \arg        FMC_FLAG_PGSERR: FMC program sequence error flag bit
+      \arg        FMC_FLAG_PGMERR: FMC program size not match error flag bit
+      \arg        FMC_FLAG_WPERR: FMC erase/program protection error flag bit
+      \arg        FMC_FLAG_OPERR: FMC operation error flag bit
+      \arg        FMC_FLAG_END: FMC end of operation flag bit
+    \param[out] none
+    \retval     none
+*/
+void fmc_flag_clear(uint32_t fmc_flag)
+{
+    /* clear the flags */
+    FMC_STAT = fmc_flag;
+}
+
+/*!
+    \brief    enable FMC interrupt
+    \param[in]  fmc_int: the FMC interrupt source
+                only one parameter can be selected which is shown as below:
+      \arg        FMC_INT_END: enable FMC end of program interrupt
+      \arg        FMC_INT_ERR: enable FMC error interrupt
+    \param[out] none
+    \retval     none
+*/
+void fmc_interrupt_enable(uint32_t fmc_int)
+{
+    FMC_CTL |= fmc_int;
+}
+
+/*!
+    \brief    disable FMC interrupt
+    \param[in]  fmc_int: the FMC interrupt source
+                only one parameter can be selected which is shown as below:
+      \arg        FMC_INT_END: disable FMC end of program interrupt
+      \arg        FMC_INT_ERR: disable FMC error interrupt
+    \param[out] none
+    \retval     none
+*/
+void fmc_interrupt_disable(uint32_t fmc_int)
+{
+    FMC_CTL &= ~(uint32_t)fmc_int;
+}
+
+/*!
+    \brief    get FMC interrupt flag set or reset
+    \param[in]  fmc_int_flag: FMC interrupt flag
+                only one parameter can be selected which is shown as below:
+      \arg        FMC_INT_FLAG_RDDERR: FMC read D-bus protection error interrupt flag
+      \arg        FMC_INT_FLAG_PGSERR: FMC program sequence error interrupt flag
+      \arg        FMC_INT_FLAG_PGMERR: FMC program size not match error interrupt flag
+      \arg        FMC_INT_FLAG_WPERR: FMC Erase/Program protection error interrupt flag
+      \arg        FMC_INT_FLAG_OPERR: FMC operation error interrupt flag
+      \arg        FMC_INT_FLAG_END: FMC end of operation interrupt flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus fmc_interrupt_flag_get(uint32_t fmc_int_flag)
+{
+    if(FMC_FLAG_END == fmc_int_flag) {
+        /* end of operation interrupt flag */
+        if(FMC_CTL & FMC_CTL_ENDIE) {
+            if(FMC_STAT & fmc_int_flag) {
+                return SET;
+            }
+        }
+    } else {
+        /* error interrupt flags */
+        if(FMC_CTL & FMC_CTL_ERRIE) {
+            if(FMC_STAT & fmc_int_flag) {
+                return SET;
+            }
+        }
+    }
+
+    return RESET;
+}
+
+/*!
+    \brief    clear the FMC interrupt flag
+    \param[in]  fmc_int_flag: FMC interrupt flag
+                only one parameter can be selected which is shown as below:
+      \arg        FMC_INT_FLAG_RDDERR: FMC read D-bus protection error interrupt flag
+      \arg        FMC_INT_FLAG_PGSERR: FMC program sequence error interrupt flag
+      \arg        FMC_INT_FLAG_PGMERR: FMC program size not match error interrupt flag
+      \arg        FMC_INT_FLAG_WPERR: FMC Erase/Program protection error interrupt flag
+      \arg        FMC_INT_FLAG_OPERR: FMC operation error interrupt flag
+      \arg        FMC_INT_FLAG_END: FMC end of operation interrupt flag
+    \param[out] none
+    \retval     none
+*/
+void fmc_interrupt_flag_clear(uint32_t fmc_int_flag)
+{
+    /* clear the interrupt flag */
+    FMC_STAT = fmc_int_flag;
+}
+
+/*!
+    \brief    get the FMC state
+    \param[in]  none
+    \param[out] none
+    \retval     state of FMC
+      \arg        FMC_READY: the operation has been completed
+      \arg        FMC_BUSY: the operation is in progress
+      \arg        FMC_RDDERR: read D-bus protection error
+      \arg        FMC_PGSERR: program sequence error
+      \arg        FMC_PGMERR: program size not match error
+      \arg        FMC_WPERR: erase/program protection error
+      \arg        FMC_OPERR: operation error
+*/
+fmc_state_enum fmc_state_get(void)
+{
+    fmc_state_enum fmc_state = FMC_READY;
+    uint32_t temp_val = FMC_STAT;
+
+    if(RESET != (temp_val & FMC_FLAG_BUSY)) {
+        fmc_state = FMC_BUSY;
+    } else if(RESET != (temp_val & FMC_FLAG_RDDERR)) {
+        fmc_state = FMC_RDDERR;
+    } else if(RESET != (temp_val & FMC_FLAG_PGSERR)) {
+        fmc_state = FMC_PGSERR;
+    } else if(RESET != (temp_val & FMC_FLAG_PGMERR)) {
+        fmc_state = FMC_PGMERR;
+    } else if(RESET != (temp_val & FMC_FLAG_WPERR)) {
+        fmc_state = FMC_WPERR;
+    } else if(RESET != (temp_val & FMC_FLAG_OPERR)) {
+        fmc_state = FMC_OPERR;
+    } else {
+        fmc_state = FMC_READY;
+    }
+
+    /* return the FMC state */
+    return fmc_state;
+}
+
+/*!
+    \brief    check whether FMC is ready or not
+    \param[in]  none
+    \param[out] none
+    \retval     state of FMC
+      \arg        FMC_READY: the operation has been completed
+      \arg        FMC_BUSY: the operation is in progress
+      \arg        FMC_RDDERR: read D-bus protection error
+      \arg        FMC_PGSERR: program sequence error
+      \arg        FMC_PGMERR: program size not match error
+      \arg        FMC_WPERR: erase/program protection error
+      \arg        FMC_OPERR: operation error
+      \arg        FMC_TOERR: timeout error
+*/
+fmc_state_enum fmc_ready_wait(uint32_t timeout)
+{
+    fmc_state_enum fmc_state = FMC_BUSY;
+
+    /* wait for FMC ready */
+    do {
+        /* get FMC state */
+        fmc_state = fmc_state_get();
+        timeout--;
+    } while((FMC_BUSY == fmc_state) && (0U != timeout));
+
+    if(0U == timeout) {
+        fmc_state = FMC_TOERR;
+    }
+
+    /* return the FMC state */
+    return fmc_state;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_fwdgt.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_fwdgt.c
@@ -1,0 +1,218 @@
+/*!
+    \file    gd32f4xx_fwdgt.c
+    \brief   FWDGT driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_fwdgt.h"
+
+/*!
+    \brief    enable write access to FWDGT_PSC and FWDGT_RLD
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void fwdgt_write_enable(void)
+{
+    FWDGT_CTL = FWDGT_WRITEACCESS_ENABLE;
+}
+
+/*!
+    \brief    disable write access to FWDGT_PSC and FWDGT_RLD
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void fwdgt_write_disable(void)
+{
+    FWDGT_CTL = FWDGT_WRITEACCESS_DISABLE;
+}
+
+/*!
+    \brief    start the free watchdog timer counter
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void fwdgt_enable(void)
+{
+    FWDGT_CTL = FWDGT_KEY_ENABLE;
+}
+
+/*!
+    \brief      configure the free watchdog timer counter prescaler value
+    \param[in]  prescaler_value: specify prescaler value
+                only one parameter can be selected which is shown as below:
+      \arg        FWDGT_PSC_DIV4: FWDGT prescaler set to 4
+      \arg        FWDGT_PSC_DIV8: FWDGT prescaler set to 8
+      \arg        FWDGT_PSC_DIV16: FWDGT prescaler set to 16
+      \arg        FWDGT_PSC_DIV32: FWDGT prescaler set to 32
+      \arg        FWDGT_PSC_DIV64: FWDGT prescaler set to 64
+      \arg        FWDGT_PSC_DIV128: FWDGT prescaler set to 128
+      \arg        FWDGT_PSC_DIV256: FWDGT prescaler set to 256
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus fwdgt_prescaler_value_config(uint16_t prescaler_value)
+{
+    uint32_t timeout = FWDGT_PSC_TIMEOUT;
+    uint32_t flag_status = RESET;
+  
+    /* enable write access to FWDGT_PSC */
+    FWDGT_CTL = FWDGT_WRITEACCESS_ENABLE;
+  
+    /* wait until the PUD flag to be reset */
+    do{
+        flag_status = FWDGT_STAT & FWDGT_STAT_PUD;
+    }while((--timeout > 0U) && ((uint32_t)RESET != flag_status));
+    
+    if ((uint32_t)RESET != flag_status){
+        return ERROR;
+    }
+    
+    /* configure FWDGT */
+    FWDGT_PSC = (uint32_t)prescaler_value; 
+
+    return SUCCESS;
+}
+
+/*!
+    \brief      configure the free watchdog timer counter reload value
+    \param[in]  reload_value: specify reload value(0x0000 - 0x0FFF)
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus fwdgt_reload_value_config(uint16_t reload_value)
+{
+    uint32_t timeout = FWDGT_RLD_TIMEOUT;
+    uint32_t flag_status = RESET;
+  
+    /* enable write access to FWDGT_RLD */
+    FWDGT_CTL = FWDGT_WRITEACCESS_ENABLE;
+  
+    /* wait until the RUD flag to be reset */
+    do{
+        flag_status = FWDGT_STAT & FWDGT_STAT_RUD;
+    }while((--timeout > 0U) && ((uint32_t)RESET != flag_status));
+   
+    if ((uint32_t)RESET != flag_status){
+        return ERROR;
+    }
+    
+    FWDGT_RLD = RLD_RLD(reload_value);
+
+    return SUCCESS;
+}
+
+/*!
+    \brief    reload the counter of FWDGT
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void fwdgt_counter_reload(void)
+{
+    FWDGT_CTL = FWDGT_KEY_RELOAD;
+}
+
+/*!
+    \brief    configure counter reload value, and prescaler divider value
+    \param[in]  reload_value: specify reload value(0x0000 - 0x0FFF)
+    \param[in]  prescaler_div: FWDGT prescaler value
+                only one parameter can be selected which is shown as below:
+      \arg        FWDGT_PSC_DIV4: FWDGT prescaler set to 4
+      \arg        FWDGT_PSC_DIV8: FWDGT prescaler set to 8
+      \arg        FWDGT_PSC_DIV16: FWDGT prescaler set to 16
+      \arg        FWDGT_PSC_DIV32: FWDGT prescaler set to 32
+      \arg        FWDGT_PSC_DIV64: FWDGT prescaler set to 64
+      \arg        FWDGT_PSC_DIV128: FWDGT prescaler set to 128
+      \arg        FWDGT_PSC_DIV256: FWDGT prescaler set to 256
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus fwdgt_config(uint16_t reload_value, uint8_t prescaler_div)
+{
+    uint32_t timeout = FWDGT_PSC_TIMEOUT;
+    uint32_t flag_status = RESET;
+  
+    /* enable write access to FWDGT_PSC,and FWDGT_RLD */
+    FWDGT_CTL = FWDGT_WRITEACCESS_ENABLE;
+  
+    /* wait until the PUD flag to be reset */
+    do{
+       flag_status = FWDGT_STAT & FWDGT_STAT_PUD;
+    }while((--timeout > 0U) && ((uint32_t)RESET != flag_status));
+    
+    if ((uint32_t)RESET != flag_status){
+        return ERROR;
+    }
+
+    /* configure FWDGT */
+    FWDGT_PSC = (uint32_t)prescaler_div;
+
+    timeout = FWDGT_RLD_TIMEOUT;
+    /* wait until the RUD flag to be reset */
+    do{
+       flag_status = FWDGT_STAT & FWDGT_STAT_RUD;
+    }while((--timeout > 0U) && ((uint32_t)RESET != flag_status));
+   
+    if ((uint32_t)RESET != flag_status){
+        return ERROR;
+    }
+    
+    FWDGT_RLD = RLD_RLD(reload_value);
+    
+    /* reload the counter */
+    FWDGT_CTL = FWDGT_KEY_RELOAD;
+
+    return SUCCESS;
+}
+
+/*!
+    \brief    get flag state of FWDGT
+    \param[in]  flag: flag to get 
+                only one parameter can be selected which is shown as below:
+      \arg        FWDGT_STAT_PUD: a write operation to FWDGT_PSC register is on going
+      \arg        FWDGT_STAT_RUD: a write operation to FWDGT_RLD register is on going
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus fwdgt_flag_get(uint16_t flag)
+{
+    if(RESET != (FWDGT_STAT & flag)){
+        return SET;
+  }
+
+    return RESET;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_gpio.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_gpio.c
@@ -1,0 +1,434 @@
+/*!
+    \file    gd32f4xx_gpio.c
+    \brief   GPIO driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_gpio.h"
+
+/*!
+    \brief      reset GPIO port
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[out] none
+    \retval     none
+*/
+void gpio_deinit(uint32_t gpio_periph)
+{
+    switch(gpio_periph) {
+    case GPIOA:
+        /* reset GPIOA */
+        rcu_periph_reset_enable(RCU_GPIOARST);
+        rcu_periph_reset_disable(RCU_GPIOARST);
+        break;
+    case GPIOB:
+        /* reset GPIOB */
+        rcu_periph_reset_enable(RCU_GPIOBRST);
+        rcu_periph_reset_disable(RCU_GPIOBRST);
+        break;
+    case GPIOC:
+        /* reset GPIOC */
+        rcu_periph_reset_enable(RCU_GPIOCRST);
+        rcu_periph_reset_disable(RCU_GPIOCRST);
+        break;
+    case GPIOD:
+        /* reset GPIOD */
+        rcu_periph_reset_enable(RCU_GPIODRST);
+        rcu_periph_reset_disable(RCU_GPIODRST);
+        break;
+    case GPIOE:
+        /* reset GPIOE */
+        rcu_periph_reset_enable(RCU_GPIOERST);
+        rcu_periph_reset_disable(RCU_GPIOERST);
+        break;
+    case GPIOF:
+        /* reset GPIOF */
+        rcu_periph_reset_enable(RCU_GPIOFRST);
+        rcu_periph_reset_disable(RCU_GPIOFRST);
+        break;
+    case GPIOG:
+        /* reset GPIOG */
+        rcu_periph_reset_enable(RCU_GPIOGRST);
+        rcu_periph_reset_disable(RCU_GPIOGRST);
+        break;
+    case GPIOH:
+        /* reset GPIOH */
+        rcu_periph_reset_enable(RCU_GPIOHRST);
+        rcu_periph_reset_disable(RCU_GPIOHRST);
+        break;
+    case GPIOI:
+        /* reset GPIOI */
+        rcu_periph_reset_enable(RCU_GPIOIRST);
+        rcu_periph_reset_disable(RCU_GPIOIRST);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      set GPIO mode
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[in]  mode: GPIO pin mode
+      \arg        GPIO_MODE_INPUT: input mode
+      \arg        GPIO_MODE_OUTPUT: output mode
+      \arg        GPIO_MODE_AF: alternate function mode
+      \arg        GPIO_MODE_ANALOG: analog mode
+    \param[in]  pull_up_down: GPIO pin with pull-up or pull-down resistor
+      \arg        GPIO_PUPD_NONE: floating mode, no pull-up and pull-down resistors
+      \arg        GPIO_PUPD_PULLUP: with pull-up resistor
+      \arg        GPIO_PUPD_PULLDOWN:with pull-down resistor
+    \param[in]  pin: GPIO pin
+                one or more parameters can be selected which are shown as below:
+      \arg        GPIO_PIN_x(x=0..15), GPIO_PIN_ALL
+    \param[out] none
+    \retval     none
+*/
+void gpio_mode_set(uint32_t gpio_periph, uint32_t mode, uint32_t pull_up_down, uint32_t pin)
+{
+    uint16_t i;
+    uint32_t ctl, pupd;
+
+    ctl = GPIO_CTL(gpio_periph);
+    pupd = GPIO_PUD(gpio_periph);
+
+    for(i = 0U; i < 16U; i++) {
+        if((1U << i) & pin) {
+            /* clear the specified pin mode bits */
+            ctl &= ~GPIO_MODE_MASK(i);
+            /* set the specified pin mode bits */
+            ctl |= GPIO_MODE_SET(i, mode);
+
+            /* clear the specified pin pupd bits */
+            pupd &= ~GPIO_PUPD_MASK(i);
+            /* set the specified pin pupd bits */
+            pupd |= GPIO_PUPD_SET(i, pull_up_down);
+        }
+    }
+
+    GPIO_CTL(gpio_periph) = ctl;
+    GPIO_PUD(gpio_periph) = pupd;
+}
+
+/*!
+    \brief      set GPIO output type and speed
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[in]  otype: GPIO pin output mode
+      \arg        GPIO_OTYPE_PP: push pull mode
+      \arg        GPIO_OTYPE_OD: open drain mode
+    \param[in]  speed: GPIO pin output max speed
+      \arg        GPIO_OSPEED_2MHZ: output max speed 2MHz
+      \arg        GPIO_OSPEED_25MHZ: output max speed 25MHz
+      \arg        GPIO_OSPEED_50MHZ: output max speed 50MHz
+      \arg        GPIO_OSPEED_MAX: output max speed more than 50MHz
+    \param[in]  pin: GPIO pin
+                one or more parameters can be selected which are shown as below:
+      \arg        GPIO_PIN_x(x=0..15), GPIO_PIN_ALL
+    \param[out] none
+    \retval     none
+*/
+void gpio_output_options_set(uint32_t gpio_periph, uint8_t otype, uint32_t speed, uint32_t pin)
+{
+    uint16_t i;
+    uint32_t ospeedr;
+
+    if(GPIO_OTYPE_OD == otype) {
+        GPIO_OMODE(gpio_periph) |= (uint32_t)pin;
+    } else {
+        GPIO_OMODE(gpio_periph) &= (uint32_t)(~pin);
+    }
+
+    /* get the specified pin output speed bits value */
+    ospeedr = GPIO_OSPD(gpio_periph);
+
+    for(i = 0U; i < 16U; i++) {
+        if((1U << i) & pin) {
+            /* clear the specified pin output speed bits */
+            ospeedr &= ~GPIO_OSPEED_MASK(i);
+            /* set the specified pin output speed bits */
+            ospeedr |= GPIO_OSPEED_SET(i, speed);
+        }
+    }
+    GPIO_OSPD(gpio_periph) = ospeedr;
+}
+
+/*!
+    \brief    set GPIO pin bit
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[in]  pin: GPIO pin
+                one or more parameters can be selected which are shown as below:
+      \arg        GPIO_PIN_x(x=0..15), GPIO_PIN_ALL
+    \param[out] none
+    \retval     none
+*/
+void gpio_bit_set(uint32_t gpio_periph, uint32_t pin)
+{
+    GPIO_BOP(gpio_periph) = (uint32_t)pin;
+}
+
+/*!
+    \brief      reset GPIO pin bit
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[in]  pin: GPIO pin
+                one or more parameters can be selected which are shown as below:
+      \arg        GPIO_PIN_x(x=0..15), GPIO_PIN_ALL
+    \param[out] none
+    \retval     none
+*/
+void gpio_bit_reset(uint32_t gpio_periph, uint32_t pin)
+{
+    GPIO_BC(gpio_periph) = (uint32_t)pin;
+}
+
+/*!
+    \brief      write data to the specified GPIO pin
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[in]  pin: GPIO pin
+                one or more parameters can be selected which are shown as below:
+      \arg        GPIO_PIN_x(x=0..15), GPIO_PIN_ALL
+    \param[in]  bit_value: SET or RESET
+      \arg        RESET: clear the port pin
+      \arg        SET: set the port pin
+    \param[out] none
+    \retval     none
+*/
+void gpio_bit_write(uint32_t gpio_periph, uint32_t pin, bit_status bit_value)
+{
+    if(RESET != bit_value) {
+        GPIO_BOP(gpio_periph) = (uint32_t)pin;
+    } else {
+        GPIO_BC(gpio_periph) = (uint32_t)pin;
+    }
+}
+
+/*!
+    \brief      write data to the specified GPIO port
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[in]  data: specify the value to be written to the port output control register
+    \param[out] none
+    \retval     none
+*/
+void gpio_port_write(uint32_t gpio_periph, uint16_t data)
+{
+    GPIO_OCTL(gpio_periph) = (uint32_t)data;
+}
+
+/*!
+    \brief      get GPIO pin input status
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[in]  pin: GPIO pin
+                one or more parameters can be selected which are shown as below:
+      \arg        GPIO_PIN_x(x=0..15), GPIO_PIN_ALL
+    \param[out] none
+    \retval     input status of GPIO pin: SET or RESET
+*/
+FlagStatus gpio_input_bit_get(uint32_t gpio_periph, uint32_t pin)
+{
+    if((uint32_t)RESET != (GPIO_ISTAT(gpio_periph) & (pin))) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      get GPIO all pins input status
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[out] none
+    \retval     input status of GPIO all pins
+*/
+uint16_t gpio_input_port_get(uint32_t gpio_periph)
+{
+    return ((uint16_t)GPIO_ISTAT(gpio_periph));
+}
+
+/*!
+    \brief      get GPIO pin output status
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[in]  pin: GPIO pin
+                one or more parameters can be selected which are shown as below:
+      \arg        GPIO_PIN_x(x=0..15), GPIO_PIN_ALL
+    \param[out] none
+    \retval     output status of GPIO pin: SET or RESET
+*/
+FlagStatus gpio_output_bit_get(uint32_t gpio_periph, uint32_t pin)
+{
+    if((uint32_t)RESET != (GPIO_OCTL(gpio_periph) & (pin))) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      get GPIO port output status
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[out] none
+    \retval     output status of GPIO all pins
+*/
+uint16_t gpio_output_port_get(uint32_t gpio_periph)
+{
+    return ((uint16_t)GPIO_OCTL(gpio_periph));
+}
+
+/*!
+    \brief      set GPIO alternate function
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[in]  alt_func_num: GPIO pin af function
+      \arg        GPIO_AF_0: SYSTEM
+      \arg        GPIO_AF_1: TIMER0, TIMER1
+      \arg        GPIO_AF_2: TIMER2, TIMER3, TIMER4
+      \arg        GPIO_AF_3: TIMER7, TIMER8, TIMER9, TIMER10
+      \arg        GPIO_AF_4: I2C0, I2C1, I2C2
+      \arg        GPIO_AF_5: SPI0, SPI1, SPI2, SPI3, SPI4, SPI5
+      \arg        GPIO_AF_6: SPI2, SPI3, SPI4
+      \arg        GPIO_AF_7: USART0, USART1, USART2, SPI1, SPI2
+      \arg        GPIO_AF_8: UART3, UART4, USART5, UART6, UART7
+      \arg        GPIO_AF_9: CAN0, CAN1, TLI, TIMER11, TIMER12, TIMER13, I2C1, I2C2, CTC
+      \arg        GPIO_AF_10: USB_FS, USB_HS
+      \arg        GPIO_AF_11: ENET
+      \arg        GPIO_AF_12: EXMC, SDIO, USB_HS
+      \arg        GPIO_AF_13: DCI
+      \arg        GPIO_AF_14: TLI
+      \arg        GPIO_AF_15: EVENTOUT
+    \param[in]  pin: GPIO pin
+                one or more parameters can be selected which are shown as below:
+      \arg        GPIO_PIN_x(x=0..15), GPIO_PIN_ALL
+    \param[out] none
+    \retval     none
+*/
+void gpio_af_set(uint32_t gpio_periph, uint32_t alt_func_num, uint32_t pin)
+{
+    uint16_t i;
+    uint32_t afrl, afrh;
+
+    afrl = GPIO_AFSEL0(gpio_periph);
+    afrh = GPIO_AFSEL1(gpio_periph);
+
+    for(i = 0U; i < 8U; i++) {
+        if((1U << i) & pin) {
+            /* clear the specified pin alternate function bits */
+            afrl &= ~GPIO_AFR_MASK(i);
+            afrl |= GPIO_AFR_SET(i, alt_func_num);
+        }
+    }
+
+    for(i = 8U; i < 16U; i++) {
+        if((1U << i) & pin) {
+            /* clear the specified pin alternate function bits */
+            afrh &= ~GPIO_AFR_MASK(i - 8U);
+            afrh |= GPIO_AFR_SET(i - 8U, alt_func_num);
+        }
+    }
+
+    GPIO_AFSEL0(gpio_periph) = afrl;
+    GPIO_AFSEL1(gpio_periph) = afrh;
+}
+
+/*!
+    \brief      lock GPIO pin bit
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[in]  pin: GPIO pin
+                one or more parameters can be selected which are shown as below:
+      \arg        GPIO_PIN_x(x=0..15), GPIO_PIN_ALL
+    \param[out] none
+    \retval     none
+*/
+void gpio_pin_lock(uint32_t gpio_periph, uint32_t pin)
+{
+    uint32_t lock = 0x00010000U;
+    lock |= pin;
+
+    /* lock key writing sequence: write 1->write 0->write 1->read 0->read 1 */
+    GPIO_LOCK(gpio_periph) = (uint32_t)lock;
+    GPIO_LOCK(gpio_periph) = (uint32_t)pin;
+    GPIO_LOCK(gpio_periph) = (uint32_t)lock;
+    lock = GPIO_LOCK(gpio_periph);
+    lock = GPIO_LOCK(gpio_periph);
+}
+
+/*!
+    \brief      toggle GPIO pin status
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+    \param[in]  pin: GPIO pin
+                one or more parameters can be selected which are shown as below:
+      \arg        GPIO_PIN_x(x=0..15), GPIO_PIN_ALL
+    \param[out] none
+    \retval     none
+*/
+void gpio_bit_toggle(uint32_t gpio_periph, uint32_t pin)
+{
+    GPIO_TG(gpio_periph) = (uint32_t)pin;
+}
+
+/*!
+    \brief      toggle GPIO port status
+    \param[in]  gpio_periph: GPIO port
+                only one parameter can be selected which is shown as below:
+      \arg        GPIOx(x = A,B,C,D,E,F,G,H,I)
+
+    \param[out] none
+    \retval     none
+*/
+void gpio_port_toggle(uint32_t gpio_periph)
+{
+    GPIO_TG(gpio_periph) = 0x0000FFFFU;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_i2c.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_i2c.c
@@ -1,0 +1,840 @@
+/*!
+    \file    gd32f4xx_i2c.c
+    \brief   I2C driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2019-04-16, V2.0.2, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_i2c.h"
+
+/* I2C register bit mask */
+#define I2CCLK_MAX                    ((uint32_t)0x0000003CU)             /*!< i2cclk maximum value */
+#define I2CCLK_MIN                    ((uint32_t)0x00000002U)             /*!< i2cclk minimum value */
+#define I2C_FLAG_MASK                 ((uint32_t)0x0000FFFFU)             /*!< i2c flag mask */
+#define I2C_ADDRESS_MASK              ((uint32_t)0x000003FFU)             /*!< i2c address mask */
+#define I2C_ADDRESS2_MASK             ((uint32_t)0x000000FEU)             /*!< the second i2c address mask */
+
+/* I2C register bit offset */
+#define STAT1_PECV_OFFSET             ((uint32_t)0x00000008U)             /* bit offset of PECV in I2C_STAT1 */
+
+/*!
+    \brief      reset I2C
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2c_deinit(uint32_t i2c_periph)
+{
+    switch(i2c_periph) {
+    case I2C0:
+        /* reset I2C0 */
+        rcu_periph_reset_enable(RCU_I2C0RST);
+        rcu_periph_reset_disable(RCU_I2C0RST);
+        break;
+    case I2C1:
+        /* reset I2C1 */
+        rcu_periph_reset_enable(RCU_I2C1RST);
+        rcu_periph_reset_disable(RCU_I2C1RST);
+        break;
+    case I2C2:
+        /* reset I2C2 */
+        rcu_periph_reset_enable(RCU_I2C2RST);
+        rcu_periph_reset_disable(RCU_I2C2RST);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      configure I2C clock
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  clkspeed: I2C clock speed, supports standard mode (up to 100 kHz), fast mode (up to 400 kHz)
+    \param[in]  dutycyc: duty cycle in fast mode
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_DTCY_2: T_low/T_high = 2 in fast mode
+      \arg        I2C_DTCY_16_9: T_low/T_high = 16/9 in fast mode
+    \param[out] none
+    \retval     none
+*/
+void i2c_clock_config(uint32_t i2c_periph, uint32_t clkspeed, uint32_t dutycyc)
+{
+    uint32_t pclk1, clkc, freq, risetime;
+    uint32_t temp;
+
+    pclk1 = rcu_clock_freq_get(CK_APB1);
+    /* I2C peripheral clock frequency */
+    freq = (uint32_t)(pclk1 / 1000000U);
+    if(freq >= I2CCLK_MAX) {
+        freq = I2CCLK_MAX;
+    }
+    temp = I2C_CTL1(i2c_periph);
+    temp &= ~I2C_CTL1_I2CCLK;
+    temp |= freq;
+
+    I2C_CTL1(i2c_periph) = temp;
+
+    if(100000U >= clkspeed) {
+        /* the maximum SCL rise time is 1000ns in standard mode */
+        risetime = (uint32_t)((pclk1 / 1000000U) + 1U);
+        if(risetime >= I2CCLK_MAX) {
+            I2C_RT(i2c_periph) = I2CCLK_MAX;
+        } else if(risetime <= I2CCLK_MIN) {
+            I2C_RT(i2c_periph) = I2CCLK_MIN;
+        } else {
+            I2C_RT(i2c_periph) = risetime;
+        }
+        clkc = (uint32_t)(pclk1 / (clkspeed * 2U));
+        if(clkc < 0x04U) {
+            /* the CLKC in standard mode minmum value is 4 */
+            clkc = 0x04U;
+        }
+
+        I2C_CKCFG(i2c_periph) |= (I2C_CKCFG_CLKC & clkc);
+
+    } else if(400000U >= clkspeed) {
+        /* the maximum SCL rise time is 300ns in fast mode */
+        I2C_RT(i2c_periph) = (uint32_t)(((freq * (uint32_t)300U) / (uint32_t)1000U) + (uint32_t)1U);
+        if(I2C_DTCY_2 == dutycyc) {
+            /* I2C duty cycle is 2 */
+            clkc = (uint32_t)(pclk1 / (clkspeed * 3U));
+            I2C_CKCFG(i2c_periph) &= ~I2C_CKCFG_DTCY;
+        } else {
+            /* I2C duty cycle is 16/9 */
+            clkc = (uint32_t)(pclk1 / (clkspeed * 25U));
+            I2C_CKCFG(i2c_periph) |= I2C_CKCFG_DTCY;
+        }
+        if(0U == (clkc & I2C_CKCFG_CLKC)) {
+            /* the CLKC in fast mode minmum value is 1 */
+            clkc |= 0x0001U;
+        }
+        I2C_CKCFG(i2c_periph) |= I2C_CKCFG_FAST;
+        I2C_CKCFG(i2c_periph) |= clkc;
+    } else {
+    }
+}
+
+/*!
+    \brief      configure I2C address
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  mode:
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_I2CMODE_ENABLE: I2C mode
+      \arg        I2C_SMBUSMODE_ENABLE: SMBus mode
+    \param[in]  addformat: 7bits or 10bits
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_ADDFORMAT_7BITS: address format is 7 bits
+      \arg        I2C_ADDFORMAT_10BITS: address format is 10 bits
+    \param[in]  addr: I2C address
+    \param[out] none
+    \retval     none
+*/
+void i2c_mode_addr_config(uint32_t i2c_periph, uint32_t mode, uint32_t addformat, uint32_t addr)
+{
+    /* SMBus/I2C mode selected */
+    uint32_t ctl = 0U;
+
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_SMBEN);
+    ctl |= mode;
+    I2C_CTL0(i2c_periph) = ctl;
+    /* configure address */
+    addr = addr & I2C_ADDRESS_MASK;
+    I2C_SADDR0(i2c_periph) = (addformat | addr);
+}
+
+/*!
+    \brief      select SMBus type
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  type:
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_SMBUS_DEVICE: SMBus mode device type
+      \arg        I2C_SMBUS_HOST: SMBus mode host type
+    \param[out] none
+    \retval     none
+*/
+void i2c_smbus_type_config(uint32_t i2c_periph, uint32_t type)
+{
+    if(I2C_SMBUS_HOST == type) {
+        I2C_CTL0(i2c_periph) |= I2C_CTL0_SMBSEL;
+    } else {
+        I2C_CTL0(i2c_periph) &= ~(I2C_CTL0_SMBSEL);
+    }
+}
+
+/*!
+    \brief      whether or not to send an ACK
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  ack:
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_ACK_ENABLE: ACK will be sent
+      \arg        I2C_ACK_DISABLE: ACK will not be sent
+    \param[out] none
+    \retval     none
+*/
+void i2c_ack_config(uint32_t i2c_periph, uint32_t ack)
+{
+    uint32_t ctl = 0U;
+
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_ACKEN);
+    ctl |= ack;
+    I2C_CTL0(i2c_periph) = ctl;
+}
+
+/*!
+    \brief      configure I2C POAP position
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  pos:
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_ACKPOS_CURRENT: ACKEN bit decides whether or not to send ACK or not for the current byte
+      \arg        I2C_ACKPOS_NEXT: ACKEN bit decides whether or not to send ACK for the next byte
+    \param[out] none
+    \retval     none
+*/
+void i2c_ackpos_config(uint32_t i2c_periph, uint32_t pos)
+{
+    uint32_t ctl = 0U;
+    /* configure I2C POAP position */
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_POAP);
+    ctl |= pos;
+    I2C_CTL0(i2c_periph) = ctl;
+}
+
+/*!
+    \brief      master sends slave address
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  addr: slave address
+    \param[in]  trandirection: transmitter or receiver
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_TRANSMITTER: transmitter
+      \arg        I2C_RECEIVER: receiver
+    \param[out] none
+    \retval     none
+*/
+void i2c_master_addressing(uint32_t i2c_periph, uint32_t addr, uint32_t trandirection)
+{
+    /* master is a transmitter or a receiver */
+    if(I2C_TRANSMITTER == trandirection) {
+        addr = addr & I2C_TRANSMITTER;
+    } else {
+        addr = addr | I2C_RECEIVER;
+    }
+    /* send slave address */
+    I2C_DATA(i2c_periph) = addr;
+}
+
+/*!
+    \brief      enable dual-address mode
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  addr: the second address in dual-address mode
+    \param[out] none
+    \retval     none
+*/
+void i2c_dualaddr_enable(uint32_t i2c_periph, uint32_t addr)
+{
+    /* configure address */
+    addr = addr & I2C_ADDRESS2_MASK;
+    I2C_SADDR1(i2c_periph) = (I2C_SADDR1_DUADEN | addr);
+}
+
+/*!
+    \brief      disable dual-address mode
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2c_dualaddr_disable(uint32_t i2c_periph)
+{
+    I2C_SADDR1(i2c_periph) &= ~(I2C_SADDR1_DUADEN);
+}
+
+/*!
+    \brief      enable I2C
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2c_enable(uint32_t i2c_periph)
+{
+    I2C_CTL0(i2c_periph) |= I2C_CTL0_I2CEN;
+}
+
+/*!
+    \brief      disable I2C
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2c_disable(uint32_t i2c_periph)
+{
+    I2C_CTL0(i2c_periph) &= ~(I2C_CTL0_I2CEN);
+}
+
+/*!
+    \brief      generate a START condition on I2C bus
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2c_start_on_bus(uint32_t i2c_periph)
+{
+    I2C_CTL0(i2c_periph) |= I2C_CTL0_START;
+}
+
+/*!
+    \brief      generate a STOP condition on I2C bus
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2c_stop_on_bus(uint32_t i2c_periph)
+{
+    I2C_CTL0(i2c_periph) |= I2C_CTL0_STOP;
+}
+
+/*!
+    \brief      I2C transmit data function
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  data: data of transmission
+    \param[out] none
+    \retval     none
+*/
+void i2c_data_transmit(uint32_t i2c_periph, uint8_t data)
+{
+    I2C_DATA(i2c_periph) = DATA_TRANS(data);
+}
+
+/*!
+    \brief      I2C receive data function
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     data of received
+*/
+uint8_t i2c_data_receive(uint32_t i2c_periph)
+{
+    return (uint8_t)DATA_RECV(I2C_DATA(i2c_periph));
+}
+
+/*!
+    \brief      configure I2C DMA mode
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  dmastate:
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_DMA_ON: enable DMA mode
+      \arg        I2C_DMA_OFF: disable DMA mode
+    \param[out] none
+    \retval     none
+*/
+void i2c_dma_config(uint32_t i2c_periph, uint32_t dmastate)
+{
+    /* configure I2C DMA function */
+    uint32_t ctl = 0U;
+
+    ctl = I2C_CTL1(i2c_periph);
+    ctl &= ~(I2C_CTL1_DMAON);
+    ctl |= dmastate;
+    I2C_CTL1(i2c_periph) = ctl;
+}
+
+/*!
+    \brief      configure whether next DMA EOT is DMA last transfer or not
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  dmalast:
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_DMALST_ON: next DMA EOT is the last transfer
+      \arg        I2C_DMALST_OFF: next DMA EOT is not the last transfer
+    \param[out] none
+    \retval     none
+*/
+void i2c_dma_last_transfer_config(uint32_t i2c_periph, uint32_t dmalast)
+{
+    /* configure DMA last transfer */
+    uint32_t ctl = 0U;
+
+    ctl = I2C_CTL1(i2c_periph);
+    ctl &= ~(I2C_CTL1_DMALST);
+    ctl |= dmalast;
+    I2C_CTL1(i2c_periph) = ctl;
+}
+
+/*!
+    \brief      whether to stretch SCL low when data is not ready in slave mode
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  stretchpara:
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_SCLSTRETCH_ENABLE: enable SCL stretching
+      \arg        I2C_SCLSTRETCH_DISABLE: disable SCL stretching
+    \param[out] none
+    \retval     none
+*/
+void i2c_stretch_scl_low_config(uint32_t i2c_periph, uint32_t stretchpara)
+{
+    /* configure I2C SCL strerching */
+    uint32_t ctl = 0U;
+
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_SS);
+    ctl |= stretchpara;
+    I2C_CTL0(i2c_periph) = ctl;
+}
+
+/*!
+    \brief      whether or not to response to a general call
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  gcallpara:
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_GCEN_ENABLE: slave will response to a general call
+      \arg        I2C_GCEN_DISABLE: slave will not response to a general call
+    \param[out] none
+    \retval     none
+*/
+void i2c_slave_response_to_gcall_config(uint32_t i2c_periph, uint32_t gcallpara)
+{
+    /* configure slave response to a general call enable or disable */
+    uint32_t ctl = 0U;
+
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_GCEN);
+    ctl |= gcallpara;
+    I2C_CTL0(i2c_periph) = ctl;
+}
+
+/*!
+    \brief      configure software reset of I2C
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  sreset:
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_SRESET_SET: I2C is under reset
+      \arg        I2C_SRESET_RESET: I2C is not under reset
+    \param[out] none
+    \retval     none
+*/
+void i2c_software_reset_config(uint32_t i2c_periph, uint32_t sreset)
+{
+    /* modify CTL0 and configure software reset I2C state */
+    uint32_t ctl = 0U;
+
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_SRESET);
+    ctl |= sreset;
+    I2C_CTL0(i2c_periph) = ctl;
+}
+
+/*!
+    \brief      configure I2C PEC calculation
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  pecstate:
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_PEC_ENABLE: PEC calculation on
+      \arg        I2C_PEC_DISABLE: PEC calculation off
+    \param[out] none
+    \retval     none
+*/
+void i2c_pec_config(uint32_t i2c_periph, uint32_t pecstate)
+{
+    /* on/off PEC calculation */
+    uint32_t ctl = 0U;
+
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_PECEN);
+    ctl |= pecstate;
+    I2C_CTL0(i2c_periph) = ctl;
+}
+
+/*!
+    \brief      configure whether to transfer PEC value
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  pecpara:
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_PECTRANS_ENABLE: transfer PEC value
+      \arg        I2C_PECTRANS_DISABLE: not transfer PEC value
+    \param[out] none
+    \retval     none
+*/
+void i2c_pec_transfer_config(uint32_t i2c_periph, uint32_t pecpara)
+{
+    /* whether to transfer PEC */
+    uint32_t ctl = 0U;
+
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_PECTRANS);
+    ctl |= pecpara;
+    I2C_CTL0(i2c_periph) = ctl;
+}
+
+/*!
+    \brief      get packet error checking value
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     PEC value
+*/
+uint8_t i2c_pec_value_get(uint32_t i2c_periph)
+{
+    return (uint8_t)((I2C_STAT1(i2c_periph) & I2C_STAT1_PECV) >> STAT1_PECV_OFFSET);
+}
+
+/*!
+    \brief      configure I2C alert through SMBA pin
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  smbuspara:
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_SALTSEND_ENABLE: issue alert through SMBA pin
+      \arg        I2C_SALTSEND_DISABLE: not issue alert through SMBA pin
+    \param[out] none
+    \retval     none
+*/
+void i2c_smbus_alert_config(uint32_t i2c_periph, uint32_t smbuspara)
+{
+    /* configure smubus alert through SMBA pin */
+    uint32_t ctl = 0U;
+
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_SALT);
+    ctl |= smbuspara;
+    I2C_CTL0(i2c_periph) = ctl;
+}
+
+/*!
+    \brief      configure I2C ARP protocol in SMBus
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  arpstate:
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_ARP_ENABLE: enable ARP
+      \arg        I2C_ARP_DISABLE: disable ARP
+    \param[out] none
+    \retval     none
+*/
+void i2c_smbus_arp_config(uint32_t i2c_periph, uint32_t arpstate)
+{
+    /* enable or disable I2C ARP protocol*/
+    uint32_t ctl = 0U;
+
+    ctl = I2C_CTL0(i2c_periph);
+    ctl &= ~(I2C_CTL0_ARPEN);
+    ctl |= arpstate;
+    I2C_CTL0(i2c_periph) = ctl;
+}
+
+/*!
+    \brief      disable analog noise filter
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2c_analog_noise_filter_disable(uint32_t i2c_periph)
+{
+    I2C_FCTL(i2c_periph) |= I2C_FCTL_AFD;
+}
+
+/*!
+    \brief      enable analog noise filter
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2c_analog_noise_filter_enable(uint32_t i2c_periph)
+{
+    I2C_FCTL(i2c_periph) &= ~(I2C_FCTL_AFD);
+}
+
+/*!
+    \brief      configure digital noise filter
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  dfilterpara: refer to i2c_digital_filter_enum
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_DF_DISABLE: disable digital noise filter
+      \arg        I2C_DF_1PCLK: enable digital noise filter and the maximum filtered spiker's length 1 PCLK1
+      \arg        I2C_DF_2PCLK: enable digital noise filter and the maximum filtered spiker's length 2 PCLK1
+      \arg        I2C_DF_3PCLK: enable digital noise filter and the maximum filtered spiker's length 3 PCLK1
+      \arg        I2C_DF_4PCLK: enable digital noise filter and the maximum filtered spiker's length 4 PCLK1
+      \arg        I2C_DF_5PCLK: enable digital noise filter and the maximum filtered spiker's length 5 PCLK1
+      \arg        I2C_DF_6PCLK: enable digital noise filter and the maximum filtered spiker's length 6 PCLK1
+      \arg        I2C_DF_7PCLK: enable digital noise filter and the maximum filtered spiker's length 7 PCLK1
+      \arg        I2C_DF_8PCLK: enable digital noise filter and the maximum filtered spiker's length 8 PCLK1
+      \arg        I2C_DF_9PCLK: enable digital noise filter and the maximum filtered spiker's length 9 PCLK1
+      \arg        I2C_DF_10PCLK: enable digital noise filter and the maximum filtered spiker's length 10 PCLK1
+      \arg        I2C_DF_11CLK: enable digital noise filter and the maximum filtered spiker's length 11 PCLK1
+      \arg        I2C_DF_12CLK: enable digital noise filter and the maximum filtered spiker's length 12 PCLK1
+      \arg        I2C_DF_13PCLK: enable digital noise filter and the maximum filtered spiker's length 13 PCLK1
+      \arg        I2C_DF_14PCLK: enable digital noise filter and the maximum filtered spiker's length 14 PCLK1
+      \arg        I2C_DF_15PCLK: enable digital noise filter and the maximum filtered spiker's length 15 PCLK1
+    \param[out] none
+    \retval     none
+*/
+void i2c_digital_noise_filter_config(uint32_t i2c_periph, i2c_digital_filter_enum dfilterpara)
+{
+    I2C_FCTL(i2c_periph) |= dfilterpara;
+}
+
+/*!
+    \brief      enable SAM_V interface
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2c_sam_enable(uint32_t i2c_periph)
+{
+    I2C_SAMCS(i2c_periph) |= I2C_SAMCS_SAMEN;
+}
+
+/*!
+    \brief      disable SAM_V interface
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2c_sam_disable(uint32_t i2c_periph)
+{
+    I2C_SAMCS(i2c_periph) &= ~(I2C_SAMCS_SAMEN);
+}
+
+/*!
+    \brief      enable SAM_V interface timeout detect
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2c_sam_timeout_enable(uint32_t i2c_periph)
+{
+    I2C_SAMCS(i2c_periph) |= I2C_SAMCS_STOEN;
+}
+
+/*!
+    \brief      disable SAM_V interface timeout detect
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2c_sam_timeout_disable(uint32_t i2c_periph)
+{
+    I2C_SAMCS(i2c_periph) &= ~(I2C_SAMCS_STOEN);
+}
+
+/*!
+    \brief      get I2C flag status
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  flag: I2C flags, refer to i2c_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_FLAG_SBSEND: start condition sent out in master mode
+      \arg        I2C_FLAG_ADDSEND: address is sent in master mode or received and matches in slave mode
+      \arg        I2C_FLAG_BTC: byte transmission finishes
+      \arg        I2C_FLAG_ADD10SEND: header of 10-bit address is sent in master mode
+      \arg        I2C_FLAG_STPDET: stop condition detected in slave mode
+      \arg        I2C_FLAG_RBNE: I2C_DATA is not empty during receiving
+      \arg        I2C_FLAG_TBE: I2C_DATA is empty during transmitting
+      \arg        I2C_FLAG_BERR: a bus error occurs indication a unexpected start or stop condition on I2C bus
+      \arg        I2C_FLAG_LOSTARB: arbitration lost in master mode
+      \arg        I2C_FLAG_AERR: acknowledge error
+      \arg        I2C_FLAG_OUERR: over-run or under-run situation occurs in slave mode
+      \arg        I2C_FLAG_PECERR: PEC error when receiving data
+      \arg        I2C_FLAG_SMBTO: timeout signal in SMBus mode
+      \arg        I2C_FLAG_SMBALT: SMBus alert status
+      \arg        I2C_FLAG_MASTER: a flag indicating whether I2C block is in master or slave mode
+      \arg        I2C_FLAG_I2CBSY: busy flag
+      \arg        I2C_FLAG_TR: whether the I2C is a transmitter or a receiver
+      \arg        I2C_FLAG_RXGC: general call address (00h) received
+      \arg        I2C_FLAG_DEFSMB: default address of SMBus device
+      \arg        I2C_FLAG_HSTSMB: SMBus host header detected in slave mode
+      \arg        I2C_FLAG_DUMOD: dual flag in slave mode indicating which address is matched in dual-address mode
+      \arg        I2C_FLAG_TFF: txframe fall flag
+      \arg        I2C_FLAG_TFR: txframe rise flag
+      \arg        I2C_FLAG_RFF: rxframe fall flag
+      \arg        I2C_FLAG_RFR: rxframe rise flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus i2c_flag_get(uint32_t i2c_periph, i2c_flag_enum flag)
+{
+    if(RESET != (I2C_REG_VAL(i2c_periph, flag) & BIT(I2C_BIT_POS(flag)))) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      clear I2C flag status
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  flag: I2C flags, refer to i2c_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg       I2C_FLAG_SMBALT: SMBus alert status
+      \arg       I2C_FLAG_SMBTO: timeout signal in SMBus mode
+      \arg       I2C_FLAG_PECERR: PEC error when receiving data
+      \arg       I2C_FLAG_OUERR: over-run or under-run situation occurs in slave mode
+      \arg       I2C_FLAG_AERR: acknowledge error
+      \arg       I2C_FLAG_LOSTARB: arbitration lost in master mode
+      \arg       I2C_FLAG_BERR: a bus error occurs indication a unexpected start or stop condition on I2C bus
+      \arg       I2C_FLAG_ADDSEND: address is sent in master mode or received and matches in slave mode
+      \arg       I2C_FLAG_TFF: txframe fall flag
+      \arg       I2C_FLAG_TFR: txframe rise flag
+      \arg       I2C_FLAG_RFF: rxframe fall flag
+      \arg       I2C_FLAG_RFR: rxframe rise flag
+    \param[out] none
+    \retval     none
+*/
+void i2c_flag_clear(uint32_t i2c_periph, i2c_flag_enum flag)
+{
+    if(I2C_FLAG_ADDSEND == flag) {
+        /* read I2C_STAT0 and then read I2C_STAT1 to clear ADDSEND */
+        I2C_STAT0(i2c_periph);
+        I2C_STAT1(i2c_periph);
+    } else {
+        I2C_REG_VAL(i2c_periph, flag) &= ~BIT(I2C_BIT_POS(flag));
+    }
+}
+
+/*!
+    \brief      enable I2C interrupt
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  interrupt: I2C interrupts, refer to i2c_interrupt_enum
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_INT_ERR: error interrupt
+      \arg        I2C_INT_EV: event interrupt
+      \arg        I2C_INT_BUF: buffer interrupt
+      \arg        I2C_INT_TFF: txframe fall interrupt
+      \arg        I2C_INT_TFR: txframe rise interrupt
+      \arg        I2C_INT_RFF: rxframe fall interrupt
+      \arg        I2C_INT_RFR: rxframe rise interrupt
+    \param[out] none
+    \retval     none
+*/
+void i2c_interrupt_enable(uint32_t i2c_periph, i2c_interrupt_enum interrupt)
+{
+    I2C_REG_VAL(i2c_periph, interrupt) |= BIT(I2C_BIT_POS(interrupt));
+}
+
+/*!
+    \brief      disable I2C interrupt
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  interrupt: I2C interrupts, refer to i2c_interrupt_enum
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_INT_ERR: error interrupt
+      \arg        I2C_INT_EV: event interrupt
+      \arg        I2C_INT_BUF: buffer interrupt
+      \arg        I2C_INT_TFF: txframe fall interrupt
+      \arg        I2C_INT_TFR: txframe rise interrupt
+      \arg        I2C_INT_RFF: rxframe fall interrupt
+      \arg        I2C_INT_RFR: rxframe rise interrupt
+    \param[out] none
+    \retval     none
+*/
+void i2c_interrupt_disable(uint32_t i2c_periph, i2c_interrupt_enum interrupt)
+{
+    I2C_REG_VAL(i2c_periph, interrupt) &= ~BIT(I2C_BIT_POS(interrupt));
+}
+
+/*!
+    \brief      get I2C interrupt flag status
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  int_flag: I2C interrupt flags, refer to i2c_interrupt_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_INT_FLAG_SBSEND: start condition sent out in master mode interrupt flag
+      \arg        I2C_INT_FLAG_ADDSEND: address is sent in master mode or received and matches in slave mode interrupt flag
+      \arg        I2C_INT_FLAG_BTC: byte transmission finishes interrupt flag
+      \arg        I2C_INT_FLAG_ADD10SEND: header of 10-bit address is sent in master mode interrupt flag
+      \arg        I2C_INT_FLAG_STPDET: stop condition detected in slave mode interrupt flag
+      \arg        I2C_INT_FLAG_RBNE: I2C_DATA is not Empty during receiving interrupt flag
+      \arg        I2C_INT_FLAG_TBE: I2C_DATA is empty during transmitting interrupt flag
+      \arg        I2C_INT_FLAG_BERR: a bus error occurs indication a unexpected start or stop condition on I2C bus interrupt flag
+      \arg        I2C_INT_FLAG_LOSTARB: arbitration lost in master mode interrupt flag
+      \arg        I2C_INT_FLAG_AERR: acknowledge error interrupt flag
+      \arg        I2C_INT_FLAG_OUERR: over-run or under-run situation occurs in slave mode interrupt flag
+      \arg        I2C_INT_FLAG_PECERR: PEC error when receiving data interrupt flag
+      \arg        I2C_INT_FLAG_SMBTO: timeout signal in SMBus mode interrupt flag
+      \arg        I2C_INT_FLAG_SMBALT: SMBus alert status interrupt flag
+      \arg        I2C_INT_FLAG_TFF: txframe fall interrupt flag
+      \arg        I2C_INT_FLAG_TFR: txframe rise interrupt flag
+      \arg        I2C_INT_FLAG_RFF: rxframe fall interrupt flag
+      \arg        I2C_INT_FLAG_RFR: rxframe rise interrupt flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus i2c_interrupt_flag_get(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag)
+{
+    uint32_t intenable = 0U, flagstatus = 0U, bufie;
+
+    /* check BUFIE */
+    bufie = I2C_CTL1(i2c_periph)&I2C_CTL1_BUFIE;
+
+    /* get the interrupt enable bit status */
+    intenable = (I2C_REG_VAL(i2c_periph, int_flag) & BIT(I2C_BIT_POS(int_flag)));
+    /* get the corresponding flag bit status */
+    flagstatus = (I2C_REG_VAL2(i2c_periph, int_flag) & BIT(I2C_BIT_POS2(int_flag)));
+
+    if((I2C_INT_FLAG_RBNE == int_flag) || (I2C_INT_FLAG_TBE == int_flag)) {
+        if(intenable && bufie) {
+            intenable = 1U;
+        } else {
+            intenable = 0U;
+        }
+    }
+    if((0U != flagstatus) && (0U != intenable)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      clear I2C interrupt flag status
+    \param[in]  i2c_periph: I2Cx(x=0,1,2)
+    \param[in]  int_flag: I2C interrupt flags, refer to i2c_interrupt_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg        I2C_INT_FLAG_ADDSEND: address is sent in master mode or received and matches in slave mode interrupt flag
+      \arg        I2C_INT_FLAG_BERR: a bus error occurs indication a unexpected start or stop condition on I2C bus interrupt flag
+      \arg        I2C_INT_FLAG_LOSTARB: arbitration lost in master mode interrupt flag
+      \arg        I2C_INT_FLAG_AERR: acknowledge error interrupt flag
+      \arg        I2C_INT_FLAG_OUERR: over-run or under-run situation occurs in slave mode interrupt flag
+      \arg        I2C_INT_FLAG_PECERR: PEC error when receiving data interrupt flag
+      \arg        I2C_INT_FLAG_SMBTO: timeout signal in SMBus mode interrupt flag
+      \arg        I2C_INT_FLAG_SMBALT: SMBus alert status interrupt flag
+      \arg        I2C_INT_FLAG_TFF: txframe fall interrupt flag
+      \arg        I2C_INT_FLAG_TFR: txframe rise interrupt flag
+      \arg        I2C_INT_FLAG_RFF: rxframe fall interrupt flag
+      \arg        I2C_INT_FLAG_RFR: rxframe rise interrupt flag
+    \param[out] none
+    \retval     none
+*/
+void i2c_interrupt_flag_clear(uint32_t i2c_periph, i2c_interrupt_flag_enum int_flag)
+{
+    if(I2C_INT_FLAG_ADDSEND == int_flag) {
+        /* read I2C_STAT0 and then read I2C_STAT1 to clear ADDSEND */
+        I2C_STAT0(i2c_periph);
+        I2C_STAT1(i2c_periph);
+    } else {
+        I2C_REG_VAL2(i2c_periph, int_flag) &= ~BIT(I2C_BIT_POS2(int_flag));
+    }
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_ipa.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_ipa.c
@@ -1,0 +1,639 @@
+/*!
+    \file    gd32f4xx_ipa.c
+    \brief   IPA driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_ipa.h"
+
+#define IPA_DEFAULT_VALUE   0x00000000U
+
+/*!
+    \brief    deinitialize IPA registers
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ipa_deinit(void)
+{
+    rcu_periph_reset_enable(RCU_IPARST);
+    rcu_periph_reset_disable(RCU_IPARST);
+}
+
+/*!
+    \brief    enable IPA transfer
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ipa_transfer_enable(void)
+{
+    IPA_CTL |= IPA_CTL_TEN;
+}
+
+/*!
+    \brief    enable IPA transfer hang up
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ipa_transfer_hangup_enable(void)
+{
+    IPA_CTL |= IPA_CTL_THU;
+}
+
+/*!
+    \brief    disable IPA transfer hang up
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ipa_transfer_hangup_disable(void)
+{
+    IPA_CTL &= ~(IPA_CTL_THU);
+}
+
+/*!
+    \brief    enable IPA transfer stop
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ipa_transfer_stop_enable(void)
+{
+    IPA_CTL |= IPA_CTL_TST;
+}
+
+/*!
+    \brief    disable IPA transfer stop
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ipa_transfer_stop_disable(void)
+{
+    IPA_CTL &= ~(IPA_CTL_TST);
+}
+/*!
+    \brief    enable IPA foreground LUT loading
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ipa_foreground_lut_loading_enable(void)
+{
+    IPA_FPCTL |= IPA_FPCTL_FLLEN;
+}
+
+/*!
+    \brief    enable IPA background LUT loading
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void ipa_background_lut_loading_enable(void)
+{
+    IPA_BPCTL |= IPA_BPCTL_BLLEN;
+}
+
+/*!
+    \brief    set pixel format convert mode, the function is invalid when the IPA transfer is enabled
+    \param[in]  pfcm: pixel format convert mode
+                only one parameter can be selected which is shown as below:
+      \arg        IPA_FGTODE: foreground memory to destination memory without pixel format convert
+      \arg        IPA_FGTODE_PF_CONVERT: foreground memory to destination memory with pixel format convert
+      \arg        IPA_FGBGTODE: blending foreground and background memory to destination memory
+      \arg        IPA_FILL_UP_DE: fill up destination memory with specific color
+    \param[out] none
+    \retval     none
+*/
+void ipa_pixel_format_convert_mode_set(uint32_t pfcm)
+{
+    IPA_CTL &= ~(IPA_CTL_PFCM);
+    IPA_CTL |= pfcm;
+}
+
+/*!
+    \brief    initialize the structure of IPA foreground parameter struct with the default values, it is
+                suggested that call this function after an ipa_foreground_parameter_struct structure is defined
+    \param[in]  none
+    \param[out] foreground_struct: the data needed to initialize foreground
+                  foreground_memaddr: foreground memory base address
+                  foreground_lineoff: foreground line offset
+                  foreground_prealpha: foreground pre-defined alpha value
+                  foreground_alpha_algorithm: IPA_FG_ALPHA_MODE_0,IPA_FG_ALPHA_MODE_1,IPA_FG_ALPHA_MODE_2
+                  foreground_pf: foreground pixel format(FOREGROUND_PPF_ARGB8888,FOREGROUND_PPF_RGB888,FOREGROUND_PPF_RGB565,
+                            FOREGROUND_PPF_ARG1555,FOREGROUND_PPF_ARGB4444,FOREGROUND_PPF_L8,FOREGROUND_PPF_AL44,
+                            FOREGROUND_PPF_AL88,FOREGROUND_PPF_L4,FOREGROUND_PPF_A8,FOREGROUND_PPF_A4)
+                  foreground_prered: foreground pre-defined red value
+                  foreground_pregreen: foreground pre-defined green value
+                  foreground_preblue: foreground pre-defined blue value
+    \retval     none
+*/
+void ipa_foreground_struct_para_init(ipa_foreground_parameter_struct *foreground_struct)
+{
+    /* initialize the struct parameters with default values */
+    foreground_struct->foreground_memaddr = IPA_DEFAULT_VALUE;
+    foreground_struct->foreground_lineoff = IPA_DEFAULT_VALUE;
+    foreground_struct->foreground_prealpha = IPA_DEFAULT_VALUE;
+    foreground_struct->foreground_alpha_algorithm = IPA_FG_ALPHA_MODE_0;
+    foreground_struct->foreground_pf = FOREGROUND_PPF_ARGB8888;
+    foreground_struct->foreground_prered = IPA_DEFAULT_VALUE;
+    foreground_struct->foreground_pregreen = IPA_DEFAULT_VALUE;
+    foreground_struct->foreground_preblue = IPA_DEFAULT_VALUE;
+}
+
+/*!
+    \brief    initialize foreground parameters
+    \param[in]  foreground_struct: the data needed to initialize foreground
+                  foreground_memaddr: foreground memory base address
+                  foreground_lineoff: foreground line offset
+                  foreground_prealpha: foreground pre-defined alpha value
+                  foreground_alpha_algorithm: IPA_FG_ALPHA_MODE_0,IPA_FG_ALPHA_MODE_1,IPA_FG_ALPHA_MODE_2
+                  foreground_pf: foreground pixel format(FOREGROUND_PPF_ARGB8888,FOREGROUND_PPF_RGB888,FOREGROUND_PPF_RGB565,
+                            FOREGROUND_PPF_ARG1555,FOREGROUND_PPF_ARGB4444,FOREGROUND_PPF_L8,FOREGROUND_PPF_AL44,
+                            FOREGROUND_PPF_AL88,FOREGROUND_PPF_L4,FOREGROUND_PPF_A8,FOREGROUND_PPF_A4)
+                  foreground_prered: foreground pre-defined red value
+                  foreground_pregreen: foreground pre-defined green value
+                  foreground_preblue: foreground pre-defined blue value
+    \param[out] none
+    \retval     none
+*/
+void ipa_foreground_init(ipa_foreground_parameter_struct *foreground_struct)
+{
+    FlagStatus tempflag = RESET;
+    if(RESET != (IPA_CTL & IPA_CTL_TEN)) {
+        tempflag = SET;
+        /* reset the TEN in order to configure the following bits */
+        IPA_CTL &= ~IPA_CTL_TEN;
+    }
+
+    /* foreground memory base address configuration */
+    IPA_FMADDR &= ~(IPA_FMADDR_FMADDR);
+    IPA_FMADDR = foreground_struct->foreground_memaddr;
+    /* foreground line offset configuration */
+    IPA_FLOFF &= ~(IPA_FLOFF_FLOFF);
+    IPA_FLOFF = foreground_struct->foreground_lineoff;
+    /* foreground pixel format pre-defined alpha, alpha calculation algorithm configuration */
+    IPA_FPCTL &= ~(IPA_FPCTL_FPDAV | IPA_FPCTL_FAVCA | IPA_FPCTL_FPF);
+    IPA_FPCTL |= (foreground_struct->foreground_prealpha << 24U);
+    IPA_FPCTL |= foreground_struct->foreground_alpha_algorithm;
+    IPA_FPCTL |= foreground_struct->foreground_pf;
+    /* foreground pre-defined red green blue configuration */
+    IPA_FPV &= ~(IPA_FPV_FPDRV | IPA_FPV_FPDGV | IPA_FPV_FPDBV);
+    IPA_FPV |= ((foreground_struct->foreground_prered << 16U) | (foreground_struct->foreground_pregreen << 8U)
+                | (foreground_struct->foreground_preblue));
+
+    if(SET == tempflag) {
+        /* restore the state of TEN */
+        IPA_CTL |= IPA_CTL_TEN;
+    }
+}
+
+/*!
+    \brief    initialize the structure of IPA background parameter struct with the default values, it is
+                suggested that call this function after an ipa_background_parameter_struct structure is defined
+    \param[in]  none
+    \param[out] background_struct: the data needed to initialize background
+                  background_memaddr: background memory base address
+                  background_lineoff: background line offset
+                  background_prealpha: background pre-defined alpha value
+                  background_alpha_algorithm: IPA_BG_ALPHA_MODE_0,IPA_BG_ALPHA_MODE_1,IPA_BG_ALPHA_MODE_2
+                  background_pf: background pixel format(BACKGROUND_PPF_ARGB8888,BACKGROUND_PPF_RGB888,BACKGROUND_PPF_RGB565,
+                            BACKGROUND_PPF_ARG1555,BACKGROUND_PPF_ARGB4444,BACKGROUND_PPF_L8,BACKGROUND_PPF_AL44,
+                            BACKGROUND_PPF_AL88,BACKGROUND_PPF_L4,BACKGROUND_PPF_A8,BACKGROUND_PPF_A4)
+                  background_prered: background pre-defined red value
+                  background_pregreen: background pre-defined green value
+                  background_preblue: background pre-defined blue value
+    \retval     none
+*/
+void ipa_background_struct_para_init(ipa_background_parameter_struct *background_struct)
+{
+    /* initialize the struct parameters with default values */
+    background_struct->background_memaddr = IPA_DEFAULT_VALUE;
+    background_struct->background_lineoff = IPA_DEFAULT_VALUE;
+    background_struct->background_prealpha = IPA_DEFAULT_VALUE;
+    background_struct->background_alpha_algorithm = IPA_BG_ALPHA_MODE_0;
+    background_struct->background_pf = BACKGROUND_PPF_ARGB8888;
+    background_struct->background_prered = IPA_DEFAULT_VALUE;
+    background_struct->background_pregreen = IPA_DEFAULT_VALUE;
+    background_struct->background_preblue = IPA_DEFAULT_VALUE;
+}
+
+/*!
+    \brief    initialize background parameters
+    \param[in]  background_struct: the data needed to initialize background
+                  background_memaddr: background memory base address
+                  background_lineoff: background line offset
+                  background_prealpha: background pre-defined alpha value
+                  background_alpha_algorithm: IPA_BG_ALPHA_MODE_0,IPA_FG_ALPHA_MODE_1,IPA_FG_ALPHA_MODE_2
+                  background_pf: background pixel format(BACKGROUND_PPF_ARGB8888,BACKGROUND_PPF_RGB888,BACKGROUND_PPF_RGB565,
+                            BACKGROUND_PPF_ARG1555,BACKGROUND_PPF_ARGB4444,BACKGROUND_PPF_L8,BACKGROUND_PPF_AL44,
+                            BACKGROUND_PPF_AL88,BACKGROUND_PPF_L4,BACKGROUND_PPF_A8,BACKGROUND_PPF_A4)
+                  background_prered: background pre-defined red value
+                  background_pregreen: background pre-defined green value
+                  background_preblue: background pre-defined blue value
+    \param[out] none
+    \retval     none
+*/
+void ipa_background_init(ipa_background_parameter_struct *background_struct)
+{
+    FlagStatus tempflag = RESET;
+    if(RESET != (IPA_CTL & IPA_CTL_TEN)) {
+        tempflag = SET;
+        /* reset the TEN in order to configure the following bits */
+        IPA_CTL &= ~IPA_CTL_TEN;
+    }
+
+    /* background memory base address configuration */
+    IPA_BMADDR &= ~(IPA_BMADDR_BMADDR);
+    IPA_BMADDR = background_struct->background_memaddr;
+    /* background line offset configuration */
+    IPA_BLOFF &= ~(IPA_BLOFF_BLOFF);
+    IPA_BLOFF = background_struct->background_lineoff;
+    /* background pixel format pre-defined alpha, alpha calculation algorithm configuration */
+    IPA_BPCTL &= ~(IPA_BPCTL_BPDAV | IPA_BPCTL_BAVCA | IPA_BPCTL_BPF);
+    IPA_BPCTL |= (background_struct->background_prealpha << 24U);
+    IPA_BPCTL |= background_struct->background_alpha_algorithm;
+    IPA_BPCTL |= background_struct->background_pf;
+    /* background pre-defined red green blue configuration */
+    IPA_BPV &= ~(IPA_BPV_BPDRV | IPA_BPV_BPDGV | IPA_BPV_BPDBV);
+    IPA_BPV |= ((background_struct->background_prered << 16U) | (background_struct->background_pregreen << 8U)
+                | (background_struct->background_preblue));
+
+    if(SET == tempflag) {
+        /* restore the state of TEN */
+        IPA_CTL |= IPA_CTL_TEN;
+    }
+}
+
+/*!
+    \brief    initialize the structure of IPA destination parameter struct with the default values, it is
+                suggested that call this function after an ipa_destination_parameter_struct structure is defined
+    \param[in]  none
+    \param[out] destination_struct: the data needed to initialize destination parameter
+                  destination_pf: IPA_DPF_ARGB8888,IPA_DPF_RGB888,IPA_DPF_RGB565,IPA_DPF_ARGB1555,
+                              IPA_DPF_ARGB4444,refer to ipa_dpf_enum
+                  destination_lineoff: destination line offset
+                  destination_prealpha: destination pre-defined alpha value
+                  destination_prered: destination pre-defined red value
+                  destination_pregreen: destination pre-defined green value
+                  destination_preblue: destination pre-defined blue value
+                  destination_memaddr: destination memory base address
+                  image_width: width of the image to be processed
+                  image_height: height of the image to be processed
+    \retval     none
+*/
+void ipa_destination_struct_para_init(ipa_destination_parameter_struct *destination_struct)
+{
+    /* initialize the struct parameters with default values */
+    destination_struct->destination_pf = IPA_DPF_ARGB8888;
+    destination_struct->destination_lineoff = IPA_DEFAULT_VALUE;
+    destination_struct->destination_prealpha = IPA_DEFAULT_VALUE;
+    destination_struct->destination_prered = IPA_DEFAULT_VALUE;
+    destination_struct->destination_pregreen = IPA_DEFAULT_VALUE;
+    destination_struct->destination_preblue = IPA_DEFAULT_VALUE;
+    destination_struct->destination_memaddr = IPA_DEFAULT_VALUE;
+    destination_struct->image_width = IPA_DEFAULT_VALUE;
+    destination_struct->image_height = IPA_DEFAULT_VALUE;
+}
+
+/*!
+    \brief    initialize destination parameters
+    \param[in]  destination_struct: the data needed to initialize destination parameters
+                  destination_pf: IPA_DPF_ARGB8888,IPA_DPF_RGB888,IPA_DPF_RGB565,IPA_DPF_ARGB1555,
+                                IPA_DPF_ARGB4444,refer to ipa_dpf_enum
+                  destination_lineoff: destination line offset
+                  destination_prealpha: destination pre-defined alpha value
+                  destination_prered: destination pre-defined red value
+                  destination_pregreen: destination pre-defined green value
+                  destination_preblue: destination pre-defined blue value
+                  destination_memaddr: destination memory base address
+                  image_width: width of the image to be processed
+                  image_height: height of the image to be processed
+    \param[out] none
+    \retval     none
+*/
+void ipa_destination_init(ipa_destination_parameter_struct *destination_struct)
+{
+    uint32_t destination_pixelformat;
+    FlagStatus tempflag = RESET;
+    if(RESET != (IPA_CTL & IPA_CTL_TEN)) {
+        tempflag = SET;
+        /* reset the TEN in order to configure the following bits */
+        IPA_CTL &= ~IPA_CTL_TEN;
+    }
+
+    /* destination pixel format configuration */
+    IPA_DPCTL &= ~(IPA_DPCTL_DPF);
+    IPA_DPCTL = destination_struct->destination_pf;
+    destination_pixelformat = destination_struct->destination_pf;
+    /* destination pixel format ARGB8888 */
+    switch(destination_pixelformat) {
+    case IPA_DPF_ARGB8888:
+        IPA_DPV &= ~(IPA_DPV_DPDBV_0 | (IPA_DPV_DPDGV_0) | (IPA_DPV_DPDRV_0) | (IPA_DPV_DPDAV_0));
+        IPA_DPV = (destination_struct->destination_preblue | (destination_struct->destination_pregreen << 8U)
+                   | (destination_struct->destination_prered << 16U)
+                   | (destination_struct->destination_prealpha << 24U));
+        break;
+    /* destination pixel format RGB888 */
+    case IPA_DPF_RGB888:
+        IPA_DPV &= ~(IPA_DPV_DPDBV_1 | (IPA_DPV_DPDGV_1) | (IPA_DPV_DPDRV_1));
+        IPA_DPV = (destination_struct->destination_preblue | (destination_struct->destination_pregreen << 8U)
+                   | (destination_struct->destination_prered << 16U));
+        break;
+    /* destination pixel format RGB565 */
+    case IPA_DPF_RGB565:
+        IPA_DPV &= ~(IPA_DPV_DPDBV_2 | (IPA_DPV_DPDGV_2) | (IPA_DPV_DPDRV_2));
+        IPA_DPV = (destination_struct->destination_preblue | (destination_struct->destination_pregreen << 5U)
+                   | (destination_struct->destination_prered << 11U));
+        break;
+    /* destination pixel format ARGB1555 */
+    case IPA_DPF_ARGB1555:
+        IPA_DPV &= ~(IPA_DPV_DPDBV_3 | (IPA_DPV_DPDGV_3) | (IPA_DPV_DPDRV_3) | (IPA_DPV_DPDAV_3));
+        IPA_DPV = (destination_struct->destination_preblue | (destination_struct->destination_pregreen << 5U)
+                   | (destination_struct->destination_prered << 10U)
+                   | (destination_struct->destination_prealpha << 15U));
+        break;
+    /* destination pixel format ARGB4444 */
+    case IPA_DPF_ARGB4444:
+        IPA_DPV &= ~(IPA_DPV_DPDBV_4 | (IPA_DPV_DPDGV_4) | (IPA_DPV_DPDRV_4) | (IPA_DPV_DPDAV_4));
+        IPA_DPV = (destination_struct->destination_preblue | (destination_struct->destination_pregreen << 4U)
+                   | (destination_struct->destination_prered << 8U)
+                   | (destination_struct->destination_prealpha << 12U));
+        break;
+    default:
+        break;
+    }
+    /* destination memory base address configuration */
+    IPA_DMADDR &= ~(IPA_DMADDR_DMADDR);
+    IPA_DMADDR = destination_struct->destination_memaddr;
+    /* destination line offset configuration */
+    IPA_DLOFF &= ~(IPA_DLOFF_DLOFF);
+    IPA_DLOFF = destination_struct->destination_lineoff;
+    /* image size configuration */
+    IPA_IMS &= ~(IPA_IMS_HEIGHT | IPA_IMS_WIDTH);
+    IPA_IMS |= ((destination_struct->image_width << 16U) | (destination_struct->image_height));
+
+    if(SET == tempflag) {
+        /* restore the state of TEN */
+        IPA_CTL |= IPA_CTL_TEN;
+    }
+}
+
+/*!
+    \brief    initialize IPA foreground LUT parameters
+    \param[in]  fg_lut_num: foreground LUT number of pixel
+    \param[in]  fg_lut_pf: foreground LUT pixel format(IPA_LUT_PF_ARGB8888, IPA_LUT_PF_RGB888)
+    \param[in]  fg_lut_addr: foreground LUT memory base address
+    \param[out] none
+    \retval     none
+*/
+void ipa_foreground_lut_init(uint8_t fg_lut_num, uint8_t fg_lut_pf, uint32_t fg_lut_addr)
+{
+    FlagStatus tempflag = RESET;
+    if(RESET != (IPA_FPCTL & IPA_FPCTL_FLLEN)) {
+        tempflag = SET;
+        /* reset the FLLEN in order to configure the following bits */
+        IPA_FPCTL &= ~IPA_FPCTL_FLLEN;
+    }
+
+    /* foreground LUT number of pixel configuration */
+    IPA_FPCTL |= ((uint32_t)fg_lut_num << 8U);
+    /* foreground LUT pixel format configuration */
+    if(IPA_LUT_PF_RGB888 == fg_lut_pf) {
+        IPA_FPCTL |= IPA_FPCTL_FLPF;
+    } else {
+        IPA_FPCTL &= ~(IPA_FPCTL_FLPF);
+    }
+    /* foreground LUT memory base address configuration */
+    IPA_FLMADDR &= ~(IPA_FLMADDR_FLMADDR);
+    IPA_FLMADDR = fg_lut_addr;
+
+    if(SET == tempflag) {
+        /* restore the state of FLLEN */
+        IPA_FPCTL |= IPA_FPCTL_FLLEN;
+    }
+}
+
+/*!
+    \brief    initialize IPA background LUT parameters
+    \param[in]  bg_lut_num: background LUT number of pixel
+    \param[in]  bg_lut_pf: background LUT pixel format(IPA_LUT_PF_ARGB8888, IPA_LUT_PF_RGB888)
+    \param[in]  bg_lut_addr: background LUT memory base address
+    \param[out] none
+    \retval     none
+*/
+void ipa_background_lut_init(uint8_t bg_lut_num, uint8_t bg_lut_pf, uint32_t bg_lut_addr)
+{
+    FlagStatus tempflag = RESET;
+    if(RESET != (IPA_BPCTL & IPA_BPCTL_BLLEN)) {
+        tempflag = SET;
+        /* reset the BLLEN in order to configure the following bits */
+        IPA_BPCTL &= ~IPA_BPCTL_BLLEN;
+    }
+
+    /* background LUT number of pixel configuration */
+    IPA_BPCTL |= ((uint32_t)bg_lut_num << 8U);
+    /* background LUT pixel format configuration */
+    if(IPA_LUT_PF_RGB888 == bg_lut_pf) {
+        IPA_BPCTL |= IPA_BPCTL_BLPF;
+    } else {
+        IPA_BPCTL &= ~(IPA_BPCTL_BLPF);
+    }
+    /* background LUT memory base address configuration */
+    IPA_BLMADDR &= ~(IPA_BLMADDR_BLMADDR);
+    IPA_BLMADDR = bg_lut_addr;
+
+    if(SET == tempflag) {
+        /* restore the state of BLLEN */
+        IPA_BPCTL |= IPA_BPCTL_BLLEN;
+    }
+}
+
+/*!
+    \brief    configure IPA line mark
+    \param[in]  line_num: line number
+    \param[out] none
+    \retval     none
+*/
+void ipa_line_mark_config(uint16_t line_num)
+{
+    IPA_LM &= ~(IPA_LM_LM);
+    IPA_LM = line_num;
+}
+
+/*!
+    \brief    inter-timer enable or disable
+    \param[in]  timer_cfg: IPA_INTER_TIMER_ENABLE,IPA_INTER_TIMER_DISABLE
+    \param[out] none
+    \retval     none
+*/
+void ipa_inter_timer_config(uint8_t timer_cfg)
+{
+    if(IPA_INTER_TIMER_ENABLE == timer_cfg) {
+        IPA_ITCTL |= IPA_ITCTL_ITEN;
+    } else {
+        IPA_ITCTL &= ~(IPA_ITCTL_ITEN);
+    }
+}
+
+/*!
+    \brief    configure the number of clock cycles interval
+    \param[in]  clk_num: the number of clock cycles
+    \param[out] none
+    \retval     none
+*/
+void ipa_interval_clock_num_config(uint8_t clk_num)
+{
+    /* NCCI[7:0] bits have no meaning if ITEN is '0' */
+    IPA_ITCTL &= ~(IPA_ITCTL_NCCI);
+    IPA_ITCTL |= ((uint32_t)clk_num << 8U);
+}
+
+/*!
+    \brief    get IPA flag status in IPA_INTF register
+    \param[in]  flag: IPA flags
+                one or more parameters can be selected which are shown as below:
+      \arg        IPA_FLAG_TAE: transfer access error interrupt flag
+      \arg        IPA_FLAG_FTF: full transfer finish interrupt flag
+      \arg        IPA_FLAG_TLM: transfer line mark interrupt flag
+      \arg        IPA_FLAG_LAC: LUT access conflict interrupt flag
+      \arg        IPA_FLAG_LLF: LUT loading finish interrupt flag
+      \arg        IPA_FLAG_WCF: wrong configuration interrupt flag
+    \param[out] none
+    \retval     none
+*/
+FlagStatus ipa_flag_get(uint32_t flag)
+{
+    if(RESET != (IPA_INTF & flag)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    clear IPA flag in IPA_INTF register
+    \param[in]  flag: IPA flags
+                one or more parameters can be selected which are shown as below:
+      \arg        IPA_FLAG_TAE: transfer access error interrupt flag
+      \arg        IPA_FLAG_FTF: full transfer finish interrupt flag
+      \arg        IPA_FLAG_TLM: transfer line mark interrupt flag
+      \arg        IPA_FLAG_LAC: LUT access conflict interrupt flag
+      \arg        IPA_FLAG_LLF: LUT loading finish interrupt flag
+      \arg        IPA_FLAG_WCF: wrong configuration interrupt flag
+    \param[out] none
+    \retval     none
+*/
+void ipa_flag_clear(uint32_t flag)
+{
+    IPA_INTC |= (flag);
+}
+
+/*!
+    \brief    enable IPA interrupt
+    \param[in]  int_flag: IPA interrupt flags
+                one or more parameters can be selected which are shown as below:
+      \arg        IPA_INT_TAE: transfer access error interrupt
+      \arg        IPA_INT_FTF: full transfer finish interrupt
+      \arg        IPA_INT_TLM: transfer line mark interrupt
+      \arg        IPA_INT_LAC: LUT access conflict interrupt
+      \arg        IPA_INT_LLF: LUT loading finish interrupt
+      \arg        IPA_INT_WCF: wrong configuration interrupt
+    \param[out] none
+    \retval     none
+*/
+void ipa_interrupt_enable(uint32_t int_flag)
+{
+    IPA_CTL |= (int_flag);
+}
+
+/*!
+    \brief    disable IPA interrupt
+    \param[in]  int_flag: IPA interrupt flags
+                one or more parameters can be selected which are shown as below:
+      \arg        IPA_INT_TAE: transfer access error interrupt
+      \arg        IPA_INT_FTF: full transfer finish interrupt
+      \arg        IPA_INT_TLM: transfer line mark interrupt
+      \arg        IPA_INT_LAC: LUT access conflict interrupt
+      \arg        IPA_INT_LLF: LUT loading finish interrupt
+      \arg        IPA_INT_WCF: wrong configuration interrupt
+    \param[out] none
+    \retval     none
+*/
+void ipa_interrupt_disable(uint32_t int_flag)
+{
+    IPA_CTL &= ~(int_flag);
+}
+
+/*!
+    \brief    get IPA interrupt flag
+    \param[in]  int_flag: IPA interrupt flag flags
+                one or more parameters can be selected which are shown as below:
+      \arg        IPA_INT_FLAG_TAE: transfer access error interrupt flag
+      \arg        IPA_INT_FLAG_FTF: full transfer finish interrupt flag
+      \arg        IPA_INT_FLAG_TLM: transfer line mark interrupt flag
+      \arg        IPA_INT_FLAG_LAC: LUT access conflict interrupt flag
+      \arg        IPA_INT_FLAG_LLF: LUT loading finish interrupt flag
+      \arg        IPA_INT_FLAG_WCF: wrong configuration interrupt flag
+    \param[out] none
+    \retval     none
+*/
+FlagStatus ipa_interrupt_flag_get(uint32_t int_flag)
+{
+    if(0U != (IPA_INTF & int_flag)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    clear IPA interrupt flag
+    \param[in]  int_flag: IPA interrupt flag flags
+                one or more parameters can be selected which are shown as below:
+      \arg        IPA_INT_FLAG_TAE: transfer access error interrupt flag
+      \arg        IPA_INT_FLAG_FTF: full transfer finish interrupt flag
+      \arg        IPA_INT_FLAG_TLM: transfer line mark interrupt flag
+      \arg        IPA_INT_FLAG_LAC: LUT access conflict interrupt flag
+      \arg        IPA_INT_FLAG_LLF: LUT loading finish interrupt flag
+      \arg        IPA_INT_FLAG_WCF: wrong configuration interrupt flag
+    \param[out] none
+    \retval     none
+*/
+void ipa_interrupt_flag_clear(uint32_t int_flag)
+{
+    IPA_INTC |= (int_flag);
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_iref.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_iref.c
@@ -1,0 +1,127 @@
+/*!
+    \file    gd32f4xx_iref.c
+    \brief   IREF driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_iref.h"
+
+/*!
+    \brief      deinitialize IREF
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void iref_deinit(void)
+{
+    rcu_periph_reset_enable(RCU_IREFRST);
+    rcu_periph_reset_disable(RCU_IREFRST);
+}
+
+/*!
+    \brief    enable IREF
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void iref_enable(void)
+{
+    IREF_CTL |= IREF_CTL_CREN;
+}
+
+/*!
+    \brief      disable IREF
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void iref_disable(void)
+{
+    IREF_CTL &= ~IREF_CTL_CREN;
+}
+
+/*!
+    \brief      set IREF mode
+    \param[in]  step
+      \arg        IREF_MODE_LOW_POWER: 1uA step
+      \arg        IREF_MODE_HIGH_CURRENT: 8uA step
+    \param[out] none
+    \retval     none
+*/
+void iref_mode_set(uint32_t step)
+{
+    IREF_CTL &= ~IREF_CTL_SSEL;
+    IREF_CTL |= step;
+}
+
+/*!
+    \brief      set IREF precision_trim_value
+    \param[in]  precisiontrim
+      \arg        IREF_CUR_PRECISION_TRIM_X(x=0..31): (-15+ x)%
+    \param[out] none
+    \retval     none
+*/
+void iref_precision_trim_value_set(uint32_t precisiontrim)
+{
+    IREF_CTL &= ~IREF_CTL_CPT;
+    IREF_CTL |= precisiontrim;
+}
+
+/*!
+    \brief      set IREF sink mode
+    \param[in]  sinkmode
+      \arg        IREF_SOURCE_CURRENT : source current.
+      \arg        IREF_SINK_CURRENT: sink current
+    \param[out] none
+    \retval     none
+*/
+void iref_sink_set(uint32_t sinkmode)
+{
+    IREF_CTL &= ~IREF_CTL_SCMOD;
+    IREF_CTL |= sinkmode;
+}
+
+/*!
+    \brief      set IREF step data
+    \param[in]  stepdata
+      \arg        IREF_CUR_STEP_DATA_X:(x=0..63): step*x
+    \param[out] none
+    \retval     none
+*/
+
+void iref_step_data_config(uint32_t stepdata)
+{
+    IREF_CTL &= ~IREF_CTL_CSDT;
+    IREF_CTL |= stepdata;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_misc.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_misc.c
@@ -1,0 +1,175 @@
+/*!
+    \file    gd32f4xx_misc.c
+    \brief   MISC driver
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_misc.h"
+
+/*!
+    \brief    set the priority group
+    \param[in]  nvic_prigroup: the NVIC priority group
+      \arg        NVIC_PRIGROUP_PRE0_SUB4:0 bits for pre-emption priority 4 bits for subpriority
+      \arg        NVIC_PRIGROUP_PRE1_SUB3:1 bits for pre-emption priority 3 bits for subpriority
+      \arg        NVIC_PRIGROUP_PRE2_SUB2:2 bits for pre-emption priority 2 bits for subpriority
+      \arg        NVIC_PRIGROUP_PRE3_SUB1:3 bits for pre-emption priority 1 bits for subpriority
+      \arg        NVIC_PRIGROUP_PRE4_SUB0:4 bits for pre-emption priority 0 bits for subpriority
+    \param[out] none
+    \retval     none
+*/
+void nvic_priority_group_set(uint32_t nvic_prigroup)
+{
+    /* set the priority group value */
+    SCB->AIRCR = NVIC_AIRCR_VECTKEY_MASK | nvic_prigroup;
+}
+
+/*!
+    \brief    enable NVIC request
+    \param[in]  nvic_irq: the NVIC interrupt request, detailed in IRQn_Type
+    \param[in]  nvic_irq_pre_priority: the pre-emption priority needed to set
+    \param[in]  nvic_irq_sub_priority: the subpriority needed to set
+    \param[out] none
+    \retval     none
+*/
+void nvic_irq_enable(uint8_t nvic_irq, uint8_t nvic_irq_pre_priority,
+                     uint8_t nvic_irq_sub_priority)
+{
+    uint32_t temp_priority = 0x00U, temp_pre = 0x00U, temp_sub = 0x00U;
+    /* use the priority group value to get the temp_pre and the temp_sub */
+    if(((SCB->AIRCR) & (uint32_t)0x700U) == NVIC_PRIGROUP_PRE0_SUB4) {
+        temp_pre = 0U;
+        temp_sub = 0x4U;
+    } else if(((SCB->AIRCR) & (uint32_t)0x700U) == NVIC_PRIGROUP_PRE1_SUB3) {
+        temp_pre = 1U;
+        temp_sub = 0x3U;
+    } else if(((SCB->AIRCR) & (uint32_t)0x700U) == NVIC_PRIGROUP_PRE2_SUB2) {
+        temp_pre = 2U;
+        temp_sub = 0x2U;
+    } else if(((SCB->AIRCR) & (uint32_t)0x700U) == NVIC_PRIGROUP_PRE3_SUB1) {
+        temp_pre = 3U;
+        temp_sub = 0x1U;
+    } else if(((SCB->AIRCR) & (uint32_t)0x700U) == NVIC_PRIGROUP_PRE4_SUB0) {
+        temp_pre = 4U;
+        temp_sub = 0x0U;
+    } else {
+        nvic_priority_group_set(NVIC_PRIGROUP_PRE2_SUB2);
+        temp_pre = 2U;
+        temp_sub = 0x2U;
+    }
+    /* get the temp_priority to fill the NVIC->IP register */
+    temp_priority = (uint32_t)nvic_irq_pre_priority << (0x4U - temp_pre);
+    temp_priority |= nvic_irq_sub_priority & (0x0FU >> (0x4U - temp_sub));
+    temp_priority = temp_priority << 0x04U;
+    NVIC->IP[nvic_irq] = (uint8_t)temp_priority;
+    /* enable the selected IRQ */
+    NVIC->ISER[nvic_irq >> 0x05U] = (uint32_t)0x01U << (nvic_irq & (uint8_t)0x1FU);
+}
+
+/*!
+    \brief    disable NVIC request
+    \param[in]  nvic_irq: the NVIC interrupt request, detailed in IRQn_Type
+    \param[out] none
+    \retval     none
+*/
+void nvic_irq_disable(uint8_t nvic_irq)
+{
+    /* disable the selected IRQ.*/
+    NVIC->ICER[nvic_irq >> 0x05] = (uint32_t)0x01 << (nvic_irq & (uint8_t)0x1F);
+}
+
+/*!
+    \brief    set the NVIC vector table base address
+    \param[in]  nvic_vict_tab: the RAM or FLASH base address
+      \arg        NVIC_VECTTAB_RAM: RAM base address
+      \are        NVIC_VECTTAB_FLASH: Flash base address
+    \param[in]  offset: Vector Table offset
+    \param[out] none
+    \retval     none
+*/
+void nvic_vector_table_set(uint32_t nvic_vict_tab, uint32_t offset)
+{
+    SCB->VTOR = nvic_vict_tab | (offset & NVIC_VECTTAB_OFFSET_MASK);
+    __DSB();
+}
+
+/*!
+    \brief    set the state of the low power mode
+    \param[in]  lowpower_mode: the low power mode state
+      \arg        SCB_LPM_SLEEP_EXIT_ISR: if chose this para, the system always enter low power
+                    mode by exiting from ISR
+      \arg        SCB_LPM_DEEPSLEEP: if chose this para, the system will enter the DEEPSLEEP mode
+      \arg        SCB_LPM_WAKE_BY_ALL_INT: if chose this para, the lowpower mode can be woke up
+                    by all the enable and disable interrupts
+    \param[out] none
+    \retval     none
+*/
+void system_lowpower_set(uint8_t lowpower_mode)
+{
+    SCB->SCR |= (uint32_t)lowpower_mode;
+}
+
+/*!
+    \brief    reset the state of the low power mode
+    \param[in]  lowpower_mode: the low power mode state
+      \arg        SCB_LPM_SLEEP_EXIT_ISR: if chose this para, the system will exit low power
+                    mode by exiting from ISR
+      \arg        SCB_LPM_DEEPSLEEP: if chose this para, the system will enter the SLEEP mode
+      \arg        SCB_LPM_WAKE_BY_ALL_INT: if chose this para, the lowpower mode only can be
+                    woke up by the enable interrupts
+    \param[out] none
+    \retval     none
+*/
+void system_lowpower_reset(uint8_t lowpower_mode)
+{
+    SCB->SCR &= (~(uint32_t)lowpower_mode);
+}
+
+/*!
+    \brief    set the systick clock source
+    \param[in]  systick_clksource: the systick clock source needed to choose
+      \arg        SYSTICK_CLKSOURCE_HCLK: systick clock source is from HCLK
+      \arg        SYSTICK_CLKSOURCE_HCLK_DIV8: systick clock source is from HCLK/8
+    \param[out] none
+    \retval     none
+*/
+
+void systick_clksource_set(uint32_t systick_clksource)
+{
+    if(SYSTICK_CLKSOURCE_HCLK == systick_clksource) {
+        /* set the systick clock source from HCLK */
+        SysTick->CTRL |= SYSTICK_CLKSOURCE_HCLK;
+    } else {
+        /* set the systick clock source from HCLK/8 */
+        SysTick->CTRL &= SYSTICK_CLKSOURCE_HCLK_DIV8;
+    }
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_pmu.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_pmu.c
@@ -1,0 +1,412 @@
+/*!
+    \file    gd32f4xx_pmu.c
+    \brief   PMU driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_pmu.h"
+#include "core_cm4.h"
+
+/*!
+    \brief      reset PMU registers
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_deinit(void)
+{
+    /* reset PMU */
+    rcu_periph_reset_enable(RCU_PMURST);
+    rcu_periph_reset_disable(RCU_PMURST);
+}
+
+/*!
+    \brief      select low voltage detector threshold
+    \param[in]  lvdt_n:
+      \arg        PMU_LVDT_0: voltage threshold is 2.1V
+      \arg        PMU_LVDT_1: voltage threshold is 2.3V
+      \arg        PMU_LVDT_2: voltage threshold is 2.4V
+      \arg        PMU_LVDT_3: voltage threshold is 2.6V
+      \arg        PMU_LVDT_4: voltage threshold is 2.7V
+      \arg        PMU_LVDT_5: voltage threshold is 2.9V
+      \arg        PMU_LVDT_6: voltage threshold is 3.0V
+      \arg        PMU_LVDT_7: voltage threshold is 3.1V
+    \param[out] none
+    \retval     none
+*/
+void pmu_lvd_select(uint32_t lvdt_n)
+{
+    /* disable LVD */
+    PMU_CTL &= ~PMU_CTL_LVDEN;
+    /* clear LVDT bits */
+    PMU_CTL &= ~PMU_CTL_LVDT;
+    /* set LVDT bits according to pmu_lvdt_n */
+    PMU_CTL |= lvdt_n;
+    /* enable LVD */
+    PMU_CTL |= PMU_CTL_LVDEN;
+}
+
+/*!
+    \brief      disable PMU lvd
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_lvd_disable(void)
+{
+    /* disable LVD */
+    PMU_CTL &= ~PMU_CTL_LVDEN;
+}
+
+/*!
+    \brief      select LDO output voltage
+                this bit set by software when the main PLL closed, before closing PLL, change the system clock to IRC16M or HXTAL
+    \param[in]  ldo_output:
+      \arg        PMU_LDOVS_LOW: low-driver mode enable in deep-sleep mode
+      \arg        PMU_LDOVS_MID: mid-driver mode disable in deep-sleep mode
+      \arg        PMU_LDOVS_HIGH: high-driver mode disable in deep-sleep mode
+    \param[out] none
+    \retval     none
+*/
+void pmu_ldo_output_select(uint32_t ldo_output)
+{
+    PMU_CTL &= ~PMU_CTL_LDOVS;
+    PMU_CTL |= ldo_output;
+}
+
+/*!
+    \brief      enable high-driver mode
+                this bit set by software only when IRC16M or HXTAL used as system clock
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_highdriver_mode_enable(void)
+{
+    PMU_CTL |= PMU_CTL_HDEN;
+}
+
+/*!
+    \brief      disable high-driver mode
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_highdriver_mode_disable(void)
+{
+    PMU_CTL &= ~PMU_CTL_HDEN;
+}
+
+/*!
+    \brief      switch high-driver mode
+                this bit set by software only when IRC16M or HXTAL used as system clock
+    \param[in]  highdr_switch:
+      \arg        PMU_HIGHDR_SWITCH_NONE: disable high-driver mode switch
+      \arg        PMU_HIGHDR_SWITCH_EN: enable high-driver mode switch
+    \param[out] none
+    \retval     none
+*/
+void pmu_highdriver_switch_select(uint32_t highdr_switch)
+{
+    /* wait for HDRF flag set */
+    while(SET != pmu_flag_get(PMU_FLAG_HDRF)) {
+    }
+    PMU_CTL &= ~PMU_CTL_HDS;
+    PMU_CTL |= highdr_switch;
+}
+
+/*!
+    \brief      enable low-driver mode in deep-sleep
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_lowdriver_mode_enable(void)
+{
+    PMU_CTL |= PMU_CTL_LDEN;
+}
+
+/*!
+    \brief      disable low-driver mode in deep-sleep
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_lowdriver_mode_disable(void)
+{
+    PMU_CTL &= ~PMU_CTL_LDEN;
+}
+
+/*!
+    \brief      in deep-sleep mode, driver mode when use low power LDO
+    \param[in]  mode:
+      \arg        PMU_NORMALDR_LOWPWR:  normal driver when use low power LDO
+      \arg        PMU_LOWDR_LOWPWR:  low-driver mode enabled when LDEN is 11 and use low power LDO
+    \param[out] none
+    \retval     none
+*/
+void pmu_lowpower_driver_config(uint32_t mode)
+{
+    PMU_CTL &= ~PMU_CTL_LDLP;
+    PMU_CTL |= mode;
+}
+
+/*!
+    \brief      in deep-sleep mode, driver mode when use normal power LDO
+    \param[in]  mode:
+      \arg        PMU_NORMALDR_NORMALPWR: normal driver when use normal power LDO
+      \arg        PMU_LOWDR_NORMALPWR: low-driver mode enabled when LDEN is 11 and use normal power LDO
+    \param[out] none
+    \retval     none
+*/
+void pmu_normalpower_driver_config(uint32_t mode)
+{
+    PMU_CTL &= ~PMU_CTL_LDNP;
+    PMU_CTL |= mode;
+}
+
+/*!
+    \brief      PMU work in sleep mode
+    \param[in]  sleepmodecmd:
+      \arg        WFI_CMD: use WFI command
+      \arg        WFE_CMD: use WFE command
+    \param[out] none
+    \retval     none
+*/
+void pmu_to_sleepmode(uint8_t sleepmodecmd)
+{
+    /* clear sleepdeep bit of Cortex-M4 system control register */
+    SCB->SCR &= ~((uint32_t)SCB_SCR_SLEEPDEEP_Msk);
+
+    /* select WFI or WFE command to enter sleep mode */
+    if(WFI_CMD == sleepmodecmd) {
+        __WFI();
+    } else {
+        __WFE();
+    }
+}
+
+/*!
+    \brief      PMU work in deep-sleep mode
+    \param[in]  ldo
+      \arg        PMU_LDO_NORMAL: LDO normal work when pmu enter deep-sleep mode
+      \arg        PMU_LDO_LOWPOWER: LDO work at low power mode when pmu enter deep-sleep mode
+    \param[in]  lowdrive:
+                only one parameter can be selected which is shown as below:
+      \arg        PMU_LOWDRIVER_DISABLE: Low-driver mode disable in deep-sleep mode
+      \arg        PMU_LOWDRIVER_ENABLE: Low-driver mode enable in deep-sleep mode
+    \param[in]  deepsleepmodecmd:
+      \arg        WFI_CMD: use WFI command
+      \arg        WFE_CMD: use WFE command
+    \param[out] none
+    \retval     none
+*/
+void pmu_to_deepsleepmode(uint32_t ldo, uint32_t lowdrive, uint8_t deepsleepmodecmd)
+{
+    static uint32_t reg_snap[4];
+    /* clear stbmod and ldolp bits */
+    PMU_CTL &= ~((uint32_t)(PMU_CTL_STBMOD | PMU_CTL_LDOLP | PMU_CTL_LDEN | PMU_CTL_LDNP | PMU_CTL_LDLP));
+
+    /* set ldolp bit according to pmu_ldo */
+    PMU_CTL |= ldo;
+
+    /* configure low drive mode in deep-sleep mode */
+    if(PMU_LOWDRIVER_ENABLE == lowdrive) {
+        if(PMU_LDO_NORMAL == ldo) {
+            PMU_CTL |= (uint32_t)(PMU_CTL_LDEN | PMU_CTL_LDNP);
+        } else {
+            PMU_CTL |= (uint32_t)(PMU_CTL_LDEN | PMU_CTL_LDLP);
+        }
+    }
+    /* set sleepdeep bit of Cortex-M4 system control register */
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+
+    reg_snap[0] = REG32(0xE000E010U);
+    reg_snap[1] = REG32(0xE000E100U);
+    reg_snap[2] = REG32(0xE000E104U);
+    reg_snap[3] = REG32(0xE000E108U);
+
+    REG32(0xE000E010U) &= 0x00010004U;
+    REG32(0xE000E180U)  = 0XFF7FF831U;
+    REG32(0xE000E184U)  = 0XBFFFF8FFU;
+    REG32(0xE000E188U)  = 0xFFFFEFFFU;
+
+    /* select WFI or WFE command to enter deep-sleep mode */
+    if(WFI_CMD == deepsleepmodecmd) {
+        __WFI();
+    } else {
+        __SEV();
+        __WFE();
+        __WFE();
+    }
+
+    REG32(0xE000E010U) = reg_snap[0];
+    REG32(0xE000E100U) = reg_snap[1];
+    REG32(0xE000E104U) = reg_snap[2];
+    REG32(0xE000E108U) = reg_snap[3];
+
+    /* reset sleepdeep bit of Cortex-M4 system control register */
+    SCB->SCR &= ~((uint32_t)SCB_SCR_SLEEPDEEP_Msk);
+}
+
+/*!
+    \brief      pmu work in standby mode
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_to_standbymode(void)
+{
+    /* set stbmod bit */
+    PMU_CTL |= PMU_CTL_STBMOD;
+
+    /* reset wakeup flag */
+    PMU_CTL |= PMU_CTL_WURST;
+
+    /* set sleepdeep bit of Cortex-M4 system control register */
+    SCB->SCR |= SCB_SCR_SLEEPDEEP_Msk;
+
+    REG32(0xE000E010U) &= 0x00010004U;
+    REG32(0xE000E180U)  = 0XFFFFFFF7U;
+    REG32(0xE000E184U)  = 0XFFFFFDFFU;
+    REG32(0xE000E188U)  = 0xFFFFFFFFU;
+
+    /* select WFI command to enter standby mode */
+    __WFI();
+}
+
+/*!
+    \brief      enable PMU wakeup pin
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_wakeup_pin_enable(void)
+{
+    PMU_CS |= PMU_CS_WUPEN;
+}
+
+/*!
+    \brief      disable PMU wakeup pin
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_wakeup_pin_disable(void)
+{
+    PMU_CS &= ~PMU_CS_WUPEN;
+}
+
+/*!
+    \brief      backup SRAM LDO on
+    \param[in]  bkp_ldo:
+      \arg        PMU_BLDOON_OFF: backup SRAM LDO closed
+      \arg        PMU_BLDOON_ON: open the backup SRAM LDO
+    \param[out] none
+    \retval     none
+*/
+void pmu_backup_ldo_config(uint32_t bkp_ldo)
+{
+    PMU_CS &= ~PMU_CS_BLDOON;
+    PMU_CS |= bkp_ldo;
+}
+
+/*!
+    \brief      enable write access to the registers in backup domain
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_backup_write_enable(void)
+{
+    PMU_CTL |= PMU_CTL_BKPWEN;
+}
+
+/*!
+    \brief      disable write access to the registers in backup domain
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void pmu_backup_write_disable(void)
+{
+    PMU_CTL &= ~PMU_CTL_BKPWEN;
+}
+
+/*!
+    \brief      get flag state
+    \param[in]  flag:
+      \arg        PMU_FLAG_WAKEUP: wakeup flag
+      \arg        PMU_FLAG_STANDBY: standby flag
+      \arg        PMU_FLAG_LVD: lvd flag
+      \arg        PMU_FLAG_BLDORF: backup SRAM LDO ready flag
+      \arg        PMU_FLAG_LDOVSRF: LDO voltage select ready flag
+      \arg        PMU_FLAG_HDRF: high-driver ready flag
+      \arg        PMU_FLAG_HDSRF: high-driver switch ready flag
+      \arg        PMU_FLAG_LDRF: low-driver mode ready flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus pmu_flag_get(uint32_t flag)
+{
+    if(PMU_CS & flag) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      clear flag bit
+    \param[in]  flag:
+      \arg        PMU_FLAG_RESET_WAKEUP: reset wakeup flag
+      \arg        PMU_FLAG_RESET_STANDBY: reset standby flag
+    \param[out] none
+    \retval     none
+*/
+void pmu_flag_clear(uint32_t flag)
+{
+    switch(flag) {
+    case PMU_FLAG_RESET_WAKEUP:
+        /* reset wakeup flag */
+        PMU_CTL |= PMU_CTL_WURST;
+        break;
+    case PMU_FLAG_RESET_STANDBY:
+        /* reset standby flag */
+        PMU_CTL |= PMU_CTL_STBRST;
+        break;
+    default :
+        break;
+    }
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_rcu.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_rcu.c
@@ -1,0 +1,1332 @@
+/*!
+    \file    gd32f4xx_rcu.c
+    \brief   RCU driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_rcu.h"
+
+/* define clock source */
+#define SEL_IRC16M                  ((uint16_t)0U)                            /* IRC16M is selected as CK_SYS */
+#define SEL_HXTAL                   ((uint16_t)1U)                            /* HXTAL is selected as CK_SYS */
+#define SEL_PLLP                    ((uint16_t)2U)                            /* PLLP is selected as CK_SYS */
+/* define startup timeout count */
+#define OSC_STARTUP_TIMEOUT         ((uint32_t)0x000fffffU)
+#define LXTAL_STARTUP_TIMEOUT       ((uint32_t)0x0fffffffU)
+
+/* RCU IRC16M adjust value mask and offset*/
+#define RCU_IRC16M_ADJUST_MASK      ((uint8_t)0x1FU)
+#define RCU_IRC16M_ADJUST_OFFSET    ((uint32_t)3U)
+
+/*!
+    \brief    deinitialize the RCU
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rcu_deinit(void)
+{
+    /* enable IRC16M */
+    RCU_CTL |= RCU_CTL_IRC16MEN;
+    rcu_osci_stab_wait(RCU_IRC16M);
+    RCU_CFG0 &= ~RCU_CFG0_SCS;
+
+    /* reset CTL register */
+    RCU_CTL &= ~(RCU_CTL_HXTALEN | RCU_CTL_CKMEN | RCU_CTL_PLLEN | RCU_CTL_PLLI2SEN
+                 | RCU_CTL_PLLSAIEN);
+    RCU_CTL &= ~(RCU_CTL_HXTALBPS);
+    /* reset CFG0 register */
+    RCU_CFG0 &= ~(RCU_CFG0_SCS | RCU_CFG0_AHBPSC | RCU_CFG0_APB1PSC | RCU_CFG0_APB2PSC |
+                  RCU_CFG0_RTCDIV | RCU_CFG0_CKOUT0SEL | RCU_CFG0_I2SSEL | RCU_CFG0_CKOUT0DIV |
+                  RCU_CFG0_CKOUT1DIV | RCU_CFG0_CKOUT1SEL);
+    /* reset PLL register */
+    RCU_PLL = 0x24003010U;
+    /* reset PLLI2S register */
+    RCU_PLLI2S = 0x24003000U;
+    /* reset PLLSAI register */
+    RCU_PLLSAI = 0x24003010U;
+    /* reset INT register */
+    RCU_INT = 0x00000000U;
+    /* reset CFG1 register */
+    RCU_CFG1 &= ~(RCU_CFG1_PLLSAIRDIV | RCU_CFG1_TIMERSEL);
+}
+
+/*!
+    \brief    enable the peripherals clock
+    \param[in]  periph: RCU peripherals, refer to rcu_periph_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_GPIOx (x = A, B, C, D, E, F, G, H, I): GPIO ports clock
+      \arg        RCU_CRC: CRC clock
+      \arg        RCU_BKPSRAM: BKPSRAM clock
+      \arg        RCU_TCMSRAM: TCMSRAM clock
+      \arg        RCU_DMAx (x=0,1): DMA clock
+      \arg        RCU_IPA: IPA clock
+      \arg        RCU_ENET: ENET clock
+      \arg        RCU_ENETTX: ENETTX clock
+      \arg        RCU_ENETRX: ENETRX clock
+      \arg        RCU_ENETPTP: ENETPTP clock
+      \arg        RCU_USBHS: USBHS clock
+      \arg        RCU_USBHSULPI: USBHSULPI clock
+      \arg        RCU_DCI: DCI clock
+      \arg        RCU_TRNG: TRNG clock
+      \arg        RCU_USBFS: USBFS clock
+      \arg        RCU_EXMC: EXMC clock
+      \arg        RCU_TIMERx (x = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13): TIMER clock
+      \arg        RCU_WWDGT: WWDGT clock
+      \arg        RCU_SPIx (x = 0, 1, 2, 3, 4, 5): SPI clock
+      \arg        RCU_USARTx (x = 0, 1, 2, 5): USART clock
+      \arg        RCU_UARTx (x = 3, 4, 6, 7): UART clock
+      \arg        RCU_I2Cx (x = 0, 1, 2): I2C clock
+      \arg        RCU_CANx (x = 0, 1): CAN clock
+      \arg        RCU_PMU: PMU clock
+      \arg        RCU_DAC: DAC clock
+      \arg        RCU_RTC: RTC clock
+      \arg        RCU_ADCx (x = 0, 1, 2): ADC clock
+      \arg        RCU_SDIO: SDIO clock
+      \arg        RCU_SYSCFG: SYSCFG clock
+      \arg        RCU_TLI: TLI clock
+      \arg        RCU_CTC: CTC clock
+      \arg        RCU_IREF: IREF clock
+    \param[out] none
+    \retval     none
+*/
+void rcu_periph_clock_enable(rcu_periph_enum periph)
+{
+    RCU_REG_VAL(periph) |= BIT(RCU_BIT_POS(periph));
+}
+
+/*!
+    \brief    disable the peripherals clock
+    \param[in]  periph: RCU peripherals, refer to rcu_periph_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_GPIOx (x = A, B, C, D, E, F, G, H, I): GPIO ports clock
+      \arg        RCU_CRC: CRC clock
+      \arg        RCU_BKPSRAM: BKPSRAM clock
+      \arg        RCU_TCMSRAM: TCMSRAM clock
+      \arg        RCU_DMAx (x=0,1): DMA clock
+      \arg        RCU_IPA: IPA clock
+      \arg        RCU_ENET: ENET clock
+      \arg        RCU_ENETTX: ENETTX clock
+      \arg        RCU_ENETRX: ENETRX clock
+      \arg        RCU_ENETPTP: ENETPTP clock
+      \arg        RCU_USBHS: USBHS clock
+      \arg        RCU_USBHSULPI: USBHSULPI clock
+      \arg        RCU_DCI: DCI clock
+      \arg        RCU_TRNG: TRNG clock
+      \arg        RCU_USBFS: USBFS clock
+      \arg        RCU_EXMC: EXMC clock
+      \arg        RCU_TIMERx (x = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13): TIMER clock
+      \arg        RCU_WWDGT: WWDGT clock
+      \arg        RCU_SPIx (x = 0, 1, 2, 3, 4, 5): SPI clock
+      \arg        RCU_USARTx (x = 0, 1, 2, 5): USART clock
+      \arg        RCU_UARTx (x = 3, 4, 6, 7): UART clock
+      \arg        RCU_I2Cx (x = 0, 1, 2): I2C clock
+      \arg        RCU_CANx (x = 0, 1): CAN clock
+      \arg        RCU_PMU: PMU clock
+      \arg        RCU_DAC: DAC clock
+      \arg        RCU_RTC: RTC clock
+      \arg        RCU_ADCx (x = 0, 1, 2): ADC clock
+      \arg        RCU_SDIO: SDIO clock
+      \arg        RCU_SYSCFG: SYSCFG clock
+      \arg        RCU_TLI: TLI clock
+      \arg        RCU_CTC: CTC clock
+      \arg        RCU_IREF: IREF clock
+    \param[out] none
+    \retval     none
+*/
+void rcu_periph_clock_disable(rcu_periph_enum periph)
+{
+    RCU_REG_VAL(periph) &= ~BIT(RCU_BIT_POS(periph));
+}
+
+/*!
+    \brief    enable the peripherals clock when sleep mode
+    \param[in]  periph: RCU peripherals, refer to rcu_periph_sleep_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_GPIOx_SLP (x = A, B, C, D, E, F, G, H, I): GPIO ports clock
+      \arg        RCU_CRC_SLP: CRC clock
+      \arg        RCU_FMC_SLP: FMC clock
+      \arg        RCU_SRAM0_SLP: SRAM0 clock
+      \arg        RCU_SRAM1_SLP: SRAM1 clock
+      \arg        RCU_BKPSRAM: BKPSRAM clock
+      \arg        RCU_SRAM2_SLP: SRAM2 clock
+      \arg        RCU_DMAx_SLP (x=0,1): DMA clock
+      \arg        RCU_IPA_SLP: IPA clock
+      \arg        RCU_ENET_SLP: ENET clock
+      \arg        RCU_ENETTX_SLP: ENETTX clock
+      \arg        RCU_ENETRX_SLP: ENETRX clock
+      \arg        RCU_ENETPTP_SLP: ENETPTP clock
+      \arg        RCU_USBHS_SLP: USBHS clock
+      \arg        RCU_USBHSULPI_SLP: USBHSULPI clock
+      \arg        RCU_DCI_SLP: DCI clock
+      \arg        RCU_TRNG_SLP: TRNG clock
+      \arg        RCU_USBFS_SLP: USBFS clock
+      \arg        RCU_EXMC_SLP: EXMC clock
+      \arg        RCU_TIMERx_SLP (x = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13): TIMER clock
+      \arg        RCU_WWDGT_SLP: WWDGT clock
+      \arg        RCU_SPIx_SLP (x = 0, 1, 2, 3, 4, 5): SPI clock
+      \arg        RCU_USARTx_SLP (x = 0, 1, 2, 5): USART clock
+      \arg        RCU_UARTx_SLP (x = 3, 4, 6, 7): UART clock
+      \arg        RCU_I2Cx_SLP (x = 0, 1, 2): I2C clock
+      \arg        RCU_CANx_SLP (x = 0, 1): CAN clock
+      \arg        RCU_PMU_SLP: PMU clock
+      \arg        RCU_DAC_SLP: DAC clock
+      \arg        RCU_RTC_SLP: RTC clock
+      \arg        RCU_ADCx_SLP (x = 0, 1, 2): ADC clock
+      \arg        RCU_SDIO_SLP: SDIO clock
+      \arg        RCU_SYSCFG_SLP: SYSCFG clock
+      \arg        RCU_TLI_SLP: TLI clock
+      \arg        RCU_CTC_SLP: CTC clock
+      \arg        RCU_IREF_SLP: IREF clock
+    \param[out] none
+    \retval     none
+*/
+void rcu_periph_clock_sleep_enable(rcu_periph_sleep_enum periph)
+{
+    RCU_REG_VAL(periph) |= BIT(RCU_BIT_POS(periph));
+}
+
+/*!
+    \brief    disable the peripherals clock when sleep mode
+    \param[in]  periph: RCU peripherals, refer to rcu_periph_sleep_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_GPIOx_SLP (x = A, B, C, D, E, F, G, H, I): GPIO ports clock
+      \arg        RCU_CRC_SLP: CRC clock
+      \arg        RCU_FMC_SLP: FMC clock
+      \arg        RCU_SRAM0_SLP: SRAM0 clock
+      \arg        RCU_SRAM1_SLP: SRAM1 clock
+      \arg        RCU_BKPSRAM: BKPSRAM clock
+      \arg        RCU_SRAM2_SLP: SRAM2 clock
+      \arg        RCU_DMAx_SLP (x=0,1): DMA clock
+      \arg        RCU_IPA_SLP: IPA clock
+      \arg        RCU_ENET_SLP: ENET clock
+      \arg        RCU_ENETTX_SLP: ENETTX clock
+      \arg        RCU_ENETRX_SLP: ENETRX clock
+      \arg        RCU_ENETPTP_SLP: ENETPTP clock
+      \arg        RCU_USBHS_SLP: USBHS clock
+      \arg        RCU_USBHSULPI_SLP: USBHSULPI clock
+      \arg        RCU_DCI_SLP: DCI clock
+      \arg        RCU_TRNG_SLP: TRNG clock
+      \arg        RCU_USBFS_SLP: USBFS clock
+      \arg        RCU_EXMC_SLP: EXMC clock
+      \arg        RCU_TIMERx_SLP (x = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13): TIMER clock
+      \arg        RCU_WWDGT_SLP: WWDGT clock
+      \arg        RCU_SPIx_SLP (x = 0, 1, 2, 3, 4, 5): SPI clock
+      \arg        RCU_USARTx_SLP (x = 0, 1, 2, 5): USART clock
+      \arg        RCU_UARTx_SLP (x = 3, 4, 6, 7): UART clock
+      \arg        RCU_I2Cx_SLP (x = 0, 1, 2): I2C clock
+      \arg        RCU_CANx_SLP (x = 0, 1): CAN clock
+      \arg        RCU_PMU_SLP: PMU clock
+      \arg        RCU_DAC_SLP: DAC clock
+      \arg        RCU_RTC_SLP: RTC clock
+      \arg        RCU_ADCx_SLP (x = 0, 1, 2): ADC clock
+      \arg        RCU_SDIO_SLP: SDIO clock
+      \arg        RCU_SYSCFG_SLP: SYSCFG clock
+      \arg        RCU_TLI_SLP: TLI clock
+      \arg        RCU_CTC_SLP: CTC clock
+      \arg        RCU_IREF_SLP: IREF clock
+    \param[out] none
+    \retval     none
+*/
+void rcu_periph_clock_sleep_disable(rcu_periph_sleep_enum periph)
+{
+    RCU_REG_VAL(periph) &= ~BIT(RCU_BIT_POS(periph));
+}
+
+/*!
+    \brief    reset the peripherals
+    \param[in]  periph_reset: RCU peripherals reset, refer to rcu_periph_reset_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_GPIOxRST (x = A, B, C, D, E, F, G, H, I): reset GPIO ports
+      \arg        RCU_CRCRST: reset CRC
+      \arg        RCU_DMAxRST (x=0,1): reset DMA
+      \arg        RCU_IPARST: reset IPA
+      \arg        RCU_ENETRST: reset ENET
+      \arg        RCU_USBHSRST: reset USBHS
+      \arg        RCU_DCIRST: reset DCI
+      \arg        RCU_TRNGRST: reset TRNG
+      \arg        RCU_USBFSRST: reset USBFS
+      \arg        RCU_EXMCRST: reset EXMC
+      \arg        RCU_TIMERxRST (x = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13): reset TIMER
+      \arg        RCU_WWDGTRST: reset WWDGT
+      \arg        RCU_SPIxRST (x = 0, 1, 2, 3, 4, 5): reset SPI
+      \arg        RCU_USARTxRST (x = 0, 1, 2, 5): reset USART
+      \arg        RCU_UARTxRST (x = 3, 4, 6, 7): reset UART
+      \arg        RCU_I2CxRST (x = 0, 1, 2): reset I2C
+      \arg        RCU_CANxRST (x = 0, 1): reset CAN
+      \arg        RCU_PMURST: reset PMU
+      \arg        RCU_DACRST: reset DAC
+      \arg        RCU_ADCRST (x = 0, 1, 2): reset ADC
+      \arg        RCU_SDIORST: reset SDIO
+      \arg        RCU_SYSCFGRST: reset SYSCFG
+      \arg        RCU_TLIRST: reset TLI
+      \arg        RCU_CTCRST: reset CTC
+      \arg        RCU_IREFRST: reset IREF
+    \param[out] none
+    \retval     none
+*/
+void rcu_periph_reset_enable(rcu_periph_reset_enum periph_reset)
+{
+    RCU_REG_VAL(periph_reset) |= BIT(RCU_BIT_POS(periph_reset));
+}
+
+/*!
+    \brief    disable reset the peripheral
+    \param[in]  periph_reset: RCU peripherals reset, refer to rcu_periph_reset_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_GPIOxRST (x = A, B, C, D, E, F, G, H, I): reset GPIO ports
+      \arg        RCU_CRCRST: reset CRC
+      \arg        RCU_DMAxRST (x=0,1): reset DMA
+      \arg        RCU_IPARST: reset IPA
+      \arg        RCU_ENETRST: reset ENET
+      \arg        RCU_USBHSRST: reset USBHS
+      \arg        RCU_DCIRST: reset DCI
+      \arg        RCU_TRNGRST: reset TRNG
+      \arg        RCU_USBFSRST: reset USBFS
+      \arg        RCU_EXMCRST: reset EXMC
+      \arg        RCU_TIMERxRST (x = 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13): reset TIMER
+      \arg        RCU_WWDGTRST: reset WWDGT
+      \arg        RCU_SPIxRST (x = 0, 1, 2, 3, 4, 5): reset SPI
+      \arg        RCU_USARTxRST (x = 0, 1, 2, 5): reset USART
+      \arg        RCU_UARTxRST (x = 3, 4, 6, 7): reset UART
+      \arg        RCU_I2CxRST (x = 0, 1, 2): reset I2C
+      \arg        RCU_CANxRST (x = 0, 1): reset CAN
+      \arg        RCU_PMURST: reset PMU
+      \arg        RCU_DACRST: reset DAC
+      \arg        RCU_ADCRST (x = 0, 1, 2): reset ADC
+      \arg        RCU_SDIORST: reset SDIO
+      \arg        RCU_SYSCFGRST: reset SYSCFG
+      \arg        RCU_TLIRST: reset TLI
+      \arg        RCU_CTCRST: reset CTC
+      \arg        RCU_IREFRST: reset IREF
+    \param[out] none
+    \retval     none
+*/
+void rcu_periph_reset_disable(rcu_periph_reset_enum periph_reset)
+{
+    RCU_REG_VAL(periph_reset) &= ~BIT(RCU_BIT_POS(periph_reset));
+}
+
+/*!
+    \brief    reset the BKP
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rcu_bkp_reset_enable(void)
+{
+    RCU_BDCTL |= RCU_BDCTL_BKPRST;
+}
+
+/*!
+    \brief    disable the BKP reset
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rcu_bkp_reset_disable(void)
+{
+    RCU_BDCTL &= ~RCU_BDCTL_BKPRST;
+}
+
+/*!
+    \brief    configure the system clock source
+    \param[in]  ck_sys: system clock source select
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_CKSYSSRC_IRC16M: select CK_IRC16M as the CK_SYS source
+      \arg        RCU_CKSYSSRC_HXTAL: select CK_HXTAL as the CK_SYS source
+      \arg        RCU_CKSYSSRC_PLLP: select CK_PLLP as the CK_SYS source
+    \param[out] none
+    \retval     none
+*/
+void rcu_system_clock_source_config(uint32_t ck_sys)
+{
+    uint32_t reg;
+
+    reg = RCU_CFG0;
+    /* reset the SCS bits and set according to ck_sys */
+    reg &= ~RCU_CFG0_SCS;
+    RCU_CFG0 = (reg | ck_sys);
+}
+
+/*!
+    \brief    get the system clock source
+    \param[in]  none
+    \param[out] none
+    \retval     which clock is selected as CK_SYS source
+      \arg        RCU_SCSS_IRC16M: CK_IRC16M is selected as the CK_SYS source
+      \arg        RCU_SCSS_HXTAL: CK_HXTAL is selected as the CK_SYS source
+      \arg        RCU_SCSS_PLLP: CK_PLLP is selected as the CK_SYS source
+*/
+uint32_t rcu_system_clock_source_get(void)
+{
+    return (RCU_CFG0 & RCU_CFG0_SCSS);
+}
+
+/*!
+    \brief    configure the AHB clock prescaler selection
+    \param[in]  ck_ahb: AHB clock prescaler selection
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_AHB_CKSYS_DIVx (x = 1, 2, 4, 8, 16, 64, 128, 256, 512): select CK_SYS / x as CK_AHB
+    \param[out] none
+    \retval     none
+*/
+void rcu_ahb_clock_config(uint32_t ck_ahb)
+{
+    uint32_t reg;
+
+    reg = RCU_CFG0;
+    /* reset the AHBPSC bits and set according to ck_ahb */
+    reg &= ~RCU_CFG0_AHBPSC;
+    RCU_CFG0 = (reg | ck_ahb);
+}
+
+/*!
+    \brief    configure the APB1 clock prescaler selection
+    \param[in]  ck_apb1: APB1 clock prescaler selection
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_APB1_CKAHB_DIV1: select CK_AHB as CK_APB1
+      \arg        RCU_APB1_CKAHB_DIV2: select CK_AHB / 2 as CK_APB1
+      \arg        RCU_APB1_CKAHB_DIV4: select CK_AHB / 4 as CK_APB1
+      \arg        RCU_APB1_CKAHB_DIV8: select CK_AHB / 8 as CK_APB1
+      \arg        RCU_APB1_CKAHB_DIV16: select CK_AHB / 16 as CK_APB1
+    \param[out] none
+    \retval     none
+*/
+void rcu_apb1_clock_config(uint32_t ck_apb1)
+{
+    uint32_t reg;
+
+    reg = RCU_CFG0;
+    /* reset the APB1PSC and set according to ck_apb1 */
+    reg &= ~RCU_CFG0_APB1PSC;
+    RCU_CFG0 = (reg | ck_apb1);
+}
+
+/*!
+    \brief    configure the APB2 clock prescaler selection
+    \param[in]  ck_apb2: APB2 clock prescaler selection
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_APB2_CKAHB_DIV1: select CK_AHB as CK_APB2
+      \arg        RCU_APB2_CKAHB_DIV2: select CK_AHB / 2 as CK_APB2
+      \arg        RCU_APB2_CKAHB_DIV4: select CK_AHB / 4 as CK_APB2
+      \arg        RCU_APB2_CKAHB_DIV8: select CK_AHB / 8 as CK_APB2
+      \arg        RCU_APB2_CKAHB_DIV16: select CK_AHB / 16 as CK_APB2
+    \param[out] none
+    \retval     none
+*/
+void rcu_apb2_clock_config(uint32_t ck_apb2)
+{
+    uint32_t reg;
+
+    reg = RCU_CFG0;
+    /* reset the APB2PSC and set according to ck_apb2 */
+    reg &= ~RCU_CFG0_APB2PSC;
+    RCU_CFG0 = (reg | ck_apb2);
+}
+
+/*!
+    \brief    configure the CK_OUT0 clock source and divider
+    \param[in]  ckout0_src: CK_OUT0 clock source selection
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_CKOUT0SRC_IRC16M: IRC16M selected
+      \arg        RCU_CKOUT0SRC_LXTAL: LXTAL selected
+      \arg        RCU_CKOUT0SRC_HXTAL: HXTAL selected
+      \arg        RCU_CKOUT0SRC_PLLP: PLLP selected
+    \param[in]  ckout0_div: CK_OUT0 divider
+      \arg        RCU_CKOUT0_DIVx(x = 1, 2, 3, 4, 5): CK_OUT0 is divided by x
+    \param[out] none
+    \retval     none
+*/
+void rcu_ckout0_config(uint32_t ckout0_src, uint32_t ckout0_div)
+{
+    uint32_t reg;
+
+    reg = RCU_CFG0;
+    /* reset the CKOUT0SRC, CKOUT0DIV and set according to ckout0_src and ckout0_div */
+    reg &= ~(RCU_CFG0_CKOUT0SEL | RCU_CFG0_CKOUT0DIV);
+    RCU_CFG0 = (reg | ckout0_src | ckout0_div);
+}
+
+/*!
+    \brief    configure the CK_OUT1 clock source and divider
+    \param[in]  ckout1_src: CK_OUT1 clock source selection
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_CKOUT1SRC_SYSTEMCLOCK: system clock selected
+      \arg        RCU_CKOUT1SRC_PLLI2SR: PLLI2SR selected
+      \arg        RCU_CKOUT1SRC_HXTAL: HXTAL selected
+      \arg        RCU_CKOUT1SRC_PLLP: PLLP selected
+    \param[in]  ckout1_div: CK_OUT1 divider
+      \arg        RCU_CKOUT1_DIVx(x = 1, 2, 3, 4, 5): CK_OUT1 is divided by x
+    \param[out] none
+    \retval     none
+*/
+void rcu_ckout1_config(uint32_t ckout1_src, uint32_t ckout1_div)
+{
+    uint32_t reg;
+
+    reg = RCU_CFG0;
+    /* reset the CKOUT1SRC, CKOUT1DIV and set according to ckout1_src and ckout1_div */
+    reg &= ~(RCU_CFG0_CKOUT1SEL | RCU_CFG0_CKOUT1DIV);
+    RCU_CFG0 = (reg | ckout1_src | ckout1_div);
+}
+
+/*!
+    \brief    configure the main PLL clock
+    \param[in]  pll_src: PLL clock source selection
+      \arg        RCU_PLLSRC_IRC16M: select IRC16M as PLL source clock
+      \arg        RCU_PLLSRC_HXTAL: select HXTAL as PLL source clock
+    \param[in]  pll_psc: the PLL VCO source clock prescaler
+      \arg         this parameter should be selected between 2 and 63
+    \param[in]  pll_n: the PLL VCO clock multi factor
+      \arg        this parameter should be selected between 64 and 500
+    \param[in]  pll_p: the PLLP output frequency division factor from PLL VCO clock
+      \arg        this parameter should be selected 2,4,6,8
+    \param[in]  pll_q: the PLL Q output frequency division factor from PLL VCO clock
+      \arg        this parameter should be selected between 2 and 15
+    \param[out] none
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus rcu_pll_config(uint32_t pll_src, uint32_t pll_psc, uint32_t pll_n, uint32_t pll_p, uint32_t pll_q)
+{
+    uint32_t ss_modulation_inc;
+    uint32_t ss_modulation_reg;
+
+    ss_modulation_inc = 0U;
+    ss_modulation_reg = RCU_PLLSSCTL;
+
+    /* calculate the minimum factor of PLLN */
+    if((ss_modulation_reg & RCU_PLLSSCTL_SSCGON) == RCU_PLLSSCTL_SSCGON) {
+        if((ss_modulation_reg & RCU_SS_TYPE_DOWN) == RCU_SS_TYPE_DOWN) {
+            ss_modulation_inc += RCU_SS_MODULATION_DOWN_INC;
+        } else {
+            ss_modulation_inc += RCU_SS_MODULATION_CENTER_INC;
+        }
+    }
+
+    /* check the function parameter */
+    if(CHECK_PLL_PSC_VALID(pll_psc) && CHECK_PLL_N_VALID(pll_n, ss_modulation_inc) &&
+            CHECK_PLL_P_VALID(pll_p) && CHECK_PLL_Q_VALID(pll_q)) {
+        RCU_PLL = pll_psc | (pll_n << 6) | (((pll_p >> 1) - 1U) << 16) |
+                  (pll_src) | (pll_q << 24);
+    } else {
+        /* return status */
+        return ERROR;
+    }
+
+    /* return status */
+    return SUCCESS;
+}
+
+/*!
+    \brief    configure the PLLI2S clock
+    \param[in]  plli2s_n: the PLLI2S VCO clock multi factor
+      \arg        this parameter should be selected between 50 and 500
+    \param[in]  plli2s_r: the PLLI2S R output frequency division factor from PLLI2S VCO clock
+      \arg        this parameter should be selected between 2 and 7
+    \param[out] none
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus rcu_plli2s_config(uint32_t plli2s_n, uint32_t plli2s_r)
+{
+    /* check the function parameter */
+    if(CHECK_PLLI2S_N_VALID(plli2s_n) && CHECK_PLLI2S_R_VALID(plli2s_r)) {
+        RCU_PLLI2S = (plli2s_n << 6) | (plli2s_r << 28);
+    } else {
+        /* return status */
+        return ERROR;
+    }
+
+    /* return status */
+    return SUCCESS;
+}
+
+/*!
+    \brief    configure the PLLSAI clock
+    \param[in]  pllsai_n: the PLLSAI VCO clock multi factor
+      \arg        this parameter should be selected between 50 and 500
+    \param[in]  pllsai_p: the PLLSAI P output frequency division factor from PLL VCO clock
+      \arg        this parameter should be selected 2,4,6,8
+    \param[in]  pllsai_r: the PLLSAI R output frequency division factor from PLL VCO clock
+      \arg        this parameter should be selected between 2 and 7
+    \param[out] none
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus rcu_pllsai_config(uint32_t pllsai_n, uint32_t pllsai_p, uint32_t pllsai_r)
+{
+    /* check the function parameter */
+    if(CHECK_PLLSAI_N_VALID(pllsai_n) && CHECK_PLLSAI_P_VALID(pllsai_p) && CHECK_PLLSAI_R_VALID(pllsai_r)) {
+        RCU_PLLSAI = (pllsai_n << 6U) | (((pllsai_p >> 1U) - 1U) << 16U) | (pllsai_r << 28U);
+    } else {
+        /* return status */
+        return ERROR;
+    }
+
+    /* return status */
+    return SUCCESS;
+}
+
+/*!
+    \brief    configure the RTC clock source selection
+    \param[in]  rtc_clock_source: RTC clock source selection
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_RTCSRC_NONE: no clock selected
+      \arg        RCU_RTCSRC_LXTAL: CK_LXTAL selected as RTC source clock
+      \arg        RCU_RTCSRC_IRC32K: CK_IRC32K selected as RTC source clock
+      \arg        RCU_RTCSRC_HXTAL_DIV_RTCDIV: CK_HXTAL / RTCDIV selected as RTC source clock
+    \param[out] none
+    \retval     none
+*/
+void rcu_rtc_clock_config(uint32_t rtc_clock_source)
+{
+    uint32_t reg;
+
+    reg = RCU_BDCTL;
+    /* reset the RTCSRC bits and set according to rtc_clock_source */
+    reg &= ~RCU_BDCTL_RTCSRC;
+    RCU_BDCTL = (reg | rtc_clock_source);
+}
+
+/*!
+    \brief    configure the frequency division of RTC clock when HXTAL was selected as its clock source
+    \param[in]  rtc_div: RTC clock frequency division
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_RTC_HXTAL_NONE: no clock for RTC
+      \arg        RCU_RTC_HXTAL_DIVx: RTCDIV clock select CK_HXTAL / x, x = 2....31
+    \param[out] none
+    \retval     none
+*/
+void rcu_rtc_div_config(uint32_t rtc_div)
+{
+    uint32_t reg;
+
+    reg = RCU_CFG0;
+    /* reset the RTCDIV bits and set according to rtc_div value */
+    reg &= ~RCU_CFG0_RTCDIV;
+    RCU_CFG0 = (reg | rtc_div);
+}
+
+
+/*!
+    \brief    configure the I2S clock source selection
+    \param[in]  i2s_clock_source: I2S clock source selection
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_I2SSRC_PLLI2S: CK_PLLI2S selected as I2S source clock
+      \arg        RCU_I2SSRC_I2S_CKIN: external i2s_ckin pin selected as I2S source clock
+    \param[out] none
+    \retval     none
+*/
+void rcu_i2s_clock_config(uint32_t i2s_clock_source)
+{
+    uint32_t reg;
+
+    reg = RCU_CFG0;
+    /* reset the I2SSEL bit and set according to i2s_clock_source */
+    reg &= ~RCU_CFG0_I2SSEL;
+    RCU_CFG0 = (reg | i2s_clock_source);
+}
+
+/*!
+    \brief    configure the CK48M clock source selection
+    \param[in]  ck48m_clock_source: CK48M clock source selection
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_CK48MSRC_PLL48M: CK_PLL48M selected as CK48M source clock
+      \arg        RCU_CK48MSRC_IRC48M: CK_IRC48M selected as CK48M source clock
+    \param[out] none
+    \retval     none
+*/
+void rcu_ck48m_clock_config(uint32_t ck48m_clock_source)
+{
+    uint32_t reg;
+
+    reg = RCU_ADDCTL;
+    /* reset the CK48MSEL bit and set according to i2s_clock_source */
+    reg &= ~RCU_ADDCTL_CK48MSEL;
+    RCU_ADDCTL = (reg | ck48m_clock_source);
+}
+
+/*!
+    \brief    configure the PLL48M clock source selection
+    \param[in]  pll48m_clock_source: PLL48M clock source selection
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_PLL48MSRC_PLLQ: CK_PLLQ selected as PLL48M source clock
+      \arg        RCU_PLL48MSRC_PLLSAIP: CK_PLLSAIP selected as PLL48M source clock
+    \param[out] none
+    \retval     none
+*/
+void rcu_pll48m_clock_config(uint32_t pll48m_clock_source)
+{
+    uint32_t reg;
+
+    reg = RCU_ADDCTL;
+    /* reset the PLL48MSEL bit and set according to pll48m_clock_source */
+    reg &= ~RCU_ADDCTL_PLL48MSEL;
+    RCU_ADDCTL = (reg | pll48m_clock_source);
+}
+
+/*!
+    \brief    configure the TIMER clock prescaler selection
+    \param[in]  timer_clock_prescaler: TIMER clock selection
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_TIMER_PSC_MUL2: if APB1PSC/APB2PSC in RCU_CFG0 register is 0b0xx(CK_APBx = CK_AHB)
+                                      or 0b100(CK_APBx = CK_AHB/2), the TIMER clock is equal to CK_AHB(CK_TIMERx = CK_AHB).
+                                      or else, the TIMER clock is twice the corresponding APB clock (TIMER in APB1 domain: CK_TIMERx = 2 x CK_APB1;
+                                      TIMER in APB2 domain: CK_TIMERx = 2 x CK_APB2)
+      \arg        RCU_TIMER_PSC_MUL4: if APB1PSC/APB2PSC in RCU_CFG0 register is 0b0xx(CK_APBx = CK_AHB),
+                                      0b100(CK_APBx = CK_AHB/2), or 0b101(CK_APBx = CK_AHB/4), the TIMER clock is equal to CK_AHB(CK_TIMERx = CK_AHB).
+                                      or else, the TIMER clock is four timers the corresponding APB clock (TIMER in APB1 domain: CK_TIMERx = 4 x CK_APB1;
+                                      TIMER in APB2 domain: CK_TIMERx = 4 x CK_APB2)
+    \param[out] none
+    \retval     none
+*/
+void rcu_timer_clock_prescaler_config(uint32_t timer_clock_prescaler)
+{
+    /* configure the TIMERSEL bit and select the TIMER clock prescaler */
+    if(timer_clock_prescaler == RCU_TIMER_PSC_MUL2) {
+        RCU_CFG1 &= timer_clock_prescaler;
+    } else {
+        RCU_CFG1 |= timer_clock_prescaler;
+    }
+}
+
+/*!
+    \brief    configure the PLLSAIR divider used as input of TLI
+    \param[in]  pllsai_r_div: PLLSAIR divider used as input of TLI
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_PLLSAIR_DIVx(x=2,4,8,16): PLLSAIR divided x used as input of TLI
+    \param[out] none
+    \retval     none
+*/
+void rcu_tli_clock_div_config(uint32_t pllsai_r_div)
+{
+    uint32_t reg;
+
+    reg = RCU_CFG1;
+    /* reset the PLLSAIRDIV bit and set according to pllsai_r_div */
+    reg &= ~RCU_CFG1_PLLSAIRDIV;
+    RCU_CFG1 = (reg | pllsai_r_div);
+}
+
+/*!
+    \brief    configure the LXTAL drive capability
+    \param[in]  lxtal_dricap: drive capability of LXTAL
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_LXTALDRI_LOWER_DRIVE: lower driving capability
+      \arg        RCU_LXTALDRI_HIGHER_DRIVE: higher driving capability
+    \param[out] none
+    \retval     none
+*/
+void rcu_lxtal_drive_capability_config(uint32_t lxtal_dricap)
+{
+    uint32_t reg;
+
+    reg = RCU_BDCTL;
+
+    /* reset the LXTALDRI bits and set according to lxtal_dricap */
+    reg &= ~RCU_BDCTL_LXTALDRI;
+    RCU_BDCTL = (reg | lxtal_dricap);
+}
+
+/*!
+    \brief    wait for oscillator stabilization flags is SET or oscillator startup is timeout
+    \param[in]  osci: oscillator types, refer to rcu_osci_type_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_HXTAL: HXTAL
+      \arg        RCU_LXTAL: LXTAL
+      \arg        RCU_IRC16M: IRC16M
+      \arg        RCU_IRC48M: IRC48M
+      \arg        RCU_IRC32K: IRC32K
+      \arg        RCU_PLL_CK: PLL
+      \arg        RCU_PLLI2S_CK: PLLI2S
+      \arg        RCU_PLLSAI_CK: PLLSAI
+    \param[out] none
+    \retval     ErrStatus: SUCCESS or ERROR
+*/
+ErrStatus rcu_osci_stab_wait(rcu_osci_type_enum osci)
+{
+    uint32_t stb_cnt = 0U;
+    ErrStatus reval = ERROR;
+    FlagStatus osci_stat = RESET;
+
+    switch(osci) {
+    /* wait HXTAL stable */
+    case RCU_HXTAL:
+        while((RESET == osci_stat) && (HXTAL_STARTUP_TIMEOUT != stb_cnt)) {
+            osci_stat = rcu_flag_get(RCU_FLAG_HXTALSTB);
+            stb_cnt++;
+        }
+
+        /* check whether flag is set */
+        if(RESET != rcu_flag_get(RCU_FLAG_HXTALSTB)) {
+            reval = SUCCESS;
+        }
+        break;
+    /* wait LXTAL stable */
+    case RCU_LXTAL:
+        while((RESET == osci_stat) && (LXTAL_STARTUP_TIMEOUT != stb_cnt)) {
+            osci_stat = rcu_flag_get(RCU_FLAG_LXTALSTB);
+            stb_cnt++;
+        }
+
+        /* check whether flag is set */
+        if(RESET != rcu_flag_get(RCU_FLAG_LXTALSTB)) {
+            reval = SUCCESS;
+        }
+        break;
+    /* wait IRC16M stable */
+    case RCU_IRC16M:
+        while((RESET == osci_stat) && (IRC16M_STARTUP_TIMEOUT != stb_cnt)) {
+            osci_stat = rcu_flag_get(RCU_FLAG_IRC16MSTB);
+            stb_cnt++;
+        }
+
+        /* check whether flag is set */
+        if(RESET != rcu_flag_get(RCU_FLAG_IRC16MSTB)) {
+            reval = SUCCESS;
+        }
+        break;
+    /* wait IRC48M stable */
+    case RCU_IRC48M:
+        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)) {
+            osci_stat = rcu_flag_get(RCU_FLAG_IRC48MSTB);
+            stb_cnt++;
+        }
+
+        /* check whether flag is set */
+        if(RESET != rcu_flag_get(RCU_FLAG_IRC48MSTB)) {
+            reval = SUCCESS;
+        }
+        break;
+    /* wait IRC32K stable */
+    case RCU_IRC32K:
+        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)) {
+            osci_stat = rcu_flag_get(RCU_FLAG_IRC32KSTB);
+            stb_cnt++;
+        }
+
+        /* check whether flag is set */
+        if(RESET != rcu_flag_get(RCU_FLAG_IRC32KSTB)) {
+            reval = SUCCESS;
+        }
+        break;
+    /* wait PLL stable */
+    case RCU_PLL_CK:
+        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)) {
+            osci_stat = rcu_flag_get(RCU_FLAG_PLLSTB);
+            stb_cnt++;
+        }
+
+        /* check whether flag is set */
+        if(RESET != rcu_flag_get(RCU_FLAG_PLLSTB)) {
+            reval = SUCCESS;
+        }
+        break;
+    /* wait PLLI2S stable */
+    case RCU_PLLI2S_CK:
+        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)) {
+            osci_stat = rcu_flag_get(RCU_FLAG_PLLI2SSTB);
+            stb_cnt++;
+        }
+
+        /* check whether flag is set */
+        if(RESET != rcu_flag_get(RCU_FLAG_PLLI2SSTB)) {
+            reval = SUCCESS;
+        }
+        break;
+    /* wait PLLSAI stable */
+    case RCU_PLLSAI_CK:
+        while((RESET == osci_stat) && (OSC_STARTUP_TIMEOUT != stb_cnt)) {
+            osci_stat = rcu_flag_get(RCU_FLAG_PLLSAISTB);
+            stb_cnt++;
+        }
+
+        /* check whether flag is set */
+        if(RESET != rcu_flag_get(RCU_FLAG_PLLSAISTB)) {
+            reval = SUCCESS;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    /* return value */
+    return reval;
+}
+
+/*!
+    \brief    turn on the oscillator
+    \param[in]  osci: oscillator types, refer to rcu_osci_type_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_HXTAL: HXTAL
+      \arg        RCU_LXTAL: LXTAL
+      \arg        RCU_IRC16M: IRC16M
+      \arg        RCU_IRC48M: IRC48M
+      \arg        RCU_IRC32K: IRC32K
+      \arg        RCU_PLL_CK: PLL
+      \arg        RCU_PLLI2S_CK: PLLI2S
+      \arg        RCU_PLLSAI_CK: PLLSAI
+    \param[out] none
+    \retval     none
+*/
+void rcu_osci_on(rcu_osci_type_enum osci)
+{
+    RCU_REG_VAL(osci) |= BIT(RCU_BIT_POS(osci));
+}
+
+/*!
+    \brief    turn off the oscillator
+    \param[in]  osci: oscillator types, refer to rcu_osci_type_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_HXTAL: HXTAL
+      \arg        RCU_LXTAL: LXTAL
+      \arg        RCU_IRC16M: IRC16M
+      \arg        RCU_IRC48M: IRC48M
+      \arg        RCU_IRC32K: IRC32K
+      \arg        RCU_PLL_CK: PLL
+      \arg        RCU_PLLI2S_CK: PLLI2S
+      \arg        RCU_PLLSAI_CK: PLLSAI
+    \param[out] none
+    \retval     none
+*/
+void rcu_osci_off(rcu_osci_type_enum osci)
+{
+    RCU_REG_VAL(osci) &= ~BIT(RCU_BIT_POS(osci));
+}
+
+/*!
+    \brief    enable the oscillator bypass mode, HXTALEN or LXTALEN must be reset before it
+    \param[in]  osci: oscillator types, refer to rcu_osci_type_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_HXTAL: high speed crystal oscillator(HXTAL)
+      \arg        RCU_LXTAL: low speed crystal oscillator(LXTAL)
+    \param[out] none
+    \retval     none
+*/
+void rcu_osci_bypass_mode_enable(rcu_osci_type_enum osci)
+{
+    uint32_t reg;
+
+    switch(osci) {
+    /* enable HXTAL to bypass mode */
+    case RCU_HXTAL:
+        reg = RCU_CTL;
+        RCU_CTL &= ~RCU_CTL_HXTALEN;
+        RCU_CTL = (reg | RCU_CTL_HXTALBPS);
+        break;
+    /* enable LXTAL to bypass mode */
+    case RCU_LXTAL:
+        reg = RCU_BDCTL;
+        RCU_BDCTL &= ~RCU_BDCTL_LXTALEN;
+        RCU_BDCTL = (reg | RCU_BDCTL_LXTALBPS);
+        break;
+    case RCU_IRC16M:
+    case RCU_IRC48M:
+    case RCU_IRC32K:
+    case RCU_PLL_CK:
+    case RCU_PLLI2S_CK:
+    case RCU_PLLSAI_CK:
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief    disable the oscillator bypass mode, HXTALEN or LXTALEN must be reset before it
+    \param[in]  osci: oscillator types, refer to rcu_osci_type_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_HXTAL: high speed crystal oscillator(HXTAL)
+      \arg        RCU_LXTAL: low speed crystal oscillator(LXTAL)
+    \param[out] none
+    \retval     none
+*/
+void rcu_osci_bypass_mode_disable(rcu_osci_type_enum osci)
+{
+    uint32_t reg;
+
+    switch(osci) {
+    /* disable HXTAL to bypass mode */
+    case RCU_HXTAL:
+        reg = RCU_CTL;
+        RCU_CTL &= ~RCU_CTL_HXTALEN;
+        RCU_CTL = (reg & ~RCU_CTL_HXTALBPS);
+        break;
+    /* disable LXTAL to bypass mode */
+    case RCU_LXTAL:
+        reg = RCU_BDCTL;
+        RCU_BDCTL &= ~RCU_BDCTL_LXTALEN;
+        RCU_BDCTL = (reg & ~RCU_BDCTL_LXTALBPS);
+        break;
+    case RCU_IRC16M:
+    case RCU_IRC48M:
+    case RCU_IRC32K:
+    case RCU_PLL_CK:
+    case RCU_PLLI2S_CK:
+    case RCU_PLLSAI_CK:
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief    set the IRC16M adjust value
+    \param[in]  irc16m_adjval: IRC16M adjust value, must be between 0 and 0x1F
+      \arg        0x00 - 0x1F
+    \param[out] none
+    \retval     none
+*/
+void rcu_irc16m_adjust_value_set(uint32_t irc16m_adjval)
+{
+    uint32_t reg;
+
+    reg = RCU_CTL;
+    /* reset the IRC16MADJ bits and set according to irc16m_adjval */
+    reg &= ~RCU_CTL_IRC16MADJ;
+    RCU_CTL = (reg | ((irc16m_adjval & RCU_IRC16M_ADJUST_MASK) << RCU_IRC16M_ADJUST_OFFSET));
+}
+
+/*!
+    \brief    configure the spread spectrum modulation for the main PLL clock
+    \param[in]  spread_spectrum_type: PLL spread spectrum modulation type select
+      \arg        RCU_SS_TYPE_CENTER: center spread type is selected
+      \arg        RCU_SS_TYPE_DOWN: down spread type is selected
+    \param[in]  modstep: configure PLL spread spectrum modulation profile amplitude and frequency
+      \arg        This parameter should be selected between 0 and 7FFF.The following criteria must be met: MODSTEP*MODCNT <=2^15-1
+    \param[in]  modcnt: configure PLL spread spectrum modulation profile amplitude and frequency
+      \arg        This parameter should be selected between 0 and 1FFF.The following criteria must be met: MODSTEP*MODCNT <=2^15-1
+    \param[out] none
+    \retval     none
+*/
+void rcu_spread_spectrum_config(uint32_t spread_spectrum_type, uint32_t modstep, uint32_t modcnt)
+{
+    uint32_t reg;
+
+    reg = RCU_PLLSSCTL;
+    /* reset the RCU_PLLSSCTL register bits */
+    reg &= ~(RCU_PLLSSCTL_MODCNT | RCU_PLLSSCTL_MODSTEP | RCU_PLLSSCTL_SS_TYPE);
+    RCU_PLLSSCTL = (reg | spread_spectrum_type | modstep << 13 | modcnt);
+}
+
+/*!
+    \brief    enable the PLL spread spectrum modulation
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rcu_spread_spectrum_enable(void)
+{
+    RCU_PLLSSCTL |= RCU_PLLSSCTL_SSCGON;
+}
+
+/*!
+    \brief    disable the PLL spread spectrum modulation
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rcu_spread_spectrum_disable(void)
+{
+    RCU_PLLSSCTL &= ~RCU_PLLSSCTL_SSCGON;
+}
+
+/*!
+    \brief    enable the HXTAL clock monitor
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+
+void rcu_hxtal_clock_monitor_enable(void)
+{
+    RCU_CTL |= RCU_CTL_CKMEN;
+}
+
+/*!
+    \brief    disable the HXTAL clock monitor
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rcu_hxtal_clock_monitor_disable(void)
+{
+    RCU_CTL &= ~RCU_CTL_CKMEN;
+}
+
+/*!
+    \brief    unlock the voltage key
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rcu_voltage_key_unlock(void)
+{
+    RCU_VKEY = RCU_VKEY_UNLOCK;
+}
+
+/*!
+    \brief    deep-sleep mode voltage select
+    \param[in]  dsvol: deep sleep mode voltage
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_DEEPSLEEP_V_0: the core voltage is default value
+      \arg        RCU_DEEPSLEEP_V_1: the core voltage is (default value-0.1)V(customers are not recommended to use it)
+      \arg        RCU_DEEPSLEEP_V_2: the core voltage is (default value-0.2)V(customers are not recommended to use it)
+      \arg        RCU_DEEPSLEEP_V_3: the core voltage is (default value-0.3)V(customers are not recommended to use it)
+    \param[out] none
+    \retval     none
+*/
+void rcu_deepsleep_voltage_set(uint32_t dsvol)
+{
+    dsvol &= RCU_DSV_DSLPVS;
+    RCU_DSV = dsvol;
+}
+
+/*!
+    \brief    get the system clock, bus and peripheral clock frequency
+    \param[in]  clock: the clock frequency which to get
+                only one parameter can be selected which is shown as below:
+      \arg        CK_SYS: system clock frequency
+      \arg        CK_AHB: AHB clock frequency
+      \arg        CK_APB1: APB1 clock frequency
+      \arg        CK_APB2: APB2 clock frequency
+    \param[out] none
+    \retval     clock frequency of system, AHB, APB1, APB2
+*/
+uint32_t rcu_clock_freq_get(rcu_clock_freq_enum clock)
+{
+    uint32_t sws, ck_freq = 0U;
+    uint32_t cksys_freq, ahb_freq, apb1_freq, apb2_freq;
+    uint32_t pllpsc, plln, pllsel, pllp, ck_src, idx, clk_exp;
+
+    /* exponent of AHB, APB1 and APB2 clock divider */
+    const uint8_t ahb_exp[16] = {0, 0, 0, 0, 0, 0, 0, 0, 1, 2, 3, 4, 6, 7, 8, 9};
+    const uint8_t apb1_exp[8] = {0, 0, 0, 0, 1, 2, 3, 4};
+    const uint8_t apb2_exp[8] = {0, 0, 0, 0, 1, 2, 3, 4};
+
+    sws = GET_BITS(RCU_CFG0, 2, 3);
+    switch(sws) {
+    /* IRC16M is selected as CK_SYS */
+    case SEL_IRC16M:
+        cksys_freq = IRC16M_VALUE;
+        break;
+    /* HXTAL is selected as CK_SYS */
+    case SEL_HXTAL:
+        cksys_freq = HXTAL_VALUE;
+        break;
+    /* PLLP is selected as CK_SYS */
+    case SEL_PLLP:
+        /* get the value of PLLPSC[5:0] */
+        pllpsc = GET_BITS(RCU_PLL, 0U, 5U);
+        plln = GET_BITS(RCU_PLL, 6U, 14U);
+        pllp = (GET_BITS(RCU_PLL, 16U, 17U) + 1U) * 2U;
+        /* PLL clock source selection, HXTAL or IRC16M/2 */
+        pllsel = (RCU_PLL & RCU_PLL_PLLSEL);
+        if(RCU_PLLSRC_HXTAL == pllsel) {
+            ck_src = HXTAL_VALUE;
+        } else {
+            ck_src = IRC16M_VALUE;
+        }
+        cksys_freq = ((ck_src / pllpsc) * plln) / pllp;
+        break;
+    /* IRC16M is selected as CK_SYS */
+    default:
+        cksys_freq = IRC16M_VALUE;
+        break;
+    }
+    /* calculate AHB clock frequency */
+    idx = GET_BITS(RCU_CFG0, 4, 7);
+    clk_exp = ahb_exp[idx];
+    ahb_freq = cksys_freq >> clk_exp;
+
+    /* calculate APB1 clock frequency */
+    idx = GET_BITS(RCU_CFG0, 10, 12);
+    clk_exp = apb1_exp[idx];
+    apb1_freq = ahb_freq >> clk_exp;
+
+    /* calculate APB2 clock frequency */
+    idx = GET_BITS(RCU_CFG0, 13, 15);
+    clk_exp = apb2_exp[idx];
+    apb2_freq = ahb_freq >> clk_exp;
+
+    /* return the clocks frequency */
+    switch(clock) {
+    case CK_SYS:
+        ck_freq = cksys_freq;
+        break;
+    case CK_AHB:
+        ck_freq = ahb_freq;
+        break;
+    case CK_APB1:
+        ck_freq = apb1_freq;
+        break;
+    case CK_APB2:
+        ck_freq = apb2_freq;
+        break;
+    default:
+        break;
+    }
+    return ck_freq;
+}
+
+/*!
+    \brief    get the clock stabilization and periphral reset flags
+    \param[in]  flag: the clock stabilization and periphral reset flags, refer to rcu_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_FLAG_IRC16MSTB: IRC16M stabilization flag
+      \arg        RCU_FLAG_HXTALSTB: HXTAL stabilization flag
+      \arg        RCU_FLAG_PLLSTB: PLL stabilization flag
+      \arg        RCU_FLAG_PLLI2SSTB: PLLI2S stabilization flag
+      \arg        RCU_FLAG_PLLSAISTB: PLLSAI stabilization flag
+      \arg        RCU_FLAG_LXTALSTB: LXTAL stabilization flag
+      \arg        RCU_FLAG_IRC32KSTB: IRC32K stabilization flag
+      \arg        RCU_FLAG_IRC48MSTB: IRC48M stabilization flag
+      \arg        RCU_FLAG_BORRST: BOR reset flags
+      \arg        RCU_FLAG_EPRST: external PIN reset flag
+      \arg        RCU_FLAG_PORRST: Power reset flag
+      \arg        RCU_FLAG_SWRST: software reset flag
+      \arg        RCU_FLAG_FWDGTRST: free watchdog timer reset flag
+      \arg        RCU_FLAG_WWDGTRST: window watchdog timer reset flag
+      \arg        RCU_FLAG_LPRST: low-power reset flag
+    \param[out] none
+    \retval     none
+*/
+FlagStatus rcu_flag_get(rcu_flag_enum flag)
+{
+    /* get the rcu flag */
+    if(RESET != (RCU_REG_VAL(flag) & BIT(RCU_BIT_POS(flag)))) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    clear all the reset flag
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rcu_all_reset_flag_clear(void)
+{
+    RCU_RSTSCK |= RCU_RSTSCK_RSTFC;
+}
+
+/*!
+    \brief    get the clock stabilization interrupt and ckm flags
+    \param[in]  int_flag: interrupt and ckm flags, refer to rcu_int_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_INT_FLAG_IRC32KSTB: IRC32K stabilization interrupt flag
+      \arg        RCU_INT_FLAG_LXTALSTB: LXTAL stabilization interrupt flag
+      \arg        RCU_INT_FLAG_IRC16MSTB: IRC16M stabilization interrupt flag
+      \arg        RCU_INT_FLAG_HXTALSTB: HXTAL stabilization interrupt flag
+      \arg        RCU_INT_FLAG_PLLSTB: PLL stabilization interrupt flag
+      \arg        RCU_INT_FLAG_PLLI2SSTB: PLLI2S stabilization interrupt flag
+      \arg        RCU_INT_FLAG_PLLSAISTB: PLLSAI stabilization interrupt flag
+      \arg        RCU_INT_FLAG_CKM: HXTAL clock stuck interrupt flag
+      \arg        RCU_INT_FLAG_IRC48MSTB: IRC48M stabilization interrupt flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus rcu_interrupt_flag_get(rcu_int_flag_enum int_flag)
+{
+    /* get the rcu interrupt flag */
+    if(RESET != (RCU_REG_VAL(int_flag) & BIT(RCU_BIT_POS(int_flag)))) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    clear the interrupt flags
+    \param[in]  int_flag: clock stabilization and stuck interrupt flags clear, refer to rcu_int_flag_clear_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_INT_FLAG_IRC32KSTB_CLR: IRC32K stabilization interrupt flag clear
+      \arg        RCU_INT_FLAG_LXTALSTB_CLR: LXTAL stabilization interrupt flag clear
+      \arg        RCU_INT_FLAG_IRC16MSTB_CLR: IRC16M stabilization interrupt flag clear
+      \arg        RCU_INT_FLAG_HXTALSTB_CLR: HXTAL stabilization interrupt flag clear
+      \arg        RCU_INT_FLAG_PLLSTB_CLR: PLL stabilization interrupt flag clear
+      \arg        RCU_INT_FLAG_PLLI2SSTB_CLR: PLLI2S stabilization interrupt flag clear
+      \arg        RCU_INT_FLAG_PLLSAISTB_CLR: PLLSAI stabilization interrupt flag clear
+      \arg        RCU_INT_FLAG_CKM_CLR: clock stuck interrupt flag clear
+      \arg        RCU_INT_FLAG_IRC48MSTB_CLR: IRC48M stabilization interrupt flag clear
+    \param[out] none
+    \retval     none
+*/
+void rcu_interrupt_flag_clear(rcu_int_flag_clear_enum int_flag)
+{
+    RCU_REG_VAL(int_flag) |= BIT(RCU_BIT_POS(int_flag));
+}
+
+/*!
+    \brief    enable the stabilization interrupt
+    \param[in]  interrupt: clock stabilization interrupt, refer to rcu_int_enum
+                Only one parameter can be selected which is shown as below:
+      \arg        RCU_INT_IRC32KSTB: IRC32K stabilization interrupt enable
+      \arg        RCU_INT_LXTALSTB: LXTAL stabilization interrupt enable
+      \arg        RCU_INT_IRC16MSTB: IRC16M stabilization interrupt enable
+      \arg        RCU_INT_HXTALSTB: HXTAL stabilization interrupt enable
+      \arg        RCU_INT_PLLSTB: PLL stabilization interrupt enable
+      \arg        RCU_INT_PLLI2SSTB: PLLI2S stabilization interrupt enable
+      \arg        RCU_INT_PLLSAISTB: PLLSAI stabilization interrupt enable
+      \arg        RCU_INT_IRC48MSTB: IRC48M stabilization interrupt enable
+    \param[out] none
+    \retval     none
+*/
+void rcu_interrupt_enable(rcu_int_enum interrupt)
+{
+    RCU_REG_VAL(interrupt) |= BIT(RCU_BIT_POS(interrupt));
+}
+
+
+/*!
+    \brief    disable the stabilization interrupt
+    \param[in]  interrupt: clock stabilization interrupt, refer to rcu_int_enum
+                only one parameter can be selected which is shown as below:
+      \arg        RCU_INT_IRC32KSTB: IRC32K stabilization interrupt disable
+      \arg        RCU_INT_LXTALSTB: LXTAL stabilization interrupt disable
+      \arg        RCU_INT_IRC16MSTB: IRC16M stabilization interrupt disable
+      \arg        RCU_INT_HXTALSTB: HXTAL stabilization interrupt disable
+      \arg        RCU_INT_PLLSTB: PLL stabilization interrupt disable
+      \arg        RCU_INT_PLLI2SSTB: PLLI2S stabilization interrupt disable
+      \arg        RCU_INT_PLLSAISTB: PLLSAI stabilization interrupt disable
+      \arg        RCU_INT_IRC48MSTB: IRC48M stabilization interrupt disable
+    \param[out] none
+    \retval     none
+*/
+void rcu_interrupt_disable(rcu_int_enum interrupt)
+{
+    RCU_REG_VAL(interrupt) &= ~BIT(RCU_BIT_POS(interrupt));
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_rtc.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_rtc.c
@@ -1,0 +1,1294 @@
+/*!
+    \file    gd32f4xx_rtc.c
+    \brief   RTC driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+
+#include "gd32f4xx_rtc.h"
+
+/* RTC timeout value */
+#define RTC_WTWF_TIMEOUT                   ((uint32_t)0x00004000U)                    /*!< wakeup timer can be write flag timeout */
+#define RTC_INITM_TIMEOUT                  ((uint32_t)0x00004000U)                    /*!< initialization state flag timeout */
+#define RTC_RSYNF_TIMEOUT                  ((uint32_t)0x00008000U)                    /*!< register synchronization flag timeout */
+#define RTC_HRFC_TIMEOUT                   ((uint32_t)0x20000000U)                    /*!< recalibration pending flag timeout */
+#define RTC_SHIFTCTL_TIMEOUT               ((uint32_t)0x00001000U)                    /*!< shift function operation pending flag timeout */
+#define RTC_ALRMXWF_TIMEOUT                ((uint32_t)0x00008000U)                    /*!< alarm configuration can be write flag timeout */
+
+/*!
+    \brief    reset most of the RTC registers
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_deinit(void)
+{
+    ErrStatus error_status = ERROR;
+    volatile uint32_t time_index = RTC_WTWF_TIMEOUT;
+    uint32_t flag_status = RESET;
+    /* RTC_TAMP register is not under write protection */
+    RTC_TAMP = RTC_REGISTER_RESET;
+
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    /* enter init mode */
+    error_status = rtc_init_mode_enter();
+
+    if(ERROR != error_status) {
+        /* reset RTC_CTL register, but RTC_CTL[2��0] */
+        RTC_CTL &= (RTC_REGISTER_RESET | RTC_CTL_WTCS);
+        /* before reset RTC_TIME and RTC_DATE, BPSHAD bit in RTC_CTL should be reset as the condition.
+           in order to read calendar from shadow register, not the real registers being reset */
+        RTC_TIME = RTC_REGISTER_RESET;
+        RTC_DATE = RTC_DATE_RESET;
+
+        RTC_PSC = RTC_PSC_RESET;
+        /* only when RTC_CTL_WTEN=0 and RTC_STAT_WTWF=1 can write RTC_CTL[2��0] */
+        /* wait until the WTWF flag to be set */
+        do {
+            flag_status = RTC_STAT & RTC_STAT_WTWF;
+        } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+
+        if((uint32_t)RESET == flag_status) {
+            error_status = ERROR;
+        } else {
+            RTC_CTL &= RTC_REGISTER_RESET;
+            RTC_WUT = RTC_WUT_RESET;
+            RTC_COSC = RTC_REGISTER_RESET;
+            /* to write RTC_ALRMxSS register, ALRMxEN bit in RTC_CTL register should be reset as the condition */
+            RTC_ALRM0TD = RTC_REGISTER_RESET;
+            RTC_ALRM1TD = RTC_REGISTER_RESET;
+            RTC_ALRM0SS = RTC_REGISTER_RESET;
+            RTC_ALRM1SS = RTC_REGISTER_RESET;
+            /* reset RTC_STAT register, also exit init mode.
+               at the same time, RTC_STAT_SOPF bit is reset, as the condition to reset RTC_SHIFTCTL register later */
+            RTC_STAT = RTC_STAT_RESET;
+            /* reset RTC_SHIFTCTL and RTC_HRFC register, this can be done without the init mode */
+            RTC_SHIFTCTL   = RTC_REGISTER_RESET;
+            RTC_HRFC       = RTC_REGISTER_RESET;
+            error_status = rtc_register_sync_wait();
+        }
+    }
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+
+    return error_status;
+}
+
+/*!
+    \brief    initialize RTC registers
+    \param[in]  rtc_initpara_struct: pointer to a rtc_parameter_struct structure which contains
+                parameters for initialization of the rtc peripheral
+                members of the structure and the member values are shown as below:
+                  year: 0x0 - 0x99(BCD format)
+                  month: RTC_JAN, RTC_FEB, RTC_MAR, RTC_APR, RTC_MAY, RTC_JUN,
+                             RTC_JUL, RTC_AUG, RTC_SEP, RTC_OCT, RTC_NOV, RTC_DEC
+                  date: 0x1 - 0x31(BCD format)
+                  day_of_week: RTC_MONDAY, RTC_TUESDAY, RTC_WEDSDAY, RTC_THURSDAY
+                                   RTC_FRIDAY, RTC_SATURDAY, RTC_SUNDAY
+                  hour: 0x0 - 0x12(BCD format) or 0x0 - 0x23(BCD format) depending on the rtc_display_format chose
+                  minute: 0x0 - 0x59(BCD format)
+                  second: 0x0 - 0x59(BCD format)
+                  factor_asyn: 0x0 - 0x7F
+                  factor_syn: 0x0 - 0x7FFF
+                  am_pm: RTC_AM, RTC_PM
+                  display_format: RTC_24HOUR, RTC_12HOUR
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_init(rtc_parameter_struct *rtc_initpara_struct)
+{
+    ErrStatus error_status = ERROR;
+    uint32_t reg_time = 0U, reg_date = 0U;
+
+    reg_date = (DATE_YR(rtc_initpara_struct->year) | \
+                DATE_DOW(rtc_initpara_struct->day_of_week) | \
+                DATE_MON(rtc_initpara_struct->month) | \
+                DATE_DAY(rtc_initpara_struct->date));
+
+    reg_time = (rtc_initpara_struct->am_pm | \
+                TIME_HR(rtc_initpara_struct->hour)  | \
+                TIME_MN(rtc_initpara_struct->minute) | \
+                TIME_SC(rtc_initpara_struct->second));
+
+    /* 1st: disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    /* 2nd: enter init mode */
+    error_status = rtc_init_mode_enter();
+
+    if(ERROR != error_status) {
+        RTC_PSC = (uint32_t)(PSC_FACTOR_A(rtc_initpara_struct->factor_asyn) | \
+                             PSC_FACTOR_S(rtc_initpara_struct->factor_syn));
+
+        RTC_TIME = (uint32_t)reg_time;
+        RTC_DATE = (uint32_t)reg_date;
+
+        RTC_CTL &= (uint32_t)(~RTC_CTL_CS);
+        RTC_CTL |=  rtc_initpara_struct->display_format;
+
+        /* 3rd: exit init mode */
+        rtc_init_mode_exit();
+
+        /* 4th: wait the RSYNF flag to set */
+        error_status = rtc_register_sync_wait();
+    }
+
+    /* 5th:  enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+
+    return error_status;
+}
+
+/*!
+    \brief    enter RTC init mode
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_init_mode_enter(void)
+{
+    volatile uint32_t time_index = RTC_INITM_TIMEOUT;
+    uint32_t flag_status = RESET;
+    ErrStatus error_status = ERROR;
+
+    /* check whether it has been in init mode */
+    if((uint32_t)RESET == (RTC_STAT & RTC_STAT_INITF)) {
+        RTC_STAT |= RTC_STAT_INITM;
+
+        /* wait until the INITF flag to be set */
+        do {
+            flag_status = RTC_STAT & RTC_STAT_INITF;
+        } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+
+        if((uint32_t)RESET != flag_status) {
+            error_status = SUCCESS;
+        }
+    } else {
+        error_status = SUCCESS;
+    }
+    return error_status;
+}
+
+/*!
+    \brief    exit RTC init mode
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rtc_init_mode_exit(void)
+{
+    RTC_STAT &= (uint32_t)(~RTC_STAT_INITM);
+}
+
+/*!
+    \brief    wait until RTC_TIME and RTC_DATE registers are synchronized with APB clock, and the shadow
+                registers are updated
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_register_sync_wait(void)
+{
+    volatile uint32_t time_index = RTC_RSYNF_TIMEOUT;
+    uint32_t flag_status = RESET;
+    ErrStatus error_status = ERROR;
+
+    if((uint32_t)RESET == (RTC_CTL & RTC_CTL_BPSHAD)) {
+        /* disable the write protection */
+        RTC_WPK = RTC_UNLOCK_KEY1;
+        RTC_WPK = RTC_UNLOCK_KEY2;
+
+        /* firstly clear RSYNF flag */
+        RTC_STAT &= (uint32_t)(~RTC_STAT_RSYNF);
+
+        /* wait until RSYNF flag to be set */
+        do {
+            flag_status = RTC_STAT & RTC_STAT_RSYNF;
+        } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+
+        if((uint32_t)RESET != flag_status) {
+            error_status = SUCCESS;
+        }
+
+        /* enable the write protection */
+        RTC_WPK = RTC_LOCK_KEY;
+    } else {
+        error_status = SUCCESS;
+    }
+
+    return error_status;
+}
+
+/*!
+    \brief    get current time and date
+    \param[in]  none
+    \param[out] rtc_initpara_struct: pointer to a rtc_parameter_struct structure which contains
+                parameters for initialization of the rtc peripheral
+                members of the structure and the member values are shown as below:
+                  year: 0x0 - 0x99(BCD format)
+                  month: RTC_JAN, RTC_FEB, RTC_MAR, RTC_APR, RTC_MAY, RTC_JUN,
+                             RTC_JUL, RTC_AUG, RTC_SEP, RTC_OCT, RTC_NOV, RTC_DEC
+                  date: 0x1 - 0x31(BCD format)
+                  day_of_week: RTC_MONDAY, RTC_TUESDAY, RTC_WEDSDAY, RTC_THURSDAY
+                                   RTC_FRIDAY, RTC_SATURDAY, RTC_SUNDAY
+                  hour: 0x0 - 0x12(BCD format) or 0x0 - 0x23(BCD format) depending on the rtc_display_format chose
+                  minute: 0x0 - 0x59(BCD format)
+                  second: 0x0 - 0x59(BCD format)
+                  factor_asyn: 0x0 - 0x7F
+                  factor_syn: 0x0 - 0x7FFF
+                  am_pm: RTC_AM, RTC_PM
+                  display_format: RTC_24HOUR, RTC_12HOUR
+    \retval     none
+*/
+void rtc_current_time_get(rtc_parameter_struct *rtc_initpara_struct)
+{
+    uint32_t temp_tr = 0U, temp_dr = 0U, temp_pscr = 0U, temp_ctlr = 0U;
+
+    temp_tr = (uint32_t)RTC_TIME;
+    temp_dr = (uint32_t)RTC_DATE;
+    temp_pscr = (uint32_t)RTC_PSC;
+    temp_ctlr = (uint32_t)RTC_CTL;
+
+    /* get current time and construct rtc_parameter_struct structure */
+    rtc_initpara_struct->year = (uint8_t)GET_DATE_YR(temp_dr);
+    rtc_initpara_struct->month = (uint8_t)GET_DATE_MON(temp_dr);
+    rtc_initpara_struct->date = (uint8_t)GET_DATE_DAY(temp_dr);
+    rtc_initpara_struct->day_of_week = (uint8_t)GET_DATE_DOW(temp_dr);
+    rtc_initpara_struct->hour = (uint8_t)GET_TIME_HR(temp_tr);
+    rtc_initpara_struct->minute = (uint8_t)GET_TIME_MN(temp_tr);
+    rtc_initpara_struct->second = (uint8_t)GET_TIME_SC(temp_tr);
+    rtc_initpara_struct->factor_asyn = (uint16_t)GET_PSC_FACTOR_A(temp_pscr);
+    rtc_initpara_struct->factor_syn = (uint16_t)GET_PSC_FACTOR_S(temp_pscr);
+    rtc_initpara_struct->am_pm = (uint32_t)(temp_tr & RTC_TIME_PM);
+    rtc_initpara_struct->display_format = (uint32_t)(temp_ctlr & RTC_CTL_CS);
+}
+
+/*!
+    \brief    get current subsecond value
+    \param[in]  none
+    \param[out] none
+    \retval     current subsecond value
+*/
+uint32_t rtc_subsecond_get(void)
+{
+    uint32_t reg = 0U;
+    /* if BPSHAD bit is reset, reading RTC_SS will lock RTC_TIME and RTC_DATE automatically */
+    reg = (uint32_t)RTC_SS;
+    /* read RTC_DATE to unlock the 3 shadow registers */
+    (void)(RTC_DATE);
+
+    return reg;
+}
+
+/*!
+    \brief    configure RTC alarm
+    \param[in]  rtc_alarm: RTC_ALARM0 or RTC_ALARM1
+    \param[in]  rtc_alarm_time: pointer to a rtc_alarm_struct structure which contains
+                parameters for RTC alarm configuration
+                members of the structure and the member values are shown as below:
+                  alarm_mask: RTC_ALARM_NONE_MASK, RTC_ALARM_DATE_MASK, RTC_ALARM_HOUR_MASK
+                                  RTC_ALARM_MINUTE_MASK, RTC_ALARM_SECOND_MASK, RTC_ALARM_ALL_MASK
+                  weekday_or_date: RTC_ALARM_DATE_SELECTED, RTC_ALARM_WEEKDAY_SELECTED
+                  alarm_day: 1) 0x1 - 0x31(BCD format) if RTC_ALARM_DATE_SELECTED is set
+                                 2) RTC_MONDAY, RTC_TUESDAY, RTC_WEDSDAY, RTC_THURSDAY, RTC_FRIDAY,
+                                    RTC_SATURDAY, RTC_SUNDAY if RTC_ALARM_WEEKDAY_SELECTED is set
+                  alarm_hour: 0x0 - 0x12(BCD format) or 0x0 - 0x23(BCD format) depending on the rtc_display_format
+                  alarm_minute: 0x0 - 0x59(BCD format)
+                  alarm_second: 0x0 - 0x59(BCD format)
+                  am_pm: RTC_AM, RTC_PM
+    \param[out] none
+    \retval     none
+*/
+void rtc_alarm_config(uint8_t rtc_alarm, rtc_alarm_struct *rtc_alarm_time)
+{
+    uint32_t reg_alrmtd = 0U;
+
+    reg_alrmtd = (rtc_alarm_time->alarm_mask | \
+                  rtc_alarm_time->weekday_or_date | \
+                  rtc_alarm_time->am_pm | \
+                  ALRMTD_DAY(rtc_alarm_time->alarm_day) | \
+                  ALRMTD_HR(rtc_alarm_time->alarm_hour) | \
+                  ALRMTD_MN(rtc_alarm_time->alarm_minute) | \
+                  ALRMTD_SC(rtc_alarm_time->alarm_second));
+
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    if(RTC_ALARM0 == rtc_alarm) {
+        RTC_ALRM0TD = (uint32_t)reg_alrmtd;
+
+    } else {
+        RTC_ALRM1TD = (uint32_t)reg_alrmtd;
+    }
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+}
+
+/*!
+    \brief    configure subsecond of RTC alarm
+    \param[in]  rtc_alarm: RTC_ALARM0 or RTC_ALARM1
+    \param[in]  mask_subsecond: alarm subsecond mask
+      \arg        RTC_MASKSSC_0_14: mask alarm subsecond configuration
+      \arg        RTC_MASKSSC_1_14: mask RTC_ALRMXSS_SSC[14:1], and RTC_ALRMXSS_SSC[0] is to be compared
+      \arg        RTC_MASKSSC_2_14: mask RTC_ALRMXSS_SSC[14:2], and RTC_ALRMXSS_SSC[1:0] is to be compared
+      \arg        RTC_MASKSSC_3_14: mask RTC_ALRMXSS_SSC[14:3], and RTC_ALRMXSS_SSC[2:0] is to be compared
+      \arg        RTC_MASKSSC_4_14: mask RTC_ALRMXSS_SSC[14:4]], and RTC_ALRMXSS_SSC[3:0] is to be compared
+      \arg        RTC_MASKSSC_5_14: mask RTC_ALRMXSS_SSC[14:5], and RTC_ALRMXSS_SSC[4:0] is to be compared
+      \arg        RTC_MASKSSC_6_14: mask RTC_ALRMXSS_SSC[14:6], and RTC_ALRMXSS_SSC[5:0] is to be compared
+      \arg        RTC_MASKSSC_7_14: mask RTC_ALRMXSS_SSC[14:7], and RTC_ALRMXSS_SSC[6:0] is to be compared
+      \arg        RTC_MASKSSC_8_14: mask RTC_ALRMXSS_SSC[14:8], and RTC_ALRMXSS_SSC[7:0] is to be compared
+      \arg        RTC_MASKSSC_9_14: mask RTC_ALRMXSS_SSC[14:9], and RTC_ALRMXSS_SSC[8:0] is to be compared
+      \arg        RTC_MASKSSC_10_14: mask RTC_ALRMXSS_SSC[14:10], and RTC_ALRMXSS_SSC[9:0] is to be compared
+      \arg        RTC_MASKSSC_11_14: mask RTC_ALRMXSS_SSC[14:11], and RTC_ALRMXSS_SSC[10:0] is to be compared
+      \arg        RTC_MASKSSC_12_14: mask RTC_ALRMXSS_SSC[14:12], and RTC_ALRMXSS_SSC[11:0] is to be compared
+      \arg        RTC_MASKSSC_13_14: mask RTC_ALRMXSS_SSC[14:13], and RTC_ALRMXSS_SSC[12:0] is to be compared
+      \arg        RTC_MASKSSC_14: mask RTC_ALRMXSS_SSC[14], and RTC_ALRMXSS_SSC[13:0] is to be compared
+      \arg        RTC_MASKSSC_NONE: mask none, and RTC_ALRMXSS_SSC[14:0] is to be compared
+    \param[in]  subsecond: alarm subsecond value(0x000 - 0x7FFF)
+    \param[out] none
+    \retval     none
+*/
+void rtc_alarm_subsecond_config(uint8_t rtc_alarm, uint32_t mask_subsecond, uint32_t subsecond)
+{
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    if(RTC_ALARM0 == rtc_alarm) {
+        RTC_ALRM0SS = mask_subsecond | subsecond;
+    } else {
+        RTC_ALRM1SS = mask_subsecond | subsecond;
+    }
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+}
+
+/*!
+    \brief    get RTC alarm
+    \param[in]  rtc_alarm: RTC_ALARM0 or RTC_ALARM1
+    \param[out] rtc_alarm_time: pointer to a rtc_alarm_struct structure which contains
+                parameters for RTC alarm configuration
+                members of the structure and the member values are shown as below:
+                  alarm_mask: RTC_ALARM_NONE_MASK, RTC_ALARM_DATE_MASK, RTC_ALARM_HOUR_MASK
+                                  RTC_ALARM_MINUTE_MASK, RTC_ALARM_SECOND_MASK, RTC_ALARM_ALL_MASK
+                  weekday_or_date: RTC_ALARM_DATE_SELECTED, RTC_ALARM_WEEKDAY_SELECTED
+                  alarm_day: 1) 0x1 - 0x31(BCD format) if RTC_ALARM_DATE_SELECTED is set
+                                 2) RTC_MONDAY, RTC_TUESDAY, RTC_WEDSDAY, RTC_THURSDAY, RTC_FRIDAY,
+                                    RTC_SATURDAY, RTC_SUNDAY if RTC_ALARM_WEEKDAY_SELECTED is set
+                  alarm_hour: 0x0 - 0x12(BCD format) or 0x0 - 0x23(BCD format) depending on the rtc_display_format
+                  alarm_minute: 0x0 - 0x59(BCD format)
+                  alarm_second: 0x0 - 0x59(BCD format)
+                  am_pm: RTC_AM, RTC_PM
+    \retval     none
+*/
+void rtc_alarm_get(uint8_t rtc_alarm, rtc_alarm_struct *rtc_alarm_time)
+{
+    uint32_t reg_alrmtd = 0U;
+
+    /* get the value of RTC_ALRM0TD register */
+    if(RTC_ALARM0 == rtc_alarm) {
+        reg_alrmtd = RTC_ALRM0TD;
+    } else {
+        reg_alrmtd = RTC_ALRM1TD;
+    }
+    /* get alarm parameters and construct the rtc_alarm_struct structure */
+    rtc_alarm_time->alarm_mask = reg_alrmtd & RTC_ALARM_ALL_MASK;
+    rtc_alarm_time->am_pm = (uint32_t)(reg_alrmtd & RTC_ALRMXTD_PM);
+    rtc_alarm_time->weekday_or_date = (uint32_t)(reg_alrmtd & RTC_ALRMXTD_DOWS);
+    rtc_alarm_time->alarm_day = (uint8_t)GET_ALRMTD_DAY(reg_alrmtd);
+    rtc_alarm_time->alarm_hour = (uint8_t)GET_ALRMTD_HR(reg_alrmtd);
+    rtc_alarm_time->alarm_minute = (uint8_t)GET_ALRMTD_MN(reg_alrmtd);
+    rtc_alarm_time->alarm_second = (uint8_t)GET_ALRMTD_SC(reg_alrmtd);
+}
+
+/*!
+    \brief    get RTC alarm subsecond
+    \param[in]  rtc_alarm: RTC_ALARM0 or RTC_ALARM1
+    \param[out] none
+    \retval     RTC alarm subsecond value
+*/
+uint32_t rtc_alarm_subsecond_get(uint8_t rtc_alarm)
+{
+    if(RTC_ALARM0 == rtc_alarm) {
+        return ((uint32_t)(RTC_ALRM0SS & RTC_ALRM0SS_SSC));
+    } else {
+        return ((uint32_t)(RTC_ALRM1SS & RTC_ALRM1SS_SSC));
+    }
+}
+
+/*!
+    \brief    enable RTC alarm
+    \param[in]  rtc_alarm: RTC_ALARM0 or RTC_ALARM1
+    \param[out] none
+    \retval     none
+*/
+void rtc_alarm_enable(uint8_t rtc_alarm)
+{
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    if(RTC_ALARM0 == rtc_alarm) {
+        RTC_CTL |= RTC_CTL_ALRM0EN;
+    } else {
+        RTC_CTL |= RTC_CTL_ALRM1EN;
+    }
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+}
+
+/*!
+    \brief    disable RTC alarm
+    \param[in]  rtc_alarm: RTC_ALARM0 or RTC_ALARM1
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_alarm_disable(uint8_t rtc_alarm)
+{
+    volatile uint32_t time_index = RTC_ALRMXWF_TIMEOUT;
+    ErrStatus error_status = ERROR;
+    uint32_t flag_status = RESET;
+
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    /* clear the state of alarm */
+    if(RTC_ALARM0 == rtc_alarm) {
+        RTC_CTL &= (uint32_t)(~RTC_CTL_ALRM0EN);
+        /* wait until ALRM0WF flag to be set after the alarm is disabled */
+        do {
+            flag_status = RTC_STAT & RTC_STAT_ALRM0WF;
+        } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+    } else {
+        RTC_CTL &= (uint32_t)(~RTC_CTL_ALRM1EN);
+        /* wait until ALRM1WF flag to be set after the alarm is disabled */
+        do {
+            flag_status = RTC_STAT & RTC_STAT_ALRM1WF;
+        } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+    }
+
+    if((uint32_t)RESET != flag_status) {
+        error_status = SUCCESS;
+    }
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+
+    return error_status;
+}
+
+/*!
+    \brief    enable RTC time-stamp
+    \param[in]  edge: specify which edge to detect of time-stamp
+      \arg        RTC_TIMESTAMP_RISING_EDGE: rising edge is valid event edge for timestamp event
+      \arg        RTC_TIMESTAMP_FALLING_EDGE: falling edge is valid event edge for timestamp event
+    \param[out] none
+    \retval     none
+*/
+void rtc_timestamp_enable(uint32_t edge)
+{
+    uint32_t reg_ctl = 0U;
+
+    /* clear the bits to be configured in RTC_CTL */
+    reg_ctl = (uint32_t)(RTC_CTL & (uint32_t)(~(RTC_CTL_TSEG | RTC_CTL_TSEN)));
+
+    /* new configuration */
+    reg_ctl |= (uint32_t)(edge | RTC_CTL_TSEN);
+
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    RTC_CTL = (uint32_t)reg_ctl;
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+}
+
+/*!
+    \brief    disable RTC time-stamp
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rtc_timestamp_disable(void)
+{
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    /* clear the TSEN bit */
+    RTC_CTL &= (uint32_t)(~ RTC_CTL_TSEN);
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+}
+
+/*!
+    \brief    get RTC timestamp time and date
+    \param[in]  none
+    \param[out] rtc_timestamp: pointer to a rtc_timestamp_struct structure which contains
+                parameters for RTC time-stamp configuration
+                members of the structure and the member values are shown as below:
+                  timestamp_month: RTC_JAN, RTC_FEB, RTC_MAR, RTC_APR, RTC_MAY, RTC_JUN,
+                                       RTC_JUL, RTC_AUG, RTC_SEP, RTC_OCT, RTC_NOV, RTC_DEC
+                  timestamp_date: 0x1 - 0x31(BCD format)
+                  timestamp_day: RTC_MONDAY, RTC_TUESDAY, RTC_WEDSDAY, RTC_THURSDAY, RTC_FRIDAY,
+                                     RTC_SATURDAY, RTC_SUNDAY if RTC_ALARM_WEEKDAY_SELECTED is set
+                  timestamp_hour: 0x0 - 0x12(BCD format) or 0x0 - 0x23(BCD format) depending on the rtc_display_format
+                  timestamp_minute: 0x0 - 0x59(BCD format)
+                  timestamp_second: 0x0 - 0x59(BCD format)
+                  am_pm: RTC_AM, RTC_PM
+    \retval     none
+*/
+void rtc_timestamp_get(rtc_timestamp_struct *rtc_timestamp)
+{
+    uint32_t temp_tts = 0U, temp_dts = 0U;
+
+    /* get the value of time_stamp registers */
+    temp_tts = (uint32_t)RTC_TTS;
+    temp_dts = (uint32_t)RTC_DTS;
+
+    /* get timestamp time and construct the rtc_timestamp_struct structure */
+    rtc_timestamp->am_pm = (uint32_t)(temp_tts & RTC_TTS_PM);
+    rtc_timestamp->timestamp_month = (uint8_t)GET_DTS_MON(temp_dts);
+    rtc_timestamp->timestamp_date = (uint8_t)GET_DTS_DAY(temp_dts);
+    rtc_timestamp->timestamp_day = (uint8_t)GET_DTS_DOW(temp_dts);
+    rtc_timestamp->timestamp_hour = (uint8_t)GET_TTS_HR(temp_tts);
+    rtc_timestamp->timestamp_minute = (uint8_t)GET_TTS_MN(temp_tts);
+    rtc_timestamp->timestamp_second = (uint8_t)GET_TTS_SC(temp_tts);
+}
+
+/*!
+    \brief    get RTC time-stamp subsecond
+    \param[in]  none
+    \param[out] none
+    \retval     RTC time-stamp subsecond value
+*/
+uint32_t rtc_timestamp_subsecond_get(void)
+{
+    return ((uint32_t)RTC_SSTS);
+}
+
+/*!
+    \brief    RTC time-stamp mapping
+    \param[in]  rtc_af:
+      \arg        RTC_AF0_TIMESTAMP: RTC_AF0 use for timestamp
+      \arg        RTC_AF1_TIMESTAMP: RTC_AF1 use for timestamp
+    \param[out] none
+    \retval     none
+*/
+void rtc_timestamp_pin_map(uint32_t rtc_af)
+{
+    RTC_TAMP &= ~RTC_TAMP_TSSEL;
+    RTC_TAMP |= rtc_af;
+}
+
+/*!
+    \brief    enable RTC tamper
+    \param[in]  rtc_tamper: pointer to a rtc_tamper_struct structure which contains
+                parameters for RTC tamper configuration
+                members of the structure and the member values are shown as below:
+                  detecting tamper event can using edge mode or level mode
+                  (1) using edge mode configuration:
+                  tamper_source: RTC_TAMPER0, RTC_TAMPER1
+                  tamper_trigger: RTC_TAMPER_TRIGGER_EDGE_RISING, RTC_TAMPER_TRIGGER_EDGE_FALLING
+                  tamper_filter: RTC_FLT_EDGE
+                  tamper_with_timestamp: DISABLE, ENABLE
+                  (2) using level mode configuration:
+                  tamper_source: RTC_TAMPER0, RTC_TAMPER1
+                  tamper_trigger:RTC_TAMPER_TRIGGER_LEVEL_LOW, RTC_TAMPER_TRIGGER_LEVEL_HIGH
+                  tamper_filter: RTC_FLT_2S, RTC_FLT_4S, RTC_FLT_8S
+                  tamper_sample_frequency: RTC_FREQ_DIV32768, RTC_FREQ_DIV16384, RTC_FREQ_DIV8192,
+                                               RTC_FREQ_DIV4096, RTC_FREQ_DIV2048, RTC_FREQ_DIV1024,
+                                               RTC_FREQ_DIV512, RTC_FREQ_DIV256
+                  tamper_precharge_enable: DISABLE, ENABLE
+                  tamper_precharge_time: RTC_PRCH_1C, RTC_PRCH_2C, RTC_PRCH_4C, RTC_PRCH_8C
+                  tamper_with_timestamp: DISABLE, ENABLE
+    \param[out] none
+    \retval     none
+*/
+void rtc_tamper_enable(rtc_tamper_struct *rtc_tamper)
+{
+    /* disable tamper */
+    RTC_TAMP &= (uint32_t)~(rtc_tamper->tamper_source);
+
+    /* tamper filter must be used when the tamper source is voltage level detection */
+    RTC_TAMP &= (uint32_t)~RTC_TAMP_FLT;
+
+    /* the tamper source is voltage level detection */
+    if((uint32_t)(rtc_tamper->tamper_filter) != RTC_FLT_EDGE) {
+        RTC_TAMP &= (uint32_t)~(RTC_TAMP_DISPU | RTC_TAMP_PRCH | RTC_TAMP_FREQ | RTC_TAMP_FLT);
+
+        /* check if the tamper pin need precharge, if need, then configure the precharge time */
+        if(DISABLE == rtc_tamper->tamper_precharge_enable) {
+            RTC_TAMP |= (uint32_t)RTC_TAMP_DISPU;
+        } else {
+            RTC_TAMP |= (uint32_t)(rtc_tamper->tamper_precharge_time);
+        }
+
+        RTC_TAMP |= (uint32_t)(rtc_tamper->tamper_sample_frequency);
+        RTC_TAMP |= (uint32_t)(rtc_tamper->tamper_filter);
+
+        /* configure the tamper trigger */
+        RTC_TAMP &= ((uint32_t)~((rtc_tamper->tamper_source) << RTC_TAMPER_TRIGGER_POS));
+        if(RTC_TAMPER_TRIGGER_LEVEL_LOW != rtc_tamper->tamper_trigger) {
+            RTC_TAMP |= (uint32_t)((rtc_tamper->tamper_source) << RTC_TAMPER_TRIGGER_POS);
+        }
+    } else {
+
+        /* configure the tamper trigger */
+        RTC_TAMP &= ((uint32_t)~((rtc_tamper->tamper_source) << RTC_TAMPER_TRIGGER_POS));
+        if(RTC_TAMPER_TRIGGER_EDGE_RISING != rtc_tamper->tamper_trigger) {
+            RTC_TAMP |= (uint32_t)((rtc_tamper->tamper_source) << RTC_TAMPER_TRIGGER_POS);
+        }
+    }
+
+    RTC_TAMP &= (uint32_t)~RTC_TAMP_TPTS;
+    if(DISABLE != rtc_tamper->tamper_with_timestamp) {
+        /* the tamper event also cause a time-stamp event */
+        RTC_TAMP |= (uint32_t)RTC_TAMP_TPTS;
+    }
+    /* enable tamper */
+    RTC_TAMP |= (uint32_t)(rtc_tamper->tamper_source);
+}
+
+/*!
+    \brief    disable RTC tamper
+    \param[in]  source: specify which tamper source to be disabled
+      \arg        RTC_TAMPER0
+      \arg        RTC_TAMPER1
+    \param[out] none
+    \retval     none
+*/
+void rtc_tamper_disable(uint32_t source)
+{
+    /* disable tamper */
+    RTC_TAMP &= (uint32_t)~source;
+
+}
+
+/*!
+    \brief    RTC tamper0 mapping
+    \param[in]  rtc_af:
+      \arg        RTC_AF0_TAMPER0: RTC_AF0 use for tamper0
+      \arg        RTC_AF1_TAMPER0: RTC_AF1 use for tamper0
+    \param[out] none
+    \retval     none
+*/
+void rtc_tamper0_pin_map(uint32_t rtc_af)
+{
+    RTC_TAMP &= ~(RTC_TAMP_TP0EN | RTC_TAMP_TP0SEL);
+    RTC_TAMP |= rtc_af;
+}
+
+/*!
+    \brief    enable specified RTC interrupt
+    \param[in]  interrupt: specify which interrupt source to be enabled
+      \arg        RTC_INT_TIMESTAMP: timestamp interrupt
+      \arg        RTC_INT_ALARM0: alarm0 interrupt
+      \arg        RTC_INT_ALARM1: alarm1 interrupt
+      \arg        RTC_INT_TAMP: tamper detection interrupt
+      \arg        RTC_INT_WAKEUP: wakeup timer interrupt
+    \param[out] none
+    \retval     none
+*/
+void rtc_interrupt_enable(uint32_t interrupt)
+{
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    /* enable the interrupts in RTC_CTL register */
+    RTC_CTL |= (uint32_t)(interrupt & (uint32_t)~RTC_TAMP_TPIE);
+    /* enable the interrupts in RTC_TAMP register */
+    RTC_TAMP |= (uint32_t)(interrupt & RTC_TAMP_TPIE);
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+}
+
+/*!
+    \brief    disble specified RTC interrupt
+    \param[in]  interrupt: specify which interrupt source to be disabled
+      \arg        RTC_INT_TIMESTAMP: timestamp interrupt
+      \arg        RTC_INT_ALARM0: alarm interrupt
+      \arg        RTC_INT_ALARM1: alarm interrupt
+      \arg        RTC_INT_TAMP: tamper detection interrupt
+      \arg        RTC_INT_WAKEUP: wakeup timer interrupt
+    \param[out] none
+    \retval     none
+*/
+void rtc_interrupt_disable(uint32_t interrupt)
+{
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    /* disable the interrupts in RTC_CTL register */
+    RTC_CTL &= (uint32_t)~(interrupt & (uint32_t)~RTC_TAMP_TPIE);
+    /* disable the interrupts in RTC_TAMP register */
+    RTC_TAMP &= (uint32_t)~(interrupt & RTC_TAMP_TPIE);
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+}
+
+/*!
+    \brief    check specified flag
+    \param[in]  flag: specify which flag to check
+      \arg        RTC_STAT_SCP: smooth calibration pending flag
+      \arg        RTC_FLAG_TP1: RTC tamper 1 detected flag
+      \arg        RTC_FLAG_TP0: RTC tamper 0 detected flag
+      \arg        RTC_FLAG_TSOVR: time-stamp overflow flag
+      \arg        RTC_FLAG_TS: time-stamp flag
+      \arg        RTC_FLAG_ALRM0: alarm0 occurs flag
+      \arg        RTC_FLAG_ALRM1: alarm1 occurs flag
+      \arg        RTC_FLAG_WT: wakeup timer occurs flag
+      \arg        RTC_FLAG_INIT: initialization state flag
+      \arg        RTC_FLAG_RSYN: register synchronization flag
+      \arg        RTC_FLAG_YCM: year configuration mark status flag
+      \arg        RTC_FLAG_SOP: shift function operation pending flag
+      \arg        RTC_FLAG_ALRM0W: alarm0 configuration can be write flag
+      \arg        RTC_FLAG_ALRM1W: alarm1 configuration can be write flag
+      \arg        RTC_FLAG_WTW: wakeup timer can be write flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus rtc_flag_get(uint32_t flag)
+{
+    FlagStatus flag_state = RESET;
+
+    if((uint32_t)RESET != (RTC_STAT & flag)) {
+        flag_state = SET;
+    }
+    return flag_state;
+}
+
+/*!
+    \brief    clear specified flag
+      \arg        RTC_FLAG_TP1: RTC tamper 1 detected flag
+      \arg        RTC_FLAG_TP0: RTC tamper 0 detected flag
+      \arg        RTC_FLAG_TSOVR: time-stamp overflow flag
+      \arg        RTC_FLAG_TS: time-stamp flag
+      \arg        RTC_FLAG_WT: wakeup timer occurs flag
+      \arg        RTC_FLAG_ALARM0: alarm0 occurs flag
+      \arg        RTC_FLAG_ALARM1: alarm1 occurs flag
+      \arg        RTC_FLAG_RSYN: register synchronization flag
+    \param[out] none
+    \retval     none
+*/
+void rtc_flag_clear(uint32_t flag)
+{
+    RTC_STAT &= (uint32_t)(~flag);
+}
+
+/*!
+    \brief    configure rtc alarm output source
+    \param[in]  source: specify signal to output
+      \arg        RTC_ALARM0_HIGH: when the  alarm0 flag is set, the output pin is high
+      \arg        RTC_ALARM0_LOW: when the  alarm0 flag is set, the output pin is low
+      \arg        RTC_ALARM1_HIGH: when the  alarm1 flag is set, the output pin is high
+      \arg        RTC_ALARM1_LOW: when the  alarm1 flag is set, the output pin is low
+      \arg        RTC_WAKEUP_HIGH: when the  wakeup flag is set, the output pin is high
+      \arg        RTC_WAKEUP_LOW: when the  wakeup flag is set, the output pin is low
+    \param[in]  mode: specify the output pin mode when output alarm signal
+      \arg        RTC_ALARM_OUTPUT_OD: open drain mode
+      \arg        RTC_ALARM_OUTPUT_PP: push pull mode
+    \param[out] none
+    \retval     none
+*/
+void rtc_alarm_output_config(uint32_t source, uint32_t mode)
+{
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    RTC_CTL &= ~(RTC_CTL_OS | RTC_CTL_OPOL);
+    RTC_TAMP &= ~RTC_TAMP_AOT;
+
+    RTC_CTL |= (uint32_t)(source);
+    /* alarm output */
+    RTC_TAMP |= (uint32_t)(mode);
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+}
+
+/*!
+    \brief    configure rtc calibration output source
+    \param[in]  source: specify signal to output
+      \arg        RTC_CALIBRATION_512HZ: when the LSE freqency is 32768Hz and the RTC_PSC
+                                         is the default value, output 512Hz signal
+      \arg        RTC_CALIBRATION_1HZ: when the LSE freqency is 32768Hz and the RTC_PSC
+                                       is the default value, output 1Hz signal
+    \param[out] none
+    \retval     none
+*/
+void rtc_calibration_output_config(uint32_t source)
+{
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    RTC_CTL &= (uint32_t)~(RTC_CTL_COEN | RTC_CTL_COS);
+
+    RTC_CTL |= (uint32_t)(source);
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+}
+
+/*!
+    \brief    adjust the daylight saving time by adding or substracting one hour from the current time
+    \param[in]  operation: hour adjustment operation
+      \arg        RTC_CTL_A1H: add one hour
+      \arg        RTC_CTL_S1H: substract one hour
+    \param[out] none
+    \retval     none
+*/
+void rtc_hour_adjust(uint32_t operation)
+{
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    RTC_CTL |= (uint32_t)(operation);
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+}
+
+/*!
+    \brief    adjust RTC second or subsecond value of current time
+    \param[in]  add: add 1s to current time or not
+      \arg        RTC_SHIFT_ADD1S_RESET: no effect
+      \arg        RTC_SHIFT_ADD1S_SET: add 1s to current time
+    \param[in]  minus: number of subsecond to minus from current time(0x0 - 0x7FFF)
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_second_adjust(uint32_t add, uint32_t minus)
+{
+    volatile uint32_t time_index = RTC_SHIFTCTL_TIMEOUT;
+    ErrStatus error_status = ERROR;
+    uint32_t flag_status = RESET;
+    uint32_t temp = 0U;
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    /* check if a shift operation is ongoing */
+    do {
+        flag_status = RTC_STAT & RTC_STAT_SOPF;
+    } while((--time_index > 0U) && ((uint32_t)RESET != flag_status));
+
+    /* check if the function of reference clock detection is disabled */
+    temp = RTC_CTL & RTC_CTL_REFEN;
+    if((RESET == flag_status) && (RESET == temp)) {
+        RTC_SHIFTCTL = (uint32_t)(add | SHIFTCTL_SFS(minus));
+        error_status = rtc_register_sync_wait();
+    }
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+
+    return error_status;
+}
+
+/*!
+    \brief    enable RTC bypass shadow registers function
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rtc_bypass_shadow_enable(void)
+{
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    RTC_CTL |= RTC_CTL_BPSHAD;
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+}
+
+/*!
+    \brief    disable RTC bypass shadow registers function
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rtc_bypass_shadow_disable(void)
+{
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    RTC_CTL &= ~RTC_CTL_BPSHAD;
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+}
+
+/*!
+    \brief    enable RTC reference clock detection function
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_refclock_detection_enable(void)
+{
+    ErrStatus error_status = ERROR;
+
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    /* enter init mode */
+    error_status = rtc_init_mode_enter();
+
+    if(ERROR != error_status) {
+        RTC_CTL |= (uint32_t)RTC_CTL_REFEN;
+        /* exit init mode */
+        rtc_init_mode_exit();
+    }
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+
+    return error_status;
+}
+
+/*!
+    \brief    disable RTC reference clock detection function
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_refclock_detection_disable(void)
+{
+    ErrStatus error_status = ERROR;
+
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    /* enter init mode */
+    error_status = rtc_init_mode_enter();
+
+    if(ERROR != error_status) {
+        RTC_CTL &= (uint32_t)~RTC_CTL_REFEN;
+        /* exit init mode */
+        rtc_init_mode_exit();
+    }
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+
+    return error_status;
+}
+
+/*!
+    \brief    enable RTC auto wakeup function
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void rtc_wakeup_enable(void)
+{
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    RTC_CTL |= RTC_CTL_WTEN;
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+}
+
+/*!
+    \brief    disable RTC auto wakeup function
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_wakeup_disable(void)
+{
+    ErrStatus error_status = ERROR;
+    volatile uint32_t time_index = RTC_WTWF_TIMEOUT;
+    uint32_t flag_status = RESET;
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+    RTC_CTL &= ~RTC_CTL_WTEN;
+    /* wait until the WTWF flag to be set */
+    do {
+        flag_status = RTC_STAT & RTC_STAT_WTWF;
+    } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+
+    if((uint32_t)RESET == flag_status) {
+        error_status = ERROR;
+    } else {
+        error_status = SUCCESS;
+    }
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+    return error_status;
+}
+
+/*!
+    \brief    set RTC auto wakeup timer clock
+    \param[in]  wakeup_clock:
+      \arg        WAKEUP_RTCCK_DIV16: RTC auto wakeup timer clock is RTC clock divided by 16
+      \arg        WAKEUP_RTCCK_DIV8: RTC auto wakeup timer clock is RTC clock divided by 8
+      \arg        WAKEUP_RTCCK_DIV4: RTC auto wakeup timer clock is RTC clock divided by 4
+      \arg        WAKEUP_RTCCK_DIV2: RTC auto wakeup timer clock is RTC clock divided by 2
+      \arg        WAKEUP_CKSPRE: RTC auto wakeup timer clock is ckspre
+      \arg        WAKEUP_CKSPRE_2EXP16: RTC auto wakeup timer clock is ckspre and wakeup timer add 2exp16
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_wakeup_clock_set(uint8_t wakeup_clock)
+{
+    ErrStatus error_status = ERROR;
+    volatile uint32_t time_index = RTC_WTWF_TIMEOUT;
+    uint32_t flag_status = RESET;
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+    /* only when RTC_CTL_WTEN=0 and RTC_STAT_WTWF=1 can write RTC_CTL[2��0] */
+    /* wait until the WTWF flag to be set */
+    do {
+        flag_status = RTC_STAT & RTC_STAT_WTWF;
+    } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+
+    if((uint32_t)RESET == flag_status) {
+        error_status = ERROR;
+    } else {
+        RTC_CTL &= (uint32_t)~ RTC_CTL_WTCS;
+        RTC_CTL |= (uint32_t)wakeup_clock;
+        error_status = SUCCESS;
+    }
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+
+    return error_status;
+}
+
+/*!
+    \brief    set wakeup timer value
+    \param[in]  wakeup_timer: 0x0000-0xffff
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_wakeup_timer_set(uint16_t wakeup_timer)
+{
+    ErrStatus error_status = ERROR;
+    volatile uint32_t time_index = RTC_WTWF_TIMEOUT;
+    uint32_t flag_status = RESET;
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+    /* wait until the WTWF flag to be set */
+    do {
+        flag_status = RTC_STAT & RTC_STAT_WTWF;
+    } while((--time_index > 0U) && ((uint32_t)RESET == flag_status));
+
+    if((uint32_t)RESET == flag_status) {
+        error_status = ERROR;
+    } else {
+        RTC_WUT = (uint32_t)wakeup_timer;
+        error_status = SUCCESS;
+    }
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+    return error_status;
+}
+
+/*!
+    \brief    get wakeup timer value
+    \param[in]  none
+    \param[out] none
+    \retval     wakeup timer value
+*/
+uint16_t rtc_wakeup_timer_get(void)
+{
+    return (uint16_t)RTC_WUT;
+}
+
+/*!
+    \brief    configure RTC smooth calibration
+    \param[in]  window: select calibration window
+      \arg        RTC_CALIBRATION_WINDOW_32S: 2exp20 RTCCLK cycles, 32s if RTCCLK = 32768 Hz
+      \arg        RTC_CALIBRATION_WINDOW_16S: 2exp19 RTCCLK cycles, 16s if RTCCLK = 32768 Hz
+      \arg        RTC_CALIBRATION_WINDOW_8S: 2exp18 RTCCLK cycles, 8s if RTCCLK = 32768 Hz
+    \param[in]  plus: add RTC clock or not
+      \arg        RTC_CALIBRATION_PLUS_SET: add one RTC clock every 2048 rtc clock
+      \arg        RTC_CALIBRATION_PLUS_RESET: no effect
+    \param[in]  minus: the RTC clock to minus during the calibration window(0x0 - 0x1FF)
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_smooth_calibration_config(uint32_t window, uint32_t plus, uint32_t minus)
+{
+    volatile uint32_t time_index = RTC_HRFC_TIMEOUT;
+    ErrStatus error_status = ERROR;
+    uint32_t flag_status = RESET;
+
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    /* check if a smooth calibration operation is ongoing */
+    do {
+        flag_status = RTC_STAT & RTC_STAT_SCPF;
+    } while((--time_index > 0U) && ((uint32_t)RESET != flag_status));
+
+    if((uint32_t)RESET == flag_status) {
+        RTC_HRFC = (uint32_t)(window | plus | HRFC_CMSK(minus));
+        error_status = SUCCESS;
+    }
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+
+    return error_status;
+}
+
+/*!
+    \brief    enable RTC coarse calibration
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_coarse_calibration_enable(void)
+{
+    ErrStatus error_status = ERROR;
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+    /* enter init mode */
+    error_status = rtc_init_mode_enter();
+
+    if(ERROR != error_status) {
+        RTC_CTL |= (uint32_t)RTC_CTL_CCEN;
+        /* exit init mode */
+        rtc_init_mode_exit();
+    }
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+    return error_status;
+}
+
+/*!
+    \brief    disable RTC coarse calibration
+    \param[in]  none
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_coarse_calibration_disable(void)
+{
+    ErrStatus error_status = ERROR;
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+    /* enter init mode */
+    error_status = rtc_init_mode_enter();
+
+    if(ERROR != error_status) {
+        RTC_CTL &= (uint32_t)~RTC_CTL_CCEN;
+        /* exit init mode */
+        rtc_init_mode_exit();
+    }
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+    return error_status;
+}
+
+/*!
+    \brief    config coarse calibration direction and step
+    \param[in]  direction: CALIB_INCREASE or CALIB_DECREASE
+    \param[in]  step: 0x00-0x1F
+                COSD=0:
+                  0x00:+0 PPM
+                  0x01:+4 PPM
+                  0x02:+8 PPM
+                  ....
+                  0x1F:+126 PPM
+                COSD=1:
+                  0x00:-0 PPM
+                  0x01:-2 PPM
+                  0x02:-4 PPM
+                  ....
+                  0x1F:-63 PPM
+    \param[out] none
+    \retval     ErrStatus: ERROR or SUCCESS
+*/
+ErrStatus rtc_coarse_calibration_config(uint8_t direction, uint8_t step)
+{
+    ErrStatus error_status = ERROR;
+    /* disable the write protection */
+    RTC_WPK = RTC_UNLOCK_KEY1;
+    RTC_WPK = RTC_UNLOCK_KEY2;
+
+    /* enter init mode */
+    error_status = rtc_init_mode_enter();
+
+    if(ERROR != error_status) {
+        if(CALIB_DECREASE == direction) {
+            RTC_COSC |= (uint32_t)RTC_COSC_COSD;
+        } else {
+            RTC_COSC &= (uint32_t)~RTC_COSC_COSD;
+        }
+        RTC_COSC &= ~RTC_COSC_COSS;
+        RTC_COSC |= (uint32_t)((uint32_t)step & 0x1FU);
+        /* exit init mode */
+        rtc_init_mode_exit();
+    }
+
+    /* enable the write protection */
+    RTC_WPK = RTC_LOCK_KEY;
+
+    return error_status;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_sdio.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_sdio.c
@@ -1,0 +1,804 @@
+/*!
+    \file    gd32f4xx_sdio.c
+    \brief   SDIO driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.1, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_sdio.h"
+
+/*!
+    \brief    deinitialize the SDIO
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_deinit(void)
+{
+    rcu_periph_reset_enable(RCU_SDIORST);
+    rcu_periph_reset_disable(RCU_SDIORST);
+}
+
+/*!
+    \brief    configure the SDIO clock
+    \param[in]  clock_edge: SDIO_CLK clock edge
+                only one parameter can be selected which is shown as below:
+      \arg        SDIO_SDIOCLKEDGE_RISING: select the rising edge of the SDIOCLK to generate SDIO_CLK
+      \arg        SDIO_SDIOCLKEDGE_FALLING: select the falling edge of the SDIOCLK to generate SDIO_CLK
+    \param[in]  clock_bypass: clock bypass
+                only one parameter can be selected which is shown as below:
+      \arg        SDIO_CLOCKBYPASS_ENABLE: clock bypass
+      \arg        SDIO_CLOCKBYPASS_DISABLE: no bypass
+    \param[in]  clock_powersave: SDIO_CLK clock dynamic switch on/off for power saving
+                only one parameter can be selected which is shown as below:
+      \arg        SDIO_CLOCKPWRSAVE_ENABLE: SDIO_CLK closed when bus is idle
+      \arg        SDIO_CLOCKPWRSAVE_DISABLE: SDIO_CLK clock is always on
+    \param[in]  clock_division: clock division, less than 512
+    \param[out] none
+    \retval     none
+*/
+void sdio_clock_config(uint32_t clock_edge, uint32_t clock_bypass, uint32_t clock_powersave, uint16_t clock_division)
+{
+    uint32_t clock_config = 0U;
+    clock_config = SDIO_CLKCTL;
+    /* reset the CLKEDGE, CLKBYP, CLKPWRSAV, DIV */
+    clock_config &= ~(SDIO_CLKCTL_CLKEDGE | SDIO_CLKCTL_CLKBYP | SDIO_CLKCTL_CLKPWRSAV | SDIO_CLKCTL_DIV8 | SDIO_CLKCTL_DIV);
+    /* if the clock division is greater or equal to 256, set the DIV[8] */
+    if(clock_division >= 256U) {
+        clock_config |= SDIO_CLKCTL_DIV8;
+        clock_division -= 256U;
+    }
+    /* configure the SDIO_CLKCTL according to the parameters */
+    clock_config |= (clock_edge | clock_bypass | clock_powersave | clock_division);
+    SDIO_CLKCTL = clock_config;
+}
+
+/*!
+    \brief    enable hardware clock control
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_hardware_clock_enable(void)
+{
+    SDIO_CLKCTL |= SDIO_CLKCTL_HWCLKEN;
+}
+
+/*!
+    \brief    disable hardware clock control
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_hardware_clock_disable(void)
+{
+    SDIO_CLKCTL &= ~SDIO_CLKCTL_HWCLKEN;
+}
+
+/*!
+    \brief    set different SDIO card bus mode
+    \param[in]  bus_mode: SDIO card bus mode
+                only one parameter can be selected which is shown as below:
+      \arg        SDIO_BUSMODE_1BIT: 1-bit SDIO card bus mode
+      \arg        SDIO_BUSMODE_4BIT: 4-bit SDIO card bus mode
+      \arg        SDIO_BUSMODE_8BIT: 8-bit SDIO card bus mode
+    \param[out] none
+    \retval     none
+*/
+void sdio_bus_mode_set(uint32_t bus_mode)
+{
+    /* reset the SDIO card bus mode bits and set according to bus_mode */
+    SDIO_CLKCTL &= ~SDIO_CLKCTL_BUSMODE;
+    SDIO_CLKCTL |= bus_mode;
+}
+
+/*!
+    \brief    set the SDIO power state
+    \param[in]  power_state: SDIO power state
+                only one parameter can be selected which is shown as below:
+      \arg        SDIO_POWER_ON: SDIO power on
+      \arg        SDIO_POWER_OFF: SDIO power off
+    \param[out] none
+    \retval     none
+*/
+void sdio_power_state_set(uint32_t power_state)
+{
+    SDIO_PWRCTL = power_state;
+}
+
+/*!
+    \brief    get the SDIO power state
+    \param[in]  none
+    \param[out] none
+    \retval     SDIO power state
+      \arg        SDIO_POWER_ON: SDIO power on
+      \arg        SDIO_POWER_OFF: SDIO power off
+*/
+uint32_t sdio_power_state_get(void)
+{
+    return SDIO_PWRCTL;
+}
+
+/*!
+    \brief    enable SDIO_CLK clock output
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_clock_enable(void)
+{
+    SDIO_CLKCTL |= SDIO_CLKCTL_CLKEN;
+}
+
+/*!
+    \brief    disable SDIO_CLK clock output
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_clock_disable(void)
+{
+    SDIO_CLKCTL &= ~SDIO_CLKCTL_CLKEN;
+}
+
+/*!
+    \brief    configure the command and response
+    \param[in]  cmd_index: command index, refer to the related specifications
+    \param[in]  cmd_argument: command argument, refer to the related specifications
+    \param[in]  response_type: response type
+                only one parameter can be selected which is shown as below:
+      \arg        SDIO_RESPONSETYPE_NO: no response
+      \arg        SDIO_RESPONSETYPE_SHORT: short response
+      \arg        SDIO_RESPONSETYPE_LONG: long response
+    \param[out] none
+    \retval     none
+*/
+void sdio_command_response_config(uint32_t cmd_index, uint32_t cmd_argument, uint32_t response_type)
+{
+    uint32_t cmd_config = 0U;
+    /* disable the CSM */
+    SDIO_CMDCTL &= ~SDIO_CMDCTL_CSMEN;
+    /* reset the command index, command argument and response type */
+    SDIO_CMDAGMT &= ~SDIO_CMDAGMT_CMDAGMT;
+    SDIO_CMDAGMT = cmd_argument;
+    cmd_config = SDIO_CMDCTL;
+    cmd_config &= ~(SDIO_CMDCTL_CMDIDX | SDIO_CMDCTL_CMDRESP);
+    /* configure SDIO_CMDCTL and SDIO_CMDAGMT according to the parameters */
+    cmd_config |= (cmd_index | response_type);
+    SDIO_CMDCTL = cmd_config;
+}
+
+/*!
+    \brief    set the command state machine wait type
+    \param[in]  wait_type: wait type
+                only one parameter can be selected which is shown as below:
+      \arg        SDIO_WAITTYPE_NO: not wait interrupt
+      \arg        SDIO_WAITTYPE_INTERRUPT: wait interrupt
+      \arg        SDIO_WAITTYPE_DATAEND: wait the end of data transfer
+    \param[out] none
+    \retval     none
+*/
+void sdio_wait_type_set(uint32_t wait_type)
+{
+    /* reset INTWAIT and WAITDEND */
+    SDIO_CMDCTL &= ~(SDIO_CMDCTL_INTWAIT | SDIO_CMDCTL_WAITDEND);
+    /* set the wait type according to wait_type */
+    SDIO_CMDCTL |= wait_type;
+}
+
+/*!
+    \brief    enable the CSM(command state machine)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_csm_enable(void)
+{
+    SDIO_CMDCTL |= SDIO_CMDCTL_CSMEN;
+}
+
+/*!
+    \brief    disable the CSM(command state machine)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_csm_disable(void)
+{
+    SDIO_CMDCTL &= ~SDIO_CMDCTL_CSMEN;
+}
+
+/*!
+    \brief    get the last response command index
+    \param[in]  none
+    \param[out] none
+    \retval     last response command index
+*/
+uint8_t sdio_command_index_get(void)
+{
+    return (uint8_t)SDIO_RSPCMDIDX;
+}
+
+/*!
+    \brief    get the response for the last received command
+    \param[in]  sdio_responsex: SDIO response
+                only one parameter can be selected which is shown as below:
+      \arg       SDIO_RESPONSE0: card response[31:0]/card response[127:96]
+      \arg       SDIO_RESPONSE1: card response[95:64]
+      \arg       SDIO_RESPONSE2: card response[63:32]
+      \arg       SDIO_RESPONSE3: card response[31:1], plus bit 0
+    \param[out] none
+    \retval     response for the last received command
+*/
+uint32_t sdio_response_get(uint32_t sdio_responsex)
+{
+    uint32_t resp_content = 0U;
+    switch(sdio_responsex) {
+    case SDIO_RESPONSE0:
+        resp_content = SDIO_RESP0;
+        break;
+    case SDIO_RESPONSE1:
+        resp_content = SDIO_RESP1;
+        break;
+    case SDIO_RESPONSE2:
+        resp_content = SDIO_RESP2;
+        break;
+    case SDIO_RESPONSE3:
+        resp_content = SDIO_RESP3;
+        break;
+    default:
+        break;
+    }
+    return resp_content;
+}
+
+/*!
+    \brief    configure the data timeout, data length and data block size
+    \param[in]  data_timeout: data timeout period in card bus clock periods
+    \param[in]  data_length: number of data bytes to be transferred
+    \param[in]  data_blocksize: size of data block for block transfer
+                only one parameter can be selected which is shown as below:
+      \arg        SDIO_DATABLOCKSIZE_1BYTE: block size = 1 byte
+      \arg        SDIO_DATABLOCKSIZE_2BYTES: block size = 2 bytes
+      \arg        SDIO_DATABLOCKSIZE_4BYTES: block size = 4 bytes
+      \arg        SDIO_DATABLOCKSIZE_8BYTES: block size = 8 bytes
+      \arg        SDIO_DATABLOCKSIZE_16BYTES: block size = 16 bytes
+      \arg        SDIO_DATABLOCKSIZE_32BYTES: block size = 32 bytes
+      \arg        SDIO_DATABLOCKSIZE_64BYTES: block size = 64 bytes
+      \arg        SDIO_DATABLOCKSIZE_128BYTES: block size = 128 bytes
+      \arg        SDIO_DATABLOCKSIZE_256BYTES: block size = 256 bytes
+      \arg        SDIO_DATABLOCKSIZE_512BYTES: block size = 512 bytes
+      \arg        SDIO_DATABLOCKSIZE_1024BYTES: block size = 1024 bytes
+      \arg        SDIO_DATABLOCKSIZE_2048BYTES: block size = 2048 bytes
+      \arg        SDIO_DATABLOCKSIZE_4096BYTES: block size = 4096 bytes
+      \arg        SDIO_DATABLOCKSIZE_8192BYTES: block size = 8192 bytes
+      \arg        SDIO_DATABLOCKSIZE_16384BYTES: block size = 16384 bytes
+    \param[out] none
+    \retval     none
+*/
+void sdio_data_config(uint32_t data_timeout, uint32_t data_length, uint32_t data_blocksize)
+{
+    /* reset data timeout, data length and data block size */
+    SDIO_DATATO &= ~SDIO_DATATO_DATATO;
+    SDIO_DATALEN &= ~SDIO_DATALEN_DATALEN;
+    SDIO_DATACTL &= ~SDIO_DATACTL_BLKSZ;
+    /* configure the related parameters of data */
+    SDIO_DATATO = data_timeout;
+    SDIO_DATALEN = data_length;
+    SDIO_DATACTL |= data_blocksize;
+}
+
+/*!
+    \brief    configure the data transfer mode and direction
+    \param[in]  transfer_mode: mode of data transfer
+                only one parameter can be selected which is shown as below:
+      \arg       SDIO_TRANSMODE_BLOCK: block transfer
+      \arg       SDIO_TRANSMODE_STREAM: stream transfer or SDIO multibyte transfer
+    \param[in]  transfer_direction: data transfer direction, read or write
+                only one parameter can be selected which is shown as below:
+      \arg       SDIO_TRANSDIRECTION_TOCARD: write data to card
+      \arg       SDIO_TRANSDIRECTION_TOSDIO: read data from card
+    \param[out] none
+    \retval     none
+*/
+void sdio_data_transfer_config(uint32_t transfer_mode, uint32_t transfer_direction)
+{
+    uint32_t data_trans = 0U;
+    /* reset the data transfer mode, transfer direction and set according to the parameters */
+    data_trans = SDIO_DATACTL;
+    data_trans &= ~(SDIO_DATACTL_TRANSMOD | SDIO_DATACTL_DATADIR);
+    data_trans |= (transfer_mode | transfer_direction);
+    SDIO_DATACTL = data_trans;
+}
+
+/*!
+    \brief    enable the DSM(data state machine) for data transfer
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_dsm_enable(void)
+{
+    SDIO_DATACTL |= SDIO_DATACTL_DATAEN;
+}
+
+/*!
+    \brief    disable the DSM(data state machine)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_dsm_disable(void)
+{
+    SDIO_DATACTL &= ~SDIO_DATACTL_DATAEN;
+}
+
+/*!
+    \brief    write data(one word) to the transmit FIFO
+    \param[in]  data: 32-bit data write to card
+    \param[out] none
+    \retval     none
+*/
+void sdio_data_write(uint32_t data)
+{
+    SDIO_FIFO = data;
+}
+
+/*!
+    \brief    read data(one word) from the receive FIFO
+    \param[in]  none
+    \param[out] none
+    \retval     received data
+*/
+uint32_t sdio_data_read(void)
+{
+    return SDIO_FIFO;
+}
+
+/*!
+    \brief    get the number of remaining data bytes to be transferred to card
+    \param[in]  none
+    \param[out] none
+    \retval     number of remaining data bytes to be transferred
+*/
+uint32_t sdio_data_counter_get(void)
+{
+    return SDIO_DATACNT;
+}
+
+/*!
+    \brief    get the number of words remaining to be written or read from FIFO
+    \param[in]  none
+    \param[out] none
+    \retval     remaining number of words
+*/
+uint32_t sdio_fifo_counter_get(void)
+{
+    return SDIO_FIFOCNT;
+}
+
+/*!
+    \brief    enable the DMA request for SDIO
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_dma_enable(void)
+{
+    SDIO_DATACTL |= SDIO_DATACTL_DMAEN;
+}
+
+/*!
+    \brief    disable the DMA request for SDIO
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_dma_disable(void)
+{
+    SDIO_DATACTL &= ~SDIO_DATACTL_DMAEN;
+}
+
+/*!
+    \brief    get the flags state of SDIO
+    \param[in]  flag: flags state of SDIO
+                one or more parameters can be selected which are shown as below:
+      \arg        SDIO_FLAG_CCRCERR: command response received (CRC check failed) flag
+      \arg        SDIO_FLAG_DTCRCERR: data block sent/received (CRC check failed) flag
+      \arg        SDIO_FLAG_CMDTMOUT: command response timeout flag
+      \arg        SDIO_FLAG_DTTMOUT: data timeout flag
+      \arg        SDIO_FLAG_TXURE: transmit FIFO underrun error occurs flag
+      \arg        SDIO_FLAG_RXORE: received FIFO overrun error occurs flag
+      \arg        SDIO_FLAG_CMDRECV: command response received (CRC check passed) flag
+      \arg        SDIO_FLAG_CMDSEND: command sent (no response required) flag
+      \arg        SDIO_FLAG_DTEND: data end (data counter, SDIO_DATACNT, is zero) flag
+      \arg        SDIO_FLAG_STBITE: start bit error in the bus flag
+      \arg        SDIO_FLAG_DTBLKEND: data block sent/received (CRC check passed) flag
+      \arg        SDIO_FLAG_CMDRUN: command transmission in progress flag
+      \arg        SDIO_FLAG_TXRUN: data transmission in progress flag
+      \arg        SDIO_FLAG_RXRUN: data reception in progress flag
+      \arg        SDIO_FLAG_TFH: transmit FIFO is half empty flag: at least 8 words can be written into the FIFO
+      \arg        SDIO_FLAG_RFH: receive FIFO is half full flag: at least 8 words can be read in the FIFO
+      \arg        SDIO_FLAG_TFF: transmit FIFO is full flag
+      \arg        SDIO_FLAG_RFF: receive FIFO is full flag
+      \arg        SDIO_FLAG_TFE: transmit FIFO is empty flag
+      \arg        SDIO_FLAG_RFE: receive FIFO is empty flag
+      \arg        SDIO_FLAG_TXDTVAL: data is valid in transmit FIFO flag
+      \arg        SDIO_FLAG_RXDTVAL: data is valid in receive FIFO flag
+      \arg        SDIO_FLAG_SDIOINT: SD I/O interrupt received flag
+      \arg        SDIO_FLAG_ATAEND: CE-ATA command completion signal received (only for CMD61) flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus sdio_flag_get(uint32_t flag)
+{
+    FlagStatus temp_flag = RESET;
+    if(RESET != (SDIO_STAT & flag)) {
+        temp_flag = SET;
+    }
+    return temp_flag;
+}
+
+/*!
+    \brief    clear the pending flags of SDIO
+    \param[in]  flag: flags state of SDIO
+                one or more parameters can be selected which are shown as below:
+      \arg        SDIO_FLAG_CCRCERR: command response received (CRC check failed) flag
+      \arg        SDIO_FLAG_DTCRCERR: data block sent/received (CRC check failed) flag
+      \arg        SDIO_FLAG_CMDTMOUT: command response timeout flag
+      \arg        SDIO_FLAG_DTTMOUT: data timeout flag
+      \arg        SDIO_FLAG_TXURE: transmit FIFO underrun error occurs flag
+      \arg        SDIO_FLAG_RXORE: received FIFO overrun error occurs flag
+      \arg        SDIO_FLAG_CMDRECV: command response received (CRC check passed) flag
+      \arg        SDIO_FLAG_CMDSEND: command sent (no response required) flag
+      \arg        SDIO_FLAG_DTEND: data end (data counter, SDIO_DATACNT, is zero) flag
+      \arg        SDIO_FLAG_STBITE: start bit error in the bus flag
+      \arg        SDIO_FLAG_DTBLKEND: data block sent/received (CRC check passed) flag
+      \arg        SDIO_FLAG_SDIOINT: SD I/O interrupt received flag
+      \arg        SDIO_FLAG_ATAEND: CE-ATA command completion signal received (only for CMD61) flag
+    \param[out] none
+    \retval     none
+*/
+void sdio_flag_clear(uint32_t flag)
+{
+    SDIO_INTC = flag;
+}
+
+/*!
+    \brief    enable the SDIO interrupt
+    \param[in]  int_flag: interrupt flags state of SDIO
+                one or more parameters can be selected which are shown as below:
+      \arg        SDIO_INT_CCRCERR: SDIO CCRCERR interrupt
+      \arg        SDIO_INT_DTCRCERR: SDIO DTCRCERR interrupt
+      \arg        SDIO_INT_CMDTMOUT: SDIO CMDTMOUT interrupt
+      \arg        SDIO_INT_DTTMOUT: SDIO DTTMOUT interrupt
+      \arg        SDIO_INT_TXURE: SDIO TXURE interrupt
+      \arg        SDIO_INT_RXORE: SDIO RXORE interrupt
+      \arg        SDIO_INT_CMDRECV: SDIO CMDRECV interrupt
+      \arg        SDIO_INT_CMDSEND: SDIO CMDSEND interrupt
+      \arg        SDIO_INT_DTEND: SDIO DTEND interrupt
+      \arg        SDIO_INT_STBITE: SDIO STBITE interrupt
+      \arg        SDIO_INT_DTBLKEND: SDIO DTBLKEND interrupt
+      \arg        SDIO_INT_CMDRUN: SDIO CMDRUN interrupt
+      \arg        SDIO_INT_TXRUN: SDIO TXRUN interrupt
+      \arg        SDIO_INT_RXRUN: SDIO RXRUN interrupt
+      \arg        SDIO_INT_TFH: SDIO TFH interrupt
+      \arg        SDIO_INT_RFH: SDIO RFH interrupt
+      \arg        SDIO_INT_TFF: SDIO TFF interrupt
+      \arg        SDIO_INT_RFF: SDIO RFF interrupt
+      \arg        SDIO_INT_TFE: SDIO TFE interrupt
+      \arg        SDIO_INT_RFE: SDIO RFE interrupt
+      \arg        SDIO_INT_TXDTVAL: SDIO TXDTVAL interrupt
+      \arg        SDIO_INT_RXDTVAL: SDIO RXDTVAL interrupt
+      \arg        SDIO_INT_SDIOINT: SDIO SDIOINT interrupt
+      \arg        SDIO_INT_ATAEND: SDIO ATAEND interrupt
+    \param[out] none
+    \retval     none
+*/
+void sdio_interrupt_enable(uint32_t int_flag)
+{
+    SDIO_INTEN |= int_flag;
+}
+
+/*!
+    \brief    disable the SDIO interrupt
+    \param[in]  int_flag: interrupt flags state of SDIO
+                one or more parameters can be selected which are shown as below:
+      \arg        SDIO_INT_CCRCERR: SDIO CCRCERR interrupt
+      \arg        SDIO_INT_DTCRCERR: SDIO DTCRCERR interrupt
+      \arg        SDIO_INT_CMDTMOUT: SDIO CMDTMOUT interrupt
+      \arg        SDIO_INT_DTTMOUT: SDIO DTTMOUT interrupt
+      \arg        SDIO_INT_TXURE: SDIO TXURE interrupt
+      \arg        SDIO_INT_RXORE: SDIO RXORE interrupt
+      \arg        SDIO_INT_CMDRECV: SDIO CMDRECV interrupt
+      \arg        SDIO_INT_CMDSEND: SDIO CMDSEND interrupt
+      \arg        SDIO_INT_DTEND: SDIO DTEND interrupt
+      \arg        SDIO_INT_STBITE: SDIO STBITE interrupt
+      \arg        SDIO_INT_DTBLKEND: SDIO DTBLKEND interrupt
+      \arg        SDIO_INT_CMDRUN: SDIO CMDRUN interrupt
+      \arg        SDIO_INT_TXRUN: SDIO TXRUN interrupt
+      \arg        SDIO_INT_RXRUN: SDIO RXRUN interrupt
+      \arg        SDIO_INT_TFH: SDIO TFH interrupt
+      \arg        SDIO_INT_RFH: SDIO RFH interrupt
+      \arg        SDIO_INT_TFF: SDIO TFF interrupt
+      \arg        SDIO_INT_RFF: SDIO RFF interrupt
+      \arg        SDIO_INT_TFE: SDIO TFE interrupt
+      \arg        SDIO_INT_RFE: SDIO RFE interrupt
+      \arg        SDIO_INT_TXDTVAL: SDIO TXDTVAL interrupt
+      \arg        SDIO_INT_RXDTVAL: SDIO RXDTVAL interrupt
+      \arg        SDIO_INT_SDIOINT: SDIO SDIOINT interrupt
+      \arg        SDIO_INT_ATAEND: SDIO ATAEND interrupt
+    \param[out] none
+    \retval     none
+*/
+void sdio_interrupt_disable(uint32_t int_flag)
+{
+    SDIO_INTEN &= ~int_flag;
+}
+
+/*!
+    \brief    get the interrupt flags state of SDIO
+    \param[in]  int_flag: interrupt flags state of SDIO
+                one or more parameters can be selected which are shown as below:
+      \arg        SDIO_INT_FLAG_CCRCERR: SDIO CCRCERR interrupt flag
+      \arg        SDIO_INT_FLAG_DTCRCERR: SDIO DTCRCERR interrupt flag
+      \arg        SDIO_INT_FLAG_CMDTMOUT: SDIO CMDTMOUT interrupt flag
+      \arg        SDIO_INT_FLAG_DTTMOUT: SDIO DTTMOUT interrupt flag
+      \arg        SDIO_INT_FLAG_TXURE: SDIO TXURE interrupt flag
+      \arg        SDIO_INT_FLAG_RXORE: SDIO RXORE interrupt flag
+      \arg        SDIO_INT_FLAG_CMDRECV: SDIO CMDRECV interrupt flag
+      \arg        SDIO_INT_FLAG_CMDSEND: SDIO CMDSEND interrupt flag
+      \arg        SDIO_INT_FLAG_DTEND: SDIO DTEND interrupt flag
+      \arg        SDIO_INT_FLAG_STBITE: SDIO STBITE interrupt flag
+      \arg        SDIO_INT_FLAG_DTBLKEND: SDIO DTBLKEND interrupt flag
+      \arg        SDIO_INT_FLAG_CMDRUN: SDIO CMDRUN interrupt flag
+      \arg        SDIO_INT_FLAG_TXRUN: SDIO TXRUN interrupt flag
+      \arg        SDIO_INT_FLAG_RXRUN: SDIO RXRUN interrupt flag
+      \arg        SDIO_INT_FLAG_TFH: SDIO TFH interrupt flag
+      \arg        SDIO_INT_FLAG_RFH: SDIO RFH interrupt flag
+      \arg        SDIO_INT_FLAG_TFF: SDIO TFF interrupt flag
+      \arg        SDIO_INT_FLAG_RFF: SDIO RFF interrupt flag
+      \arg        SDIO_INT_FLAG_TFE: SDIO TFE interrupt flag
+      \arg        SDIO_INT_FLAG_RFE: SDIO RFE interrupt flag
+      \arg        SDIO_INT_FLAG_TXDTVAL: SDIO TXDTVAL interrupt flag
+      \arg        SDIO_INT_FLAG_RXDTVAL: SDIO RXDTVAL interrupt flag
+      \arg        SDIO_INT_FLAG_SDIOINT: SDIO SDIOINT interrupt flag
+      \arg        SDIO_INT_FLAG_ATAEND: SDIO ATAEND interrupt flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus sdio_interrupt_flag_get(uint32_t int_flag)
+{
+    FlagStatus temp_flag = RESET;
+    if(RESET != (SDIO_STAT & int_flag)) {
+        temp_flag = SET;
+    }
+    return temp_flag;
+}
+
+/*!
+    \brief    clear the interrupt pending flags of SDIO
+    \param[in]  int_flag: interrupt flags state of SDIO
+                one or more parameters can be selected which are shown as below:
+      \arg        SDIO_INT_FLAG_CCRCERR: command response received (CRC check failed) flag
+      \arg        SDIO_INT_FLAG_DTCRCERR: data block sent/received (CRC check failed) flag
+      \arg        SDIO_INT_FLAG_CMDTMOUT: command response timeout flag
+      \arg        SDIO_INT_FLAG_DTTMOUT: data timeout flag
+      \arg        SDIO_INT_FLAG_TXURE: transmit FIFO underrun error occurs flag
+      \arg        SDIO_INT_FLAG_RXORE: received FIFO overrun error occurs flag
+      \arg        SDIO_INT_FLAG_CMDRECV: command response received (CRC check passed) flag
+      \arg        SDIO_INT_FLAG_CMDSEND: command sent (no response required) flag
+      \arg        SDIO_INT_FLAG_DTEND: data end (data counter, SDIO_DATACNT, is zero) flag
+      \arg        SDIO_INT_FLAG_STBITE: start bit error in the bus flag
+      \arg        SDIO_INT_FLAG_DTBLKEND: data block sent/received (CRC check passed) flag
+      \arg        SDIO_INT_FLAG_SDIOINT: SD I/O interrupt received flag
+      \arg        SDIO_INT_FLAG_ATAEND: CE-ATA command completion signal received (only for CMD61) flag
+    \param[out] none
+    \retval     none
+*/
+void sdio_interrupt_flag_clear(uint32_t int_flag)
+{
+    SDIO_INTC = int_flag;
+}
+
+/*!
+    \brief    enable the read wait mode(SD I/O only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_readwait_enable(void)
+{
+    SDIO_DATACTL |= SDIO_DATACTL_RWEN;
+}
+
+/*!
+    \brief    disable the read wait mode(SD I/O only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_readwait_disable(void)
+{
+    SDIO_DATACTL &= ~SDIO_DATACTL_RWEN;
+}
+
+/*!
+    \brief    enable the function that stop the read wait process(SD I/O only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_stop_readwait_enable(void)
+{
+    SDIO_DATACTL |= SDIO_DATACTL_RWSTOP;
+}
+
+/*!
+    \brief    disable the function that stop the read wait process(SD I/O only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_stop_readwait_disable(void)
+{
+    SDIO_DATACTL &= ~SDIO_DATACTL_RWSTOP;
+}
+
+/*!
+    \brief    set the read wait type(SD I/O only)
+    \param[in]  readwait_type: SD I/O read wait type
+                only one parameter can be selected which is shown as below:
+      \arg        SDIO_READWAITTYPE_CLK: read wait control by stopping SDIO_CLK
+      \arg        SDIO_READWAITTYPE_DAT2: read wait control using SDIO_DAT[2]
+    \param[out] none
+    \retval     none
+*/
+void sdio_readwait_type_set(uint32_t readwait_type)
+{
+    if(SDIO_READWAITTYPE_CLK == readwait_type) {
+        SDIO_DATACTL |= SDIO_DATACTL_RWTYPE;
+    } else {
+        SDIO_DATACTL &= ~SDIO_DATACTL_RWTYPE;
+    }
+}
+
+/*!
+    \brief    enable the SD I/O mode specific operation(SD I/O only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_operation_enable(void)
+{
+    SDIO_DATACTL |= SDIO_DATACTL_IOEN;
+}
+
+/*!
+    \brief    disable the SD I/O mode specific operation(SD I/O only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_operation_disable(void)
+{
+    SDIO_DATACTL &= ~SDIO_DATACTL_IOEN;
+}
+
+/*!
+    \brief    enable the SD I/O suspend operation(SD I/O only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_suspend_enable(void)
+{
+    SDIO_CMDCTL |= SDIO_CMDCTL_SUSPEND;
+}
+
+/*!
+    \brief    disable the SD I/O suspend operation(SD I/O only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_suspend_disable(void)
+{
+    SDIO_CMDCTL &= ~SDIO_CMDCTL_SUSPEND;
+}
+
+/*!
+    \brief    enable the CE-ATA command(CE-ATA only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_ceata_command_enable(void)
+{
+    SDIO_CMDCTL |= SDIO_CMDCTL_ATAEN;
+}
+
+/*!
+    \brief    disable the CE-ATA command(CE-ATA only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_ceata_command_disable(void)
+{
+    SDIO_CMDCTL &= ~SDIO_CMDCTL_ATAEN;
+}
+
+/*!
+    \brief    enable the CE-ATA interrupt(CE-ATA only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_ceata_interrupt_enable(void)
+{
+    SDIO_CMDCTL &= ~SDIO_CMDCTL_NINTEN;
+}
+
+/*!
+    \brief    disable the CE-ATA interrupt(CE-ATA only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_ceata_interrupt_disable(void)
+{
+    SDIO_CMDCTL |= SDIO_CMDCTL_NINTEN;
+}
+
+/*!
+    \brief    enable the CE-ATA command completion signal(CE-ATA only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_ceata_command_completion_enable(void)
+{
+    SDIO_CMDCTL |= SDIO_CMDCTL_ENCMDC;
+}
+
+/*!
+    \brief    disable the CE-ATA command completion signal(CE-ATA only)
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void sdio_ceata_command_completion_disable(void)
+{
+    SDIO_CMDCTL &= ~SDIO_CMDCTL_ENCMDC;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_spi.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_spi.c
@@ -1,0 +1,880 @@
+/*!
+    \file    gd32f4xx_spi.c
+    \brief   SPI driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+
+#include "gd32f4xx_spi.h"
+#include "gd32f4xx_rcu.h"
+
+/* SPI/I2S parameter initialization mask */
+#define SPI_INIT_MASK                   ((uint32_t)0x00003040U)  /*!< SPI parameter initialization mask */
+#define I2S_INIT_MASK                   ((uint32_t)0x0000F047U)  /*!< I2S parameter initialization mask */
+#define I2S_FULL_DUPLEX_MASK            ((uint32_t)0x00000480U)  /*!< I2S full duples mode configure parameter initialization mask */
+
+/* default value */
+#define SPI_I2SPSC_DEFAULT_VALUE        ((uint32_t)0x00000002U)  /*!< default value of SPI_I2SPSC register */
+
+/*!
+    \brief      deinitialize SPI and I2S
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5),include I2S1_ADD and I2S2_ADD
+    \param[out] none
+    \retval     none
+*/
+void spi_i2s_deinit(uint32_t spi_periph)
+{
+    switch(spi_periph) {
+    case SPI0:
+        /* reset SPI0 */
+        rcu_periph_reset_enable(RCU_SPI0RST);
+        rcu_periph_reset_disable(RCU_SPI0RST);
+        break;
+    case SPI1:
+        /* reset SPI1,I2S1 and I2S1_ADD */
+        rcu_periph_reset_enable(RCU_SPI1RST);
+        rcu_periph_reset_disable(RCU_SPI1RST);
+        break;
+    case SPI2:
+        /* reset SPI2,I2S2 and I2S2_ADD */
+        rcu_periph_reset_enable(RCU_SPI2RST);
+        rcu_periph_reset_disable(RCU_SPI2RST);
+        break;
+    case SPI3:
+        /* reset SPI3 */
+        rcu_periph_reset_enable(RCU_SPI3RST);
+        rcu_periph_reset_disable(RCU_SPI3RST);
+        break;
+    case SPI4:
+        /* reset SPI4 */
+        rcu_periph_reset_enable(RCU_SPI4RST);
+        rcu_periph_reset_disable(RCU_SPI4RST);
+        break;
+    case SPI5:
+        /* reset SPI5 */
+        rcu_periph_reset_enable(RCU_SPI5RST);
+        rcu_periph_reset_disable(RCU_SPI5RST);
+        break;
+    default :
+        break;
+    }
+}
+
+/*!
+    \brief      initialize the parameters of SPI struct with default values
+    \param[in]  none
+    \param[out] spi_parameter_struct: the initialized struct spi_parameter_struct pointer
+    \retval     none
+*/
+void spi_struct_para_init(spi_parameter_struct *spi_struct)
+{
+    /* configure the structure with default value */
+    spi_struct->device_mode          = SPI_SLAVE;
+    spi_struct->trans_mode           = SPI_TRANSMODE_FULLDUPLEX;
+    spi_struct->frame_size           = SPI_FRAMESIZE_8BIT;
+    spi_struct->nss                  = SPI_NSS_HARD;
+    spi_struct->clock_polarity_phase = SPI_CK_PL_LOW_PH_1EDGE;
+    spi_struct->prescale             = SPI_PSC_2;
+    spi_struct->endian               = SPI_ENDIAN_MSB;
+}
+/*!
+    \brief      initialize SPI parameter
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[in]  spi_struct: SPI parameter initialization stuct members of the structure
+                and the member values are shown as below:
+                  device_mode: SPI_MASTER, SPI_SLAVE.
+                  trans_mode: SPI_TRANSMODE_FULLDUPLEX, SPI_TRANSMODE_RECEIVEONLY,
+                              SPI_TRANSMODE_BDRECEIVE, SPI_TRANSMODE_BDTRANSMIT
+                  frame_size: SPI_FRAMESIZE_16BIT, SPI_FRAMESIZE_8BIT
+                  nss: SPI_NSS_SOFT, SPI_NSS_HARD
+                  endian: SPI_ENDIAN_MSB, SPI_ENDIAN_LSB
+                  clock_polarity_phase: SPI_CK_PL_LOW_PH_1EDGE, SPI_CK_PL_HIGH_PH_1EDGE
+                                        SPI_CK_PL_LOW_PH_2EDGE, SPI_CK_PL_HIGH_PH_2EDGE
+                  prescale: SPI_PSC_n (n=2,4,8,16,32,64,128,256)
+    \param[out] none
+    \retval     none
+*/
+void spi_init(uint32_t spi_periph, spi_parameter_struct *spi_struct)
+{
+    uint32_t reg = 0U;
+    reg = SPI_CTL0(spi_periph);
+    reg &= SPI_INIT_MASK;
+
+    /* select SPI as master or slave */
+    reg |= spi_struct->device_mode;
+    /* select SPI transfer mode */
+    reg |= spi_struct->trans_mode;
+    /* select SPI frame size */
+    reg |= spi_struct->frame_size;
+    /* select SPI nss use hardware or software */
+    reg |= spi_struct->nss;
+    /* select SPI LSB or MSB */
+    reg |= spi_struct->endian;
+    /* select SPI polarity and phase */
+    reg |= spi_struct->clock_polarity_phase;
+    /* select SPI prescale to adjust transmit speed */
+    reg |= spi_struct->prescale;
+
+    /* write to SPI_CTL0 register */
+    SPI_CTL0(spi_periph) = (uint32_t)reg;
+
+    SPI_I2SCTL(spi_periph) &= (uint32_t)(~SPI_I2SCTL_I2SSEL);
+}
+
+/*!
+    \brief      enable SPI
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     none
+*/
+void spi_enable(uint32_t spi_periph)
+{
+    SPI_CTL0(spi_periph) |= (uint32_t)SPI_CTL0_SPIEN;
+}
+
+/*!
+    \brief      disable SPI
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     none
+*/
+void spi_disable(uint32_t spi_periph)
+{
+    SPI_CTL0(spi_periph) &= (uint32_t)(~SPI_CTL0_SPIEN);
+}
+
+/*!
+    \brief      initialize I2S parameter
+    \param[in]  spi_periph: SPIx(x=1,2)
+    \param[in]  i2s_mode: I2S operation mode
+                only one parameter can be selected which is shown as below:
+      \arg        I2S_MODE_SLAVETX : I2S slave transmit mode
+      \arg        I2S_MODE_SLAVERX : I2S slave receive mode
+      \arg        I2S_MODE_MASTERTX : I2S master transmit mode
+      \arg        I2S_MODE_MASTERRX : I2S master receive mode
+    \param[in]  i2s_standard: I2S standard
+                only one parameter can be selected which is shown as below:
+      \arg        I2S_STD_PHILLIPS : I2S phillips standard
+      \arg        I2S_STD_MSB : I2S MSB standard
+      \arg        I2S_STD_LSB : I2S LSB standard
+      \arg        I2S_STD_PCMSHORT : I2S PCM short standard
+      \arg        I2S_STD_PCMLONG : I2S PCM long standard
+    \param[in]  i2s_ckpl: I2S idle state clock polarity
+                only one parameter can be selected which is shown as below:
+      \arg        I2S_CKPL_LOW : I2S clock polarity low level
+      \arg        I2S_CKPL_HIGH : I2S clock polarity high level
+    \param[out] none
+    \retval     none
+*/
+void i2s_init(uint32_t spi_periph, uint32_t i2s_mode, uint32_t i2s_standard, uint32_t i2s_ckpl)
+{
+    uint32_t reg = 0U;
+    reg = SPI_I2SCTL(spi_periph);
+    reg &= I2S_INIT_MASK;
+
+    /* enable I2S mode */
+    reg |= (uint32_t)SPI_I2SCTL_I2SSEL;
+    /* select I2S mode */
+    reg |= (uint32_t)i2s_mode;
+    /* select I2S standard */
+    reg |= (uint32_t)i2s_standard;
+    /* select I2S polarity */
+    reg |= (uint32_t)i2s_ckpl;
+
+    /* write to SPI_I2SCTL register */
+    SPI_I2SCTL(spi_periph) = (uint32_t)reg;
+}
+
+/*!
+    \brief      configure I2S prescale
+    \param[in]  spi_periph: SPIx(x=1,2)
+    \param[in]  i2s_audiosample: I2S audio sample rate
+                only one parameter can be selected which is shown as below:
+      \arg        I2S_AUDIOSAMPLE_8K: audio sample rate is 8KHz
+      \arg        I2S_AUDIOSAMPLE_11K: audio sample rate is 11KHz
+      \arg        I2S_AUDIOSAMPLE_16K: audio sample rate is 16KHz
+      \arg        I2S_AUDIOSAMPLE_22K: audio sample rate is 22KHz
+      \arg        I2S_AUDIOSAMPLE_32K: audio sample rate is 32KHz
+      \arg        I2S_AUDIOSAMPLE_44K: audio sample rate is 44KHz
+      \arg        I2S_AUDIOSAMPLE_48K: audio sample rate is 48KHz
+      \arg        I2S_AUDIOSAMPLE_96K: audio sample rate is 96KHz
+      \arg        I2S_AUDIOSAMPLE_192K: audio sample rate is 192KHz
+    \param[in]  i2s_frameformat: I2S data length and channel length
+                only one parameter can be selected which is shown as below:
+      \arg        I2S_FRAMEFORMAT_DT16B_CH16B: I2S data length is 16 bit and channel length is 16 bit
+      \arg        I2S_FRAMEFORMAT_DT16B_CH32B: I2S data length is 16 bit and channel length is 32 bit
+      \arg        I2S_FRAMEFORMAT_DT24B_CH32B: I2S data length is 24 bit and channel length is 32 bit
+      \arg        I2S_FRAMEFORMAT_DT32B_CH32B: I2S data length is 32 bit and channel length is 32 bit
+    \param[in]  i2s_mckout: I2S master clock output
+                only one parameter can be selected which is shown as below:
+      \arg        I2S_MCKOUT_ENABLE: I2S master clock output enable
+      \arg        I2S_MCKOUT_DISABLE: I2S master clock output disable
+    \param[out] none
+    \retval     none
+*/
+void i2s_psc_config(uint32_t spi_periph, uint32_t i2s_audiosample, uint32_t i2s_frameformat, uint32_t i2s_mckout)
+{
+    uint32_t i2sdiv = 2U, i2sof = 0U;
+    uint32_t clks = 0U;
+    uint32_t i2sclock = 0U;
+
+#ifndef I2S_EXTERNAL_CLOCK_IN
+    uint32_t plli2sm = 0U, plli2sn = 0U, plli2sr = 0U;
+#endif /* I2S_EXTERNAL_CLOCK_IN */
+
+    /* deinit SPI_I2SPSC register */
+    SPI_I2SPSC(spi_periph) = SPI_I2SPSC_DEFAULT_VALUE;
+
+#ifdef I2S_EXTERNAL_CLOCK_IN
+    rcu_i2s_clock_config(RCU_I2SSRC_I2S_CKIN);
+
+    /* set the I2S clock to the external clock input value */
+    i2sclock = I2S_EXTERNAL_CLOCK_IN;
+#else
+
+    /* turn on the oscillator HXTAL */
+    rcu_osci_on(RCU_HXTAL);
+    /* wait for oscillator stabilization flags is SET */
+    rcu_osci_stab_wait(RCU_HXTAL);
+    /* turn on the PLLI2S */
+    rcu_osci_on(RCU_PLLI2S_CK);
+    /* wait for PLLI2S flags is SET */
+    rcu_osci_stab_wait(RCU_PLLI2S_CK);
+    /* configure the I2S clock source selection */
+    rcu_i2s_clock_config(RCU_I2SSRC_PLLI2S);
+
+    /* get the RCU_PLL_PLLPSC value */
+    plli2sm = (uint32_t)(RCU_PLL & RCU_PLL_PLLPSC);
+    /* get the RCU_PLLI2S_PLLI2SN value */
+    plli2sn = (uint32_t)((RCU_PLLI2S & RCU_PLLI2S_PLLI2SN) >> 6);
+    /* get the RCU_PLLI2S_PLLI2SR value */
+    plli2sr = (uint32_t)((RCU_PLLI2S & RCU_PLLI2S_PLLI2SR) >> 28);
+
+    if((RCU_PLL & RCU_PLL_PLLSEL) == RCU_PLLSRC_HXTAL) {
+        /* get the I2S source clock value */
+        i2sclock = (uint32_t)(((HXTAL_VALUE / plli2sm) * plli2sn) / plli2sr);
+    } else {
+        /* get the I2S source clock value */
+        i2sclock = (uint32_t)(((IRC16M_VALUE / plli2sm) * plli2sn) / plli2sr);
+    }
+#endif /* I2S_EXTERNAL_CLOCK_IN */
+
+    /* config the prescaler depending on the mclk output state, the frame format and audio sample rate */
+    if(I2S_MCKOUT_ENABLE == i2s_mckout) {
+        clks = (uint32_t)(((i2sclock / 256U) * 10U) / i2s_audiosample);
+    } else {
+        if(I2S_FRAMEFORMAT_DT16B_CH16B == i2s_frameformat) {
+            clks = (uint32_t)(((i2sclock / 32U) * 10U) / i2s_audiosample);
+        } else {
+            clks = (uint32_t)(((i2sclock / 64U) * 10U) / i2s_audiosample);
+        }
+    }
+    /* remove the floating point */
+    clks = (clks + 5U) / 10U;
+    i2sof = (clks & 0x00000001U);
+    i2sdiv = ((clks - i2sof) / 2U);
+    i2sof = (i2sof << 8U);
+
+    /* set the default values */
+    if((i2sdiv < 2U) || (i2sdiv > 255U)) {
+        i2sdiv = 2U;
+        i2sof = 0U;
+    }
+
+    /* configure SPI_I2SPSC */
+    SPI_I2SPSC(spi_periph) = (uint32_t)(i2sdiv | i2sof | i2s_mckout);
+
+    /* clear SPI_I2SCTL_DTLEN and SPI_I2SCTL_CHLEN bits */
+    SPI_I2SCTL(spi_periph) &= (uint32_t)(~(SPI_I2SCTL_DTLEN | SPI_I2SCTL_CHLEN));
+    /* configure data frame format */
+    SPI_I2SCTL(spi_periph) |= (uint32_t)i2s_frameformat;
+}
+
+/*!
+    \brief      enable I2S
+    \param[in]  spi_periph: SPIx(x=1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2s_enable(uint32_t spi_periph)
+{
+    SPI_I2SCTL(spi_periph) |= (uint32_t)SPI_I2SCTL_I2SEN;
+}
+
+/*!
+    \brief      disable I2S
+    \param[in]  spi_periph: SPIx(x=1,2)
+    \param[out] none
+    \retval     none
+*/
+void i2s_disable(uint32_t spi_periph)
+{
+    SPI_I2SCTL(spi_periph) &= (uint32_t)(~SPI_I2SCTL_I2SEN);
+}
+
+/*!
+    \brief      enable SPI nss output
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     none
+*/
+void spi_nss_output_enable(uint32_t spi_periph)
+{
+    SPI_CTL1(spi_periph) |= (uint32_t)SPI_CTL1_NSSDRV;
+}
+
+/*!
+    \brief      disable SPI nss output
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     none
+*/
+void spi_nss_output_disable(uint32_t spi_periph)
+{
+    SPI_CTL1(spi_periph) &= (uint32_t)(~SPI_CTL1_NSSDRV);
+}
+
+/*!
+    \brief      SPI nss pin high level in software mode
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     none
+*/
+void spi_nss_internal_high(uint32_t spi_periph)
+{
+    SPI_CTL0(spi_periph) |= (uint32_t)SPI_CTL0_SWNSS;
+}
+
+/*!
+    \brief      SPI nss pin low level in software mode
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     none
+*/
+void spi_nss_internal_low(uint32_t spi_periph)
+{
+    SPI_CTL0(spi_periph) &= (uint32_t)(~SPI_CTL0_SWNSS);
+}
+
+/*!
+    \brief      enable SPI DMA send or receive
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[in]  spi_dma: SPI DMA mode
+                only one parameter can be selected which is shown as below:
+      \arg        SPI_DMA_TRANSMIT: SPI transmit data use DMA
+      \arg        SPI_DMA_RECEIVE: SPI receive data use DMA
+    \param[out] none
+    \retval     none
+*/
+void spi_dma_enable(uint32_t spi_periph, uint8_t spi_dma)
+{
+    if(SPI_DMA_TRANSMIT == spi_dma) {
+        SPI_CTL1(spi_periph) |= (uint32_t)SPI_CTL1_DMATEN;
+    } else {
+        SPI_CTL1(spi_periph) |= (uint32_t)SPI_CTL1_DMAREN;
+    }
+}
+
+/*!
+    \brief      diable SPI DMA send or receive
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[in]  spi_dma: SPI DMA mode
+                only one parameter can be selected which is shown as below:
+      \arg        SPI_DMA_TRANSMIT: SPI transmit data use DMA
+      \arg        SPI_DMA_RECEIVE: SPI receive data use DMA
+    \param[out] none
+    \retval     none
+*/
+void spi_dma_disable(uint32_t spi_periph, uint8_t spi_dma)
+{
+    if(SPI_DMA_TRANSMIT == spi_dma) {
+        SPI_CTL1(spi_periph) &= (uint32_t)(~SPI_CTL1_DMATEN);
+    } else {
+        SPI_CTL1(spi_periph) &= (uint32_t)(~SPI_CTL1_DMAREN);
+    }
+}
+
+/*!
+    \brief      configure SPI/I2S data frame format
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[in]  frame_format: SPI frame size
+                only one parameter can be selected which is shown as below:
+      \arg        SPI_FRAMESIZE_16BIT: SPI frame size is 16 bits
+      \arg        SPI_FRAMESIZE_8BIT: SPI frame size is 8 bits
+    \param[out] none
+    \retval     none
+*/
+void spi_i2s_data_frame_format_config(uint32_t spi_periph, uint16_t frame_format)
+{
+    /* clear SPI_CTL0_FF16 bit */
+    SPI_CTL0(spi_periph) &= (uint32_t)(~SPI_CTL0_FF16);
+    /* configure SPI_CTL0_FF16 bit */
+    SPI_CTL0(spi_periph) |= (uint32_t)frame_format;
+}
+
+/*!
+    \brief      SPI transmit data
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[in]  data: 16-bit data
+    \param[out] none
+    \retval     none
+*/
+void spi_i2s_data_transmit(uint32_t spi_periph, uint16_t data)
+{
+    SPI_DATA(spi_periph) = (uint32_t)data;
+}
+
+/*!
+    \brief      SPI receive data
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     16-bit data
+*/
+uint16_t spi_i2s_data_receive(uint32_t spi_periph)
+{
+    return ((uint16_t)SPI_DATA(spi_periph));
+}
+
+/*!
+    \brief      configure SPI bidirectional transfer direction
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[in]  transfer_direction: SPI transfer direction
+                only one parameter can be selected which is shown as below:
+      \arg        SPI_BIDIRECTIONAL_TRANSMIT: SPI work in transmit-only mode
+      \arg        SPI_BIDIRECTIONAL_RECEIVE: SPI work in receive-only mode
+    \retval     none
+*/
+void spi_bidirectional_transfer_config(uint32_t spi_periph, uint32_t transfer_direction)
+{
+    if(SPI_BIDIRECTIONAL_TRANSMIT == transfer_direction) {
+        /* set the transmit only mode */
+        SPI_CTL0(spi_periph) |= (uint32_t)SPI_BIDIRECTIONAL_TRANSMIT;
+    } else {
+        /* set the receive only mode */
+        SPI_CTL0(spi_periph) &= SPI_BIDIRECTIONAL_RECEIVE;
+    }
+}
+
+/*!
+    \brief      set SPI CRC polynomial
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[in]  crc_poly: CRC polynomial value
+    \param[out] none
+    \retval     none
+*/
+void spi_crc_polynomial_set(uint32_t spi_periph, uint16_t crc_poly)
+{
+    /* set SPI CRC polynomial */
+    SPI_CRCPOLY(spi_periph) = (uint32_t)crc_poly;
+}
+
+/*!
+    \brief      get SPI CRC polynomial
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     16-bit CRC polynomial
+*/
+uint16_t spi_crc_polynomial_get(uint32_t spi_periph)
+{
+    return ((uint16_t)SPI_CRCPOLY(spi_periph));
+}
+
+/*!
+    \brief      turn on SPI CRC function
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     none
+*/
+void spi_crc_on(uint32_t spi_periph)
+{
+    SPI_CTL0(spi_periph) |= (uint32_t)SPI_CTL0_CRCEN;
+}
+
+/*!
+    \brief      turn off SPI CRC function
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     none
+*/
+void spi_crc_off(uint32_t spi_periph)
+{
+    SPI_CTL0(spi_periph) &= (uint32_t)(~SPI_CTL0_CRCEN);
+}
+
+/*!
+    \brief      SPI next data is CRC value
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     none
+*/
+void spi_crc_next(uint32_t spi_periph)
+{
+    SPI_CTL0(spi_periph) |= (uint32_t)SPI_CTL0_CRCNT;
+}
+
+/*!
+    \brief      get SPI CRC send value or receive value
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[in]  spi_crc: SPI crc value
+                only one parameter can be selected which is shown as below:
+      \arg        SPI_CRC_TX: get transmit crc value
+      \arg        SPI_CRC_RX: get receive crc value
+    \param[out] none
+    \retval     16-bit CRC value
+*/
+uint16_t spi_crc_get(uint32_t spi_periph, uint8_t spi_crc)
+{
+    if(SPI_CRC_TX == spi_crc) {
+        return ((uint16_t)(SPI_TCRC(spi_periph)));
+    } else {
+        return ((uint16_t)(SPI_RCRC(spi_periph)));
+    }
+}
+
+/*!
+    \brief      enable SPI TI mode
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     none
+*/
+void spi_ti_mode_enable(uint32_t spi_periph)
+{
+    SPI_CTL1(spi_periph) |= (uint32_t)SPI_CTL1_TMOD;
+}
+
+/*!
+    \brief      disable SPI TI mode
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     none
+*/
+void spi_ti_mode_disable(uint32_t spi_periph)
+{
+    SPI_CTL1(spi_periph) &= (uint32_t)(~SPI_CTL1_TMOD);
+}
+
+/*!
+    \brief      configure i2s full duplex mode
+    \param[in]  i2s_add_periph: I2Sx_ADD(x=1,2)
+    \param[in]  i2s_mode:
+      \arg        I2S_MODE_SLAVETX : I2S slave transmit mode
+      \arg        I2S_MODE_SLAVERX : I2S slave receive mode
+      \arg        I2S_MODE_MASTERTX : I2S master transmit mode
+      \arg        I2S_MODE_MASTERRX : I2S master receive mode
+    \param[in]  i2s_standard:
+      \arg        I2S_STD_PHILLIPS : I2S phillips standard
+      \arg        I2S_STD_MSB : I2S MSB standard
+      \arg        I2S_STD_LSB : I2S LSB standard
+      \arg        I2S_STD_PCMSHORT : I2S PCM short standard
+      \arg        I2S_STD_PCMLONG : I2S PCM long standard
+    \param[in]  i2s_ckpl:
+      \arg        I2S_CKPL_LOW : I2S clock polarity low level
+      \arg        I2S_CKPL_HIGH : I2S clock polarity high level
+    \param[in]  i2s_frameformat:
+      \arg        I2S_FRAMEFORMAT_DT16B_CH16B: I2S data length is 16 bit and channel length is 16 bit
+      \arg        I2S_FRAMEFORMAT_DT16B_CH32B: I2S data length is 16 bit and channel length is 32 bit
+      \arg        I2S_FRAMEFORMAT_DT24B_CH32B: I2S data length is 24 bit and channel length is 32 bit
+      \arg        I2S_FRAMEFORMAT_DT32B_CH32B: I2S data length is 32 bit and channel length is 32 bit
+    \param[out] none
+    \retval     none
+*/
+void i2s_full_duplex_mode_config(uint32_t i2s_add_periph, uint32_t i2s_mode, uint32_t i2s_standard,
+                                 uint32_t i2s_ckpl, uint32_t i2s_frameformat)
+{
+    uint32_t reg = 0U, tmp = 0U;
+
+    reg = I2S_ADD_I2SCTL(i2s_add_periph);
+    reg &= I2S_FULL_DUPLEX_MASK;
+
+    /* get the mode of the extra I2S module I2Sx_ADD */
+    if((I2S_MODE_MASTERTX == i2s_mode) || (I2S_MODE_SLAVETX == i2s_mode)) {
+        tmp = I2S_MODE_SLAVERX;
+    } else {
+        tmp = I2S_MODE_SLAVETX;
+    }
+
+    /* enable I2S mode */
+    reg |= (uint32_t)SPI_I2SCTL_I2SSEL;
+    /* select I2S mode */
+    reg |= (uint32_t)tmp;
+    /* select I2S standard */
+    reg |= (uint32_t)i2s_standard;
+    /* select I2S polarity */
+    reg |= (uint32_t)i2s_ckpl;
+    /* configure data frame format */
+    reg |= (uint32_t)i2s_frameformat;
+
+    /* write to SPI_I2SCTL register */
+    I2S_ADD_I2SCTL(i2s_add_periph) = (uint32_t)reg;
+}
+
+/*!
+    \brief      enable quad wire SPI
+    \param[in]  spi_periph: SPIx(only x=5)
+    \param[out] none
+    \retval     none
+*/
+void spi_quad_enable(uint32_t spi_periph)
+{
+    SPI_QCTL(spi_periph) |= (uint32_t)SPI_QCTL_QMOD;
+}
+
+/*!
+    \brief      disable quad wire SPI
+    \param[in]  spi_periph: SPIx(only x=5)
+    \param[out] none
+    \retval     none
+*/
+void spi_quad_disable(uint32_t spi_periph)
+{
+    SPI_QCTL(spi_periph) &= (uint32_t)(~SPI_QCTL_QMOD);
+}
+
+/*!
+    \brief      enable quad wire SPI write
+    \param[in]  spi_periph: SPIx(only x=5)
+    \param[out] none
+    \retval     none
+*/
+void spi_quad_write_enable(uint32_t spi_periph)
+{
+    SPI_QCTL(spi_periph) &= (uint32_t)(~SPI_QCTL_QRD);
+}
+
+/*!
+    \brief      enable quad wire SPI read
+    \param[in]  spi_periph: SPIx(only x=5)
+    \param[out] none
+    \retval     none
+*/
+void spi_quad_read_enable(uint32_t spi_periph)
+{
+    SPI_QCTL(spi_periph) |= (uint32_t)SPI_QCTL_QRD;
+}
+
+/*!
+    \brief      enable SPI_IO2 and SPI_IO3 pin output
+    \param[in]  spi_periph: SPIx(only x=5)
+    \param[out] none
+    \retval     none
+*/
+void spi_quad_io23_output_enable(uint32_t spi_periph)
+{
+    SPI_QCTL(spi_periph) |= (uint32_t)SPI_QCTL_IO23_DRV;
+}
+
+/*!
+   \brief      disable SPI_IO2 and SPI_IO3 pin output
+   \param[in]  spi_periph: SPIx(only x=5)
+   \param[out] none
+   \retval     none
+*/
+void spi_quad_io23_output_disable(uint32_t spi_periph)
+{
+    SPI_QCTL(spi_periph) &= (uint32_t)(~SPI_QCTL_IO23_DRV);
+}
+
+/*!
+    \brief      enable SPI and I2S interrupt
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[in]  spi_i2s_int: SPI/I2S interrupt
+                only one parameter can be selected which is shown as below:
+      \arg        SPI_I2S_INT_TBE: transmit buffer empty interrupt
+      \arg        SPI_I2S_INT_RBNE: receive buffer not empty interrupt
+      \arg        SPI_I2S_INT_ERR: CRC error,configuration error,reception overrun error,
+                                   transmission underrun error and format error interrupt
+    \param[out] none
+    \retval     none
+*/
+void spi_i2s_interrupt_enable(uint32_t spi_periph, uint8_t spi_i2s_int)
+{
+    switch(spi_i2s_int) {
+    /* SPI/I2S transmit buffer empty interrupt */
+    case SPI_I2S_INT_TBE:
+        SPI_CTL1(spi_periph) |= (uint32_t)SPI_CTL1_TBEIE;
+        break;
+    /* SPI/I2S receive buffer not empty interrupt */
+    case SPI_I2S_INT_RBNE:
+        SPI_CTL1(spi_periph) |= (uint32_t)SPI_CTL1_RBNEIE;
+        break;
+    /* SPI/I2S error */
+    case SPI_I2S_INT_ERR:
+        SPI_CTL1(spi_periph) |= (uint32_t)SPI_CTL1_ERRIE;
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      disable SPI and I2S interrupt
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[in]  spi_i2s_int: SPI/I2S interrupt
+                only one parameter can be selected which is shown as below:
+      \arg        SPI_I2S_INT_TBE: transmit buffer empty interrupt
+      \arg        SPI_I2S_INT_RBNE: receive buffer not empty interrupt
+      \arg        SPI_I2S_INT_ERR: CRC error,configuration error,reception overrun error,
+                                   transmission underrun error and format error interrupt
+    \param[out] none
+    \retval     none
+*/
+void spi_i2s_interrupt_disable(uint32_t spi_periph, uint8_t spi_i2s_int)
+{
+    switch(spi_i2s_int) {
+    /* SPI/I2S transmit buffer empty interrupt */
+    case SPI_I2S_INT_TBE :
+        SPI_CTL1(spi_periph) &= (uint32_t)(~SPI_CTL1_TBEIE);
+        break;
+    /* SPI/I2S receive buffer not empty interrupt */
+    case SPI_I2S_INT_RBNE :
+        SPI_CTL1(spi_periph) &= (uint32_t)(~SPI_CTL1_RBNEIE);
+        break;
+    /* SPI/I2S error */
+    case SPI_I2S_INT_ERR :
+        SPI_CTL1(spi_periph) &= (uint32_t)(~SPI_CTL1_ERRIE);
+        break;
+    default :
+        break;
+    }
+}
+
+/*!
+    \brief      get SPI and I2S interrupt flag status
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[in]  spi_i2s_int: SPI/I2S interrupt flag status
+                only one parameter can be selected which are shown as below:
+      \arg        SPI_I2S_INT_FLAG_TBE: transmit buffer empty interrupt flag
+      \arg        SPI_I2S_INT_FLAG_RBNE: receive buffer not empty interrupt flag
+      \arg        SPI_I2S_INT_FLAG_RXORERR: overrun interrupt flag
+      \arg        SPI_INT_FLAG_CONFERR: config error interrupt flag
+      \arg        SPI_INT_FLAG_CRCERR: CRC error interrupt flag
+      \arg        I2S_INT_FLAG_TXURERR: underrun error interrupt flag
+      \arg        SPI_I2S_INT_FLAG_FERR: format error interrupt flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus spi_i2s_interrupt_flag_get(uint32_t spi_periph, uint8_t spi_i2s_int)
+{
+    uint32_t reg1 = SPI_STAT(spi_periph);
+    uint32_t reg2 = SPI_CTL1(spi_periph);
+
+    switch(spi_i2s_int) {
+    /* SPI/I2S transmit buffer empty interrupt */
+    case SPI_I2S_INT_FLAG_TBE :
+        reg1 = reg1 & SPI_STAT_TBE;
+        reg2 = reg2 & SPI_CTL1_TBEIE;
+        break;
+    /* SPI/I2S receive buffer not empty interrupt */
+    case SPI_I2S_INT_FLAG_RBNE :
+        reg1 = reg1 & SPI_STAT_RBNE;
+        reg2 = reg2 & SPI_CTL1_RBNEIE;
+        break;
+    /* SPI/I2S overrun interrupt */
+    case SPI_I2S_INT_FLAG_RXORERR :
+        reg1 = reg1 & SPI_STAT_RXORERR;
+        reg2 = reg2 & SPI_CTL1_ERRIE;
+        break;
+    /* SPI config error interrupt */
+    case SPI_INT_FLAG_CONFERR :
+        reg1 = reg1 & SPI_STAT_CONFERR;
+        reg2 = reg2 & SPI_CTL1_ERRIE;
+        break;
+    /* SPI CRC error interrupt */
+    case SPI_INT_FLAG_CRCERR :
+        reg1 = reg1 & SPI_STAT_CRCERR;
+        reg2 = reg2 & SPI_CTL1_ERRIE;
+        break;
+    /* I2S underrun error interrupt */
+    case I2S_INT_FLAG_TXURERR :
+        reg1 = reg1 & SPI_STAT_TXURERR;
+        reg2 = reg2 & SPI_CTL1_ERRIE;
+        break;
+    /* SPI/I2S format error interrupt */
+    case SPI_I2S_INT_FLAG_FERR :
+        reg1 = reg1 & SPI_STAT_FERR;
+        reg2 = reg2 & SPI_CTL1_ERRIE;
+        break;
+    default :
+        break;
+    }
+    /*get SPI/I2S interrupt flag status */
+    if(reg1 && reg2) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      get SPI and I2S flag status
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[in]  spi_i2s_flag: SPI/I2S flag status
+                only one parameter can be selected which are shown as below:
+      \arg        SPI_FLAG_TBE: transmit buffer empty flag
+      \arg        SPI_FLAG_RBNE: receive buffer not empty flag
+      \arg        SPI_FLAG_TRANS: transmit on-going flag
+      \arg        SPI_FLAG_RXORERR: receive overrun error flag
+      \arg        SPI_FLAG_CONFERR: mode config error flag
+      \arg        SPI_FLAG_CRCERR: CRC error flag
+      \arg        SPI_FLAG_FERR: format error flag
+      \arg        I2S_FLAG_TBE: transmit buffer empty flag
+      \arg        I2S_FLAG_RBNE: receive buffer not empty flag
+      \arg        I2S_FLAG_TRANS: transmit on-going flag
+      \arg        I2S_FLAG_RXORERR: overrun error flag
+      \arg        I2S_FLAG_TXURERR: underrun error flag
+      \arg        I2S_FLAG_CH: channel side flag
+      \arg        I2S_FLAG_FERR: format error flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus spi_i2s_flag_get(uint32_t spi_periph, uint32_t spi_i2s_flag)
+{
+    if(SPI_STAT(spi_periph) & spi_i2s_flag) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      clear SPI CRC error flag status
+    \param[in]  spi_periph: SPIx(x=0,1,2,3,4,5)
+    \param[out] none
+    \retval     none
+*/
+void spi_crc_error_clear(uint32_t spi_periph)
+{
+    SPI_STAT(spi_periph) &= (uint32_t)(~SPI_FLAG_CRCERR);
+}
+

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_syscfg.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_syscfg.c
@@ -1,0 +1,205 @@
+/*!
+    \file    gd32f4xx_syscfg.c
+    \brief   SYSCFG driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_syscfg.h"
+
+/*!
+    \brief    reset the SYSCFG registers
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void syscfg_deinit(void)
+{
+    rcu_periph_reset_enable(RCU_SYSCFGRST);
+    rcu_periph_reset_disable(RCU_SYSCFGRST);
+}
+
+/*!
+    \brief    configure the boot mode
+    \param[in]  syscfg_bootmode: selects the memory remapping
+                only one parameter can be selected which is shown as below:
+      \arg        SYSCFG_BOOTMODE_FLASH: main flash memory (0x08000000~0x083BFFFF) is mapped at address 0x00000000
+      \arg        SYSCFG_BOOTMODE_BOOTLOADER: boot loader (0x1FFF0000 - 0x1FFF77FF) is mapped at address 0x00000000
+      \arg        SYSCFG_BOOTMODE_EXMC_SRAM: SRAM/NOR 0 and 1 of EXMC (0x60000000~0x67FFFFFF) is mapped at address 0x00000000
+      \arg        SYSCFG_BOOTMODE_SRAM: SRAM0 of on-chip SRAM (0x20000000~0x2001BFFF) is mapped at address 0x00000000
+      \arg        SYSCFG_BOOTMODE_EXMC_SDRAM: SDRAM bank0 of EXMC (0xC0000000~0xC7FFFFFF) is mapped at address 0x00000000
+    \param[out] none
+    \retval     none
+*/
+void syscfg_bootmode_config(uint8_t syscfg_bootmode)
+{
+    /* reset the SYSCFG_CFG0_BOOT_MODE bit and set according to syscfg_bootmode */
+    SYSCFG_CFG0 &= ~SYSCFG_CFG0_BOOT_MODE;
+    SYSCFG_CFG0 |= (uint32_t)syscfg_bootmode;
+}
+
+/*!
+    \brief    FMC memory mapping swap
+    \param[in]  syscfg_fmc_swap: selects the interal flash bank swapping
+                only one parameter can be selected which is shown as below:
+      \arg        SYSCFG_FMC_SWP_BANK0: bank 0 is mapped at address 0x08000000 and bank 1 is mapped at address 0x08100000
+      \arg        SYSCFG_FMC_SWP_BANK1: bank 1 is mapped at address 0x08000000 and bank 0 is mapped at address 0x08100000
+    \param[out] none
+    \retval     none
+*/
+void syscfg_fmc_swap_config(uint32_t syscfg_fmc_swap)
+{
+    uint32_t reg;
+    reg = SYSCFG_CFG0;
+    /* reset the FMC_SWP bit and set according to syscfg_fmc_swap */
+    reg &= ~SYSCFG_CFG0_FMC_SWP;
+    SYSCFG_CFG0 = (reg | syscfg_fmc_swap);
+}
+
+/*!
+    \brief    EXMC memory mapping swap
+    \param[in]  syscfg_exmc_swap: selects the memories in EXMC swapping
+                only one parameter can be selected which is shown as below:
+      \arg        SYSCFG_EXMC_SWP_ENABLE: SDRAM bank 0 and bank 1 are swapped with NAND bank 1 and PC card
+      \arg        SYSCFG_EXMC_SWP_DISABLE: no memory mapping swap
+    \param[out] none
+    \retval     none
+*/
+void syscfg_exmc_swap_config(uint32_t syscfg_exmc_swap)
+{
+    uint32_t reg;
+
+    reg = SYSCFG_CFG0;
+    /* reset the SYSCFG_CFG0_EXMC_SWP bits and set according to syscfg_exmc_swap */
+    reg &= ~SYSCFG_CFG0_EXMC_SWP;
+    SYSCFG_CFG0 = (reg | syscfg_exmc_swap);
+}
+
+/*!
+    \brief    configure the GPIO pin as EXTI Line
+    \param[in]  exti_port: specify the GPIO port used in EXTI
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_SOURCE_GPIOx(x = A,B,C,D,E,F,G,H,I): EXTI GPIO port
+    \param[in]  exti_pin: specify the EXTI line
+                only one parameter can be selected which is shown as below:
+      \arg        EXTI_SOURCE_PINx(x = 0..15): EXTI GPIO pin
+    \param[out] none
+    \retval     none
+*/
+void syscfg_exti_line_config(uint8_t exti_port, uint8_t exti_pin)
+{
+    uint32_t clear_exti_mask = ~((uint32_t)EXTI_SS_MASK << (EXTI_SS_MSTEP(exti_pin)));
+    uint32_t config_exti_mask = ((uint32_t)exti_port) << (EXTI_SS_MSTEP(exti_pin));
+
+    switch(exti_pin / EXTI_SS_JSTEP) {
+    case EXTISS0:
+        /* clear EXTI source line(0..3) */
+        SYSCFG_EXTISS0 &= clear_exti_mask;
+        /* configure EXTI soure line(0..3) */
+        SYSCFG_EXTISS0 |= config_exti_mask;
+        break;
+    case EXTISS1:
+        /* clear EXTI soure line(4..7) */
+        SYSCFG_EXTISS1 &= clear_exti_mask;
+        /* configure EXTI soure line(4..7) */
+        SYSCFG_EXTISS1 |= config_exti_mask;
+        break;
+    case EXTISS2:
+        /* clear EXTI soure line(8..11) */
+        SYSCFG_EXTISS2 &= clear_exti_mask;
+        /* configure EXTI soure line(8..11) */
+        SYSCFG_EXTISS2 |= config_exti_mask;
+        break;
+    case EXTISS3:
+        /* clear EXTI soure line(12..15) */
+        SYSCFG_EXTISS3 &= clear_exti_mask;
+        /* configure EXTI soure line(12..15) */
+        SYSCFG_EXTISS3 |= config_exti_mask;
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief    configure the PHY interface for the ethernet MAC
+    \param[in]  syscfg_enet_phy_interface: specifies the media interface mode.
+                only one parameter can be selected which is shown as below:
+      \arg        SYSCFG_ENET_PHY_MII: MII mode is selected
+      \arg        SYSCFG_ENET_PHY_RMII: RMII mode is selected
+    \param[out] none
+    \retval     none
+*/
+void syscfg_enet_phy_interface_config(uint32_t syscfg_enet_phy_interface)
+{
+    uint32_t reg;
+
+    reg = SYSCFG_CFG1;
+    /* reset the ENET_PHY_SEL bit and set according to syscfg_enet_phy_interface */
+    reg &= ~SYSCFG_CFG1_ENET_PHY_SEL;
+    SYSCFG_CFG1 = (reg | syscfg_enet_phy_interface);
+}
+
+/*!
+    \brief    configure the I/O compensation cell
+    \param[in]  syscfg_compensation: specifies the I/O compensation cell mode
+                only one parameter can be selected which is shown as below:
+      \arg        SYSCFG_COMPENSATION_ENABLE: I/O compensation cell is enabled
+      \arg        SYSCFG_COMPENSATION_DISABLE: I/O compensation cell is disabled
+    \param[out] none
+    \retval     none
+*/
+void syscfg_compensation_config(uint32_t syscfg_compensation)
+{
+    uint32_t reg;
+
+    reg = SYSCFG_CPSCTL;
+    /* reset the SYSCFG_CPSCTL_CPS_EN bit and set according to syscfg_compensation */
+    reg &= ~SYSCFG_CPSCTL_CPS_EN;
+    SYSCFG_CPSCTL = (reg | syscfg_compensation);
+}
+
+/*!
+    \brief    checks whether the I/O compensation cell ready flag is set or not
+    \param[in]  none
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+  */
+FlagStatus syscfg_flag_get(void)
+{
+    if(((uint32_t)RESET) != (SYSCFG_CPSCTL & SYSCFG_CPSCTL_CPS_RDY)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_timer.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_timer.c
@@ -1,0 +1,2064 @@
+/*!
+    \file    gd32f4xx_timer.c
+    \brief   TIMER driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+
+#include "gd32f4xx_timer.h"
+
+/*!
+    \brief      deinit a TIMER
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[out] none
+    \retval     none
+*/
+void timer_deinit(uint32_t timer_periph)
+{
+    switch(timer_periph) {
+    case TIMER0:
+        /* reset TIMER0 */
+        rcu_periph_reset_enable(RCU_TIMER0RST);
+        rcu_periph_reset_disable(RCU_TIMER0RST);
+        break;
+    case TIMER1:
+        /* reset TIMER1 */
+        rcu_periph_reset_enable(RCU_TIMER1RST);
+        rcu_periph_reset_disable(RCU_TIMER1RST);
+        break;
+    case TIMER2:
+        /* reset TIMER2 */
+        rcu_periph_reset_enable(RCU_TIMER2RST);
+        rcu_periph_reset_disable(RCU_TIMER2RST);
+        break;
+    case TIMER3:
+        /* reset TIMER3 */
+        rcu_periph_reset_enable(RCU_TIMER3RST);
+        rcu_periph_reset_disable(RCU_TIMER3RST);
+        break;
+    case TIMER4:
+        /* reset TIMER4 */
+        rcu_periph_reset_enable(RCU_TIMER4RST);
+        rcu_periph_reset_disable(RCU_TIMER4RST);
+        break;
+    case TIMER5:
+        /* reset TIMER5 */
+        rcu_periph_reset_enable(RCU_TIMER5RST);
+        rcu_periph_reset_disable(RCU_TIMER5RST);
+        break;
+    case TIMER6:
+        /* reset TIMER6 */
+        rcu_periph_reset_enable(RCU_TIMER6RST);
+        rcu_periph_reset_disable(RCU_TIMER6RST);
+        break;
+    case TIMER7:
+        /* reset TIMER7 */
+        rcu_periph_reset_enable(RCU_TIMER7RST);
+        rcu_periph_reset_disable(RCU_TIMER7RST);
+        break;
+    case TIMER8:
+        /* reset TIMER8 */
+        rcu_periph_reset_enable(RCU_TIMER8RST);
+        rcu_periph_reset_disable(RCU_TIMER8RST);
+        break;
+    case TIMER9:
+        /* reset TIMER9 */
+        rcu_periph_reset_enable(RCU_TIMER9RST);
+        rcu_periph_reset_disable(RCU_TIMER9RST);
+        break;
+    case TIMER10:
+        /* reset TIMER10 */
+        rcu_periph_reset_enable(RCU_TIMER10RST);
+        rcu_periph_reset_disable(RCU_TIMER10RST);
+        break;
+    case TIMER11:
+        /* reset TIMER11 */
+        rcu_periph_reset_enable(RCU_TIMER11RST);
+        rcu_periph_reset_disable(RCU_TIMER11RST);
+        break;
+    case TIMER12:
+        /* reset TIMER12 */
+        rcu_periph_reset_enable(RCU_TIMER12RST);
+        rcu_periph_reset_disable(RCU_TIMER12RST);
+        break;
+    case TIMER13:
+        /* reset TIMER13 */
+        rcu_periph_reset_enable(RCU_TIMER13RST);
+        rcu_periph_reset_disable(RCU_TIMER13RST);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      initialize TIMER init parameter struct with a default value
+    \param[in]  initpara: init parameter struct
+    \param[out] none
+    \retval     none
+*/
+void timer_struct_para_init(timer_parameter_struct *initpara)
+{
+    /* initialize the init parameter struct member with the default value */
+    initpara->prescaler         = 0U;
+    initpara->alignedmode       = TIMER_COUNTER_EDGE;
+    initpara->counterdirection  = TIMER_COUNTER_UP;
+    initpara->period            = 65535U;
+    initpara->clockdivision     = TIMER_CKDIV_DIV1;
+    initpara->repetitioncounter = 0U;
+}
+
+/*!
+    \brief      initialize TIMER counter
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[in]  initpara: init parameter struct
+                prescaler: prescaler value of the counter clock,0~65535
+                alignedmode: TIMER_COUNTER_EDGE,TIMER_COUNTER_CENTER_DOWN,TIMER_COUNTER_CENTER_UP,TIMER_COUNTER_CENTER_BOTH
+                counterdirection: TIMER_COUNTER_UP,TIMER_COUNTER_DOWN
+                period: counter auto reload value,(TIMER1,TIMER4,32 bit)
+                clockdivision: TIMER_CKDIV_DIV1,TIMER_CKDIV_DIV2,TIMER_CKDIV_DIV4
+                repetitioncounter: counter repetition value,0~255
+    \param[out] none
+    \retval     none
+*/
+void timer_init(uint32_t timer_periph, timer_parameter_struct *initpara)
+{
+    /* configure the counter prescaler value */
+    TIMER_PSC(timer_periph) = (uint16_t)initpara->prescaler;
+
+    /* configure the counter direction and aligned mode */
+    if((TIMER0 == timer_periph) || (TIMER1 == timer_periph) || (TIMER2 == timer_periph)
+            || (TIMER3 == timer_periph) || (TIMER4 == timer_periph) || (TIMER7 == timer_periph)) {
+        TIMER_CTL0(timer_periph) &= ~(uint32_t)(TIMER_CTL0_DIR | TIMER_CTL0_CAM);
+        TIMER_CTL0(timer_periph) |= (uint32_t)initpara->alignedmode;
+        TIMER_CTL0(timer_periph) |= (uint32_t)initpara->counterdirection;
+    }
+
+    /* configure the autoreload value */
+    TIMER_CAR(timer_periph) = (uint32_t)initpara->period;
+
+    if((TIMER5 != timer_periph) && (TIMER6 != timer_periph)) {
+        /* reset the CKDIV bit */
+        TIMER_CTL0(timer_periph) &= ~(uint32_t)TIMER_CTL0_CKDIV;
+        TIMER_CTL0(timer_periph) |= (uint32_t)initpara->clockdivision;
+    }
+
+    if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)) {
+        /* configure the repetition counter value */
+        TIMER_CREP(timer_periph) = (uint32_t)initpara->repetitioncounter;
+    }
+
+    /* generate an update event */
+    TIMER_SWEVG(timer_periph) |= (uint32_t)TIMER_SWEVG_UPG;
+}
+
+/*!
+    \brief      enable a TIMER
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[out] none
+    \retval     none
+*/
+void timer_enable(uint32_t timer_periph)
+{
+    TIMER_CTL0(timer_periph) |= (uint32_t)TIMER_CTL0_CEN;
+}
+
+/*!
+    \brief      disable a TIMER
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[out] none
+    \retval     none
+*/
+void timer_disable(uint32_t timer_periph)
+{
+    TIMER_CTL0(timer_periph) &= ~(uint32_t)TIMER_CTL0_CEN;
+}
+
+/*!
+    \brief      enable the auto reload shadow function
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[out] none
+    \retval     none
+*/
+void timer_auto_reload_shadow_enable(uint32_t timer_periph)
+{
+    TIMER_CTL0(timer_periph) |= (uint32_t)TIMER_CTL0_ARSE;
+}
+
+/*!
+    \brief      disable the auto reload shadow function
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[out] none
+    \retval     none
+*/
+void timer_auto_reload_shadow_disable(uint32_t timer_periph)
+{
+    TIMER_CTL0(timer_periph) &= ~(uint32_t)TIMER_CTL0_ARSE;
+}
+
+/*!
+    \brief      enable the update event
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[out] none
+    \retval     none
+*/
+void timer_update_event_enable(uint32_t timer_periph)
+{
+    TIMER_CTL0(timer_periph) &= ~(uint32_t)TIMER_CTL0_UPDIS;
+}
+
+/*!
+    \brief      disable the update event
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[out] none
+    \retval     none
+*/
+void timer_update_event_disable(uint32_t timer_periph)
+{
+    TIMER_CTL0(timer_periph) |= (uint32_t) TIMER_CTL0_UPDIS;
+}
+
+/*!
+    \brief      set TIMER counter alignment mode
+    \param[in]  timer_periph: TIMERx(x=0..4,7)
+    \param[in]  aligned:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_COUNTER_EDGE: edge-aligned mode
+      \arg        TIMER_COUNTER_CENTER_DOWN: center-aligned and counting down assert mode
+      \arg        TIMER_COUNTER_CENTER_UP: center-aligned and counting up assert mode
+      \arg        TIMER_COUNTER_CENTER_BOTH: center-aligned and counting up/down assert mode
+    \param[out] none
+    \retval     none
+*/
+void timer_counter_alignment(uint32_t timer_periph, uint16_t aligned)
+{
+    TIMER_CTL0(timer_periph) &= ~(uint32_t)TIMER_CTL0_CAM;
+    TIMER_CTL0(timer_periph) |= (uint32_t)aligned;
+}
+
+/*!
+    \brief      set TIMER counter up direction
+    \param[in]  timer_periph: TIMERx(x=0..4,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_counter_up_direction(uint32_t timer_periph)
+{
+    TIMER_CTL0(timer_periph) &= ~(uint32_t)TIMER_CTL0_DIR;
+}
+
+/*!
+    \brief      set TIMER counter down direction
+    \param[in]  timer_periph: TIMERx(x=0..4,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_counter_down_direction(uint32_t timer_periph)
+{
+    TIMER_CTL0(timer_periph) |= (uint32_t)TIMER_CTL0_DIR;
+}
+
+/*!
+    \brief      configure TIMER prescaler
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[in]  prescaler: prescaler value,0~65535
+    \param[in]  pscreload: prescaler reload mode
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_PSC_RELOAD_NOW: the prescaler is loaded right now
+      \arg        TIMER_PSC_RELOAD_UPDATE: the prescaler is loaded at the next update event
+    \param[out] none
+    \retval     none
+*/
+void timer_prescaler_config(uint32_t timer_periph, uint16_t prescaler, uint8_t pscreload)
+{
+    TIMER_PSC(timer_periph) = (uint32_t)prescaler;
+
+    if(TIMER_PSC_RELOAD_NOW == pscreload) {
+        TIMER_SWEVG(timer_periph) |= (uint32_t)TIMER_SWEVG_UPG;
+    }
+}
+
+/*!
+    \brief      configure TIMER repetition register value
+    \param[in]  timer_periph: TIMERx(x=0,7)
+    \param[in]  repetition: the counter repetition value,0~255
+    \param[out] none
+    \retval     none
+*/
+void timer_repetition_value_config(uint32_t timer_periph, uint16_t repetition)
+{
+    TIMER_CREP(timer_periph) = (uint32_t)repetition;
+}
+
+/*!
+    \brief      configure TIMER autoreload register value
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[in]  autoreload: the counter auto-reload value
+    \param[out] none
+    \retval     none
+*/
+void timer_autoreload_value_config(uint32_t timer_periph, uint32_t autoreload)
+{
+    TIMER_CAR(timer_periph) = (uint32_t)autoreload;
+}
+
+/*!
+    \brief      configure TIMER counter register value
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[in]  counter: the counter value,0~65535
+    \param[out] none
+    \retval     none
+*/
+void timer_counter_value_config(uint32_t timer_periph, uint32_t counter)
+{
+    TIMER_CNT(timer_periph) = (uint32_t)counter;
+}
+
+/*!
+    \brief      read TIMER counter value
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[out] none
+    \retval     counter value
+*/
+uint32_t timer_counter_read(uint32_t timer_periph)
+{
+    uint32_t count_value = 0U;
+    count_value = TIMER_CNT(timer_periph);
+    return (count_value);
+}
+
+/*!
+    \brief      read TIMER prescaler value
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[out] none
+    \retval     prescaler register value
+*/
+uint16_t timer_prescaler_read(uint32_t timer_periph)
+{
+    uint16_t prescaler_value = 0U;
+    prescaler_value = (uint16_t)(TIMER_PSC(timer_periph));
+    return (prescaler_value);
+}
+
+/*!
+    \brief      configure TIMER single pulse mode
+    \param[in]  timer_periph: TIMERx(x=0..8,11)
+    \param[in]  spmode:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_SP_MODE_SINGLE: single pulse mode
+      \arg        TIMER_SP_MODE_REPETITIVE: repetitive pulse mode
+    \param[out] none
+    \retval     none
+*/
+void timer_single_pulse_mode_config(uint32_t timer_periph, uint32_t spmode)
+{
+    if(TIMER_SP_MODE_SINGLE == spmode) {
+        TIMER_CTL0(timer_periph) |= (uint32_t)TIMER_CTL0_SPM;
+    } else if(TIMER_SP_MODE_REPETITIVE == spmode) {
+        TIMER_CTL0(timer_periph) &= ~((uint32_t)TIMER_CTL0_SPM);
+    } else {
+        /* illegal parameters */
+    }
+}
+
+/*!
+    \brief      configure TIMER update source
+    \param[in]  timer_periph: TIMERx(x=0..13)
+    \param[in]  update:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_UPDATE_SRC_GLOBAL: update generate by setting of UPG bit or the counter overflow/underflow,or the slave mode controller trigger
+      \arg        TIMER_UPDATE_SRC_REGULAR: update generate only by counter overflow/underflow
+    \param[out] none
+    \retval     none
+*/
+void timer_update_source_config(uint32_t timer_periph, uint32_t update)
+{
+    if(TIMER_UPDATE_SRC_REGULAR == update) {
+        TIMER_CTL0(timer_periph) |= (uint32_t)TIMER_CTL0_UPS;
+    } else if(TIMER_UPDATE_SRC_GLOBAL == update) {
+        TIMER_CTL0(timer_periph) &= ~(uint32_t)TIMER_CTL0_UPS;
+    } else {
+        /* illegal parameters */
+    }
+}
+
+/*!
+    \brief      enable the TIMER DMA
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  dma: specify which DMA to enable
+                one or more parameters can be selected which is shown as below:
+      \arg        TIMER_DMA_UPD:  update DMA,TIMERx(x=0..7)
+      \arg        TIMER_DMA_CH0D: channel 0 DMA request,TIMERx(x=0..4,7)
+      \arg        TIMER_DMA_CH1D: channel 1 DMA request,TIMERx(x=0..4,7)
+      \arg        TIMER_DMA_CH2D: channel 2 DMA request,TIMERx(x=0..4,7)
+      \arg        TIMER_DMA_CH3D: channel 3 DMA request,TIMERx(x=0..4,7)
+      \arg        TIMER_DMA_CMTD: commutation DMA request,TIMERx(x=0,7)
+      \arg        TIMER_DMA_TRGD: trigger DMA request,TIMERx(x=0..4,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_dma_enable(uint32_t timer_periph, uint16_t dma)
+{
+    TIMER_DMAINTEN(timer_periph) |= (uint32_t) dma;
+}
+
+/*!
+    \brief      disable the TIMER DMA
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  dma: specify which DMA to disable
+                one or more parameters can be selected which are shown as below:
+      \arg        TIMER_DMA_UPD:  update DMA,TIMERx(x=0..7)
+      \arg        TIMER_DMA_CH0D: channel 0 DMA request,TIMERx(x=0..4,7)
+      \arg        TIMER_DMA_CH1D: channel 1 DMA request,TIMERx(x=0..4,7)
+      \arg        TIMER_DMA_CH2D: channel 2 DMA request,TIMERx(x=0..4,7)
+      \arg        TIMER_DMA_CH3D: channel 3 DMA request,TIMERx(x=0..4,7)
+      \arg        TIMER_DMA_CMTD: commutation DMA request ,TIMERx(x=0,7)
+      \arg        TIMER_DMA_TRGD: trigger DMA request,TIMERx(x=0..4,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_dma_disable(uint32_t timer_periph, uint16_t dma)
+{
+    TIMER_DMAINTEN(timer_periph) &= (~(uint32_t)(dma));
+}
+
+/*!
+    \brief      channel DMA request source selection
+    \param[in]  timer_periph: TIMERx(x=0..4,7)
+    \param[in]  dma_request: channel DMA request source selection
+                only one parameter can be selected which is shown as below:
+       \arg        TIMER_DMAREQUEST_CHANNELEVENT: DMA request of channel y is sent when channel y event occurs
+       \arg        TIMER_DMAREQUEST_UPDATEEVENT: DMA request of channel y is sent when update event occurs
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_dma_request_source_select(uint32_t timer_periph, uint8_t dma_request)
+{
+    if(TIMER_DMAREQUEST_UPDATEEVENT == dma_request) {
+        TIMER_CTL1(timer_periph) |= (uint32_t)TIMER_CTL1_DMAS;
+    } else if(TIMER_DMAREQUEST_CHANNELEVENT == dma_request) {
+        TIMER_CTL1(timer_periph) &= ~(uint32_t)TIMER_CTL1_DMAS;
+    } else {
+        /* illegal parameters */
+    }
+}
+
+/*!
+    \brief      configure the TIMER DMA transfer
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  dma_baseaddr:
+                only one parameter can be selected which is shown as below:
+       \arg        TIMER_DMACFG_DMATA_CTL0: DMA transfer address is TIMER_CTL0,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_CTL1: DMA transfer address is TIMER_CTL1,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_SMCFG: DMA transfer address is TIMER_SMCFG,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_DMAINTEN: DMA transfer address is TIMER_DMAINTEN,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_INTF: DMA transfer address is TIMER_INTF,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_SWEVG: DMA transfer address is TIMER_SWEVG,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_CHCTL0: DMA transfer address is TIMER_CHCTL0,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_CHCTL1: DMA transfer address is TIMER_CHCTL1,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_CHCTL2: DMA transfer address is TIMER_CHCTL2,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_CNT: DMA transfer address is TIMER_CNT,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_PSC: DMA transfer address is TIMER_PSC,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_CAR: DMA transfer address is TIMER_CAR,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_CREP: DMA transfer address is TIMER_CREP,TIMERx(x=0,7)
+       \arg        TIMER_DMACFG_DMATA_CH0CV: DMA transfer address is TIMER_CH0CV,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_CH1CV: DMA transfer address is TIMER_CH1CV,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_CH2CV: DMA transfer address is TIMER_CH2CV,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_CH3CV: DMA transfer address is TIMER_CH3CV,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_CCHP: DMA transfer address is TIMER_CCHP,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_DMACFG: DMA transfer address is TIMER_DMACFG,TIMERx(x=0..4,7)
+       \arg        TIMER_DMACFG_DMATA_DMATB: DMA transfer address is TIMER_DMATB,TIMERx(x=0..4,7)
+    \param[in]  dma_lenth:
+                only one parameter can be selected which is shown as below:
+       \arg        TIMER_DMACFG_DMATC_xTRANSFER(x=1..18): DMA transfer x time
+    \param[out] none
+    \retval     none
+*/
+void timer_dma_transfer_config(uint32_t timer_periph, uint32_t dma_baseaddr, uint32_t dma_lenth)
+{
+    TIMER_DMACFG(timer_periph) &= (~(uint32_t)(TIMER_DMACFG_DMATA | TIMER_DMACFG_DMATC));
+    TIMER_DMACFG(timer_periph) |= (uint32_t)(dma_baseaddr | dma_lenth);
+}
+
+/*!
+    \brief      software generate events
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  event: the timer software event generation sources
+                one or more parameters can be selected which are shown as below:
+      \arg        TIMER_EVENT_SRC_UPG: update event,TIMERx(x=0..13)
+      \arg        TIMER_EVENT_SRC_CH0G: channel 0 capture or compare event generation,TIMERx(x=0..4,7..13)
+      \arg        TIMER_EVENT_SRC_CH1G: channel 1 capture or compare event generation,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_EVENT_SRC_CH2G: channel 2 capture or compare event generation,TIMERx(x=0..4,7)
+      \arg        TIMER_EVENT_SRC_CH3G: channel 3 capture or compare event generation,TIMERx(x=0..4,7)
+      \arg        TIMER_EVENT_SRC_CMTG: channel commutation event generation,TIMERx(x=0,7)
+      \arg        TIMER_EVENT_SRC_TRGG: trigger event generation,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_EVENT_SRC_BRKG:  break event generation,TIMERx(x=0,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_event_software_generate(uint32_t timer_periph, uint16_t event)
+{
+    TIMER_SWEVG(timer_periph) |= (uint32_t)event;
+}
+
+/*!
+    \brief      initialize TIMER break parameter struct
+    \param[in]  breakpara: TIMER break parameter struct
+    \param[out] none
+    \retval     none
+*/
+void timer_break_struct_para_init(timer_break_parameter_struct *breakpara)
+{
+    /* initialize the break parameter struct member with the default value */
+    breakpara->runoffstate     = TIMER_ROS_STATE_DISABLE;
+    breakpara->ideloffstate    = TIMER_IOS_STATE_DISABLE;
+    breakpara->deadtime        = 0U;
+    breakpara->breakpolarity   = TIMER_BREAK_POLARITY_LOW;
+    breakpara->outputautostate = TIMER_OUTAUTO_DISABLE;
+    breakpara->protectmode     = TIMER_CCHP_PROT_OFF;
+    breakpara->breakstate      = TIMER_BREAK_DISABLE;
+}
+
+/*!
+    \brief      configure TIMER break function
+    \param[in]  timer_periph: TIMERx(x=0,7)
+    \param[in]  breakpara: TIMER break parameter struct
+                runoffstate: TIMER_ROS_STATE_ENABLE,TIMER_ROS_STATE_DISABLE
+                ideloffstate: TIMER_IOS_STATE_ENABLE,TIMER_IOS_STATE_DISABLE
+                deadtime: 0~255
+                breakpolarity: TIMER_BREAK_POLARITY_LOW,TIMER_BREAK_POLARITY_HIGH
+                outputautostate: TIMER_OUTAUTO_ENABLE,TIMER_OUTAUTO_DISABLE
+                protectmode: TIMER_CCHP_PROT_OFF,TIMER_CCHP_PROT_0,TIMER_CCHP_PROT_1,TIMER_CCHP_PROT_2
+                breakstate: TIMER_BREAK_ENABLE,TIMER_BREAK_DISABLE
+    \param[out] none
+    \retval     none
+*/
+void timer_break_config(uint32_t timer_periph, timer_break_parameter_struct *breakpara)
+{
+    TIMER_CCHP(timer_periph) = (uint32_t)(((uint32_t)(breakpara->runoffstate)) |
+                                          ((uint32_t)(breakpara->ideloffstate)) |
+                                          ((uint32_t)(breakpara->deadtime)) |
+                                          ((uint32_t)(breakpara->breakpolarity)) |
+                                          ((uint32_t)(breakpara->outputautostate)) |
+                                          ((uint32_t)(breakpara->protectmode)) |
+                                          ((uint32_t)(breakpara->breakstate))) ;
+}
+
+/*!
+    \brief      enable TIMER break function
+    \param[in]  timer_periph: TIMERx(x=0,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_break_enable(uint32_t timer_periph)
+{
+    TIMER_CCHP(timer_periph) |= (uint32_t)TIMER_CCHP_BRKEN;
+}
+
+/*!
+    \brief      disable TIMER break function
+    \param[in]  timer_periph: TIMERx(x=0,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_break_disable(uint32_t timer_periph)
+{
+    TIMER_CCHP(timer_periph) &= ~(uint32_t)TIMER_CCHP_BRKEN;
+}
+
+/*!
+    \brief      enable TIMER output automatic function
+    \param[in]  timer_periph: TIMERx(x=0,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_automatic_output_enable(uint32_t timer_periph)
+{
+    TIMER_CCHP(timer_periph) |= (uint32_t)TIMER_CCHP_OAEN;
+}
+
+/*!
+    \brief      disable TIMER output automatic function
+    \param[in]  timer_periph: TIMERx(x=0,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_automatic_output_disable(uint32_t timer_periph)
+{
+    TIMER_CCHP(timer_periph) &= ~(uint32_t)TIMER_CCHP_OAEN;
+}
+
+/*!
+    \brief      configure TIMER primary output function
+    \param[in]  timer_periph: TIMERx(x=0,7)
+    \param[in]  newvalue: ENABLE or DISABLE
+    \param[out] none
+    \retval     none
+*/
+void timer_primary_output_config(uint32_t timer_periph, ControlStatus newvalue)
+{
+    if(ENABLE == newvalue) {
+        TIMER_CCHP(timer_periph) |= (uint32_t)TIMER_CCHP_POEN;
+    } else {
+        TIMER_CCHP(timer_periph) &= (~(uint32_t)TIMER_CCHP_POEN);
+    }
+}
+
+/*!
+    \brief      enable or disable channel capture/compare control shadow register
+    \param[in]  timer_periph: TIMERx(x=0,7)
+    \param[in]  newvalue: ENABLE or DISABLE
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_control_shadow_config(uint32_t timer_periph, ControlStatus newvalue)
+{
+    if(ENABLE == newvalue) {
+        TIMER_CTL1(timer_periph) |= (uint32_t)TIMER_CTL1_CCSE;
+    } else {
+        TIMER_CTL1(timer_periph) &= (~(uint32_t)TIMER_CTL1_CCSE);
+    }
+}
+
+/*!
+    \brief      configure TIMER channel control shadow register update control
+    \param[in]  timer_periph: TIMERx(x=0,7)
+    \param[in]  ccuctl: channel control shadow register update control
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_UPDATECTL_CCU: the shadow registers update by when CMTG bit is set
+      \arg        TIMER_UPDATECTL_CCUTRI: the shadow registers update by when CMTG bit is set or an rising edge of TRGI occurs
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_control_shadow_update_config(uint32_t timer_periph, uint8_t ccuctl)
+{
+    if(TIMER_UPDATECTL_CCU == ccuctl) {
+        TIMER_CTL1(timer_periph) &= (~(uint32_t)TIMER_CTL1_CCUC);
+    } else if(TIMER_UPDATECTL_CCUTRI == ccuctl) {
+        TIMER_CTL1(timer_periph) |= (uint32_t)TIMER_CTL1_CCUC;
+    } else {
+        /* illegal parameters */
+    }
+}
+
+/*!
+    \brief      initialize TIMER channel output parameter struct with a default value
+    \param[in]  ocpara: TIMER channel n output parameter struct
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_output_struct_para_init(timer_oc_parameter_struct *ocpara)
+{
+    /* initialize the channel output parameter struct member with the default value */
+    ocpara->outputstate  = (uint16_t)TIMER_CCX_DISABLE;
+    ocpara->outputnstate = TIMER_CCXN_DISABLE;
+    ocpara->ocpolarity   = TIMER_OC_POLARITY_HIGH;
+    ocpara->ocnpolarity  = TIMER_OCN_POLARITY_HIGH;
+    ocpara->ocidlestate  = TIMER_OC_IDLE_STATE_LOW;
+    ocpara->ocnidlestate = TIMER_OCN_IDLE_STATE_LOW;
+}
+
+/*!
+    \brief      configure TIMER channel output function
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel 0(TIMERx(x=0..4,7..13))
+      \arg        TIMER_CH_1: TIMER channel 1(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_CH_2: TIMER channel 2(TIMERx(x=0..4,7))
+      \arg        TIMER_CH_3: TIMER channel 3(TIMERx(x=0..4,7))
+    \param[in]  ocpara: TIMER channeln output parameter struct
+                outputstate: TIMER_CCX_ENABLE,TIMER_CCX_DISABLE
+                outputnstate: TIMER_CCXN_ENABLE,TIMER_CCXN_DISABLE
+                ocpolarity: TIMER_OC_POLARITY_HIGH,TIMER_OC_POLARITY_LOW
+                ocnpolarity: TIMER_OCN_POLARITY_HIGH,TIMER_OCN_POLARITY_LOW
+                ocidlestate: TIMER_OC_IDLE_STATE_LOW,TIMER_OC_IDLE_STATE_HIGH
+                ocnidlestate: TIMER_OCN_IDLE_STATE_LOW,TIMER_OCN_IDLE_STATE_HIGH
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_output_config(uint32_t timer_periph, uint16_t channel, timer_oc_parameter_struct *ocpara)
+{
+    switch(channel) {
+    /* configure TIMER_CH_0 */
+    case TIMER_CH_0:
+        /* reset the CH0EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0EN);
+        TIMER_CHCTL0(timer_periph) &= ~(uint32_t)TIMER_CHCTL0_CH0MS;
+        /* set the CH0EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)ocpara->outputstate;
+        /* reset the CH0P bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0P);
+        /* set the CH0P bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)ocpara->ocpolarity;
+
+        if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)) {
+            /* reset the CH0NEN bit */
+            TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0NEN);
+            /* set the CH0NEN bit */
+            TIMER_CHCTL2(timer_periph) |= (uint32_t)ocpara->outputnstate;
+            /* reset the CH0NP bit */
+            TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0NP);
+            /* set the CH0NP bit */
+            TIMER_CHCTL2(timer_periph) |= (uint32_t)ocpara->ocnpolarity;
+            /* reset the ISO0 bit */
+            TIMER_CTL1(timer_periph) &= (~(uint32_t)TIMER_CTL1_ISO0);
+            /* set the ISO0 bit */
+            TIMER_CTL1(timer_periph) |= (uint32_t)ocpara->ocidlestate;
+            /* reset the ISO0N bit */
+            TIMER_CTL1(timer_periph) &= (~(uint32_t)TIMER_CTL1_ISO0N);
+            /* set the ISO0N bit */
+            TIMER_CTL1(timer_periph) |= (uint32_t)ocpara->ocnidlestate;
+        }
+        break;
+    /* configure TIMER_CH_1 */
+    case TIMER_CH_1:
+        /* reset the CH1EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1EN);
+        TIMER_CHCTL0(timer_periph) &= ~(uint32_t)TIMER_CHCTL0_CH1MS;
+        /* set the CH1EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)ocpara->outputstate << 4U);
+        /* reset the CH1P bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1P);
+        /* set the CH1P bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(ocpara->ocpolarity) << 4U);
+
+        if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)) {
+            /* reset the CH1NEN bit */
+            TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1NEN);
+            /* set the CH1NEN bit */
+            TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(ocpara->outputnstate) << 4U);
+            /* reset the CH1NP bit */
+            TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1NP);
+            /* set the CH1NP bit */
+            TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(ocpara->ocnpolarity) << 4U);
+            /* reset the ISO1 bit */
+            TIMER_CTL1(timer_periph) &= (~(uint32_t)TIMER_CTL1_ISO1);
+            /* set the ISO1 bit */
+            TIMER_CTL1(timer_periph) |= (uint32_t)((uint32_t)(ocpara->ocidlestate) << 2U);
+            /* reset the ISO1N bit */
+            TIMER_CTL1(timer_periph) &= (~(uint32_t)TIMER_CTL1_ISO1N);
+            /* set the ISO1N bit */
+            TIMER_CTL1(timer_periph) |= (uint32_t)((uint32_t)(ocpara->ocnidlestate) << 2U);
+        }
+        break;
+    /* configure TIMER_CH_2 */
+    case TIMER_CH_2:
+        /* reset the CH2EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH2EN);
+        TIMER_CHCTL1(timer_periph) &= ~(uint32_t)TIMER_CHCTL1_CH2MS;
+        /* set the CH2EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)ocpara->outputstate << 8U);
+        /* reset the CH2P bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH2P);
+        /* set the CH2P bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(ocpara->ocpolarity) << 8U);
+
+        if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)) {
+            /* reset the CH2NEN bit */
+            TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH2NEN);
+            /* set the CH2NEN bit */
+            TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(ocpara->outputnstate) << 8U);
+            /* reset the CH2NP bit */
+            TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH2NP);
+            /* set the CH2NP bit */
+            TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(ocpara->ocnpolarity) << 8U);
+            /* reset the ISO2 bit */
+            TIMER_CTL1(timer_periph) &= (~(uint32_t)TIMER_CTL1_ISO2);
+            /* set the ISO2 bit */
+            TIMER_CTL1(timer_periph) |= (uint32_t)((uint32_t)(ocpara->ocidlestate) << 4U);
+            /* reset the ISO2N bit */
+            TIMER_CTL1(timer_periph) &= (~(uint32_t)TIMER_CTL1_ISO2N);
+            /* set the ISO2N bit */
+            TIMER_CTL1(timer_periph) |= (uint32_t)((uint32_t)(ocpara->ocnidlestate) << 4U);
+        }
+        break;
+    /* configure TIMER_CH_3 */
+    case TIMER_CH_3:
+        /* reset the CH3EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH3EN);
+        TIMER_CHCTL1(timer_periph) &= ~(uint32_t)TIMER_CHCTL1_CH3MS;
+        /* set the CH3EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)ocpara->outputstate << 12U);
+        /* reset the CH3P bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH3P);
+        /* set the CH3P bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(ocpara->ocpolarity) << 12U);
+
+        if((TIMER0 == timer_periph) || (TIMER7 == timer_periph)) {
+            /* reset the ISO3 bit */
+            TIMER_CTL1(timer_periph) &= (~(uint32_t)TIMER_CTL1_ISO3);
+            /* set the ISO3 bit */
+            TIMER_CTL1(timer_periph) |= (uint32_t)((uint32_t)(ocpara->ocidlestate) << 6U);
+        }
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      configure TIMER channel output compare mode
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
+      \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_CH_2: TIMER channel2(TIMERx(x=0..4,7))
+      \arg        TIMER_CH_3: TIMER channel3(TIMERx(x=0..4,7))
+    \param[in]  ocmode: channel output compare mode
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_OC_MODE_TIMING: timing mode
+      \arg        TIMER_OC_MODE_ACTIVE: active mode
+      \arg        TIMER_OC_MODE_INACTIVE: inactive mode
+      \arg        TIMER_OC_MODE_TOGGLE: toggle mode
+      \arg        TIMER_OC_MODE_LOW: force low mode
+      \arg        TIMER_OC_MODE_HIGH: force high mode
+      \arg        TIMER_OC_MODE_PWM0: PWM0 mode
+      \arg        TIMER_OC_MODE_PWM1: PWM1 mode
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_output_mode_config(uint32_t timer_periph, uint16_t channel, uint16_t ocmode)
+{
+    switch(channel) {
+    /* configure TIMER_CH_0 */
+    case TIMER_CH_0:
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0COMCTL);
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)ocmode;
+        break;
+    /* configure TIMER_CH_1 */
+    case TIMER_CH_1:
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH1COMCTL);
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)((uint32_t)(ocmode) << 8U);
+        break;
+    /* configure TIMER_CH_2 */
+    case TIMER_CH_2:
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH2COMCTL);
+        TIMER_CHCTL1(timer_periph) |= (uint32_t)ocmode;
+        break;
+    /* configure TIMER_CH_3 */
+    case TIMER_CH_3:
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH3COMCTL);
+        TIMER_CHCTL1(timer_periph) |= (uint32_t)((uint32_t)(ocmode) << 8U);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      configure TIMER channel output pulse value
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
+      \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_CH_2: TIMER channel2(TIMERx(x=0..4,7))
+      \arg        TIMER_CH_3: TIMER channel3(TIMERx(x=0..4,7))
+    \param[in]  pulse: channel output pulse value,0~65535
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_output_pulse_value_config(uint32_t timer_periph, uint16_t channel, uint32_t pulse)
+{
+    switch(channel) {
+    /* configure TIMER_CH_0 */
+    case TIMER_CH_0:
+        TIMER_CH0CV(timer_periph) = (uint32_t)pulse;
+        break;
+    /* configure TIMER_CH_1 */
+    case TIMER_CH_1:
+        TIMER_CH1CV(timer_periph) = (uint32_t)pulse;
+        break;
+    /* configure TIMER_CH_2 */
+    case TIMER_CH_2:
+        TIMER_CH2CV(timer_periph) = (uint32_t)pulse;
+        break;
+    /* configure TIMER_CH_3 */
+    case TIMER_CH_3:
+        TIMER_CH3CV(timer_periph) = (uint32_t)pulse;
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      configure TIMER channel output shadow function
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
+      \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_CH_2: TIMER channel2(TIMERx(x=0..4,7))
+      \arg        TIMER_CH_3: TIMER channel3(TIMERx(x=0..4,7))
+    \param[in]  ocshadow: channel output shadow state
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_OC_SHADOW_ENABLE: channel output shadow state enable
+      \arg        TIMER_OC_SHADOW_DISABLE: channel output shadow state disable
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_output_shadow_config(uint32_t timer_periph, uint16_t channel, uint16_t ocshadow)
+{
+    switch(channel) {
+    /* configure TIMER_CH_0 */
+    case TIMER_CH_0:
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0COMSEN);
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)ocshadow;
+        break;
+    /* configure TIMER_CH_1 */
+    case TIMER_CH_1:
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH1COMSEN);
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)((uint32_t)(ocshadow) << 8U);
+        break;
+    /* configure TIMER_CH_2 */
+    case TIMER_CH_2:
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH2COMSEN);
+        TIMER_CHCTL1(timer_periph) |= (uint32_t)ocshadow;
+        break;
+    /* configure TIMER_CH_3 */
+    case TIMER_CH_3:
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH3COMSEN);
+        TIMER_CHCTL1(timer_periph) |= (uint32_t)((uint32_t)(ocshadow) << 8U);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      configure TIMER channel output fast function
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
+      \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_CH_2: TIMER channel2(TIMERx(x=0..4,7))
+      \arg        TIMER_CH_3: TIMER channel3(TIMERx(x=0..4,7))
+    \param[in]  ocfast: channel output fast function
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_OC_FAST_ENABLE: channel output fast function enable
+      \arg        TIMER_OC_FAST_DISABLE: channel output fast function disable
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_output_fast_config(uint32_t timer_periph, uint16_t channel, uint16_t ocfast)
+{
+    switch(channel) {
+    /* configure TIMER_CH_0 */
+    case TIMER_CH_0:
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0COMFEN);
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)ocfast;
+        break;
+    /* configure TIMER_CH_1 */
+    case TIMER_CH_1:
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH1COMFEN);
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)((uint32_t)ocfast << 8U);
+        break;
+    /* configure TIMER_CH_2 */
+    case TIMER_CH_2:
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH2COMFEN);
+        TIMER_CHCTL1(timer_periph) |= (uint32_t)ocfast;
+        break;
+    /* configure TIMER_CH_3 */
+    case TIMER_CH_3:
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH3COMFEN);
+        TIMER_CHCTL1(timer_periph) |= (uint32_t)((uint32_t)ocfast << 8U);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      configure TIMER channel output clear function
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7))
+      \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7))
+      \arg        TIMER_CH_2: TIMER channel2(TIMERx(x=0..4,7))
+      \arg        TIMER_CH_3: TIMER channel3(TIMERx(x=0..4,7))
+    \param[in]  occlear: channel output clear function
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_OC_CLEAR_ENABLE: channel output clear function enable
+      \arg        TIMER_OC_CLEAR_DISABLE: channel output clear function disable
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_output_clear_config(uint32_t timer_periph, uint16_t channel, uint16_t occlear)
+{
+    switch(channel) {
+    /* configure TIMER_CH_0 */
+    case TIMER_CH_0:
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0COMCEN);
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)occlear;
+        break;
+    /* configure TIMER_CH_1 */
+    case TIMER_CH_1:
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH1COMCEN);
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)((uint32_t)occlear << 8U);
+        break;
+    /* configure TIMER_CH_2 */
+    case TIMER_CH_2:
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH2COMCEN);
+        TIMER_CHCTL1(timer_periph) |= (uint32_t)occlear;
+        break;
+    /* configure TIMER_CH_3 */
+    case TIMER_CH_3:
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH3COMCEN);
+        TIMER_CHCTL1(timer_periph) |= (uint32_t)((uint32_t)occlear << 8U);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      configure TIMER channel output polarity
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
+      \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_CH_2: TIMER channel2(TIMERx(x=0..4,7))
+      \arg        TIMER_CH_3: TIMER channel3(TIMERx(x=0..4,7))
+    \param[in]  ocpolarity: channel output polarity
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_OC_POLARITY_HIGH: channel output polarity is high
+      \arg        TIMER_OC_POLARITY_LOW: channel output polarity is low
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_output_polarity_config(uint32_t timer_periph, uint16_t channel, uint16_t ocpolarity)
+{
+    switch(channel) {
+    /* configure TIMER_CH_0 */
+    case TIMER_CH_0:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0P);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)ocpolarity;
+        break;
+    /* configure TIMER_CH_1 */
+    case TIMER_CH_1:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1P);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)ocpolarity << 4U);
+        break;
+    /* configure TIMER_CH_2 */
+    case TIMER_CH_2:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH2P);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)ocpolarity << 8U);
+        break;
+    /* configure TIMER_CH_3 */
+    case TIMER_CH_3:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH3P);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)ocpolarity << 12U);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      configure TIMER channel complementary output polarity
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
+      \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_CH_2: TIMER channel2(TIMERx(x=0..4,7))
+    \param[in]  ocnpolarity: channel complementary output polarity
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_OCN_POLARITY_HIGH: channel complementary output polarity is high
+      \arg        TIMER_OCN_POLARITY_LOW: channel complementary output polarity is low
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_complementary_output_polarity_config(uint32_t timer_periph, uint16_t channel, uint16_t ocnpolarity)
+{
+    switch(channel) {
+    /* configure TIMER_CH_0 */
+    case TIMER_CH_0:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0NP);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)ocnpolarity;
+        break;
+    /* configure TIMER_CH_1 */
+    case TIMER_CH_1:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1NP);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)ocnpolarity << 4U);
+        break;
+    /* configure TIMER_CH_2 */
+    case TIMER_CH_2:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH2NP);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)ocnpolarity << 8U);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      configure TIMER channel enable state
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
+      \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_CH_2: TIMER channel2(TIMERx(x=0..4,7))
+      \arg        TIMER_CH_3: TIMER channel3(TIMERx(x=0..4,7))
+    \param[in]  state: TIMER channel enable state
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CCX_ENABLE: channel enable
+      \arg        TIMER_CCX_DISABLE: channel disable
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_output_state_config(uint32_t timer_periph, uint16_t channel, uint32_t state)
+{
+    switch(channel) {
+    /* configure TIMER_CH_0 */
+    case TIMER_CH_0:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0EN);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)state;
+        break;
+    /* configure TIMER_CH_1 */
+    case TIMER_CH_1:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1EN);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)state << 4U);
+        break;
+    /* configure TIMER_CH_2 */
+    case TIMER_CH_2:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH2EN);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)state << 8U);
+        break;
+    /* configure TIMER_CH_3 */
+    case TIMER_CH_3:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH3EN);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)state << 12U);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      configure TIMER channel complementary output enable state
+    \param[in]  timer_periph: TIMERx(x=0,7)
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel0
+      \arg        TIMER_CH_1: TIMER channel1
+      \arg        TIMER_CH_2: TIMER channel2
+    \param[in]  ocnstate: TIMER channel complementary output enable state
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CCXN_ENABLE: channel complementary enable
+      \arg        TIMER_CCXN_DISABLE: channel complementary disable
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_complementary_output_state_config(uint32_t timer_periph, uint16_t channel, uint16_t ocnstate)
+{
+    switch(channel) {
+    /* configure TIMER_CH_0 */
+    case TIMER_CH_0:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0NEN);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)ocnstate;
+        break;
+    /* configure TIMER_CH_1 */
+    case TIMER_CH_1:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1NEN);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)ocnstate << 4U);
+        break;
+    /* configure TIMER_CH_2 */
+    case TIMER_CH_2:
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH2NEN);
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)ocnstate << 8U);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      initialize TIMER channel input parameter struct
+    \param[in]  icpara: TIMER channel intput parameter struct
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_input_struct_para_init(timer_ic_parameter_struct *icpara)
+{
+    /* initialize the channel input parameter struct member with the default value */
+    icpara->icpolarity  = TIMER_IC_POLARITY_RISING;
+    icpara->icselection = TIMER_IC_SELECTION_DIRECTTI;
+    icpara->icprescaler = TIMER_IC_PSC_DIV1;
+    icpara->icfilter    = 0U;
+}
+
+/*!
+    \brief      configure TIMER input capture parameter
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
+      \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_CH_2: TIMER channel2(TIMERx(x=0..4,7))
+      \arg        TIMER_CH_3: TIMER channel3(TIMERx(x=0..4,7))
+     \param[in]  icpara: TIMER channel intput parameter struct
+                 icpolarity: TIMER_IC_POLARITY_RISING,TIMER_IC_POLARITY_FALLING,TIMER_IC_POLARITY_BOTH_EDGE
+                 icselection: TIMER_IC_SELECTION_DIRECTTI,TIMER_IC_SELECTION_INDIRECTTI,TIMER_IC_SELECTION_ITS
+                 icprescaler: TIMER_IC_PSC_DIV1,TIMER_IC_PSC_DIV2,TIMER_IC_PSC_DIV4,TIMER_IC_PSC_DIV8
+                 icfilter: 0~15
+    \param[out]  none
+    \retval      none
+*/
+void timer_input_capture_config(uint32_t timer_periph, uint16_t channel, timer_ic_parameter_struct *icpara)
+{
+    switch(channel) {
+    /* configure TIMER_CH_0 */
+    case TIMER_CH_0:
+        /* reset the CH0EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0EN);
+
+        /* reset the CH0P and CH0NP bits */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH0P | TIMER_CHCTL2_CH0NP));
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)(icpara->icpolarity);
+        /* reset the CH0MS bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0MS);
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)(icpara->icselection);
+        /* reset the CH0CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0CAPFLT);
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)((uint32_t)(icpara->icfilter) << 4U);
+
+        /* set the CH0EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH0EN;
+        break;
+
+    /* configure TIMER_CH_1 */
+    case TIMER_CH_1:
+        /* reset the CH1EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1EN);
+
+        /* reset the CH1P and CH1NP bits */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH1P | TIMER_CHCTL2_CH1NP));
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(icpara->icpolarity) << 4U);
+        /* reset the CH1MS bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH1MS);
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)((uint32_t)(icpara->icselection) << 8U);
+        /* reset the CH1CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH1CAPFLT);
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)((uint32_t)(icpara->icfilter) << 12U);
+
+        /* set the CH1EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH1EN;
+        break;
+    /* configure TIMER_CH_2 */
+    case TIMER_CH_2:
+        /* reset the CH2EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH2EN);
+
+        /* reset the CH2P and CH2NP bits */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH2P | TIMER_CHCTL2_CH2NP));
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(icpara->icpolarity) << 8U);
+
+        /* reset the CH2MS bit */
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH2MS);
+        TIMER_CHCTL1(timer_periph) |= (uint32_t)((uint32_t)(icpara->icselection));
+
+        /* reset the CH2CAPFLT bit */
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH2CAPFLT);
+        TIMER_CHCTL1(timer_periph) |= (uint32_t)((uint32_t)(icpara->icfilter) << 4U);
+
+        /* set the CH2EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH2EN;
+        break;
+    /* configure TIMER_CH_3 */
+    case TIMER_CH_3:
+        /* reset the CH3EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH3EN);
+
+        /* reset the CH3P bits */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH3P));
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(icpara->icpolarity) << 12U);
+
+        /* reset the CH3MS bit */
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH3MS);
+        TIMER_CHCTL1(timer_periph) |= (uint32_t)((uint32_t)(icpara->icselection) << 8U);
+
+        /* reset the CH3CAPFLT bit */
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH3CAPFLT);
+        TIMER_CHCTL1(timer_periph) |= (uint32_t)((uint32_t)(icpara->icfilter) << 12U);
+
+        /* set the CH3EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH3EN;
+        break;
+    default:
+        break;
+    }
+    /* configure TIMER channel input capture prescaler value */
+    timer_channel_input_capture_prescaler_config(timer_periph, channel, (uint16_t)(icpara->icprescaler));
+}
+
+/*!
+    \brief      configure TIMER channel input capture prescaler value
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
+      \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_CH_2: TIMER channel2(TIMERx(x=0..4,7))
+      \arg        TIMER_CH_3: TIMER channel3(TIMERx(x=0..4,7))
+    \param[in]  prescaler: channel input capture prescaler value
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_IC_PSC_DIV1: no prescaler
+      \arg        TIMER_IC_PSC_DIV2: divided by 2
+      \arg        TIMER_IC_PSC_DIV4: divided by 4
+      \arg        TIMER_IC_PSC_DIV8: divided by 8
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_input_capture_prescaler_config(uint32_t timer_periph, uint16_t channel, uint16_t prescaler)
+{
+    switch(channel) {
+    /* configure TIMER_CH_0 */
+    case TIMER_CH_0:
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0CAPPSC);
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)prescaler;
+        break;
+    /* configure TIMER_CH_1 */
+    case TIMER_CH_1:
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH1CAPPSC);
+        TIMER_CHCTL0(timer_periph) |= ((uint32_t)prescaler << 8U);
+        break;
+    /* configure TIMER_CH_2 */
+    case TIMER_CH_2:
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH2CAPPSC);
+        TIMER_CHCTL1(timer_periph) |= (uint32_t)prescaler;
+        break;
+    /* configure TIMER_CH_3 */
+    case TIMER_CH_3:
+        TIMER_CHCTL1(timer_periph) &= (~(uint32_t)TIMER_CHCTL1_CH3CAPPSC);
+        TIMER_CHCTL1(timer_periph) |= ((uint32_t)prescaler << 8U);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      read TIMER channel capture compare register value
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel0(TIMERx(x=0..4,7..13))
+      \arg        TIMER_CH_1: TIMER channel1(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_CH_2: TIMER channel2(TIMERx(x=0..4,7))
+      \arg        TIMER_CH_3: TIMER channel3(TIMERx(x=0..4,7))
+    \param[out] none
+    \retval     channel capture compare register value
+*/
+uint32_t timer_channel_capture_value_register_read(uint32_t timer_periph, uint16_t channel)
+{
+    uint32_t count_value = 0U;
+
+    switch(channel) {
+    /* read TIMER channel 0 capture compare register value */
+    case TIMER_CH_0:
+        count_value = TIMER_CH0CV(timer_periph);
+        break;
+    /* read TIMER channel 1 capture compare register value */
+    case TIMER_CH_1:
+        count_value = TIMER_CH1CV(timer_periph);
+        break;
+    /* read TIMER channel 2 capture compare register value */
+    case TIMER_CH_2:
+        count_value = TIMER_CH2CV(timer_periph);
+        break;
+    /* read TIMER channel 3 capture compare register value */
+    case TIMER_CH_3:
+        count_value = TIMER_CH3CV(timer_periph);
+        break;
+    default:
+        break;
+    }
+    return (count_value);
+}
+
+/*!
+    \brief      configure TIMER input pwm capture function
+    \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
+    \param[in]  channel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CH_0: TIMER channel0
+      \arg        TIMER_CH_1: TIMER channel1
+     \param[in]  icpwm:TIMER channel intput pwm parameter struct
+                 icpolarity: TIMER_IC_POLARITY_RISING,TIMER_IC_POLARITY_FALLING
+                 icselection: TIMER_IC_SELECTION_DIRECTTI,TIMER_IC_SELECTION_INDIRECTTI
+                 icprescaler: TIMER_IC_PSC_DIV1,TIMER_IC_PSC_DIV2,TIMER_IC_PSC_DIV4,TIMER_IC_PSC_DIV8
+                 icfilter: 0~15
+    \param[out] none
+    \retval     none
+*/
+void timer_input_pwm_capture_config(uint32_t timer_periph, uint16_t channel, timer_ic_parameter_struct *icpwm)
+{
+    uint16_t icpolarity  = 0x0U;
+    uint16_t icselection = 0x0U;
+
+    /* Set channel input polarity */
+    if(TIMER_IC_POLARITY_RISING == icpwm->icpolarity) {
+        icpolarity = TIMER_IC_POLARITY_FALLING;
+    } else {
+        icpolarity = TIMER_IC_POLARITY_RISING;
+    }
+
+    /* Set channel input mode selection */
+    if(TIMER_IC_SELECTION_DIRECTTI == icpwm->icselection) {
+        icselection = TIMER_IC_SELECTION_INDIRECTTI;
+    } else {
+        icselection = TIMER_IC_SELECTION_DIRECTTI;
+    }
+
+    if(TIMER_CH_0 == channel) {
+        /* reset the CH0EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0EN);
+        /* reset the CH0P and CH0NP bits */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH0P | TIMER_CHCTL2_CH0NP));
+        /* set the CH0P and CH0NP bits */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)(icpwm->icpolarity);
+        /* reset the CH0MS bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0MS);
+        /* set the CH0MS bit */
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)(icpwm->icselection);
+        /* reset the CH0CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0CAPFLT);
+        /* set the CH0CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) |= ((uint32_t)(icpwm->icfilter) << 4U);
+        /* set the CH0EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH0EN;
+        /* configure TIMER channel input capture prescaler value */
+        timer_channel_input_capture_prescaler_config(timer_periph, TIMER_CH_0, (uint16_t)(icpwm->icprescaler));
+
+        /* reset the CH1EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1EN);
+        /* reset the CH1P and CH1NP bits */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH1P | TIMER_CHCTL2_CH1NP));
+        /* set the CH1P and CH1NP bits */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)icpolarity << 4U);
+        /* reset the CH1MS bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH1MS);
+        /* set the CH1MS bit */
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)((uint32_t)icselection << 8U);
+        /* reset the CH1CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH1CAPFLT);
+        /* set the CH1CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)((uint32_t)(icpwm->icfilter) << 12U);
+        /* set the CH1EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH1EN;
+        /* configure TIMER channel input capture prescaler value */
+        timer_channel_input_capture_prescaler_config(timer_periph, TIMER_CH_1, (uint16_t)(icpwm->icprescaler));
+    } else {
+        /* reset the CH1EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1EN);
+        /* reset the CH1P and CH1NP bits */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH1P | TIMER_CHCTL2_CH1NP));
+        /* set the CH1P and CH1NP bits */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)(icpwm->icpolarity) << 4U);
+        /* reset the CH1MS bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH1MS);
+        /* set the CH1MS bit */
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)((uint32_t)(icpwm->icselection) << 8U);
+        /* reset the CH1CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH1CAPFLT);
+        /* set the CH1CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)((uint32_t)(icpwm->icfilter) << 12U);
+        /* set the CH1EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH1EN;
+        /* configure TIMER channel input capture prescaler value */
+        timer_channel_input_capture_prescaler_config(timer_periph, TIMER_CH_1, (uint16_t)(icpwm->icprescaler));
+
+        /* reset the CH0EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0EN);
+        /* reset the CH0P and CH0NP bits */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH0P | TIMER_CHCTL2_CH0NP));
+        /* set the CH0P and CH0NP bits */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)icpolarity;
+        /* reset the CH0MS bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0MS);
+        /* set the CH0MS bit */
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)icselection;
+        /* reset the CH0CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0CAPFLT);
+        /* set the CH0CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) |= ((uint32_t)(icpwm->icfilter) << 4U);
+        /* set the CH0EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH0EN;
+        /* configure TIMER channel input capture prescaler value */
+        timer_channel_input_capture_prescaler_config(timer_periph, TIMER_CH_0, (uint16_t)(icpwm->icprescaler));
+    }
+}
+
+/*!
+    \brief      configure TIMER hall sensor mode
+    \param[in]  timer_periph: TIMERx(x=0..4,7)
+    \param[in]  hallmode:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_HALLINTERFACE_ENABLE: TIMER hall sensor mode enable
+      \arg        TIMER_HALLINTERFACE_DISABLE: TIMER hall sensor mode disable
+    \param[out] none
+    \retval     none
+*/
+void timer_hall_mode_config(uint32_t timer_periph, uint32_t hallmode)
+{
+    if(TIMER_HALLINTERFACE_ENABLE == hallmode) {
+        TIMER_CTL1(timer_periph) |= (uint32_t)TIMER_CTL1_TI0S;
+    } else if(TIMER_HALLINTERFACE_DISABLE == hallmode) {
+        TIMER_CTL1(timer_periph) &= ~(uint32_t)TIMER_CTL1_TI0S;
+    } else {
+        /* illegal parameters */
+    }
+}
+
+/*!
+    \brief      select TIMER input trigger source
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  intrigger:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_SMCFG_TRGSEL_ITI0: internal trigger 0(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_SMCFG_TRGSEL_ITI1: internal trigger 1(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_SMCFG_TRGSEL_ITI2: internal trigger 2(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_SMCFG_TRGSEL_ITI3: internal trigger 3(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_SMCFG_TRGSEL_CI0F_ED: TI0 edge detector(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_SMCFG_TRGSEL_CI0FE0: filtered TIMER input 0(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_SMCFG_TRGSEL_CI1FE1: filtered TIMER input 1(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_SMCFG_TRGSEL_ETIFP: external trigger(TIMERx(x=0..4,7,8,11))
+    \param[out] none
+    \retval     none
+*/
+void timer_input_trigger_source_select(uint32_t timer_periph, uint32_t intrigger)
+{
+    TIMER_SMCFG(timer_periph) &= (~(uint32_t)TIMER_SMCFG_TRGS);
+    TIMER_SMCFG(timer_periph) |= (uint32_t)intrigger;
+}
+
+/*!
+    \brief      select TIMER master mode output trigger source
+    \param[in]  timer_periph: TIMERx(x=0..7)
+    \param[in]  outrigger:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_TRI_OUT_SRC_RESET: the UPG bit as trigger output(TIMERx(x=0..7,9,10,12,13))
+      \arg        TIMER_TRI_OUT_SRC_ENABLE: the counter enable signal TIMER_CTL0_CEN as trigger output(TIMERx(x=0..7,9,10,12,13))
+      \arg        TIMER_TRI_OUT_SRC_UPDATE: update event as trigger output(TIMERx(x=0..7,9,10,12,13))
+      \arg        TIMER_TRI_OUT_SRC_CH0: a capture or a compare match occurred in channal0 as trigger output TRGO(TIMERx(x=0..4,7,9,10,12,13))
+      \arg        TIMER_TRI_OUT_SRC_O0CPRE: O0CPRE as trigger output(TIMERx(x=0..4,7,9,10,12,13))
+      \arg        TIMER_TRI_OUT_SRC_O1CPRE: O1CPRE as trigger output(TIMERx(x=0..4,7))
+      \arg        TIMER_TRI_OUT_SRC_O2CPRE: O2CPRE as trigger output(TIMERx(x=0..4,7))
+      \arg        TIMER_TRI_OUT_SRC_O3CPRE: O3CPRE as trigger output(TIMERx(x=0..4,7))
+    \param[out] none
+    \retval     none
+*/
+void timer_master_output_trigger_source_select(uint32_t timer_periph, uint32_t outrigger)
+{
+    TIMER_CTL1(timer_periph) &= (~(uint32_t)TIMER_CTL1_MMC);
+    TIMER_CTL1(timer_periph) |= (uint32_t)outrigger;
+}
+
+/*!
+    \brief      select TIMER slave mode
+    \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
+    \param[in]  slavemode:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_SLAVE_MODE_DISABLE: slave mode disable(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_ENCODER_MODE0: encoder mode 0(TIMERx(x=0..4,7))
+      \arg        TIMER_ENCODER_MODE1: encoder mode 1(TIMERx(x=0..4,7))
+      \arg        TIMER_ENCODER_MODE2: encoder mode 2(TIMERx(x=0..4,7))
+      \arg        TIMER_SLAVE_MODE_RESTART: restart mode(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_SLAVE_MODE_PAUSE: pause mode(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_SLAVE_MODE_EVENT: event mode(TIMERx(x=0..4,7,8,11))
+      \arg        TIMER_SLAVE_MODE_EXTERNAL0: external clock mode 0.(TIMERx(x=0..4,7,8,11))
+    \param[out] none
+    \retval     none
+*/
+
+void timer_slave_mode_select(uint32_t timer_periph, uint32_t slavemode)
+{
+    TIMER_SMCFG(timer_periph) &= (~(uint32_t)TIMER_SMCFG_SMC);
+
+    TIMER_SMCFG(timer_periph) |= (uint32_t)slavemode;
+}
+
+/*!
+    \brief      configure TIMER master slave mode
+    \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
+    \param[in]  masterslave:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_MASTER_SLAVE_MODE_ENABLE: master slave mode enable
+      \arg        TIMER_MASTER_SLAVE_MODE_DISABLE: master slave mode disable
+    \param[out] none
+    \retval     none
+*/
+void timer_master_slave_mode_config(uint32_t timer_periph, uint32_t masterslave)
+{
+    if(TIMER_MASTER_SLAVE_MODE_ENABLE == masterslave) {
+        TIMER_SMCFG(timer_periph) |= (uint32_t)TIMER_SMCFG_MSM;
+    } else if(TIMER_MASTER_SLAVE_MODE_DISABLE == masterslave) {
+        TIMER_SMCFG(timer_periph) &= ~(uint32_t)TIMER_SMCFG_MSM;
+    } else {
+        /* illegal parameters */
+    }
+}
+
+/*!
+    \brief      configure TIMER external trigger input
+    \param[in]  timer_periph: TIMERx(x=0..4,7)
+    \param[in]  extprescaler:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_EXT_TRI_PSC_OFF: no divided
+      \arg        TIMER_EXT_TRI_PSC_DIV2: divided by 2
+      \arg        TIMER_EXT_TRI_PSC_DIV4: divided by 4
+      \arg        TIMER_EXT_TRI_PSC_DIV8: divided by 8
+    \param[in]  extpolarity:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_ETP_FALLING: active low or falling edge active
+      \arg        TIMER_ETP_RISING: active high or rising edge active
+    \param[in]  extfilter: a value between 0 and 15
+    \param[out] none
+    \retval     none
+*/
+void timer_external_trigger_config(uint32_t timer_periph, uint32_t extprescaler,
+                                   uint32_t extpolarity, uint32_t extfilter)
+{
+    TIMER_SMCFG(timer_periph) &= (~(uint32_t)(TIMER_SMCFG_ETP | TIMER_SMCFG_ETPSC | TIMER_SMCFG_ETFC));
+    TIMER_SMCFG(timer_periph) |= (uint32_t)(extprescaler | extpolarity);
+    TIMER_SMCFG(timer_periph) |= (uint32_t)(extfilter << 8U);
+}
+
+/*!
+    \brief      configure TIMER quadrature decoder mode
+    \param[in]  timer_periph: TIMERx(x=0..4,7)
+    \param[in]  decomode:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_ENCODER_MODE0: counter counts on CI0FE0 edge depending on CI1FE1 level
+      \arg        TIMER_ENCODER_MODE1: counter counts on CI1FE1 edge depending on CI0FE0 level
+      \arg        TIMER_ENCODER_MODE2: counter counts on both CI0FE0 and CI1FE1 edges depending on the level of the other input
+    \param[in]  ic0polarity:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_IC_POLARITY_RISING: capture rising edge
+      \arg        TIMER_IC_POLARITY_FALLING: capture falling edge
+    \param[in]  ic1polarity:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_IC_POLARITY_RISING: capture rising edge
+      \arg        TIMER_IC_POLARITY_FALLING: capture falling edge
+    \param[out] none
+    \retval     none
+*/
+void timer_quadrature_decoder_mode_config(uint32_t timer_periph, uint32_t decomode,
+        uint16_t ic0polarity, uint16_t ic1polarity)
+{
+    TIMER_SMCFG(timer_periph) &= (~(uint32_t)TIMER_SMCFG_SMC);
+    TIMER_SMCFG(timer_periph) |= (uint32_t)decomode;
+
+    TIMER_CHCTL0(timer_periph) &= (uint32_t)(((~(uint32_t)TIMER_CHCTL0_CH0MS)) & ((~(uint32_t)TIMER_CHCTL0_CH1MS)));
+    TIMER_CHCTL0(timer_periph) |= (uint32_t)(TIMER_IC_SELECTION_DIRECTTI | ((uint32_t)TIMER_IC_SELECTION_DIRECTTI << 8U));
+
+    TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH0P | TIMER_CHCTL2_CH0NP));
+    TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH1P | TIMER_CHCTL2_CH1NP));
+    TIMER_CHCTL2(timer_periph) |= ((uint32_t)ic0polarity | ((uint32_t)ic1polarity << 4U));
+}
+
+/*!
+    \brief      configure TIMER internal clock mode
+    \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
+    \param[out] none
+    \retval     none
+*/
+void timer_internal_clock_config(uint32_t timer_periph)
+{
+    TIMER_SMCFG(timer_periph) &= ~(uint32_t)TIMER_SMCFG_SMC;
+}
+
+/*!
+    \brief      configure TIMER the internal trigger as external clock input
+    \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
+    \param[in]  intrigger:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_SMCFG_TRGSEL_ITI0: internal trigger 0
+      \arg        TIMER_SMCFG_TRGSEL_ITI1: internal trigger 1
+      \arg        TIMER_SMCFG_TRGSEL_ITI2: internal trigger 2
+      \arg        TIMER_SMCFG_TRGSEL_ITI3: internal trigger 3
+    \param[out] none
+    \retval     none
+*/
+void timer_internal_trigger_as_external_clock_config(uint32_t timer_periph, uint32_t intrigger)
+{
+    timer_input_trigger_source_select(timer_periph, intrigger);
+    TIMER_SMCFG(timer_periph) &= ~(uint32_t)TIMER_SMCFG_SMC;
+    TIMER_SMCFG(timer_periph) |= (uint32_t)TIMER_SLAVE_MODE_EXTERNAL0;
+}
+
+/*!
+    \brief      configure TIMER the external trigger as external clock input
+    \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
+    \param[in]  extrigger:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_SMCFG_TRGSEL_CI0F_ED: TI0 edge detector
+      \arg        TIMER_SMCFG_TRGSEL_CI0FE0: filtered TIMER input 0
+      \arg        TIMER_SMCFG_TRGSEL_CI1FE1: filtered TIMER input 1
+    \param[in]  extpolarity:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_IC_POLARITY_RISING: active high or rising edge active
+      \arg        TIMER_IC_POLARITY_FALLING: active low or falling edge active
+    \param[in]  extfilter: a value between 0 and 15
+    \param[out] none
+    \retval     none
+*/
+void timer_external_trigger_as_external_clock_config(uint32_t timer_periph, uint32_t extrigger,
+        uint16_t extpolarity, uint32_t extfilter)
+{
+    if(TIMER_SMCFG_TRGSEL_CI1FE1 == extrigger) {
+        /* reset the CH1EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH1EN);
+        /* reset the CH1NP bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH1P | TIMER_CHCTL2_CH1NP));
+        /* set the CH1NP bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)((uint32_t)extpolarity << 4U);
+        /* reset the CH1MS bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH1MS);
+        /* set the CH1MS bit */
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)((uint32_t)TIMER_IC_SELECTION_DIRECTTI << 8U);
+        /* reset the CH1CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH1CAPFLT);
+        /* set the CH1CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)(extfilter << 12U);
+        /* set the CH1EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH1EN;
+    } else {
+        /* reset the CH0EN bit */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)TIMER_CHCTL2_CH0EN);
+        /* reset the CH0P and CH0NP bits */
+        TIMER_CHCTL2(timer_periph) &= (~(uint32_t)(TIMER_CHCTL2_CH0P | TIMER_CHCTL2_CH0NP));
+        /* set the CH0P and CH0NP bits */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)extpolarity;
+        /* reset the CH0MS bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0MS);
+        /* set the CH0MS bit */
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)TIMER_IC_SELECTION_DIRECTTI;
+        /* reset the CH0CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) &= (~(uint32_t)TIMER_CHCTL0_CH0CAPFLT);
+        /* reset the CH0CAPFLT bit */
+        TIMER_CHCTL0(timer_periph) |= (uint32_t)(extfilter << 4U);
+        /* set the CH0EN bit */
+        TIMER_CHCTL2(timer_periph) |= (uint32_t)TIMER_CHCTL2_CH0EN;
+    }
+    /* select TIMER input trigger source */
+    timer_input_trigger_source_select(timer_periph, extrigger);
+    /* reset the SMC bit */
+    TIMER_SMCFG(timer_periph) &= (~(uint32_t)TIMER_SMCFG_SMC);
+    /* set the SMC bit */
+    TIMER_SMCFG(timer_periph) |= (uint32_t)TIMER_SLAVE_MODE_EXTERNAL0;
+}
+
+/*!
+    \brief      configure TIMER the external clock mode0
+    \param[in]  timer_periph: TIMERx(x=0..4,7,8,11)
+    \param[in]  extprescaler:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_EXT_TRI_PSC_OFF: no divided
+      \arg        TIMER_EXT_TRI_PSC_DIV2: divided by 2
+      \arg        TIMER_EXT_TRI_PSC_DIV4: divided by 4
+      \arg        TIMER_EXT_TRI_PSC_DIV8: divided by 8
+    \param[in]  extpolarity:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_ETP_FALLING: active low or falling edge active
+      \arg        TIMER_ETP_RISING: active high or rising edge active
+    \param[in]  extfilter: a value between 0 and 15
+    \param[out] none
+    \retval     none
+*/
+void timer_external_clock_mode0_config(uint32_t timer_periph, uint32_t extprescaler,
+                                       uint32_t extpolarity, uint32_t extfilter)
+{
+    /* configure TIMER external trigger input */
+    timer_external_trigger_config(timer_periph, extprescaler, extpolarity, extfilter);
+
+    /* reset the SMC bit,TRGS bit */
+    TIMER_SMCFG(timer_periph) &= (~(uint32_t)(TIMER_SMCFG_SMC | TIMER_SMCFG_TRGS));
+    /* set the SMC bit,TRGS bit */
+    TIMER_SMCFG(timer_periph) |= (uint32_t)(TIMER_SLAVE_MODE_EXTERNAL0 | TIMER_SMCFG_TRGSEL_ETIFP);
+}
+
+/*!
+    \brief      configure TIMER the external clock mode1
+    \param[in]  timer_periph: TIMERx(x=0..4,7)
+    \param[in]  extprescaler:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_EXT_TRI_PSC_OFF: no divided
+      \arg        TIMER_EXT_TRI_PSC_DIV2: divided by 2
+      \arg        TIMER_EXT_TRI_PSC_DIV4: divided by 4
+      \arg        TIMER_EXT_TRI_PSC_DIV8: divided by 8
+    \param[in]  extpolarity:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_ETP_FALLING: active low or falling edge active
+      \arg        TIMER_ETP_RISING: active high or rising edge active
+    \param[in]  extfilter: a value between 0 and 15
+    \param[out] none
+    \retval     none
+*/
+void timer_external_clock_mode1_config(uint32_t timer_periph, uint32_t extprescaler,
+                                       uint32_t extpolarity, uint32_t extfilter)
+{
+    /* configure TIMER external trigger input */
+    timer_external_trigger_config(timer_periph, extprescaler, extpolarity, extfilter);
+
+    TIMER_SMCFG(timer_periph) |= (uint32_t)TIMER_SMCFG_SMC1;
+}
+
+/*!
+    \brief      disable TIMER the external clock mode1
+    \param[in]  timer_periph: TIMERx(x=0..4,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_external_clock_mode1_disable(uint32_t timer_periph)
+{
+    TIMER_SMCFG(timer_periph) &= ~(uint32_t)TIMER_SMCFG_SMC1;
+}
+
+/*!
+    \brief      configure TIMER channel remap function
+    \param[in]  timer_periph: TIMERx(x=1,4,10)
+    \param[in]  remap:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER1_ITI1_RMP_TIMER7_TRGO: timer1 internal trigger input1 remap to TIMER7_TRGO
+      \arg        TIMER1_ITI1_RMP_ETHERNET_PTP: timer1 internal trigger input1 remap to ethernet PTP
+      \arg        TIMER1_ITI1_RMP_USB_FS_SOF: timer1 internal trigger input1 remap to USB FS SOF
+      \arg        TIMER1_ITI1_RMP_USB_HS_SOF: timer1 internal trigger input1 remap to USB HS SOF
+      \arg        TIMER4_CI3_RMP_GPIO: timer4 channel 3 input remap to GPIO pin
+      \arg        TIMER4_CI3_RMP_IRC32K: timer4 channel 3 input remap to IRC32K
+      \arg        TIMER4_CI3_RMP_LXTAL: timer4 channel 3 input remap to  LXTAL
+      \arg        TIMER4_CI3_RMP_RTC_WAKEUP_INT: timer4 channel 3 input remap to RTC wakeup interrupt
+      \arg        TIMER10_ITI1_RMP_GPIO: timer10 internal trigger input1 remap based on GPIO setting
+      \arg        TIMER10_ITI1_RMP_RTC_HXTAL_DIV: timer10 internal trigger input1 remap  HXTAL _DIV(clock used for RTC which is HXTAL clock divided by RTCDIV bits in RCU_CFG0 register)
+    \param[out] none
+    \retval     none
+*/
+void timer_channel_remap_config(uint32_t timer_periph, uint32_t remap)
+{
+    TIMER_IRMP(timer_periph) = (uint32_t)remap;
+}
+
+/*!
+    \brief      configure TIMER write CHxVAL register selection
+    \param[in]  timer_periph: TIMERx(x=0,1,2,13,14,15,16)
+    \param[in]  ccsel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_CHVSEL_DISABLE: no effect
+      \arg        TIMER_CHVSEL_ENABLE:  when write the CHxVAL register, if the write value is same as the CHxVAL value, the write access is ignored
+    \param[out] none
+    \retval     none
+*/
+void timer_write_chxval_register_config(uint32_t timer_periph, uint16_t ccsel)
+{
+    if(TIMER_CHVSEL_ENABLE == ccsel) {
+        TIMER_CFG(timer_periph) |= (uint32_t)TIMER_CFG_CHVSEL;
+    } else if(TIMER_CHVSEL_DISABLE == ccsel) {
+        TIMER_CFG(timer_periph) &= ~(uint32_t)TIMER_CFG_CHVSEL;
+    } else {
+        /* illegal parameters */
+    }
+}
+
+/*!
+    \brief      configure TIMER output value selection
+    \param[in]  timer_periph: TIMERx(x=0,7)
+    \param[in]  outsel:
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_OUTSEL_DISABLE: no effect
+      \arg        TIMER_OUTSEL_ENABLE: if POEN and IOS is 0, the output disabled
+    \param[out] none
+    \retval     none
+*/
+void timer_output_value_selection_config(uint32_t timer_periph, uint16_t outsel)
+{
+    if(TIMER_OUTSEL_ENABLE == outsel) {
+        TIMER_CFG(timer_periph) |= (uint32_t)TIMER_CFG_OUTSEL;
+    } else if(TIMER_OUTSEL_DISABLE == outsel) {
+        TIMER_CFG(timer_periph) &= ~(uint32_t)TIMER_CFG_OUTSEL;
+    } else {
+        /* illegal parameters */
+    }
+}
+
+/*!
+    \brief      get TIMER flags
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  flag: the timer interrupt flags
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_FLAG_UP: update flag,TIMERx(x=0..13)
+      \arg        TIMER_FLAG_CH0: channel 0 flag,TIMERx(x=0..4,7..13)
+      \arg        TIMER_FLAG_CH1: channel 1 flag,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_FLAG_CH2: channel 2 flag,TIMERx(x=0..4,7)
+      \arg        TIMER_FLAG_CH3: channel 3 flag,TIMERx(x=0..4,7)
+      \arg        TIMER_FLAG_CMT: channel control update flag,TIMERx(x=0,7)
+      \arg        TIMER_FLAG_TRG: trigger flag,TIMERx(x=0,7,8,11)
+      \arg        TIMER_FLAG_BRK: break flag,TIMERx(x=0,7)
+      \arg        TIMER_FLAG_CH0O: channel 0 overcapture flag,TIMERx(x=0..4,7..11)
+      \arg        TIMER_FLAG_CH1O: channel 1 overcapture flag,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_FLAG_CH2O: channel 2 overcapture flag,TIMERx(x=0..4,7)
+      \arg        TIMER_FLAG_CH3O: channel 3 overcapture flag,TIMERx(x=0..4,7)
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus timer_flag_get(uint32_t timer_periph, uint32_t flag)
+{
+    if(RESET != (TIMER_INTF(timer_periph) & flag)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      clear TIMER flags
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  flag: the timer interrupt flags
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_FLAG_UP: update flag,TIMERx(x=0..13)
+      \arg        TIMER_FLAG_CH0: channel 0 flag,TIMERx(x=0..4,7..13)
+      \arg        TIMER_FLAG_CH1: channel 1 flag,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_FLAG_CH2: channel 2 flag,TIMERx(x=0..4,7)
+      \arg        TIMER_FLAG_CH3: channel 3 flag,TIMERx(x=0..4,7)
+      \arg        TIMER_FLAG_CMT: channel control update flag,TIMERx(x=0,7)
+      \arg        TIMER_FLAG_TRG: trigger flag,TIMERx(x=0,7,8,11)
+      \arg        TIMER_FLAG_BRK: break flag,TIMERx(x=0,7)
+      \arg        TIMER_FLAG_CH0O: channel 0 overcapture flag,TIMERx(x=0..4,7..11)
+      \arg        TIMER_FLAG_CH1O: channel 1 overcapture flag,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_FLAG_CH2O: channel 2 overcapture flag,TIMERx(x=0..4,7)
+      \arg        TIMER_FLAG_CH3O: channel 3 overcapture flag,TIMERx(x=0..4,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_flag_clear(uint32_t timer_periph, uint32_t flag)
+{
+    TIMER_INTF(timer_periph) = (~(uint32_t)flag);
+}
+
+/*!
+    \brief      enable the TIMER interrupt
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  interrupt: timer interrupt enable source
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_INT_UP: update interrupt enable, TIMERx(x=0..13)
+      \arg        TIMER_INT_CH0: channel 0 interrupt enable, TIMERx(x=0..4,7..13)
+      \arg        TIMER_INT_CH1: channel 1 interrupt enable, TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_INT_CH2: channel 2 interrupt enable, TIMERx(x=0..4,7)
+      \arg        TIMER_INT_CH3: channel 3 interrupt enable , TIMERx(x=0..4,7)
+      \arg        TIMER_INT_CMT: commutation interrupt enable, TIMERx(x=0,7)
+      \arg        TIMER_INT_TRG: trigger interrupt enable, TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_INT_BRK: break interrupt enable, TIMERx(x=0,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_interrupt_enable(uint32_t timer_periph, uint32_t interrupt)
+{
+    TIMER_DMAINTEN(timer_periph) |= (uint32_t) interrupt;
+}
+
+/*!
+    \brief      disable the TIMER interrupt
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  interrupt: timer interrupt source enable
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_INT_UP: update interrupt enable, TIMERx(x=0..13)
+      \arg        TIMER_INT_CH0: channel 0 interrupt enable, TIMERx(x=0..4,7..13)
+      \arg        TIMER_INT_CH1: channel 1 interrupt enable, TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_INT_CH2: channel 2 interrupt enable, TIMERx(x=0..4,7)
+      \arg        TIMER_INT_CH3: channel 3 interrupt enable , TIMERx(x=0..4,7)
+      \arg        TIMER_INT_CMT: commutation interrupt enable, TIMERx(x=0,7)
+      \arg        TIMER_INT_TRG: trigger interrupt enable, TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_INT_BRK: break interrupt enable, TIMERx(x=0,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_interrupt_disable(uint32_t timer_periph, uint32_t interrupt)
+{
+    TIMER_DMAINTEN(timer_periph) &= (~(uint32_t)interrupt);
+}
+
+/*!
+    \brief      get timer interrupt flag
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  interrupt: the timer interrupt bits
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_INT_FLAG_UP: update interrupt flag,TIMERx(x=0..13)
+      \arg        TIMER_INT_FLAG_CH0: channel 0 interrupt flag,TIMERx(x=0..4,7..13)
+      \arg        TIMER_INT_FLAG_CH1: channel 1 interrupt flag,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_INT_FLAG_CH2: channel 2 interrupt flag,TIMERx(x=0..4,7)
+      \arg        TIMER_INT_FLAG_CH3: channel 3 interrupt flag,TIMERx(x=0..4,7)
+      \arg        TIMER_INT_FLAG_CMT: channel commutation interrupt flag,TIMERx(x=0,7)
+      \arg        TIMER_INT_FLAG_TRG: trigger interrupt flag,TIMERx(x=0,7,8,11)
+      \arg        TIMER_INT_FLAG_BRK:  break interrupt flag,TIMERx(x=0,7)
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus timer_interrupt_flag_get(uint32_t timer_periph, uint32_t interrupt)
+{
+    uint32_t val;
+    val = (TIMER_DMAINTEN(timer_periph) & interrupt);
+    if((RESET != (TIMER_INTF(timer_periph) & interrupt)) && (RESET != val)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      clear TIMER interrupt flag
+    \param[in]  timer_periph: please refer to the following parameters
+    \param[in]  interrupt: the timer interrupt bits
+                only one parameter can be selected which is shown as below:
+      \arg        TIMER_INT_FLAG_UP: update interrupt flag,TIMERx(x=0..13)
+      \arg        TIMER_INT_FLAG_CH0: channel 0 interrupt flag,TIMERx(x=0..4,7..13)
+      \arg        TIMER_INT_FLAG_CH1: channel 1 interrupt flag,TIMERx(x=0..4,7,8,11)
+      \arg        TIMER_INT_FLAG_CH2: channel 2 interrupt flag,TIMERx(x=0..4,7)
+      \arg        TIMER_INT_FLAG_CH3: channel 3 interrupt flag,TIMERx(x=0..4,7)
+      \arg        TIMER_INT_FLAG_CMT: channel commutation interrupt flag,TIMERx(x=0,7)
+      \arg        TIMER_INT_FLAG_TRG: trigger interrupt flag,TIMERx(x=0,7,8,11)
+      \arg        TIMER_INT_FLAG_BRK:  break interrupt flag,TIMERx(x=0,7)
+    \param[out] none
+    \retval     none
+*/
+void timer_interrupt_flag_clear(uint32_t timer_periph, uint32_t interrupt)
+{
+    TIMER_INTF(timer_periph) = (~(uint32_t)interrupt);
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_tli.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_tli.c
@@ -1,0 +1,598 @@
+/*!
+    \file    gd32f4xx_tli.c
+    \brief   TLI driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_tli.h"
+
+#define TLI_DEFAULT_VALUE   0x00000000U
+#define TLI_OPAQUE_VALUE    0x000000FFU
+
+/*!
+    \brief    deinitialize TLI registers
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void tli_deinit(void)
+{
+    rcu_periph_reset_enable(RCU_TLIRST);
+    rcu_periph_reset_disable(RCU_TLIRST);
+}
+
+/*!
+    \brief    initialize the parameters of TLI parameter structure with the default values, it is suggested
+                that call this function after a tli_parameter_struct structure is defined
+    \param[in]  none
+    \param[out] tli_struct: the data needed to initialize TLI
+                  synpsz_vpsz: size of the vertical synchronous pulse
+                  synpsz_hpsz: size of the horizontal synchronous pulse
+                  backpsz_vbpsz: size of the vertical back porch plus synchronous pulse
+                  backpsz_hbpsz: size of the horizontal back porch plus synchronous pulse
+                  activesz_vasz: size of the vertical active area width plus back porch and synchronous pulse
+                  activesz_hasz: size of the horizontal active area width plus back porch and synchronous pulse
+                  totalsz_vtsz: vertical total size of the display, including active area, back porch, synchronous
+                  totalsz_htsz: vorizontal total size of the display, including active area, back porch, synchronous
+                  backcolor_red: background value red
+                  backcolor_green: background value green
+                  backcolor_blue: background value blue
+                  signalpolarity_hs: TLI_HSYN_ACTLIVE_LOW,TLI_HSYN_ACTLIVE_HIGHT
+                  signalpolarity_vs: TLI_VSYN_ACTLIVE_LOW,TLI_VSYN_ACTLIVE_HIGHT
+                  signalpolarity_de: TLI_DE_ACTLIVE_LOW,TLI_DE_ACTLIVE_HIGHT
+                  signalpolarity_pixelck: TLI_PIXEL_CLOCK_TLI,TLI_PIXEL_CLOCK_INVERTEDTLI
+    \retval     none
+*/
+void tli_struct_para_init(tli_parameter_struct *tli_struct)
+{
+    /* initialize the struct parameters with default values */
+    tli_struct->synpsz_vpsz = TLI_DEFAULT_VALUE;
+    tli_struct->synpsz_hpsz = TLI_DEFAULT_VALUE;
+    tli_struct->backpsz_vbpsz = TLI_DEFAULT_VALUE;
+    tli_struct->backpsz_hbpsz = TLI_DEFAULT_VALUE;
+    tli_struct->activesz_vasz = TLI_DEFAULT_VALUE;
+    tli_struct->activesz_hasz = TLI_DEFAULT_VALUE;
+    tli_struct->totalsz_vtsz = TLI_DEFAULT_VALUE;
+    tli_struct->totalsz_htsz = TLI_DEFAULT_VALUE;
+    tli_struct->backcolor_red = TLI_DEFAULT_VALUE;
+    tli_struct->backcolor_green = TLI_DEFAULT_VALUE;
+    tli_struct->backcolor_blue = TLI_DEFAULT_VALUE;
+    tli_struct->signalpolarity_hs = TLI_HSYN_ACTLIVE_LOW;
+    tli_struct->signalpolarity_vs = TLI_VSYN_ACTLIVE_LOW;
+    tli_struct->signalpolarity_de = TLI_DE_ACTLIVE_LOW;
+    tli_struct->signalpolarity_pixelck = TLI_PIXEL_CLOCK_TLI;
+}
+
+/*!
+    \brief    initialize TLI display timing parameters
+    \param[in]  tli_struct: the data needed to initialize TLI
+                  synpsz_vpsz: size of the vertical synchronous pulse
+                  synpsz_hpsz: size of the horizontal synchronous pulse
+                  backpsz_vbpsz: size of the vertical back porch plus synchronous pulse
+                  backpsz_hbpsz: size of the horizontal back porch plus synchronous pulse
+                  activesz_vasz: size of the vertical active area width plus back porch and synchronous pulse
+                  activesz_hasz: size of the horizontal active area width plus back porch and synchronous pulse
+                  totalsz_vtsz: vertical total size of the display, including active area, back porch, synchronous
+                  totalsz_htsz: vorizontal total size of the display, including active area, back porch, synchronous
+                  backcolor_red: background value red
+                  backcolor_green: background value green
+                  backcolor_blue: background value blue
+                  signalpolarity_hs: TLI_HSYN_ACTLIVE_LOW,TLI_HSYN_ACTLIVE_HIGHT
+                  signalpolarity_vs: TLI_VSYN_ACTLIVE_LOW,TLI_VSYN_ACTLIVE_HIGHT
+                  signalpolarity_de: TLI_DE_ACTLIVE_LOW,TLI_DE_ACTLIVE_HIGHT
+                  signalpolarity_pixelck: TLI_PIXEL_CLOCK_TLI,TLI_PIXEL_CLOCK_INVERTEDTLI
+    \param[out] none
+    \retval     none
+*/
+void tli_init(tli_parameter_struct *tli_struct)
+{
+    /* synchronous pulse size configuration */
+    TLI_SPSZ &= ~(TLI_SPSZ_VPSZ | TLI_SPSZ_HPSZ);
+    TLI_SPSZ = (uint32_t)((uint32_t)tli_struct->synpsz_vpsz | ((uint32_t)tli_struct->synpsz_hpsz << 16U));
+    /* back-porch size configuration */
+    TLI_BPSZ &= ~(TLI_BPSZ_VBPSZ | TLI_BPSZ_HBPSZ);
+    TLI_BPSZ = (uint32_t)((uint32_t)tli_struct->backpsz_vbpsz | ((uint32_t)tli_struct->backpsz_hbpsz << 16U));
+    /* active size configuration */
+    TLI_ASZ &= ~(TLI_ASZ_VASZ | TLI_ASZ_HASZ);
+    TLI_ASZ = (tli_struct->activesz_vasz | (tli_struct->activesz_hasz << 16U));
+    /* total size configuration */
+    TLI_TSZ &= ~(TLI_TSZ_VTSZ | TLI_TSZ_HTSZ);
+    TLI_TSZ = (tli_struct->totalsz_vtsz | (tli_struct->totalsz_htsz << 16U));
+    /* background color configuration */
+    TLI_BGC &= ~(TLI_BGC_BVB | (TLI_BGC_BVG) | (TLI_BGC_BVR));
+    TLI_BGC = (tli_struct->backcolor_blue | (tli_struct->backcolor_green << 8U) | (tli_struct->backcolor_red << 16U));
+    TLI_CTL &= ~(TLI_CTL_HPPS | TLI_CTL_VPPS | TLI_CTL_DEPS | TLI_CTL_CLKPS);
+    TLI_CTL |= (tli_struct->signalpolarity_hs | tli_struct->signalpolarity_vs | \
+                tli_struct->signalpolarity_de | tli_struct->signalpolarity_pixelck);
+
+}
+
+/*!
+    \brief    configure TLI dither function
+    \param[in]  dither_stat
+                only one parameter can be selected which is shown as below:
+      \arg        TLI_DITHER_ENABLE
+      \arg        TLI_DITHER_DISABLE
+    \param[out] none
+    \retval     none
+*/
+void tli_dither_config(uint8_t dither_stat)
+{
+    if(TLI_DITHER_ENABLE == dither_stat) {
+        TLI_CTL |= TLI_CTL_DFEN;
+    } else {
+        TLI_CTL &= ~(TLI_CTL_DFEN);
+    }
+}
+
+/*!
+    \brief    enable TLI
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void tli_enable(void)
+{
+    TLI_CTL |= TLI_CTL_TLIEN;
+}
+
+/*!
+    \brief    disable TLI
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void tli_disable(void)
+{
+    TLI_CTL &= ~(TLI_CTL_TLIEN);
+}
+
+/*!
+    \brief    configure TLI reload mode
+    \param[in]  reload_mod
+                only one parameter can be selected which is shown as below:
+      \arg        TLI_FRAME_BLANK_RELOAD_EN
+      \arg        TLI_REQUEST_RELOAD_EN
+    \param[out] none
+    \retval     none
+*/
+void tli_reload_config(uint8_t reload_mod)
+{
+    if(TLI_FRAME_BLANK_RELOAD_EN == reload_mod) {
+        /* the layer configuration will be reloaded at frame blank */
+        TLI_RL |= TLI_RL_FBR;
+    } else {
+        /* the layer configuration will be reloaded after this bit sets */
+        TLI_RL |= TLI_RL_RQR;
+    }
+}
+
+/*!
+    \brief    initialize the parameters of TLI layer structure with the default values, it is suggested
+                that call this function after a tli_layer_parameter_struct structure is defined
+    \param[in]  none
+    \param[out] layer_struct: TLI Layer parameter struct
+                  layer_window_rightpos: window right position
+                  layer_window_leftpos: window left position
+                  layer_window_bottompos: window bottom position
+                  layer_window_toppos: window top position
+                  layer_ppf: LAYER_PPF_ARGB8888,LAYER_PPF_RGB888,LAYER_PPF_RGB565,
+                                 LAYER_PPF_ARG1555,LAYER_PPF_ARGB4444,LAYER_PPF_L8,
+                                 LAYER_PPF_AL44,LAYER_PPF_AL88
+                  layer_sa: specified alpha
+                  layer_default_alpha: the default color alpha
+                  layer_default_red: the default color red
+                  layer_default_green: the default color green
+                  layer_default_blue: the default color blue
+                  layer_acf1: LAYER_ACF1_SA,LAYER_ACF1_PASA
+                  layer_acf2: LAYER_ACF2_SA,LAYER_ACF2_PASA
+                  layer_frame_bufaddr: frame buffer base address
+                  layer_frame_buf_stride_offset: frame buffer stride offset
+                  layer_frame_line_length: frame line length
+                  layer_frame_total_line_number: frame total line number
+    \retval     none
+*/
+void tli_layer_struct_para_init(tli_layer_parameter_struct *layer_struct)
+{
+    /* initialize the struct parameters with default values */
+    layer_struct->layer_window_rightpos = TLI_DEFAULT_VALUE;
+    layer_struct->layer_window_leftpos = TLI_DEFAULT_VALUE;
+    layer_struct->layer_window_bottompos = TLI_DEFAULT_VALUE;
+    layer_struct->layer_window_toppos = TLI_DEFAULT_VALUE;
+    layer_struct->layer_ppf = LAYER_PPF_ARGB8888;
+    layer_struct->layer_sa = TLI_OPAQUE_VALUE;
+    layer_struct->layer_default_alpha = TLI_DEFAULT_VALUE;
+    layer_struct->layer_default_red = TLI_DEFAULT_VALUE;
+    layer_struct->layer_default_green = TLI_DEFAULT_VALUE;
+    layer_struct->layer_default_blue = TLI_DEFAULT_VALUE;
+    layer_struct->layer_acf1 = LAYER_ACF1_PASA;
+    layer_struct->layer_acf2 = LAYER_ACF2_PASA;
+    layer_struct->layer_frame_bufaddr = TLI_DEFAULT_VALUE;
+    layer_struct->layer_frame_buf_stride_offset = TLI_DEFAULT_VALUE;
+    layer_struct->layer_frame_line_length = TLI_DEFAULT_VALUE;
+    layer_struct->layer_frame_total_line_number = TLI_DEFAULT_VALUE;
+}
+
+/*!
+    \brief    initialize TLI layer
+    \param[in]  layerx: LAYERx(x=0,1)
+    \param[in]  layer_struct: TLI Layer parameter struct
+                  layer_window_rightpos: window right position
+                  layer_window_leftpos: window left position
+                  layer_window_bottompos: window bottom position
+                  layer_window_toppos: window top position
+                  layer_ppf: LAYER_PPF_ARGB8888,LAYER_PPF_RGB888,LAYER_PPF_RGB565,
+                                 LAYER_PPF_ARG1555,LAYER_PPF_ARGB4444,LAYER_PPF_L8,
+                                 LAYER_PPF_AL44,LAYER_PPF_AL88
+                  layer_sa: specified alpha
+                  layer_default_alpha: the default color alpha
+                  layer_default_red: the default color red
+                  layer_default_green: the default color green
+                  layer_default_blue: the default color blue
+                  layer_acf1: LAYER_ACF1_SA,LAYER_ACF1_PASA
+                  layer_acf2: LAYER_ACF2_SA,LAYER_ACF2_PASA
+                  layer_frame_bufaddr: frame buffer base address
+                  layer_frame_buf_stride_offset: frame buffer stride offset
+                  layer_frame_line_length: frame line length
+                  layer_frame_total_line_number: frame total line number
+    \param[out] none
+    \retval     none
+*/
+void tli_layer_init(uint32_t layerx, tli_layer_parameter_struct *layer_struct)
+{
+    /* configure layer window horizontal position */
+    TLI_LxHPOS(layerx) &= ~(TLI_LxHPOS_WLP | (TLI_LxHPOS_WRP));
+    TLI_LxHPOS(layerx) = (uint32_t)((uint32_t)layer_struct->layer_window_leftpos | ((uint32_t)layer_struct->layer_window_rightpos << 16U));
+    /* configure layer window vertical position */
+    TLI_LxVPOS(layerx) &= ~(TLI_LxVPOS_WTP | (TLI_LxVPOS_WBP));
+    TLI_LxVPOS(layerx) = (uint32_t)((uint32_t)layer_struct->layer_window_toppos | ((uint32_t)layer_struct->layer_window_bottompos << 16U));
+    /* configure layer packeted pixel format */
+    TLI_LxPPF(layerx) &= ~(TLI_LxPPF_PPF);
+    TLI_LxPPF(layerx) = layer_struct->layer_ppf;
+    /* configure layer specified alpha */
+    TLI_LxSA(layerx) &= ~(TLI_LxSA_SA);
+    TLI_LxSA(layerx) = layer_struct->layer_sa;
+    /* configure layer default color */
+    TLI_LxDC(layerx) &= ~(TLI_LxDC_DCB | (TLI_LxDC_DCG) | (TLI_LxDC_DCR) | (TLI_LxDC_DCA));
+    TLI_LxDC(layerx) = (uint32_t)((uint32_t)layer_struct->layer_default_blue | ((uint32_t)layer_struct->layer_default_green << 8U)
+                                  | ((uint32_t)layer_struct->layer_default_red << 16U)
+                                  | ((uint32_t)layer_struct->layer_default_alpha << 24U));
+
+    /* configure layer alpha calculation factors */
+    TLI_LxBLEND(layerx) &= ~(TLI_LxBLEND_ACF2 | (TLI_LxBLEND_ACF1));
+    TLI_LxBLEND(layerx) = ((layer_struct->layer_acf2) | (layer_struct->layer_acf1));
+    /* configure layer frame buffer base address */
+    TLI_LxFBADDR(layerx) &= ~(TLI_LxFBADDR_FBADD);
+    TLI_LxFBADDR(layerx) = (layer_struct->layer_frame_bufaddr);
+    /* configure layer frame line length */
+    TLI_LxFLLEN(layerx) &= ~(TLI_LxFLLEN_FLL | (TLI_LxFLLEN_STDOFF));
+    TLI_LxFLLEN(layerx) = (uint32_t)((uint32_t)layer_struct->layer_frame_line_length | ((uint32_t)layer_struct->layer_frame_buf_stride_offset << 16U));
+    /* configure layer frame total line number */
+    TLI_LxFTLN(layerx) &= ~(TLI_LxFTLN_FTLN);
+    TLI_LxFTLN(layerx) = (uint32_t)(layer_struct->layer_frame_total_line_number);
+
+}
+
+/*!
+    \brief    reconfigure window position
+    \param[in]  layerx: LAYERx(x=0,1)
+    \param[in]  offset_x: new horizontal offset
+    \param[in]  offset_y: new vertical offset
+    \param[out] none
+    \retval     none
+*/
+void tli_layer_window_offset_modify(uint32_t layerx, uint16_t offset_x, uint16_t offset_y)
+{
+    /* configure window start position */
+    uint32_t layer_ppf, line_num, hstart, vstart;
+    uint32_t line_length = 0U;
+    TLI_LxHPOS(layerx) &= ~(TLI_LxHPOS_WLP | (TLI_LxHPOS_WRP));
+    TLI_LxVPOS(layerx) &= ~(TLI_LxVPOS_WTP | (TLI_LxVPOS_WBP));
+    hstart = (uint32_t)offset_x + (((TLI_BPSZ & TLI_BPSZ_HBPSZ) >> 16U) + 1U);
+    vstart = (uint32_t)offset_y + ((TLI_BPSZ & TLI_BPSZ_VBPSZ) + 1U);
+    line_num = (TLI_LxFTLN(layerx) & TLI_LxFTLN_FTLN);
+    layer_ppf = (TLI_LxPPF(layerx) & TLI_LxPPF_PPF);
+    /* the bytes of a line equal TLI_LxFLLEN_FLL bits value minus 3 */
+    switch(layer_ppf) {
+    case LAYER_PPF_ARGB8888:
+        /* each pixel includes 4bytes, when pixel format is ARGB8888 */
+        line_length = (((TLI_LxFLLEN(layerx) & TLI_LxFLLEN_FLL) - 3U) / 4U);
+        break;
+    case LAYER_PPF_RGB888:
+        /* each pixel includes 3bytes, when pixel format is RGB888 */
+        line_length = (((TLI_LxFLLEN(layerx) & TLI_LxFLLEN_FLL) - 3U) / 3U);
+        break;
+    case LAYER_PPF_RGB565:
+    case LAYER_PPF_ARGB1555:
+    case LAYER_PPF_ARGB4444:
+    case LAYER_PPF_AL88:
+        /* each pixel includes 2bytes, when pixel format is RGB565,ARG1555,ARGB4444 or AL88 */
+        line_length = (((TLI_LxFLLEN(layerx) & TLI_LxFLLEN_FLL) - 3U) / 2U);
+        break;
+    case LAYER_PPF_L8:
+    case LAYER_PPF_AL44:
+        /* each pixel includes 1byte, when pixel format is L8 or AL44 */
+        line_length = (((TLI_LxFLLEN(layerx) & TLI_LxFLLEN_FLL) - 3U));
+        break;
+    default:
+        break;
+    }
+    /* reconfigure window position */
+    TLI_LxHPOS(layerx) = (hstart | ((hstart + line_length - 1U) << 16U));
+    TLI_LxVPOS(layerx) = (vstart | ((vstart + line_num - 1U) << 16U));
+}
+
+/*!
+    \brief    initialize the parameters of TLI layer LUT structure with the default values, it is suggested
+                that call this function after a tli_layer_lut_parameter_struct structure is defined
+    \param[in]  none
+    \param[out] lut_struct: TLI layer LUT parameter struct
+                  layer_table_addr: look up table write address
+                  layer_lut_channel_red: red channel of a LUT entry
+                  layer_lut_channel_green: green channel of a LUT entry
+                  layer_lut_channel_blue: blue channel of a LUT entry
+    \retval     none
+*/
+void tli_lut_struct_para_init(tli_layer_lut_parameter_struct *lut_struct)
+{
+    /* initialize the struct parameters with default values */
+    lut_struct->layer_table_addr = TLI_DEFAULT_VALUE;
+    lut_struct->layer_lut_channel_red = TLI_DEFAULT_VALUE;
+    lut_struct->layer_lut_channel_green = TLI_DEFAULT_VALUE;
+    lut_struct->layer_lut_channel_blue = TLI_DEFAULT_VALUE;
+}
+
+/*!
+    \brief    initialize TLI layer LUT
+    \param[in]  layerx: LAYERx(x=0,1)
+    \param[in]  lut_struct: TLI layer LUT parameter struct
+                  layer_table_addr: look up table write address
+                  layer_lut_channel_red: red channel of a LUT entry
+                  layer_lut_channel_green: green channel of a LUT entry
+                  layer_lut_channel_blue: blue channel of a LUT entry
+    \param[out] none
+    \retval     none
+*/
+void tli_lut_init(uint32_t layerx, tli_layer_lut_parameter_struct *lut_struct)
+{
+    TLI_LxLUT(layerx) = (uint32_t)(((uint32_t)lut_struct->layer_lut_channel_blue) | ((uint32_t)lut_struct->layer_lut_channel_green << 8U)
+                                   | ((uint32_t)lut_struct->layer_lut_channel_red << 16U
+                                      | ((uint32_t)lut_struct->layer_table_addr << 24U)));
+}
+
+/*!
+    \brief    initialize TLI layer color key
+    \param[in]  layerx: LAYERx(x=0,1)
+    \param[in]  redkey: color key red
+    \param[in]  greenkey: color key green
+    \param[in]  bluekey: color key blue
+    \param[out] none
+    \retval     none
+*/
+void tli_color_key_init(uint32_t layerx, uint8_t redkey, uint8_t greenkey, uint8_t bluekey)
+{
+    TLI_LxCKEY(layerx) = (((uint32_t)bluekey) | ((uint32_t)greenkey << 8U) | ((uint32_t)redkey << 16U));
+}
+
+/*!
+    \brief    enable TLI layer
+    \param[in]  layerx: LAYERx(x=0,1)
+    \param[out] none
+    \retval     none
+*/
+void tli_layer_enable(uint32_t layerx)
+{
+    TLI_LxCTL(layerx) |= TLI_LxCTL_LEN;
+}
+
+/*!
+    \brief    disable TLI layer
+    \param[in]  layerx: LAYERx(x=0,1)
+    \param[out] none
+    \retval     none
+*/
+void tli_layer_disable(uint32_t layerx)
+{
+    TLI_LxCTL(layerx) &= ~(TLI_LxCTL_LEN);
+}
+
+/*!
+    \brief    enable TLI layer color keying
+    \param[in]  layerx: LAYERx(x=0,1)
+    \param[out] none
+    \retval     none
+*/
+void tli_color_key_enable(uint32_t layerx)
+{
+    TLI_LxCTL(layerx) |= TLI_LxCTL_CKEYEN;
+}
+
+/*!
+    \brief    disable TLI layer color keying
+    \param[in]  layerx: LAYERx(x=0,1)
+    \param[out] none
+    \retval     none
+*/
+void tli_color_key_disable(uint32_t layerx)
+{
+    TLI_LxCTL(layerx) &= ~(TLI_LxCTL_CKEYEN);
+}
+
+/*!
+    \brief    enable TLI layer LUT
+    \param[in]  layerx: LAYERx(x=0,1)
+    \param[out] none
+    \retval     none
+*/
+void tli_lut_enable(uint32_t layerx)
+{
+    TLI_LxCTL(layerx) |= TLI_LxCTL_LUTEN;
+}
+
+/*!
+    \brief    disable TLI layer LUT
+    \param[in]  layerx: LAYERx(x=0,1)
+    \param[out] none
+    \retval     none
+*/
+void tli_lut_disable(uint32_t layerx)
+{
+    TLI_LxCTL(layerx) &= ~(TLI_LxCTL_LUTEN);
+}
+
+/*!
+    \brief    set line mark value
+    \param[in]  line_num: line number
+    \param[out] none
+    \retval     none
+*/
+void tli_line_mark_set(uint16_t line_num)
+{
+    TLI_LM &= ~(TLI_LM_LM);
+    TLI_LM = (uint32_t)line_num;
+}
+
+/*!
+    \brief    get current displayed position
+    \param[in]  none
+    \param[out] none
+    \retval     position of current pixel
+*/
+uint32_t tli_current_pos_get(void)
+{
+    return TLI_CPPOS;
+}
+
+/*!
+    \brief    enable TLI interrupt
+    \param[in]  int_flag: TLI interrupt flags
+                one or more parameters can be selected which are shown as below:
+      \arg        TLI_INT_LM: line mark interrupt
+      \arg        TLI_INT_FE: FIFO error interrupt
+      \arg        TLI_INT_TE: transaction error interrupt
+      \arg        TLI_INT_LCR: layer configuration reloaded interrupt
+    \param[out] none
+    \retval     none
+*/
+void tli_interrupt_enable(uint32_t int_flag)
+{
+    TLI_INTEN |= (int_flag);
+}
+
+/*!
+    \brief    disable TLI interrupt
+    \param[in]  int_flag: TLI interrupt flags
+                one or more parameters can be selected which are shown as below:
+      \arg        TLI_INT_LM: line mark interrupt
+      \arg        TLI_INT_FE: FIFO error interrupt
+      \arg        TLI_INT_TE: transaction error interrupt
+      \arg        TLI_INT_LCR: layer configuration reloaded interrupt
+    \param[out] none
+    \retval     none
+*/
+void tli_interrupt_disable(uint32_t int_flag)
+{
+    TLI_INTEN &= ~(int_flag);
+}
+
+/*!
+    \brief    get TLI interrupt flag
+    \param[in]  int_flag: TLI interrupt flags
+                one or more parameters can be selected which are shown as below:
+      \arg        TLI_INT_FLAG_LM: line mark interrupt flag
+      \arg        TLI_INT_FLAG_FE: FIFO error interrupt flag
+      \arg        TLI_INT_FLAG_TE: transaction error interrupt flag
+      \arg        TLI_INT_FLAG_LCR: layer configuration reloaded interrupt flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus tli_interrupt_flag_get(uint32_t int_flag)
+{
+    uint32_t state;
+    state = TLI_INTF;
+    if(state & int_flag) {
+        state = TLI_INTEN;
+        if(state & int_flag) {
+            return SET;
+        }
+    }
+    return RESET;
+}
+
+/*!
+    \brief    clear TLI interrupt flag
+    \param[in]  int_flag: TLI interrupt flags
+                one or more parameters can be selected which are shown as below:
+      \arg        TLI_INT_FLAG_LM: line mark interrupt flag
+      \arg        TLI_INT_FLAG_FE: FIFO error interrupt flag
+      \arg        TLI_INT_FLAG_TE: transaction error interrupt flag
+      \arg        TLI_INT_FLAG_LCR: layer configuration reloaded interrupt flag
+    \param[out] none
+    \retval     none
+*/
+void tli_interrupt_flag_clear(uint32_t int_flag)
+{
+    TLI_INTC |= (int_flag);
+}
+
+/*!
+    \brief    get TLI flag or state in TLI_INTF register or TLI_STAT register
+    \param[in]  flag: TLI flags or states
+                only one parameter can be selected which is shown as below:
+      \arg        TLI_FLAG_VDE: current VDE state
+      \arg        TLI_FLAG_HDE: current HDE state
+      \arg        TLI_FLAG_VS: current VS status of the TLI
+      \arg        TLI_FLAG_HS: current HS status of the TLI
+      \arg        TLI_FLAG_LM: line mark interrupt flag
+      \arg        TLI_FLAG_FE: FIFO error interrupt flag
+      \arg        TLI_FLAG_TE: transaction error interrupt flag
+      \arg        TLI_FLAG_LCR: layer configuration reloaded interrupt flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus tli_flag_get(uint32_t flag)
+{
+    uint32_t stat;
+    /* choose which register to get flag or state */
+    if(flag >> 31U) {
+        stat = TLI_INTF;
+    } else {
+        stat = TLI_STAT;
+    }
+    if(flag & stat) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_trng.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_trng.c
@@ -1,0 +1,156 @@
+/*!
+    \file    gd32f4xx_trng.c
+    \brief   TRNG driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_trng.h"
+
+/*!
+    \brief      reset TRNG
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void trng_deinit(void)
+{
+    rcu_periph_reset_enable(RCU_TRNGRST);
+    rcu_periph_reset_disable(RCU_TRNGRST);
+}
+
+/*!
+    \brief      enable TRNG 
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void trng_enable(void)
+{
+    TRNG_CTL |= TRNG_CTL_TRNGEN;
+}
+
+/*!
+    \brief      disable TRNG 
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void trng_disable(void)
+{
+    TRNG_CTL &= ~TRNG_CTL_TRNGEN;
+}
+
+/*!
+    \brief      get the true random data
+    \param[in]  none
+    \param[out] none
+    \retval     uint32_t: 0x0-0xFFFFFFFF
+*/
+uint32_t trng_get_true_random_data(void)
+{
+    return (TRNG_DATA);
+}
+
+/*!
+    \brief      enable TRNG interrupt
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void trng_interrupt_enable(void)
+{
+    TRNG_CTL |= TRNG_CTL_TRNGIE;
+}
+
+/*!
+    \brief      disable TRNG interrupt
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void trng_interrupt_disable(void)
+{
+    TRNG_CTL &= ~TRNG_CTL_TRNGIE;
+}
+
+/*!
+    \brief      get TRNG flag status
+    \param[in]  flag: TRNG flag
+                only one parameter can be selected which is shown as below:
+      \arg        TRNG_FLAG_DRDY: random Data ready status
+      \arg        TRNG_FLAG_CECS: clock error current status
+      \arg        TRNG_FLAG_SECS: seed error current status
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus trng_flag_get(trng_flag_enum flag)
+{
+    if(RESET != (TRNG_STAT & flag)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      get TRNG interrupt flag status
+    \param[in]  int_flag: TRNG interrupt flag
+                only one parameter can be selected which is shown as below:
+      \arg        TRNG_INT_FLAG_CEIF: clock error interrupt flag
+      \arg        TRNG_INT_FLAG_SEIF: seed error interrupt flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus trng_interrupt_flag_get(trng_int_flag_enum int_flag)
+{
+    if(RESET != (TRNG_STAT & int_flag)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief      clear TRNG interrupt flag status
+    \param[in]  int_flag: TRNG interrupt flag
+                only one parameter can be selected which is shown as below:
+      \arg        TRNG_INT_FLAG_CEIF: clock error interrupt flag
+      \arg        TRNG_INT_FLAG_SEIF: seed error interrupt flag
+    \param[out] none
+    \retval     none
+*/
+void trng_interrupt_flag_clear(trng_int_flag_enum int_flag)
+{
+    TRNG_STAT &= ~(uint32_t)int_flag;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_usart.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_usart.c
@@ -1,0 +1,1009 @@
+/*!
+    \file    gd32f4xx_usart.c
+    \brief   USART driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors
+       may be used to endorse or promote products derived from this software without
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_usart.h"
+
+/* USART register bit offset */
+#define GP_GUAT_OFFSET            ((uint32_t)8U)       /* bit offset of GUAT in USART_GP */
+#define CTL3_SCRTNUM_OFFSET       ((uint32_t)1U)       /* bit offset of SCRTNUM in USART_CTL3 */
+#define RT_BL_OFFSET              ((uint32_t)24U)      /* bit offset of BL in USART_RT */
+
+/*!
+    \brief    reset USART/UART
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[out] none
+    \retval     none
+*/
+void usart_deinit(uint32_t usart_periph)
+{
+    switch(usart_periph) {
+    case USART0:
+        rcu_periph_reset_enable(RCU_USART0RST);
+        rcu_periph_reset_disable(RCU_USART0RST);
+        break;
+    case USART1:
+        rcu_periph_reset_enable(RCU_USART1RST);
+        rcu_periph_reset_disable(RCU_USART1RST);
+        break;
+    case USART2:
+        rcu_periph_reset_enable(RCU_USART2RST);
+        rcu_periph_reset_disable(RCU_USART2RST);
+        break;
+    case USART5:
+        rcu_periph_reset_enable(RCU_USART5RST);
+        rcu_periph_reset_disable(RCU_USART5RST);
+        break;
+    case UART3:
+        rcu_periph_reset_enable(RCU_UART3RST);
+        rcu_periph_reset_disable(RCU_UART3RST);
+        break;
+    case UART4:
+        rcu_periph_reset_enable(RCU_UART4RST);
+        rcu_periph_reset_disable(RCU_UART4RST);
+        break;
+    case UART6:
+        rcu_periph_reset_enable(RCU_UART6RST);
+        rcu_periph_reset_disable(RCU_UART6RST);
+        break;
+    case UART7:
+        rcu_periph_reset_enable(RCU_UART7RST);
+        rcu_periph_reset_disable(RCU_UART7RST);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief    configure USART baud rate value
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  baudval: baud rate value
+    \param[out] none
+    \retval     none
+*/
+void usart_baudrate_set(uint32_t usart_periph, uint32_t baudval)
+{
+    uint32_t uclk = 0U, intdiv = 0U, fradiv = 0U, udiv = 0U;
+    switch(usart_periph) {
+    /* get clock frequency */
+    case USART0:
+        uclk = rcu_clock_freq_get(CK_APB2);
+        break;
+    case USART5:
+        uclk = rcu_clock_freq_get(CK_APB2);
+        break;
+    case USART1:
+        uclk = rcu_clock_freq_get(CK_APB1);
+        break;
+    case USART2:
+        uclk = rcu_clock_freq_get(CK_APB1);
+        break;
+    case UART3:
+        uclk = rcu_clock_freq_get(CK_APB1);
+        break;
+    case UART4:
+        uclk = rcu_clock_freq_get(CK_APB1);
+        break;
+    case UART6:
+        uclk = rcu_clock_freq_get(CK_APB1);
+        break;
+    case UART7:
+        uclk = rcu_clock_freq_get(CK_APB1);
+        break;
+    default:
+        break;
+    }
+    if(USART_CTL0(usart_periph) & USART_CTL0_OVSMOD) {
+        /* when oversampling by 8, configure the value of USART_BAUD */
+        udiv = ((2U * uclk) + baudval / 2U) / baudval;
+        intdiv = udiv & 0xfff0U;
+        fradiv = (udiv >> 1U) & 0x7U;
+        USART_BAUD(usart_periph) = ((USART_BAUD_FRADIV | USART_BAUD_INTDIV) & (intdiv | fradiv));
+    } else {
+        /* when oversampling by 16, configure the value of USART_BAUD */
+        udiv = (uclk + baudval / 2U) / baudval;
+        intdiv = udiv & 0xfff0U;
+        fradiv = udiv & 0xfU;
+        USART_BAUD(usart_periph) = ((USART_BAUD_FRADIV | USART_BAUD_INTDIV) & (intdiv | fradiv));
+    }
+}
+
+/*!
+    \brief   configure USART parity function
+    \param[in] usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in] paritycfg: configure USART parity
+               only one parameter can be selected which is shown as below:
+      \arg       USART_PM_NONE: no parity
+      \arg       USART_PM_EVEN: even parity
+      \arg       USART_PM_ODD:  odd parity
+    \param[out] none
+    \retval     none
+*/
+void usart_parity_config(uint32_t usart_periph, uint32_t paritycfg)
+{
+    /* clear USART_CTL0 PM,PCEN Bits */
+    USART_CTL0(usart_periph) &= ~(USART_CTL0_PM | USART_CTL0_PCEN);
+    /* configure USART parity mode */
+    USART_CTL0(usart_periph) |= paritycfg ;
+}
+
+/*!
+    \brief   configure USART word length
+    \param[in] usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in] wlen: USART word length configure
+               only one parameter can be selected which is shown as below:
+      \arg       USART_WL_8BIT: 8 bits
+      \arg       USART_WL_9BIT: 9 bits
+    \param[out] none
+    \retval     none
+*/
+void usart_word_length_set(uint32_t usart_periph, uint32_t wlen)
+{
+    /* clear USART_CTL0 WL bit */
+    USART_CTL0(usart_periph) &= ~USART_CTL0_WL;
+    /* configure USART word length */
+    USART_CTL0(usart_periph) |= wlen;
+}
+
+/*!
+    \brief   configure USART stop bit length
+    \param[in] usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in] stblen: USART stop bit configure
+               only one parameter can be selected which is shown as below:
+      \arg       USART_STB_1BIT:   1 bit
+      \arg       USART_STB_0_5BIT: 0.5 bit(not available for UARTx(x=3,4,6,7))
+      \arg       USART_STB_2BIT:   2 bits
+      \arg       USART_STB_1_5BIT: 1.5 bits(not available for UARTx(x=3,4,6,7))
+    \param[out] none
+    \retval     none
+*/
+void usart_stop_bit_set(uint32_t usart_periph, uint32_t stblen)
+{
+    /* clear USART_CTL1 STB bits */
+    USART_CTL1(usart_periph) &= ~USART_CTL1_STB;
+    /* configure USART stop bits */
+    USART_CTL1(usart_periph) |= stblen;
+}
+/*!
+    \brief    enable USART
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[out] none
+    \retval     none
+*/
+void usart_enable(uint32_t usart_periph)
+{
+    USART_CTL0(usart_periph) |= USART_CTL0_UEN;
+}
+
+/*!
+    \brief   disable USART
+    \param[in] usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[out] none
+    \retval     none
+*/
+void usart_disable(uint32_t usart_periph)
+{
+    USART_CTL0(usart_periph) &= ~(USART_CTL0_UEN);
+}
+
+/*!
+    \brief    configure USART transmitter
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  txconfig: enable or disable USART transmitter
+                only one parameter can be selected which is shown as below:
+      \arg        USART_TRANSMIT_ENABLE: enable USART transmission
+      \arg        USART_TRANSMIT_DISABLE: enable USART transmission
+    \param[out] none
+    \retval     none
+*/
+void usart_transmit_config(uint32_t usart_periph, uint32_t txconfig)
+{
+    uint32_t ctl = 0U;
+
+    ctl = USART_CTL0(usart_periph);
+    ctl &= ~USART_CTL0_TEN;
+    ctl |= txconfig;
+    /* configure transfer mode */
+    USART_CTL0(usart_periph) = ctl;
+}
+
+/*!
+    \brief    configure USART receiver
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  rxconfig: enable or disable USART receiver
+                only one parameter can be selected which is shown as below:
+      \arg        USART_RECEIVE_ENABLE: enable USART reception
+      \arg        USART_RECEIVE_DISABLE: disable USART reception
+    \param[out] none
+    \retval     none
+*/
+void usart_receive_config(uint32_t usart_periph, uint32_t rxconfig)
+{
+    uint32_t ctl = 0U;
+
+    ctl = USART_CTL0(usart_periph);
+    ctl &= ~USART_CTL0_REN;
+    ctl |= rxconfig;
+    /* configure transfer mode */
+    USART_CTL0(usart_periph) = ctl;
+}
+
+/*!
+    \brief    data is transmitted/received with the LSB/MSB first
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[in]  msbf: LSB/MSB
+                only one parameter can be selected which is shown as below:
+      \arg        USART_MSBF_LSB: LSB first
+      \arg        USART_MSBF_MSB: MSB first
+    \param[out] none
+    \retval     none
+*/
+void usart_data_first_config(uint32_t usart_periph, uint32_t msbf)
+{
+    uint32_t ctl = 0U;
+
+    ctl = USART_CTL3(usart_periph);
+    ctl &= ~(USART_CTL3_MSBF);
+    ctl |= msbf;
+    /* configure data transmitted/received mode */
+    USART_CTL3(usart_periph) = ctl;
+}
+
+/*!
+    \brief    configure USART inversion
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[in]  invertpara: refer to enum USART_INVERT_CONFIG
+                only one parameter can be selected which is shown as below:
+      \arg        USART_DINV_ENABLE: data bit level inversion
+      \arg        USART_DINV_DISABLE: data bit level not inversion
+      \arg        USART_TXPIN_ENABLE: TX pin level inversion
+      \arg        USART_TXPIN_DISABLE: TX pin level not inversion
+      \arg        USART_RXPIN_ENABLE: RX pin level inversion
+      \arg        USART_RXPIN_DISABLE: RX pin level not inversion
+    \param[out] none
+    \retval     none
+*/
+void usart_invert_config(uint32_t usart_periph, usart_invert_enum invertpara)
+{
+    /* inverted or not the specified siginal */
+    switch(invertpara) {
+    case USART_DINV_ENABLE:
+        USART_CTL3(usart_periph) |= USART_CTL3_DINV;
+        break;
+    case USART_TXPIN_ENABLE:
+        USART_CTL3(usart_periph) |= USART_CTL3_TINV;
+        break;
+    case USART_RXPIN_ENABLE:
+        USART_CTL3(usart_periph) |= USART_CTL3_RINV;
+        break;
+    case USART_DINV_DISABLE:
+        USART_CTL3(usart_periph) &= ~(USART_CTL3_DINV);
+        break;
+    case USART_TXPIN_DISABLE:
+        USART_CTL3(usart_periph) &= ~(USART_CTL3_TINV);
+        break;
+    case USART_RXPIN_DISABLE:
+        USART_CTL3(usart_periph) &= ~(USART_CTL3_RINV);
+        break;
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief    configure the USART oversample mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  oversamp: oversample value
+                only one parameter can be selected which is shown as below:
+      \arg        USART_OVSMOD_8: 8 bits
+      \arg        USART_OVSMOD_16: 16 bits
+    \param[out] none
+    \retval     none
+*/
+void usart_oversample_config(uint32_t usart_periph, uint32_t oversamp)
+{
+    /*  clear OVSMOD bit */
+    USART_CTL0(usart_periph) &= ~(USART_CTL0_OVSMOD);
+    USART_CTL0(usart_periph) |= oversamp;
+}
+
+/*!
+    \brief    configure sample bit method
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  obsm: sample bit
+                only one parameter can be selected which is shown as below:
+      \arg        USART_OSB_1bit: 1 bit
+      \arg        USART_OSB_3bit: 3 bits
+    \param[out] none
+    \retval     none
+*/
+void usart_sample_bit_config(uint32_t usart_periph, uint32_t obsm)
+{
+    USART_CTL2(usart_periph) &= ~(USART_CTL2_OSB);
+    USART_CTL2(usart_periph) |= obsm;
+}
+
+/*!
+    \brief    enable receiver timeout of USART
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[out] none
+    \retval     none
+*/
+void usart_receiver_timeout_enable(uint32_t usart_periph)
+{
+    USART_CTL3(usart_periph) |= USART_CTL3_RTEN;
+}
+
+/*!
+    \brief    disable receiver timeout of USART
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[out] none
+    \retval     none
+*/
+void usart_receiver_timeout_disable(uint32_t usart_periph)
+{
+    USART_CTL3(usart_periph) &= ~(USART_CTL3_RTEN);
+}
+
+/*!
+    \brief    set the receiver timeout threshold of USART
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[in]  rtimeout: 0-0x00FFFFFF
+    \param[out] none
+    \retval     none
+*/
+void usart_receiver_timeout_threshold_config(uint32_t usart_periph, uint32_t rtimeout)
+{
+    USART_RT(usart_periph) &= ~(USART_RT_RT);
+    USART_RT(usart_periph) |= rtimeout;
+}
+
+/*!
+    \brief    USART transmit data function
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  data: data of transmission
+    \param[out] none
+    \retval     none
+*/
+void usart_data_transmit(uint32_t usart_periph, uint32_t data)
+{
+    USART_DATA(usart_periph) = ((uint16_t)USART_DATA_DATA & data);
+}
+
+/*!
+    \brief    USART receive data function
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[out] none
+    \retval     data of received
+*/
+uint16_t usart_data_receive(uint32_t usart_periph)
+{
+    return (uint16_t)(GET_BITS(USART_DATA(usart_periph), 0U, 8U));
+}
+
+/*!
+    \brief    configure the address of the USART in wake up by address match mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  addr: address of USART/UART
+    \param[out] none
+    \retval     none
+*/
+void usart_address_config(uint32_t usart_periph, uint8_t addr)
+{
+    USART_CTL1(usart_periph) &= ~(USART_CTL1_ADDR);
+    USART_CTL1(usart_periph) |= (USART_CTL1_ADDR & addr);
+}
+
+/*!
+    \brief    enable mute mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[out] none
+    \retval     none
+*/
+void usart_mute_mode_enable(uint32_t usart_periph)
+{
+    USART_CTL0(usart_periph) |= USART_CTL0_RWU;
+}
+
+/*!
+    \brief    disable mute mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[out] none
+    \retval     none
+*/
+void usart_mute_mode_disable(uint32_t usart_periph)
+{
+    USART_CTL0(usart_periph) &= ~(USART_CTL0_RWU);
+}
+
+/*!
+    \brief    configure wakeup method in mute mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  wmehtod: two method be used to enter or exit the mute mode
+                only one parameter can be selected which is shown as below:
+      \arg        USART_WM_IDLE: idle line
+      \arg        USART_WM_ADDR: address mask
+    \param[out] none
+    \retval     none
+*/
+void usart_mute_mode_wakeup_config(uint32_t usart_periph, uint32_t wmehtod)
+{
+    USART_CTL0(usart_periph) &= ~(USART_CTL0_WM);
+    USART_CTL0(usart_periph) |= wmehtod;
+}
+
+/*!
+    \brief    enable LIN mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[out] none
+    \retval     none
+*/
+void usart_lin_mode_enable(uint32_t usart_periph)
+{
+    USART_CTL1(usart_periph) |= USART_CTL1_LMEN;
+}
+
+/*!
+    \brief    disable LIN mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[out] none
+    \retval     none
+*/
+void usart_lin_mode_disable(uint32_t usart_periph)
+{
+    USART_CTL1(usart_periph) &= ~(USART_CTL1_LMEN);
+}
+
+/*!
+    \brief    configure lin break frame length
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  lblen: lin break frame length
+                only one parameter can be selected which is shown as below:
+      \arg        USART_LBLEN_10B: 10 bits
+      \arg        USART_LBLEN_11B: 11 bits
+    \param[out] none
+    \retval     none
+*/
+void usart_lin_break_detection_length_config(uint32_t usart_periph, uint32_t lblen)
+{
+    USART_CTL1(usart_periph) &= ~(USART_CTL1_LBLEN);
+    USART_CTL1(usart_periph) |= (USART_CTL1_LBLEN & lblen);
+}
+
+/*!
+    \brief    send break frame
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[out] none
+    \retval     none
+*/
+void usart_send_break(uint32_t usart_periph)
+{
+    USART_CTL0(usart_periph) |= USART_CTL0_SBKCMD;
+}
+
+/*!
+    \brief    enable half duplex mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[out] none
+    \retval     none
+*/
+void usart_halfduplex_enable(uint32_t usart_periph)
+{
+    USART_CTL2(usart_periph) |= USART_CTL2_HDEN;
+}
+
+/*!
+    \brief    disable half duplex mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[out] none
+    \retval     none
+*/
+void usart_halfduplex_disable(uint32_t usart_periph)
+{
+    USART_CTL2(usart_periph) &= ~(USART_CTL2_HDEN);
+}
+
+/*!
+    \brief    enable CK pin in synchronous mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[out] none
+    \retval     none
+*/
+void usart_synchronous_clock_enable(uint32_t usart_periph)
+{
+    USART_CTL1(usart_periph) |= USART_CTL1_CKEN;
+}
+
+/*!
+    \brief    disable CK pin in synchronous mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[out] none
+    \retval     none
+*/
+void usart_synchronous_clock_disable(uint32_t usart_periph)
+{
+    USART_CTL1(usart_periph) &= ~(USART_CTL1_CKEN);
+}
+
+/*!
+    \brief    configure USART synchronous mode parameters
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[in]  clen: CK length
+                only one parameter can be selected which is shown as below:
+      \arg        USART_CLEN_NONE: there are 7 CK pulses for an 8 bit frame and 8 CK pulses for a 9 bit frame
+      \arg        USART_CLEN_EN:   there are 8 CK pulses for an 8 bit frame and 9 CK pulses for a 9 bit frame
+    \param[in]  cph: clock phase
+                only one parameter can be selected which is shown as below:
+      \arg        USART_CPH_1CK: first clock transition is the first data capture edge
+      \arg        USART_CPH_2CK: second clock transition is the first data capture edge
+    \param[in]  cpl: clock polarity
+                only one parameter can be selected which is shown as below:
+      \arg        USART_CPL_LOW:  steady low value on CK pin
+      \arg        USART_CPL_HIGH: steady high value on CK pin
+    \param[out] none
+    \retval     none
+*/
+void usart_synchronous_clock_config(uint32_t usart_periph, uint32_t clen, uint32_t cph, uint32_t cpl)
+{
+    uint32_t ctl = 0U;
+
+    /* read USART_CTL1 register */
+    ctl = USART_CTL1(usart_periph);
+    ctl &= ~(USART_CTL1_CLEN | USART_CTL1_CPH | USART_CTL1_CPL);
+    /* set CK length, CK phase, CK polarity */
+    ctl |= (USART_CTL1_CLEN & clen) | (USART_CTL1_CPH & cph) | (USART_CTL1_CPL & cpl);
+
+    USART_CTL1(usart_periph) = ctl;
+}
+
+/*!
+    \brief    configure guard time value in smartcard mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[in]  guat: guard time value, 0-0xFF
+    \param[out] none
+    \retval     none
+*/
+void usart_guard_time_config(uint32_t usart_periph, uint32_t guat)
+{
+    USART_GP(usart_periph) &= ~(USART_GP_GUAT);
+    USART_GP(usart_periph) |= (USART_GP_GUAT & ((guat) << GP_GUAT_OFFSET));
+}
+
+/*!
+    \brief    enable smartcard mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[out] none
+    \retval     none
+*/
+void usart_smartcard_mode_enable(uint32_t usart_periph)
+{
+    USART_CTL2(usart_periph) |= USART_CTL2_SCEN;
+}
+
+/*!
+    \brief    disable smartcard mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[out] none
+    \retval     none
+*/
+void usart_smartcard_mode_disable(uint32_t usart_periph)
+{
+    USART_CTL2(usart_periph) &= ~(USART_CTL2_SCEN);
+}
+
+/*!
+    \brief    enable NACK in smartcard mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[out] none
+    \retval     none
+*/
+void usart_smartcard_mode_nack_enable(uint32_t usart_periph)
+{
+    USART_CTL2(usart_periph) |= USART_CTL2_NKEN;
+}
+
+/*!
+    \brief    disable NACK in smartcard mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[out] none
+    \retval     none
+*/
+void usart_smartcard_mode_nack_disable(uint32_t usart_periph)
+{
+    USART_CTL2(usart_periph) &= ~(USART_CTL2_NKEN);
+}
+
+/*!
+    \brief    configure smartcard auto-retry number
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[in]  scrtnum: smartcard auto-retry number
+    \param[out] none
+    \retval     none
+*/
+void usart_smartcard_autoretry_config(uint32_t usart_periph, uint32_t scrtnum)
+{
+    USART_CTL3(usart_periph) &= ~(USART_CTL3_SCRTNUM);
+    USART_CTL3(usart_periph) |= (USART_CTL3_SCRTNUM & ((scrtnum) << CTL3_SCRTNUM_OFFSET));
+}
+
+/*!
+    \brief    configure block length in Smartcard T=1 reception
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[in]  bl: block length
+    \param[out] none
+    \retval     none
+*/
+void usart_block_length_config(uint32_t usart_periph, uint32_t bl)
+{
+    USART_RT(usart_periph) &= ~(USART_RT_BL);
+    USART_RT(usart_periph) |= (USART_RT_BL & ((bl) << RT_BL_OFFSET));
+}
+
+/*!
+    \brief    enable IrDA mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[out] none
+    \retval     none
+*/
+void usart_irda_mode_enable(uint32_t usart_periph)
+{
+    USART_CTL2(usart_periph) |= USART_CTL2_IREN;
+}
+
+/*!
+    \brief    disable IrDA mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[out] none
+    \retval     none
+*/
+void usart_irda_mode_disable(uint32_t usart_periph)
+{
+    USART_CTL2(usart_periph) &= ~(USART_CTL2_IREN);
+}
+
+/*!
+    \brief    configure the peripheral clock prescaler in USART IrDA low-power mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  psc: 0-0xFF
+    \param[out] none
+    \retval     none
+*/
+void usart_prescaler_config(uint32_t usart_periph, uint8_t psc)
+{
+    USART_GP(usart_periph) &= ~(USART_GP_PSC);
+    USART_GP(usart_periph) |= psc;
+}
+
+/*!
+    \brief    configure IrDA low-power
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  irlp: IrDA low-power or normal
+                only one parameter can be selected which is shown as below:
+      \arg        USART_IRLP_LOW: low-power
+      \arg        USART_IRLP_NORMAL: normal
+    \param[out] none
+    \retval     none
+*/
+void usart_irda_lowpower_config(uint32_t usart_periph, uint32_t irlp)
+{
+    USART_CTL2(usart_periph) &= ~(USART_CTL2_IRLP);
+    USART_CTL2(usart_periph) |= (USART_CTL2_IRLP & irlp);
+}
+
+/*!
+    \brief    configure hardware flow control RTS
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[in]  rtsconfig: enable or disable RTS
+                only one parameter can be selected which is shown as below:
+      \arg        USART_RTS_ENABLE:  enable RTS
+      \arg        USART_RTS_DISABLE: disable RTS
+    \param[out] none
+    \retval     none
+*/
+void usart_hardware_flow_rts_config(uint32_t usart_periph, uint32_t rtsconfig)
+{
+    uint32_t ctl = 0U;
+
+    ctl = USART_CTL2(usart_periph);
+    ctl &= ~USART_CTL2_RTSEN;
+    ctl |= rtsconfig;
+    /* configure RTS */
+    USART_CTL2(usart_periph) = ctl;
+}
+
+/*!
+    \brief    configure hardware flow control CTS
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[in]  ctsconfig: enable or disable CTS
+                only one parameter can be selected which is shown as below:
+      \arg        USART_CTS_ENABLE:  enable CTS
+      \arg        USART_CTS_DISABLE: disable CTS
+    \param[out] none
+    \retval     none
+*/
+void usart_hardware_flow_cts_config(uint32_t usart_periph, uint32_t ctsconfig)
+{
+    uint32_t ctl = 0U;
+
+    ctl = USART_CTL2(usart_periph);
+    ctl &= ~USART_CTL2_CTSEN;
+    ctl |= ctsconfig;
+    /* configure CTS */
+    USART_CTL2(usart_periph) = ctl;
+}
+
+/*!
+    \brief    configure break frame coherence mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[in]  bcm:
+                only one parameter can be selected which is shown as below:
+      \arg        USART_BCM_NONE: no parity error is detected
+      \arg        USART_BCM_EN:   parity error is detected
+    \param[out] none
+    \retval     none
+*/
+void usart_break_frame_coherence_config(uint32_t usart_periph, uint32_t bcm)
+{
+    USART_CHC(usart_periph) &= ~(USART_CHC_BCM);
+    USART_CHC(usart_periph) |= (USART_CHC_BCM & bcm);
+}
+
+/*!
+    \brief    configure parity check coherence mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  pcm:
+                only one parameter can be selected which is shown as below:
+      \arg        USART_PCM_NONE: not check parity
+      \arg        USART_PCM_EN:   check the parity
+    \param[out] none
+    \retval     none
+*/
+void usart_parity_check_coherence_config(uint32_t usart_periph, uint32_t pcm)
+{
+    USART_CHC(usart_periph) &= ~(USART_CHC_PCM);
+    USART_CHC(usart_periph) |= (USART_CHC_PCM & pcm);
+}
+
+/*!
+    \brief    configure hardware flow control coherence mode
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)
+    \param[in]  hcm:
+                only one parameter can be selected which is shown as below:
+      \arg        USART_HCM_NONE: nRTS signal equals to the rxne status register
+      \arg        USART_HCM_EN:   nRTS signal is set when the last data bit has been sampled
+    \param[out] none
+    \retval     none
+*/
+void usart_hardware_flow_coherence_config(uint32_t usart_periph, uint32_t hcm)
+{
+    USART_CHC(usart_periph) &= ~(USART_CHC_HCM);
+    USART_CHC(usart_periph) |= (USART_CHC_HCM & hcm);
+}
+
+/*!
+    \brief    configure USART DMA reception
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  dmacmd: enable or disable DMA for reception
+                only one parameter can be selected which is shown as below:
+      \arg        USART_DENR_ENABLE:  DMA enable for reception
+      \arg        USART_DENR_DISABLE: DMA disable for reception
+    \param[out] none
+    \retval     none
+*/
+void usart_dma_receive_config(uint32_t usart_periph, uint32_t dmacmd)
+{
+    uint32_t ctl = 0U;
+
+    ctl = USART_CTL2(usart_periph);
+    ctl &= ~USART_CTL2_DENR;
+    ctl |= dmacmd;
+    /* configure DMA reception */
+    USART_CTL2(usart_periph) = ctl;
+}
+
+/*!
+    \brief    configure USART DMA transmission
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  dmacmd: enable or disable DMA for transmission
+                only one parameter can be selected which is shown as below:
+      \arg        USART_DENT_ENABLE:  DMA enable for transmission
+      \arg        USART_DENT_DISABLE: DMA disable for transmission
+    \param[out] none
+    \retval     none
+*/
+void usart_dma_transmit_config(uint32_t usart_periph, uint32_t dmacmd)
+{
+    uint32_t ctl = 0U;
+
+    ctl = USART_CTL2(usart_periph);
+    ctl &= ~USART_CTL2_DENT;
+    ctl |= dmacmd;
+    /* configure DMA transmission */
+    USART_CTL2(usart_periph) = ctl;
+}
+
+/*!
+    \brief    get flag in STAT0/STAT1/CHC register
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  flag: USART flags, refer to usart_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg        USART_FLAG_CTS: CTS change flag
+      \arg        USART_FLAG_LBD: LIN break detected flag
+      \arg        USART_FLAG_TBE: transmit data buffer empty
+      \arg        USART_FLAG_TC: transmission complete
+      \arg        USART_FLAG_RBNE: read data buffer not empty
+      \arg        USART_FLAG_IDLE: IDLE frame detected flag
+      \arg        USART_FLAG_ORERR: overrun error
+      \arg        USART_FLAG_NERR: noise error flag
+      \arg        USART_FLAG_FERR: frame error flag
+      \arg        USART_FLAG_PERR: parity error flag
+      \arg        USART_FLAG_BSY: busy flag
+      \arg        USART_FLAG_EB: end of block flag
+      \arg        USART_FLAG_RT: receiver timeout flag
+      \arg        USART_FLAG_EPERR: early parity error flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus usart_flag_get(uint32_t usart_periph, usart_flag_enum flag)
+{
+    if(RESET != (USART_REG_VAL(usart_periph, flag) & BIT(USART_BIT_POS(flag)))) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    clear flag in STAT0/STAT1/CHC register
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  flag: USART flags, refer to usart_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg        USART_FLAG_CTS: CTS change flag
+      \arg        USART_FLAG_LBD: LIN break detected flag
+      \arg        USART_FLAG_TC: transmission complete
+      \arg        USART_FLAG_RBNE: read data buffer not empty
+      \arg        USART_FLAG_EB: end of block flag
+      \arg        USART_FLAG_RT: receiver timeout flag
+      \arg        USART_FLAG_EPERR: early parity error flag
+    \param[out] none
+    \retval     none
+*/
+void usart_flag_clear(uint32_t usart_periph, usart_flag_enum flag)
+{
+    USART_REG_VAL(usart_periph, flag) &= ~BIT(USART_BIT_POS(flag));
+}
+
+/*!
+    \brief    enable USART interrupt
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  interrupt: USART interrupts, refer to usart_interrupt_enum
+                only one parameter can be selected which is shown as below:
+      \arg        USART_INT_PERR: parity error interrupt
+      \arg        USART_INT_TBE: transmitter buffer empty interrupt
+      \arg        USART_INT_TC: transmission complete interrupt
+      \arg        USART_INT_RBNE: read data buffer not empty interrupt and overrun error interrupt
+      \arg        USART_INT_IDLE: IDLE line detected interrupt
+      \arg        USART_INT_LBD: LIN break detected interrupt
+      \arg        USART_INT_ERR: error interrupt
+      \arg        USART_INT_CTS: CTS interrupt
+      \arg        USART_INT_RT: interrupt enable bit of receive timeout event
+      \arg        USART_INT_EB: interrupt enable bit of end of block event
+    \param[out] none
+    \retval     none
+*/
+void usart_interrupt_enable(uint32_t usart_periph, usart_interrupt_enum interrupt)
+{
+    USART_REG_VAL(usart_periph, interrupt) |= BIT(USART_BIT_POS(interrupt));
+}
+
+/*!
+    \brief    disable USART interrupt
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  interrupt: USART interrupts, refer to usart_interrupt_enum
+                only one parameter can be selected which is shown as below:
+      \arg        USART_INT_PERR: parity error interrupt
+      \arg        USART_INT_TBE: transmitter buffer empty interrupt
+      \arg        USART_INT_TC: transmission complete interrupt
+      \arg        USART_INT_RBNE: read data buffer not empty interrupt and overrun error interrupt
+      \arg        USART_INT_IDLE: IDLE line detected interrupt
+      \arg        USART_INT_LBD: LIN break detected interrupt
+      \arg        USART_INT_ERR: error interrupt
+      \arg        USART_INT_CTS: CTS interrupt
+      \arg        USART_INT_RT: interrupt enable bit of receive timeout event
+      \arg        USART_INT_EB: interrupt enable bit of end of block event
+    \param[out] none
+    \retval     none
+*/
+void usart_interrupt_disable(uint32_t usart_periph, usart_interrupt_enum interrupt)
+{
+    USART_REG_VAL(usart_periph, interrupt) &= ~BIT(USART_BIT_POS(interrupt));
+}
+
+/*!
+    \brief    get USART interrupt and flag status
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  int_flag: USART interrupt flags, refer to usart_interrupt_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg        USART_INT_FLAG_PERR: parity error interrupt and flag
+      \arg        USART_INT_FLAG_TBE: transmitter buffer empty interrupt and flag
+      \arg        USART_INT_FLAG_TC: transmission complete interrupt and flag
+      \arg        USART_INT_FLAG_RBNE: read data buffer not empty interrupt and flag
+      \arg        USART_INT_FLAG_RBNE_ORERR: read data buffer not empty interrupt and overrun error flag
+      \arg        USART_INT_FLAG_IDLE: IDLE line detected interrupt and flag
+      \arg        USART_INT_FLAG_LBD: LIN break detected interrupt and flag
+      \arg        USART_INT_FLAG_CTS: CTS interrupt and flag
+      \arg        USART_INT_FLAG_ERR_ORERR: error interrupt and overrun error
+      \arg        USART_INT_FLAG_ERR_NERR: error interrupt and noise error flag
+      \arg        USART_INT_FLAG_ERR_FERR: error interrupt and frame error flag
+      \arg        USART_INT_FLAG_EB: interrupt enable bit of end of block event and flag
+      \arg        USART_INT_FLAG_RT: interrupt enable bit of receive timeout event and flag
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus usart_interrupt_flag_get(uint32_t usart_periph, usart_interrupt_flag_enum int_flag)
+{
+    uint32_t intenable = 0U, flagstatus = 0U;
+    /* get the interrupt enable bit status */
+    intenable = (USART_REG_VAL(usart_periph, int_flag) & BIT(USART_BIT_POS(int_flag)));
+    /* get the corresponding flag bit status */
+    flagstatus = (USART_REG_VAL2(usart_periph, int_flag) & BIT(USART_BIT_POS2(int_flag)));
+
+    if((0U != flagstatus) && (0U != intenable)) {
+        return SET;
+    } else {
+        return RESET;
+    }
+}
+
+/*!
+    \brief    clear USART interrupt flag in STAT0/STAT1 register
+    \param[in]  usart_periph: USARTx(x=0,1,2,5)/UARTx(x=3,4,6,7)
+    \param[in]  int_flag: USART interrupt flags, refer to usart_interrupt_flag_enum
+                only one parameter can be selected which is shown as below:
+      \arg        USART_INT_FLAG_CTS: CTS change flag
+      \arg        USART_INT_FLAG_LBD: LIN break detected flag
+      \arg        USART_INT_FLAG_TC: transmission complete
+      \arg        USART_INT_FLAG_RBNE: read data buffer not empty
+      \arg        USART_INT_FLAG_EB: end of block flag
+      \arg        USART_INT_FLAG_RT: receiver timeout flag
+    \param[out] none
+    \retval     none
+*/
+void usart_interrupt_flag_clear(uint32_t usart_periph, usart_interrupt_flag_enum int_flag)
+{
+    USART_REG_VAL2(usart_periph, int_flag) &= ~BIT(USART_BIT_POS2(int_flag));
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_wwdgt.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_standard_peripheral/Source/gd32f4xx_wwdgt.c
@@ -1,0 +1,129 @@
+/*!
+    \file    gd32f4xx_wwdgt.c
+    \brief   WWDGT driver
+
+    \version 2016-08-15, V1.0.0, firmware for GD32F4xx
+    \version 2018-12-12, V2.0.0, firmware for GD32F4xx
+    \version 2020-09-30, V2.1.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.0.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "gd32f4xx_wwdgt.h"
+
+/*!
+    \brief    reset the window watchdog timer configuration
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void wwdgt_deinit(void)
+{
+    rcu_periph_reset_enable(RCU_WWDGTRST);
+    rcu_periph_reset_disable(RCU_WWDGTRST);
+}
+
+/*!
+    \brief    start the window watchdog timer counter
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void wwdgt_enable(void)
+{
+    WWDGT_CTL |= WWDGT_CTL_WDGTEN;
+}
+
+/*!
+    \brief    configure the window watchdog timer counter value
+    \param[in]  counter_value: 0x00 - 0x7F
+    \param[out] none
+    \retval     none
+*/
+void wwdgt_counter_update(uint16_t counter_value)
+{
+    WWDGT_CTL = (uint32_t)(CTL_CNT(counter_value));
+}
+
+/*!
+    \brief    configure counter value, window value, and prescaler divider value  
+    \param[in]  counter: 0x00 - 0x7F   
+    \param[in]  window: 0x00 - 0x7F
+    \param[in]  prescaler: wwdgt prescaler value
+                only one parameter can be selected which is shown as below:
+      \arg        WWDGT_CFG_PSC_DIV1: the time base of window watchdog counter = (PCLK1/4096)/1
+      \arg        WWDGT_CFG_PSC_DIV2: the time base of window watchdog counter = (PCLK1/4096)/2
+      \arg        WWDGT_CFG_PSC_DIV4: the time base of window watchdog counter = (PCLK1/4096)/4
+      \arg        WWDGT_CFG_PSC_DIV8: the time base of window watchdog counter = (PCLK1/4096)/8
+    \param[out] none
+    \retval     none
+*/
+void wwdgt_config(uint16_t counter, uint16_t window, uint32_t prescaler)
+{
+    /* configure WIN and PSC bits, configure CNT bit */
+    WWDGT_CTL = (uint32_t)(CTL_CNT(counter));
+    WWDGT_CFG = (uint32_t)(CFG_WIN(window) | prescaler);
+}
+
+/*!
+    \brief    check early wakeup interrupt state of WWDGT
+    \param[in]  none
+    \param[out] none
+    \retval     FlagStatus: SET or RESET
+*/
+FlagStatus wwdgt_flag_get(void)
+{
+    if(RESET != (WWDGT_STAT & WWDGT_STAT_EWIF)){
+        return SET;
+    }
+
+    return RESET;
+}
+
+/*!
+    \brief    clear early wakeup interrupt state of WWDGT
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void wwdgt_flag_clear(void)
+{
+    WWDGT_STAT = (uint32_t)(RESET);
+}
+
+/*!
+    \brief    enable early wakeup interrupt of WWDGT
+    \param[in]  none
+    \param[out] none
+    \retval     none
+*/
+void wwdgt_interrupt_enable(void)
+{
+    WWDGT_CFG |= WWDGT_CFG_EWIE;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/audio/Include/audio_core.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/audio/Include/audio_core.h
@@ -1,0 +1,322 @@
+/*!
+    \file    audio_core.h
+    \brief   the header file of USB audio device class core functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __AUDIO_CORE_H
+#define __AUDIO_CORE_H
+
+#include "usbd_enum.h"
+
+#define FORMAT_24BIT(x)                           (uint8_t)(x);(uint8_t)((x) >> 8U);(uint8_t)((x) >> 16U)
+
+/* number of sub-packets in the audio transfer buffer. you can modify this value but always make sure
+   that it is an even number and higher than 3 */
+#define OUT_PACKET_NUM                            200U
+
+/* total size of the audio transfer buffer */
+#define OUT_BUF_MARGIN                            0U
+#define TOTAL_OUT_BUF_SIZE                        ((uint32_t)((SPEAKER_OUT_PACKET + OUT_BUF_MARGIN) * OUT_PACKET_NUM))
+
+#define AD_CONFIG_DESC_SET_LEN                    (sizeof(usb_desc_config_set))
+#define AD_INTERFACE_DESC_SIZE                    9U
+
+#define USB_AD_DESC_SIZ                           0x09U
+#define AD_STANDARD_EP_DESC_SIZE                  0x09U
+#define AD_STREAMING_EP_DESC_SIZE                 0x07U
+
+/* audio interface class code */
+#define USB_CLASS_AUDIO                           0x01U
+
+/* audio interface subclass codes */
+#define AD_SUBCLASS_CONTROL                       0x01U
+#define AD_SUBCLASS_AUDIOSTREAMING                0x02U
+#define AD_SUBCLASS_MIDISTREAMING                 0x03U
+
+/* audio interface protocol codes */
+#define AD_PROTOCOL_UNDEFINED                     0x00U
+#define AD_STREAMING_GENERAL                      0x01U
+#define AD_STREAMING_FORMAT_TYPE                  0x02U
+
+/* audio class-specific descriptor types */
+#define AD_DESCTYPE_UNDEFINED                     0x20U
+#define AD_DESCTYPE_DEVICE                        0x21U
+#define AD_DESCTYPE_CONFIGURATION                 0x22U
+#define AD_DESCTYPE_STRING                        0x23U
+#define AD_DESCTYPE_INTERFACE                     0x24U
+#define AD_DESCTYPE_ENDPOINT                      0x25U
+
+/* audio control interface descriptor subtypes */
+#define AD_CONTROL_HEADER                         0x01U
+#define AD_CONTROL_INPUT_TERMINAL                 0x02U
+#define AD_CONTROL_OUTPUT_TERMINAL                0x03U
+#define AD_CONTROL_MIXER_UNIT                     0x04U
+#define AD_CONTROL_SELECTOR_UNIT                  0x05U
+#define AD_CONTROL_FEATURE_UNIT                   0x06U
+#define AD_CONTROL_PROCESSING_UNIT                0x07U
+#define AD_CONTROL_EXTENSION_UNIT                 0x08U
+
+#define AD_INPUT_TERMINAL_DESC_SIZE               0x0CU
+#define AD_OUTPUT_TERMINAL_DESC_SIZE              0x09U
+#define AD_STREAMING_INTERFACE_DESC_SIZE          0x07U
+
+#define AD_CONTROL_MUTE                           0x01U
+#define AD_CONTROL_VOLUME                         0x02U
+
+#define AD_FORMAT_TYPE_I                          0x01U
+#define AD_FORMAT_TYPE_III                        0x03U
+
+#define USB_ENDPOINT_TYPE_ISOCHRONOUS             0x01U
+#define AD_ENDPOINT_GENERAL                       0x01U
+
+#define AD_REQ_UNDEFINED                          0x00U
+#define AD_REQ_SET_CUR                            0x01U
+#define AD_REQ_GET_CUR                            0x81U
+#define AD_REQ_SET_MIN                            0x02U
+#define AD_REQ_GET_MIN                            0x82U
+#define AD_REQ_SET_MAX                            0x03U
+#define AD_REQ_GET_MAX                            0x83U
+#define AD_REQ_SET_RES                            0x04U
+#define AD_REQ_GET_RES                            0x84U
+#define AD_REQ_SET_MEM                            0x05U
+#define AD_REQ_GET_MEM                            0x85U
+#define AD_REQ_GET_STAT                           0xFFU
+
+#define AD_OUT_STREAMING_CTRL                     0x05U
+#define AD_IN_STREAMING_CTRL                      0x02U
+
+/* audio stream interface number */
+enum
+{
+#ifdef USE_USB_AD_MICPHONE
+    MIC_INTERFACE_COUNT,
+#endif /* USE_USB_AD_MICPHONE */
+
+#ifdef USE_USB_AD_SPEAKER
+    SPEAK_INTERFACE_COUNT,
+#endif /* USE_USB_AD_SPEAKER */
+    CONFIG_DESC_AS_ITF_COUNT,
+};
+
+#define AC_ITF_TOTAL_LEN                         (sizeof(usb_desc_AC_itf) + CONFIG_DESC_AS_ITF_COUNT*(sizeof(usb_desc_input_terminal) + \
+                                                      sizeof(usb_desc_mono_feature_unit) + sizeof(usb_desc_output_terminal)))
+
+#pragma pack(1)
+
+typedef struct
+{
+    usb_desc_header header;           /*!< descriptor header, including type and size */
+    uint8_t  bDescriptorSubtype;      /*!< header descriptor subtype */
+    uint16_t bcdADC;                  /*!< audio device class specification release number in binary-coded decimal */
+    uint16_t wTotalLength;            /*!< total number of bytes */
+    uint8_t  bInCollection;           /*!< the number of the streaming interfaces */
+#ifdef USE_USB_AD_MICPHONE
+    uint8_t  baInterfaceNr0;          /*!< interface number of the streaming interfaces */
+#endif /* USE_USB_AD_MICPHONE */
+
+#ifdef USE_USB_AD_SPEAKER
+    uint8_t  baInterfaceNr1;          /*!< interface number of the streaming interfaces */
+#endif /* USE_USB_AD_SPEAKER */
+} usb_desc_AC_itf;
+
+typedef struct
+{
+    usb_desc_header header;           /*!< descriptor header, including type and size */
+    uint8_t  bDescriptorSubtype;      /*!< AS_GENERAL descriptor subtype */
+    uint8_t  bTerminalLink;           /*!< the terminal ID */
+    uint8_t  bDelay;                  /*!< delay introduced by the data path */
+    uint16_t wFormatTag;              /*!< the audio data format */
+} usb_desc_AS_itf;
+
+typedef struct
+{
+    usb_desc_header header;           /*!< descriptor header, including type and size */
+    uint8_t  bDescriptorSubtype;      /*!< INPUT_TERMINAL descriptor subtype. */
+    uint8_t  bTerminalID;             /*!< constant uniquely identifying the terminal within the audio function */
+    uint16_t wTerminalType;           /*!< constant characterizing the type of terminal */
+    uint8_t  bAssocTerminal;          /*!< ID of the output terminal */
+    uint8_t  bNrChannels;             /*!< number of logical output channels */
+    uint16_t wChannelConfig;          /*!< describes the spatial location of the logical channels */
+    uint8_t  iChannelNames;           /*!< index of a string descriptor */
+    uint8_t  iTerminal;               /*!< index of a string descriptor */
+} usb_desc_input_terminal;
+
+typedef struct
+{
+    usb_desc_header header;           /*!< descriptor header, including type and size */
+    uint8_t  bDescriptorSubtype;      /*!< OUTPUT_TERMINAL descriptor subtype */
+    uint8_t  bTerminalID;             /*!< constant uniquely identifying the terminal within the audio function */
+    uint16_t wTerminalType;           /*!< constant characterizing the type of terminal */
+    uint8_t  bAssocTerminal;          /*!< constant, identifying the input terminal to which this output terminal is associated */
+    uint8_t  bSourceID;               /*!< ID of the unit or terminal */
+    uint8_t  iTerminal;               /*!< index of a string descriptor */
+} usb_desc_output_terminal;
+
+typedef struct
+{
+    usb_desc_header header;           /*!< descriptor header, including type and size */
+    uint8_t  bDescriptorSubtype;      /*!< FEATURE_UNIT descriptor subtype */
+    uint8_t  bUnitID;                 /*!< constant uniquely identifying the unit within the audio function */
+    uint8_t  bSourceID;               /*!< ID of the unit or terminal */
+    uint8_t  bControlSize;            /*!< size in bytes of an element of the bmaControls() array */
+    uint8_t  bmaControls0;            /*!< a bit set to 1 indicates that the mentioned control is supported for master channel 0 */
+    uint8_t  bmaControls1;            /*!< a bit set to 1 indicates that the mentioned control is supported for logical channel 1 */
+    uint8_t  iFeature;                /*!< index of a string descriptor */
+} usb_desc_mono_feature_unit;
+
+typedef struct
+{
+    usb_desc_header header;           /*!< descriptor header, including type and size */
+    uint8_t  bDescriptorSubtype;      /*!< FEATURE_UNIT descriptor subtype */
+    uint8_t  bUnitID;                 /*!< constant uniquely identifying the unit within the audio function */
+    uint8_t  bSourceID;               /*!< ID of the unit or terminal */
+    uint8_t  bControlSize;            /*!< size in bytes of an element of the bmaControls() array */
+    uint16_t bmaControls0;            /*!< a bit set to 1 indicates that the mentioned control is supported for master channel 0 */
+    uint16_t bmaControls1;            /*!< a bit set to 1 indicates that the mentioned control is supported for logical channel 1 */
+    uint16_t bmaControls2;            /*!< a bit set to 1 indicates that the mentioned control is supported for logical channel 2 */
+    uint8_t  iFeature;                /*!< index of a string descriptor */
+} usb_desc_stereo_feature_unit;
+
+typedef struct
+{
+    usb_desc_header header;           /*!< descriptor header, including type and size */
+    uint8_t  bDescriptorSubtype;      /*!< FORMAT_TYPE descriptor subtype */
+    uint8_t  bFormatType;             /*!< constant identifying the format type */
+    uint8_t  bNrChannels;             /*!< indicates the number of physical channels in the audio data stream */
+    uint8_t  bSubFrameSize;           /*!< the number of bytes occupied by one audio subframe */
+    uint8_t  bBitResolution;          /*!< the number of effectively used bits from the available bits in an audio subframe */
+    uint8_t  bSamFreqType;            /*!< indicates how the sampling frequency can be programmed */
+    uint8_t  bSamFreq[3];             /*!< sampling frequency ns in Hz for this isochronous data endpoint */
+} usb_desc_format_type;
+
+typedef struct
+{
+    usb_desc_header header;           /*!< descriptor header, including type and size */
+    uint8_t  bEndpointAddress;        /*!< the address of the endpoint */
+    uint8_t  bmAttributes;            /*!< transfer type and synchronization type */
+    uint16_t wMaxPacketSize;          /*!< maximum packet size this endpoint is capable of sending or receiving */
+    uint8_t  bInterval;               /*!< left to the designer's discretion */
+    uint8_t  bRefresh;                /*!< reset to 0 */
+    uint8_t  bSynchAddress;           /*!< reset to 0 */
+} usb_desc_std_ep;
+
+typedef struct
+{
+    usb_desc_header header;           /*!< descriptor header, including type and size */
+    uint8_t  bDescriptorSubtype;      /*!< EP_GENERAL descriptor subtype */
+    uint8_t  bmAttributes;            /*!< transfer type and synchronization type */
+    uint8_t  bLockDelayUnits;         /*!< indicates the units used for the wLockDelay field */
+    uint16_t wLockDelay;              /*!< indicates the time it takes this endpoint to reliably lock its internal clock recovery circuitry */
+} usb_desc_AS_ep;
+
+typedef struct
+{
+    usb_desc_header header;           /*!< descriptor header, including type and size */
+    uint8_t  bEndpointAddress;        /*!< EP_GENERAL descriptor subtype */
+    uint8_t  bmAttributes;            /*!< transfer type and synchronization type */
+    uint16_t wMaxPacketSize;          /*!< maximum packet size this endpoint is capable of sending or receiving */
+    uint8_t  bInterval;               /*!< polling interval in milliseconds for the endpoint if it is an INTERRUPT or ISOCHRONOUS type */
+    uint8_t  Refresh;                 /*!< bRefresh 1~9, power of 2 */
+    uint8_t  bSynchAddress;           /* bSynchAddress */
+} usb_desc_FeedBack_ep;
+
+#pragma pack()
+
+/* USB configuration descriptor structure */
+typedef struct
+{
+    usb_desc_config              config;
+    usb_desc_itf                 std_itf;
+    usb_desc_AC_itf              ac_itf;
+
+#ifdef USE_USB_AD_MICPHONE
+    usb_desc_input_terminal      mic_in_terminal;
+    usb_desc_mono_feature_unit   mic_feature_unit;
+    usb_desc_output_terminal     mic_out_terminal;
+#endif
+
+#ifdef USE_USB_AD_SPEAKER
+    usb_desc_input_terminal       speak_in_terminal;
+    usb_desc_mono_feature_unit    speak_feature_unit;
+    usb_desc_output_terminal      speak_out_terminal;
+#endif /* USE_USB_AD_SPEAKER */
+
+#ifdef USE_USB_AD_MICPHONE
+    usb_desc_itf                 mic_std_as_itf_zeroband;
+    usb_desc_itf                 mic_std_as_itf_opera;
+    usb_desc_AS_itf              mic_as_itf;
+    usb_desc_format_type         mic_format_typeI;
+    usb_desc_std_ep              mic_std_endpoint;
+    usb_desc_AS_ep               mic_as_endpoint;
+#endif /* USE_USB_AD_MICPHONE */
+
+#ifdef USE_USB_AD_SPEAKER
+    usb_desc_itf                speak_std_as_itf_zeroband;
+    usb_desc_itf                speak_std_as_itf_opera;
+    usb_desc_AS_itf             speak_as_itf;
+    usb_desc_format_type        speak_format_typeI;
+    usb_desc_std_ep             speak_std_endpoint;
+    usb_desc_AS_ep              speak_as_endpoint;
+    usb_desc_FeedBack_ep        speak_feedback_endpoint;
+#endif /* USE_USB_AD_SPEAKER */
+} usb_desc_config_set;
+
+typedef struct
+{
+    /* main buffer for audio data out transfers and its relative pointers */
+    uint8_t  isoc_out_buff[TOTAL_OUT_BUF_SIZE];
+    uint8_t* isoc_out_wrptr;
+    uint8_t* isoc_out_rdptr;
+    uint16_t buf_free_size;
+    uint16_t dam_tx_len;
+
+    __IO uint32_t actual_freq;
+    __IO uint8_t play_flag;
+    uint8_t feedback_freq[3];
+    uint32_t cur_sam_freq;
+
+    /* usb receive buffer */
+    uint8_t usb_rx_buffer[SPEAKER_OUT_MAX_PACKET];
+
+    /* main buffer for audio control requests transfers and its relative variables */
+    uint8_t  audioctl[64];
+    uint8_t  audioctl_unit;
+    uint32_t audioctl_len;
+} usbd_audio_handler;
+
+extern usb_desc audio_desc;
+extern usb_class_core usbd_audio_cb;
+extern usbd_audio_handler audio_handler;
+
+#endif /* __AUDIO_CORE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/audio/Include/audio_out_itf.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/audio/Include/audio_out_itf.h
@@ -1,0 +1,51 @@
+/*!
+    \file    audio_out_itf.h
+    \brief   audio OUT (playback) interface header file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __AUDIO_OUT_ITF_H
+#define __AUDIO_OUT_ITF_H
+
+#include "usbd_conf.h"
+#include "string.h"
+
+typedef struct {
+    uint8_t  (*audio_init)        (uint32_t audio_freq, uint32_t volume);
+    uint8_t  (*audio_deinit)      (void);
+    uint8_t  (*audio_cmd)         (uint8_t* pbuf, uint32_t size, uint8_t cmd);
+} audio_fops_struct;
+
+extern audio_fops_struct audio_out_fops;
+
+#endif /* __AUDIO_OUT_ITF_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/audio/Source/audio_core.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/audio/Source/audio_core.c
@@ -1,0 +1,961 @@
+/*!
+    \file    audio_core.c
+    \brief   USB audio device class core functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "audio_out_itf.h"
+#include "audio_core.h"
+#include <string.h>
+#include <math.h>
+
+#define USBD_VID                     0x28E9U
+#define USBD_PID                     0x9574U
+
+#define VOL_MIN                      0U    /* volume Minimum Value */
+#define VOL_MAX                      100U  /* volume Maximum Value */
+#define VOL_RES                      1U    /* volume Resolution */
+#define VOL_0dB                      70U   /* 0dB is in the middle of VOL_MIN and VOL_MAX */
+
+#ifdef USE_USB_AD_MICPHONE
+extern volatile uint32_t count_data;
+extern const char wavetestdata[];
+#define LENGTH_DATA    (1747 * 32)
+#endif /* USE_USB_AD_MICPHONE */
+
+__ALIGN_BEGIN usbd_audio_handler audio_handler __ALIGN_END;
+
+/* local function prototypes ('static') */
+static uint8_t audio_init (usb_dev *udev, uint8_t config_index);
+static uint8_t audio_deinit (usb_dev *udev, uint8_t config_index);
+static uint8_t audio_req_handler (usb_dev *udev, usb_req *req);
+static uint8_t audio_set_intf (usb_dev *udev, usb_req *req);
+static uint8_t audio_ctlx_out (usb_dev *udev);
+static uint8_t audio_data_in (usb_dev *udev, uint8_t ep_num);
+static uint8_t audio_data_out (usb_dev *udev, uint8_t ep_num);
+static uint8_t audio_sof (usb_dev *udev);
+static uint8_t audio_iso_in_incomplete (usb_dev *udev);
+static uint8_t audio_iso_out_incomplete (usb_dev *udev);
+static uint32_t usbd_audio_spk_get_feedback(usb_dev *udev);
+static void get_feedback_fs_rate(uint32_t rate, uint8_t *buf);
+
+usb_class_core usbd_audio_cb = {
+    .init      = audio_init,
+    .deinit    = audio_deinit,
+    .req_proc  = audio_req_handler,
+    .set_intf  = audio_set_intf,
+    .ctlx_out  = audio_ctlx_out,
+    .data_in   = audio_data_in,
+    .data_out  = audio_data_out,
+    .SOF       = audio_sof,
+    .incomplete_isoc_in = audio_iso_in_incomplete,
+    .incomplete_isoc_out = audio_iso_out_incomplete
+};
+
+/* note:it should use the c99 standard when compiling the below codes */
+/* USB standard device descriptor */
+__ALIGN_BEGIN const usb_desc_dev audio_dev_desc __ALIGN_END =
+{
+    .header = 
+     {
+         .bLength          = USB_DEV_DESC_LEN, 
+         .bDescriptorType  = USB_DESCTYPE_DEV
+     },
+    .bcdUSB                = 0x0200U,
+    .bDeviceClass          = 0x00U,
+    .bDeviceSubClass       = 0x00U,
+    .bDeviceProtocol       = 0x00U,
+    .bMaxPacketSize0       = USB_FS_EP0_MAX_LEN,
+    .idVendor              = USBD_VID,
+    .idProduct             = USBD_PID,
+    .bcdDevice             = 0x0100U,
+    .iManufacturer         = STR_IDX_MFC,
+    .iProduct              = STR_IDX_PRODUCT,
+    .iSerialNumber         = STR_IDX_SERIAL,
+    .bNumberConfigurations = USBD_CFG_MAX_NUM
+};
+
+/* USB device configuration descriptor */
+__ALIGN_BEGIN const usb_desc_config_set audio_config_set __ALIGN_END = 
+{
+    .config = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_config), 
+             .bDescriptorType = USB_DESCTYPE_CONFIG 
+         },
+        .wTotalLength         = AD_CONFIG_DESC_SET_LEN,
+        .bNumInterfaces       = 0x01U + CONFIG_DESC_AS_ITF_COUNT,
+        .bConfigurationValue  = 0x01U,
+        .iConfiguration       = 0x00U,
+        .bmAttributes         = 0xC0U,
+        .bMaxPower            = 0x32U
+    },
+
+    .std_itf = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_itf), 
+             .bDescriptorType = USB_DESCTYPE_ITF 
+         },
+         .bInterfaceNumber    = 0x00U,
+         .bAlternateSetting   = 0x00U,
+         .bNumEndpoints       = 0x00U,
+         .bInterfaceClass     = USB_CLASS_AUDIO,
+         .bInterfaceSubClass  = AD_SUBCLASS_CONTROL,
+         .bInterfaceProtocol  = AD_PROTOCOL_UNDEFINED,
+         .iInterface          = 0x00U
+    },
+
+    .ac_itf = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_AC_itf), 
+             .bDescriptorType = AD_DESCTYPE_INTERFACE 
+         },
+         .bDescriptorSubtype  = 0x01U,
+         .bcdADC              = 0x0100U,
+         .wTotalLength        = AC_ITF_TOTAL_LEN,
+         .bInCollection       = CONFIG_DESC_AS_ITF_COUNT,
+#ifdef USE_USB_AD_MICPHONE
+         .baInterfaceNr0       = 0x01U,
+#endif /* USE_USB_AD_MICPHONE */
+
+#ifdef USE_USB_AD_SPEAKER
+         .baInterfaceNr1       = 0x02U
+#endif /* USE_USB_AD_SPEAKER */
+    },
+
+#ifdef USE_USB_AD_MICPHONE
+    .mic_in_terminal = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_input_terminal), 
+             .bDescriptorType = AD_DESCTYPE_INTERFACE
+         },
+         .bDescriptorSubtype  = 0x02U,
+         .bTerminalID         = 0x01U,
+         .wTerminalType       = 0x0201U,
+         .bAssocTerminal      = 0x00U,
+         .bNrChannels         = 0x02U,
+         .wChannelConfig      = 0x0003U,
+         .iChannelNames       = 0x00U,
+         .iTerminal           = 0x00U
+    },
+
+    .mic_feature_unit = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_mono_feature_unit), 
+             .bDescriptorType = AD_DESCTYPE_INTERFACE 
+         },
+         .bDescriptorSubtype  = AD_CONTROL_FEATURE_UNIT,
+         .bUnitID             = AD_IN_STREAMING_CTRL,
+         .bSourceID           = 0x01U,
+         .bControlSize        = 0x01U,
+         .bmaControls0        = AD_CONTROL_MUTE | AD_CONTROL_VOLUME,
+         .bmaControls1        = 0x00U,
+         .iFeature            = 0x00U
+    },
+
+    .mic_out_terminal = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_output_terminal), 
+             .bDescriptorType = AD_DESCTYPE_INTERFACE
+         },
+         .bDescriptorSubtype  = AD_CONTROL_OUTPUT_TERMINAL,
+         .bTerminalID         = 0x03U,
+         .wTerminalType       = 0x0101U,
+         .bAssocTerminal      = 0x00U,
+         .bSourceID           = 0x02U,
+         .iTerminal           = 0x00U
+    },
+#endif /* USE_USB_AD_MICPHONE */
+
+#ifdef USE_USB_AD_SPEAKER
+    .speak_in_terminal = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_input_terminal), 
+             .bDescriptorType = AD_DESCTYPE_INTERFACE
+         },
+         .bDescriptorSubtype  = AD_CONTROL_INPUT_TERMINAL,
+         .bTerminalID         = 0x04U,
+         .wTerminalType       = 0x0101U,
+         .bAssocTerminal      = 0x00U,
+         .bNrChannels         = 0x02U,
+         .wChannelConfig      = 0x0003U,
+         .iChannelNames       = 0x00U,
+         .iTerminal           = 0x00U
+    },
+
+    .speak_feature_unit = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_mono_feature_unit), 
+             .bDescriptorType = AD_DESCTYPE_INTERFACE 
+         },
+         .bDescriptorSubtype  = AD_CONTROL_FEATURE_UNIT,
+         .bUnitID             = AD_OUT_STREAMING_CTRL,
+         .bSourceID           = 0x04U,
+         .bControlSize        = 0x01U,
+         .bmaControls0        = AD_CONTROL_MUTE | AD_CONTROL_VOLUME,
+         .bmaControls1        = 0x00U,
+         .iFeature            = 0x00U
+    },
+
+    .speak_out_terminal = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_output_terminal), 
+             .bDescriptorType = AD_DESCTYPE_INTERFACE
+         },
+         .bDescriptorSubtype  = AD_CONTROL_OUTPUT_TERMINAL,
+         .bTerminalID         = 0x06U,
+         .wTerminalType       = 0x0301U,
+         .bAssocTerminal      = 0x00U,
+         .bSourceID           = 0x05U,
+         .iTerminal           = 0x00U
+    },
+#endif /* USE_USB_AD_SPEAKER */
+
+#ifdef USE_USB_AD_MICPHONE
+    .mic_std_as_itf_zeroband = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_itf), 
+             .bDescriptorType = USB_DESCTYPE_ITF 
+         },
+         .bInterfaceNumber    = 0x01U,
+         .bAlternateSetting   = 0x00U,
+         .bNumEndpoints       = 0x00U,
+         .bInterfaceClass     = USB_CLASS_AUDIO,
+         .bInterfaceSubClass  = AD_SUBCLASS_AUDIOSTREAMING,
+         .bInterfaceProtocol  = AD_PROTOCOL_UNDEFINED,
+         .iInterface          = 0x00U
+    },
+
+    .mic_std_as_itf_opera = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_itf), 
+             .bDescriptorType = USB_DESCTYPE_ITF 
+         },
+         .bInterfaceNumber    = 0x01U,
+         .bAlternateSetting   = 0x01U,
+         .bNumEndpoints       = 0x01U,
+         .bInterfaceClass     = USB_CLASS_AUDIO,
+         .bInterfaceSubClass  = AD_SUBCLASS_AUDIOSTREAMING,
+         .bInterfaceProtocol  = AD_PROTOCOL_UNDEFINED,
+         .iInterface          = 0x00U
+    },
+
+    .mic_as_itf = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_AS_itf), 
+             .bDescriptorType = AD_DESCTYPE_INTERFACE 
+         },
+         .bDescriptorSubtype  = AD_STREAMING_GENERAL,
+         .bTerminalLink       = 0x03U,
+         .bDelay              = 0x01U,
+         .wFormatTag          = 0x0001U,
+    },
+
+    .mic_format_typeI = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_format_type), 
+             .bDescriptorType = AD_DESCTYPE_INTERFACE 
+         },
+         .bDescriptorSubtype  = AD_STREAMING_FORMAT_TYPE,
+         .bFormatType         = AD_FORMAT_TYPE_I,
+         .bNrChannels         = MIC_IN_CHANNEL_NBR,
+         .bSubFrameSize       = 0x02U,
+         .bBitResolution      = MIC_IN_BIT_RESOLUTION,
+         .bSamFreqType        = 0x01U,
+         .bSamFreq[0]         = (uint8_t)USBD_MIC_FREQ,
+         .bSamFreq[1]         = USBD_MIC_FREQ >> 8U,
+         .bSamFreq[2]         = USBD_MIC_FREQ >> 16U
+    },
+
+    .mic_std_endpoint = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_std_ep), 
+             .bDescriptorType = USB_DESCTYPE_EP 
+         },
+         .bEndpointAddress    = AD_IN_EP,
+         .bmAttributes        = USB_ENDPOINT_TYPE_ISOCHRONOUS,
+         .wMaxPacketSize      = MIC_IN_PACKET,
+         .bInterval           = 0x01U,
+         .bRefresh            = 0x00U,
+         .bSynchAddress       = 0x00U
+    },
+
+    .mic_as_endpoint = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_AS_ep), 
+             .bDescriptorType = AD_DESCTYPE_ENDPOINT 
+         },
+         .bDescriptorSubtype  = AD_ENDPOINT_GENERAL,
+         .bmAttributes        = 0x00U,
+         .bLockDelayUnits     = 0x00U,
+         .wLockDelay          = 0x0000U,
+    },
+#endif /* USE_USB_AD_MICPHONE */
+
+#ifdef USE_USB_AD_SPEAKER
+    .speak_std_as_itf_zeroband = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_itf), 
+             .bDescriptorType = USB_DESCTYPE_ITF 
+         },
+         .bInterfaceNumber    = 0x02U,
+         .bAlternateSetting   = 0x00U,
+         .bNumEndpoints       = 0x00U,
+         .bInterfaceClass     = USB_CLASS_AUDIO,
+         .bInterfaceSubClass  = AD_SUBCLASS_AUDIOSTREAMING,
+         .bInterfaceProtocol  = AD_PROTOCOL_UNDEFINED,
+         .iInterface          = 0x00U
+    },
+
+    .speak_std_as_itf_opera = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_itf), 
+             .bDescriptorType = USB_DESCTYPE_ITF 
+         },
+         .bInterfaceNumber    = 0x02U,
+         .bAlternateSetting   = 0x01U,
+         .bNumEndpoints       = 0x02U,
+         .bInterfaceClass     = USB_CLASS_AUDIO,
+         .bInterfaceSubClass  = AD_SUBCLASS_AUDIOSTREAMING,
+         .bInterfaceProtocol  = AD_PROTOCOL_UNDEFINED,
+         .iInterface          = 0x00U
+    },
+
+    .speak_as_itf = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_AS_itf), 
+             .bDescriptorType = AD_DESCTYPE_INTERFACE 
+         },
+         .bDescriptorSubtype  = AD_STREAMING_GENERAL,
+         .bTerminalLink       = 0x04U,
+         .bDelay              = 0x01U,
+         .wFormatTag          = 0x0001U,
+    },
+
+    .speak_format_typeI = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_format_type), 
+             .bDescriptorType = AD_DESCTYPE_INTERFACE 
+         },
+         .bDescriptorSubtype  = AD_STREAMING_FORMAT_TYPE,
+         .bFormatType         = AD_FORMAT_TYPE_I,
+         .bNrChannels         = SPEAKER_OUT_CHANNEL_NBR,
+         .bSubFrameSize       = 0x02U,
+         .bBitResolution      = SPEAKER_OUT_BIT_RESOLUTION,
+         .bSamFreqType        = 0x01U,
+         .bSamFreq[0]         = (uint8_t)USBD_SPEAKER_FREQ,
+         .bSamFreq[1]         = USBD_SPEAKER_FREQ >> 8U,
+         .bSamFreq[2]         = USBD_SPEAKER_FREQ >> 16U
+    },
+
+    .speak_std_endpoint = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_std_ep), 
+             .bDescriptorType = USB_DESCTYPE_EP 
+         },
+         .bEndpointAddress    = AD_OUT_EP,
+         .bmAttributes        = USB_EP_ATTR_ISO | USB_EP_ATTR_ASYNC,
+         .wMaxPacketSize      = SPEAKER_OUT_PACKET,
+         .bInterval           = 0x01U,
+         .bRefresh            = 0x00U,
+         .bSynchAddress       = AD_FEEDBACK_IN_EP,
+    },
+
+    .speak_as_endpoint = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_AS_ep), 
+             .bDescriptorType = AD_DESCTYPE_ENDPOINT 
+         },
+         .bDescriptorSubtype  = AD_ENDPOINT_GENERAL,
+         .bmAttributes        = 0x00U,
+         .bLockDelayUnits     = 0x00U,
+         .wLockDelay          = 0x0000U,
+    },
+
+    .speak_feedback_endpoint = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_FeedBack_ep), 
+             .bDescriptorType = USB_DESCTYPE_EP 
+         },
+         .bEndpointAddress    = AD_FEEDBACK_IN_EP,
+         .bmAttributes        = USB_EP_ATTR_ISO | USB_EP_ATTR_ASYNC | USB_EP_ATTR_FEEDBACK,
+         .wMaxPacketSize      = FEEDBACK_IN_PACKET,
+         .bInterval           = 0x01U,
+         .Refresh             = FEEDBACK_IN_INTERVAL, /* refresh every 32(2^5) ms */
+         .bSynchAddress       = 0x00U,
+    },
+#endif /* USE_USB_AD_SPEAKER */
+};
+
+/* USB language ID descriptor */
+static __ALIGN_BEGIN const usb_desc_LANGID usbd_language_id_desc __ALIGN_END = 
+{
+    .header = 
+     {
+         .bLength         = sizeof(usb_desc_LANGID), 
+         .bDescriptorType = USB_DESCTYPE_STR
+     },
+
+    .wLANGID = ENG_LANGID
+};
+
+/* USB manufacture string */
+static __ALIGN_BEGIN const usb_desc_str manufacturer_string __ALIGN_END = 
+{
+    .header = 
+     {
+         .bLength         = USB_STRING_LEN(10), 
+         .bDescriptorType = USB_DESCTYPE_STR,
+     },
+    .unicode_string = {'G', 'i', 'g', 'a', 'D', 'e', 'v', 'i', 'c', 'e'}
+};
+
+/* USB product string */
+static __ALIGN_BEGIN const usb_desc_str product_string __ALIGN_END = 
+{
+    .header = 
+     {
+         .bLength         = USB_STRING_LEN(14), 
+         .bDescriptorType = USB_DESCTYPE_STR,
+     },
+    .unicode_string = {'G', 'D', '3', '2', '-', 'U', 'S', 'B', '_', 'A', 'u', 'd', 'i', 'o'}
+};
+
+/* USBD serial string */
+static __ALIGN_BEGIN usb_desc_str serial_string __ALIGN_END = 
+{
+    .header = 
+     {
+         .bLength         = USB_STRING_LEN(12), 
+         .bDescriptorType = USB_DESCTYPE_STR,
+     }
+};
+
+/* USB string descriptor */
+void *const usbd_audio_strings[] = 
+{
+    [STR_IDX_LANGID]  = (uint8_t *)&usbd_language_id_desc,
+    [STR_IDX_MFC]     = (uint8_t *)&manufacturer_string,
+    [STR_IDX_PRODUCT] = (uint8_t *)&product_string,
+    [STR_IDX_SERIAL]  = (uint8_t *)&serial_string
+};
+
+/* USB descriptor configure */
+usb_desc audio_desc = {
+    .dev_desc    = (uint8_t *)&audio_dev_desc,
+    .config_desc = (uint8_t *)&audio_config_set,
+    .strings     = usbd_audio_strings
+};
+
+/*!
+    \brief      initialize the AUDIO device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t audio_init (usb_dev *udev, uint8_t config_index)
+{
+    memset((void *)&audio_handler, 0, sizeof(usbd_audio_handler));
+
+#ifdef USE_USB_AD_MICPHONE
+{
+    usb_desc_std_ep std_ep = audio_config_set.mic_std_endpoint;
+
+    usb_desc_ep ep = {
+        .header           = std_ep.header,
+        .bEndpointAddress = std_ep.bEndpointAddress,
+        .bmAttributes     = std_ep.bmAttributes,
+        .wMaxPacketSize   = std_ep.wMaxPacketSize,
+        .bInterval        = std_ep.bInterval 
+    };
+
+    /* initialize TX endpoint */
+    usbd_ep_setup (udev, &ep);
+}
+#endif /* USE_USB_AD_MICPHONE */
+
+#ifdef USE_USB_AD_SPEAKER
+{
+    audio_handler.isoc_out_rdptr = audio_handler.isoc_out_buff;
+    audio_handler.isoc_out_wrptr = audio_handler.isoc_out_buff;
+
+    usb_desc_std_ep std_ep = audio_config_set.speak_std_endpoint;
+
+    usb_desc_ep ep1 = {
+        .header           = std_ep.header,
+        .bEndpointAddress = std_ep.bEndpointAddress,
+        .bmAttributes     = std_ep.bmAttributes,
+        .wMaxPacketSize   = SPEAKER_OUT_MAX_PACKET,
+        .bInterval        = std_ep.bInterval 
+    };
+
+    /* initialize RX endpoint */
+    usbd_ep_setup (udev, &ep1);
+
+    /* prepare out endpoint to receive next audio packet */
+    usbd_ep_recev (udev, AD_OUT_EP, audio_handler.usb_rx_buffer, SPEAKER_OUT_MAX_PACKET);
+
+    /* initialize the audio output hardware layer */
+    if (USBD_OK != audio_out_fops.audio_init(USBD_SPEAKER_FREQ, DEFAULT_VOLUME)) {
+        return USBD_FAIL;
+    }
+
+    usb_desc_FeedBack_ep feedback_ep = audio_config_set.speak_feedback_endpoint;
+
+    usb_desc_ep ep2 = {
+        .header           = feedback_ep.header,
+        .bEndpointAddress = feedback_ep.bEndpointAddress,
+        .bmAttributes     = feedback_ep.bmAttributes,
+        .wMaxPacketSize   = feedback_ep.wMaxPacketSize,
+        .bInterval        = feedback_ep.bInterval 
+    };
+
+    /* initialize Tx endpoint */
+    usbd_ep_setup (udev, &ep2);
+}
+#endif /* USE_USB_AD_SPEAKER */
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      de-initialize the AUDIO device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t audio_deinit (usb_dev *udev, uint8_t config_index)
+{
+#ifdef USE_USB_AD_MICPHONE
+    /* deinitialize AUDIO endpoints */
+    usbd_ep_clear(udev, AD_IN_EP);
+#endif /* USE_USB_AD_MICPHONE */
+
+#ifdef USE_USB_AD_SPEAKER
+    /* deinitialize AUDIO endpoints */
+    usbd_ep_clear(udev, AD_OUT_EP);
+
+    /* deinitialize the audio output hardware layer */
+    if (USBD_OK != audio_out_fops.audio_deinit()) {
+        return USBD_FAIL;
+    }
+
+    /* deinitialize AUDIO endpoints */
+    usbd_ep_clear(udev, AD_FEEDBACK_IN_EP);
+#endif /* USE_USB_AD_SPEAKER */
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle the AUDIO class-specific requests
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: device class-specific request
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t audio_req_handler (usb_dev *udev, usb_req *req)
+{
+    uint8_t status = REQ_NOTSUPP;
+
+    usb_transc *transc_in = &udev->dev.transc_in[0];
+    usb_transc *transc_out = &udev->dev.transc_out[0];
+
+    switch (req->bRequest) {
+    case AD_REQ_GET_CUR:
+        transc_in->xfer_buf = audio_handler.audioctl;
+        transc_in->remain_len = req->wLength;
+
+        status = REQ_SUPP;
+        break;
+
+    case AD_REQ_SET_CUR:
+        if (req->wLength) {
+            transc_out->xfer_buf = audio_handler.audioctl;
+            transc_out->remain_len = req->wLength;
+
+            udev->dev.class_core->command = AD_REQ_SET_CUR;
+
+            audio_handler.audioctl_len = req->wLength;
+            audio_handler.audioctl_unit = BYTE_HIGH(req->wIndex);
+
+            status = REQ_SUPP;
+        }
+        break;
+
+    case AD_REQ_GET_MIN:
+        *((uint16_t *)audio_handler.audioctl) = VOL_MIN;
+        transc_in->xfer_buf = audio_handler.audioctl;
+        transc_in->remain_len = req->wLength;
+        status = REQ_SUPP;
+        break;
+
+    case AD_REQ_GET_MAX:
+        *((uint16_t *)audio_handler.audioctl) = VOL_MAX;
+        transc_in->xfer_buf = audio_handler.audioctl;
+        transc_in->remain_len = req->wLength;
+        status = REQ_SUPP;
+        break;
+
+    case AD_REQ_GET_RES:
+        *((uint16_t *)audio_handler.audioctl) = VOL_RES;
+        transc_in->xfer_buf = audio_handler.audioctl;
+        transc_in->remain_len = req->wLength;
+        status = REQ_SUPP;
+        break;
+
+    default:
+        break;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      handle the AUDIO set interface requests
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: device class-specific request
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t audio_set_intf(usb_dev *udev, usb_req *req)
+{
+    udev->dev.class_core->alter_set = req->wValue;
+
+    if(0xFF != req->wValue){
+        if (req->wValue != 0){
+            /* deinit audio handler */
+            memset((void *)&audio_handler, 0, sizeof(usbd_audio_handler));
+
+            audio_handler.play_flag = 0;
+            audio_handler.isoc_out_rdptr = audio_handler.isoc_out_buff;
+            audio_handler.isoc_out_wrptr = audio_handler.isoc_out_buff;
+
+            /* feedback calculate sample freq */
+            audio_handler.actual_freq = I2S_ACTUAL_SAM_FREQ(USBD_SPEAKER_FREQ);
+            get_feedback_fs_rate(audio_handler.actual_freq, audio_handler.feedback_freq);
+
+            /* send feedback data of estimated frequence*/
+            usbd_ep_send(udev, AD_FEEDBACK_IN_EP, audio_handler.feedback_freq, FEEDBACK_IN_PACKET);
+        } else {
+            /* stop audio output */
+            audio_out_fops.audio_cmd(audio_handler.isoc_out_rdptr, SPEAKER_OUT_PACKET/2, AD_CMD_STOP);
+
+            audio_handler.play_flag = 0;
+            audio_handler.isoc_out_rdptr = audio_handler.isoc_out_buff;
+            audio_handler.isoc_out_wrptr = audio_handler.isoc_out_buff;
+
+            usbd_fifo_flush (udev, AD_IN_EP);
+            usbd_fifo_flush (udev, AD_FEEDBACK_IN_EP);
+            usbd_fifo_flush (udev, AD_OUT_EP);
+        }
+    }
+
+    return 0;
+}
+
+/*!
+    \brief      handles the control transfer OUT callback
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t audio_ctlx_out (usb_dev *udev)
+{
+#ifdef USE_USB_AD_SPEAKER
+    /* handles audio control requests data */
+    /* check if an audio_control request has been issued */
+    if (AD_REQ_SET_CUR == udev->dev.class_core->command) {
+        /* in this driver, to simplify code, only SET_CUR request is managed */
+
+        /* check for which addressed unit the audio_control request has been issued */
+        if (AD_OUT_STREAMING_CTRL == audio_handler.audioctl_unit) {
+            /* in this driver, to simplify code, only one unit is manage */
+
+            /* reset the audioctl_cmd variable to prevent re-entering this function */
+            udev->dev.class_core->command = 0U;
+
+            audio_handler.audioctl_len = 0U;
+        }
+    }
+#endif /* USE_USB_AD_SPEAKER */
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handles the audio IN data stage
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint number
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t audio_data_in (usb_dev *udev, uint8_t ep_num)
+{
+#ifdef USE_USB_AD_MICPHONE
+    if(ep_num == EP_ID(AD_IN_EP)){
+        if(count_data < LENGTH_DATA){
+            /* Prepare next buffer to be sent: dummy data */
+            usbd_ep_send(udev, AD_IN_EP,(uint8_t*)&wavetestdata[count_data],MIC_IN_PACKET);
+            count_data += MIC_IN_PACKET;
+        } else {
+            usbd_ep_send(udev, AD_IN_EP,(uint8_t*)wavetestdata,MIC_IN_PACKET);
+            count_data = MIC_IN_PACKET;
+        }
+    }
+#endif /* USE_USB_AD_MICPHONE */
+
+#ifdef USE_USB_AD_SPEAKER
+    if(ep_num == EP_ID(AD_FEEDBACK_IN_EP)){
+        /* calculate feedback actual freq */
+        audio_handler.actual_freq = usbd_audio_spk_get_feedback(udev);
+        get_feedback_fs_rate(audio_handler.actual_freq, audio_handler.feedback_freq);
+
+        usbd_ep_send(udev, AD_FEEDBACK_IN_EP, audio_handler.feedback_freq, FEEDBACK_IN_PACKET);
+    }
+#endif /* USE_USB_AD_SPEAKER */
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handles the audio OUT data stage
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint number
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t audio_data_out (usb_dev *udev, uint8_t ep_num)
+{
+    uint16_t usb_rx_length, tail_len;
+
+    /* get receive length */
+    usb_rx_length = ((usb_core_driver *)udev)->dev.transc_out[ep_num].xfer_count;
+
+    if(audio_handler.isoc_out_wrptr >= audio_handler.isoc_out_rdptr){
+        audio_handler.buf_free_size = TOTAL_OUT_BUF_SIZE + audio_handler.isoc_out_rdptr - audio_handler.isoc_out_wrptr;
+    }else{
+        audio_handler.buf_free_size = audio_handler.isoc_out_rdptr - audio_handler.isoc_out_wrptr;
+    }
+
+    /* free buffer enough to save rx data */
+    if(audio_handler.buf_free_size > usb_rx_length){
+        if(audio_handler.isoc_out_wrptr >= audio_handler.isoc_out_rdptr){
+            tail_len = audio_handler.isoc_out_buff + TOTAL_OUT_BUF_SIZE - audio_handler.isoc_out_wrptr;
+
+            if(tail_len >= usb_rx_length){
+                memcpy(audio_handler.isoc_out_wrptr, audio_handler.usb_rx_buffer, usb_rx_length);
+
+                /* increment the buffer pointer */
+                audio_handler.isoc_out_wrptr += usb_rx_length;
+
+                /* increment the Buffer pointer or roll it back when all buffers are full */
+                if(audio_handler.isoc_out_wrptr >= (audio_handler.isoc_out_buff + TOTAL_OUT_BUF_SIZE)){
+                    /* all buffers are full: roll back */
+                    audio_handler.isoc_out_wrptr = audio_handler.isoc_out_buff;
+                }
+            }else{
+                memcpy(audio_handler.isoc_out_wrptr, audio_handler.usb_rx_buffer, tail_len);
+                /* adjust write pointer */
+                audio_handler.isoc_out_wrptr = audio_handler.isoc_out_buff;
+
+                memcpy(audio_handler.isoc_out_wrptr, &audio_handler.usb_rx_buffer[tail_len], usb_rx_length - tail_len);
+                /* adjust write pointer */
+                audio_handler.isoc_out_wrptr += usb_rx_length - tail_len;
+            }
+        }else{
+            memcpy(audio_handler.isoc_out_wrptr, audio_handler.usb_rx_buffer, usb_rx_length);
+
+            /* increment the buffer pointer */
+            audio_handler.isoc_out_wrptr += usb_rx_length;
+        }
+    }
+
+    /* Toggle the frame index */  
+    udev->dev.transc_out[ep_num].frame_num = (udev->dev.transc_out[ep_num].frame_num)? 0U:1U;
+
+    /* prepare out endpoint to receive next audio packet */
+    usbd_ep_recev (udev, AD_OUT_EP, audio_handler.usb_rx_buffer, SPEAKER_OUT_MAX_PACKET);
+
+    if(audio_handler.isoc_out_wrptr >= audio_handler.isoc_out_rdptr){
+        audio_handler.buf_free_size = TOTAL_OUT_BUF_SIZE + audio_handler.isoc_out_rdptr - audio_handler.isoc_out_wrptr;
+    }else{
+        audio_handler.buf_free_size = audio_handler.isoc_out_rdptr - audio_handler.isoc_out_wrptr;
+    }
+
+    if ((0U == audio_handler.play_flag) && (audio_handler.buf_free_size < TOTAL_OUT_BUF_SIZE/2)) {
+        /* enable start of streaming */
+        audio_handler.play_flag = 1U;
+
+        /* initialize the audio output hardware layer */
+        if (USBD_OK != audio_out_fops.audio_cmd(audio_handler.isoc_out_rdptr, SPEAKER_OUT_MAX_PACKET/2, AD_CMD_PLAY)) {
+            return USBD_FAIL;
+        }
+
+        audio_handler.dam_tx_len = SPEAKER_OUT_MAX_PACKET;
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handles the SOF event (data buffer update and synchronization)
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t audio_sof (usb_dev *udev)
+{
+    return USBD_OK;
+}
+
+/*!
+    \brief      handles the audio ISO IN Incomplete event
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t audio_iso_in_incomplete (usb_dev *udev)
+{
+    (void)usb_txfifo_flush (&udev->regs, EP_ID(AD_FEEDBACK_IN_EP));
+
+    audio_handler.actual_freq = usbd_audio_spk_get_feedback(udev);
+    get_feedback_fs_rate(audio_handler.actual_freq, audio_handler.feedback_freq);
+
+    /* send feedback data of estimated frequence*/
+    usbd_ep_send(udev, AD_FEEDBACK_IN_EP, audio_handler.feedback_freq, FEEDBACK_IN_PACKET);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handles the audio ISO OUT Incomplete event
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t audio_iso_out_incomplete (usb_dev *udev)
+{
+    return USBD_OK;
+}
+
+/*!
+    \brief      calculate feedback sample frequency
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     feedback frequency value
+*/
+static uint32_t usbd_audio_spk_get_feedback(usb_dev *udev)
+{
+    static uint32_t fb_freq;
+
+    /* calculate buffer free size */
+    if(audio_handler.isoc_out_wrptr >= audio_handler.isoc_out_rdptr){
+        audio_handler.buf_free_size = TOTAL_OUT_BUF_SIZE + audio_handler.isoc_out_rdptr - audio_handler.isoc_out_wrptr;
+    }else{
+        audio_handler.buf_free_size = audio_handler.isoc_out_rdptr - audio_handler.isoc_out_wrptr;
+    }
+
+    /* calculate feedback frequency */
+    if(audio_handler.buf_free_size <= (TOTAL_OUT_BUF_SIZE/4)){
+        fb_freq = I2S_ACTUAL_SAM_FREQ(USBD_SPEAKER_FREQ) - FEEDBACK_FREQ_OFFSET;
+    }else if(audio_handler.buf_free_size >= (TOTAL_OUT_BUF_SIZE*3/4)){
+        fb_freq = I2S_ACTUAL_SAM_FREQ(USBD_SPEAKER_FREQ) + FEEDBACK_FREQ_OFFSET;
+    }else{
+        fb_freq = I2S_ACTUAL_SAM_FREQ(USBD_SPEAKER_FREQ);
+    }
+
+    return fb_freq;
+}
+
+/*!
+    \brief      get feedback value from rate in USB full speed
+    \param[in]  rate: sample frequence
+    \param[in]  buf: pointer to result buffer
+    \param[out] none
+    \retval     USB device operation status
+*/
+static void get_feedback_fs_rate(uint32_t rate, uint8_t *buf)
+{
+    rate = ((rate / 1000) << 14) | ((rate % 1000) << 4);
+
+    buf[0] = rate;
+    buf[1] = rate >> 8;
+    buf[2] = rate >> 16;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/audio/Source/audio_out_itf.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/audio/Source/audio_out_itf.c
@@ -1,0 +1,170 @@
+/*!
+    \file    audio_out_itf.c
+    \brief   audio OUT (playback) interface functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "audio_core.h"
+#include "audio_out_itf.h"
+
+/* local function prototypes ('static') */
+static uint8_t init (uint32_t audio_freq, uint32_t volume);
+static uint8_t deinit (void);
+static uint8_t audio_cmd (uint8_t* pbuf, uint32_t size, uint8_t cmd);
+
+/* local variable defines */
+static uint8_t audio_state = AD_STATE_INACTIVE;
+
+audio_fops_struct audio_out_fops = 
+{
+    .audio_init   = init,
+    .audio_deinit = deinit,
+    .audio_cmd    = audio_cmd,
+};
+
+/*!
+    \brief      initialize and configures all required resources
+    \param[in]  audio_freq: statrt_up audio frequency
+    \param[in]  volume: start_up volume to be set
+    \param[out] none
+    \retval     AD_OK if all operations succeed, otherwise, AD_FAIL.
+*/
+static uint8_t init (uint32_t audio_freq, uint32_t volume)
+{
+    static uint32_t initialized = 0U;
+
+    /* check if the low layer has already been initialized */
+    if (0U == initialized) {
+        /* initialize GPIO */
+        codec_gpio_init();
+
+        /* initialize i2s */
+        codec_audio_interface_init(audio_freq);
+
+        /* initialize DMA */
+        codec_i2s_dma_init();
+
+        /* prevent reinitializing the interface again */
+        initialized = 1U;
+    }
+
+    /* update the audio state machine */
+    audio_state = AD_STATE_ACTIVE;
+
+    return AD_OK;
+}
+
+/*!
+    \brief      free all resources used by low layer and stops audio-play function
+    \param[in]  none
+    \param[out] none
+    \retval     AD_OK if all operations succeed, otherwise, AD_FAIL.
+*/
+static uint8_t deinit (void)
+{
+    /* update the audio state machine */
+    audio_state = AD_STATE_INACTIVE;
+
+    return AD_OK;
+}
+
+/*!
+    \brief      play, stop, pause or resume current file
+    \param[in]  pbuf: address from which file should be played
+    \param[in]  size: size of the current buffer/file
+    \param[in]  cmd: command to be executed, can be:
+      \arg        AD_CMD_PLAY
+      \arg        AD_CMD_PAUSE
+      \arg        AD_CMD_RESUME
+      \arg        AD_CMD_STOP
+    \param[out] none
+    \retval     AD_OK if all operations succeed, otherwise, AD_FAIL.
+*/
+static uint8_t audio_cmd (uint8_t* pbuf, uint32_t size, uint8_t cmd)
+{
+    /* check the current state */
+    if ((AD_STATE_INACTIVE == audio_state) || (AD_STATE_ERROR == audio_state)) {
+        audio_state = AD_STATE_ERROR;
+
+        return AD_FAIL;
+    }
+
+    switch (cmd) {
+    /* process the play command */
+    case AD_CMD_PLAY:
+        /* if current state is active or stopped */
+        if ((AD_STATE_ACTIVE == audio_state) || \
+            (AD_STATE_STOPPED == audio_state) || \
+            (AD_STATE_PLAYING == audio_state)) {
+            audio_play((uint32_t)pbuf, size);
+            audio_state = AD_STATE_PLAYING;
+
+            return AD_OK;
+        } else if (AD_STATE_PAUSED == audio_state) {
+            audio_pause_resume(AD_RESUME, (uint32_t)pbuf, (size/2));
+            audio_state = AD_STATE_PLAYING;
+
+            return AD_OK;
+        } else {
+            return AD_FAIL;
+        }
+
+    /* process the stop command */
+    case AD_CMD_STOP:
+        if (AD_STATE_PLAYING != audio_state) {
+            /* unsupported command */
+            return AD_FAIL;
+        } else {
+            audio_stop();
+            audio_state = AD_STATE_STOPPED;
+
+            return AD_OK;
+        }
+
+    /* process the pause command */
+    case AD_CMD_PAUSE:
+        if (AD_STATE_PLAYING != audio_state) {
+            /* unsupported command */
+            return AD_FAIL;
+        } else {
+            audio_pause_resume(AD_PAUSE, (uint32_t)pbuf, (size/2));
+            audio_state = AD_STATE_PAUSED;
+
+            return AD_OK;
+        }
+
+    /* unsupported command */
+    default:
+        return AD_FAIL;
+    }
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/cdc/Include/cdc_acm_core.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/cdc/Include/cdc_acm_core.h
@@ -1,0 +1,68 @@
+/*!
+    \file    cdc_acm_core.h
+    \brief   the header file of cdc acm driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __CDC_ACM_CORE_H
+#define __CDC_ACM_CORE_H
+
+#include "usbd_enum.h"
+#include "usb_cdc.h"
+
+#define USB_CDC_RX_LEN      USB_CDC_DATA_PACKET_SIZE
+
+typedef struct {
+    uint8_t packet_sent;
+    uint8_t packet_receive;
+
+    uint8_t data[USB_CDC_RX_LEN];
+    uint8_t cmd[USB_CDC_CMD_PACKET_SIZE];
+
+    uint32_t receive_length;
+
+    acm_line line_coding;
+} usb_cdc_handler;
+
+extern usb_desc cdc_desc;
+extern usb_class_core cdc_class;
+
+/* function declarations */
+/* check CDC ACM is ready for data transfer */
+uint8_t cdc_acm_check_ready(usb_dev *udev);
+/* send CDC ACM data */
+void cdc_acm_data_send(usb_dev *udev);
+/* receive CDC ACM data */
+void cdc_acm_data_receive(usb_dev *udev);
+
+#endif /* __CDC_ACM_CORE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/cdc/Source/cdc_acm_core.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/cdc/Source/cdc_acm_core.c
@@ -1,0 +1,531 @@
+/*!
+    \file    cdc_acm_core.c
+    \brief   CDC ACM driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "cdc_acm_core.h"
+
+#define USBD_VID                          0x28E9U
+#define USBD_PID                          0x018AU
+
+/* note:it should use the C99 standard when compiling the below codes */
+/* USB standard device descriptor */
+__ALIGN_BEGIN const usb_desc_dev cdc_dev_desc __ALIGN_END =
+{
+    .header = 
+     {
+         .bLength          = USB_DEV_DESC_LEN, 
+         .bDescriptorType  = USB_DESCTYPE_DEV,
+     },
+    .bcdUSB                = 0x0200U,
+    .bDeviceClass          = USB_CLASS_CDC,
+    .bDeviceSubClass       = 0x00U,
+    .bDeviceProtocol       = 0x00U,
+    .bMaxPacketSize0       = USB_FS_EP0_MAX_LEN,
+    .idVendor              = USBD_VID,
+    .idProduct             = USBD_PID,
+    .bcdDevice             = 0x0100U,
+    .iManufacturer         = STR_IDX_MFC,
+    .iProduct              = STR_IDX_PRODUCT,
+    .iSerialNumber         = STR_IDX_SERIAL,
+    .bNumberConfigurations = USBD_CFG_MAX_NUM,
+};
+
+/* USB device configuration descriptor */
+__ALIGN_BEGIN const usb_cdc_desc_config_set cdc_config_desc __ALIGN_END = 
+{
+    .config = 
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_config),
+            .bDescriptorType = USB_DESCTYPE_CONFIG,
+        },
+        .wTotalLength         = USB_CDC_ACM_CONFIG_DESC_SIZE,
+        .bNumInterfaces       = 0x02U,
+        .bConfigurationValue  = 0x01U,
+        .iConfiguration       = 0x00U,
+        .bmAttributes         = 0x80U,
+        .bMaxPower            = 0x32U
+    },
+
+    .cmd_itf = 
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_itf),
+            .bDescriptorType = USB_DESCTYPE_ITF
+        },
+        .bInterfaceNumber     = 0x00U,
+        .bAlternateSetting    = 0x00U,
+        .bNumEndpoints        = 0x01U,
+        .bInterfaceClass      = USB_CLASS_CDC,
+        .bInterfaceSubClass   = USB_CDC_SUBCLASS_ACM,
+        .bInterfaceProtocol   = USB_CDC_PROTOCOL_AT,
+        .iInterface           = 0x00U
+    },
+
+    .cdc_header =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_header_func),
+            .bDescriptorType = USB_DESCTYPE_CS_INTERFACE
+        },
+        .bDescriptorSubtype  = 0x00U,
+        .bcdCDC              = 0x0110U
+    },
+
+    .cdc_call_managment =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_call_managment_func),
+            .bDescriptorType = USB_DESCTYPE_CS_INTERFACE
+        },
+        .bDescriptorSubtype  = 0x01U,
+        .bmCapabilities      = 0x00U,
+        .bDataInterface      = 0x01U
+    },
+
+    .cdc_acm =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_acm_func),
+            .bDescriptorType = USB_DESCTYPE_CS_INTERFACE
+        },
+        .bDescriptorSubtype  = 0x02U,
+        .bmCapabilities      = 0x02U,
+    },
+
+    .cdc_union =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_union_func),
+            .bDescriptorType = USB_DESCTYPE_CS_INTERFACE
+        },
+        .bDescriptorSubtype  = 0x06U,
+        .bMasterInterface    = 0x00U,
+        .bSlaveInterface0    = 0x01U,
+    },
+
+    .cdc_cmd_endpoint =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_ep),
+            .bDescriptorType = USB_DESCTYPE_EP,
+        },
+        .bEndpointAddress    = CDC_CMD_EP,
+        .bmAttributes        = USB_EP_ATTR_INT,
+        .wMaxPacketSize      = USB_CDC_CMD_PACKET_SIZE,
+        .bInterval           = 0x0AU
+    },
+
+    .cdc_data_interface =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_itf),
+            .bDescriptorType = USB_DESCTYPE_ITF,
+        },
+        .bInterfaceNumber    = 0x01U,
+        .bAlternateSetting   = 0x00U,
+        .bNumEndpoints       = 0x02U,
+        .bInterfaceClass     = USB_CLASS_DATA,
+        .bInterfaceSubClass  = 0x00U,
+        .bInterfaceProtocol  = USB_CDC_PROTOCOL_NONE,
+        .iInterface          = 0x00U
+    },
+
+    .cdc_out_endpoint =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_ep),
+            .bDescriptorType = USB_DESCTYPE_EP,
+        },
+        .bEndpointAddress     = CDC_DATA_OUT_EP,
+        .bmAttributes         = USB_EP_ATTR_BULK,
+        .wMaxPacketSize       = USB_CDC_DATA_PACKET_SIZE,
+        .bInterval            = 0x00U
+    },
+
+    .cdc_in_endpoint =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_ep),
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress     = CDC_DATA_IN_EP,
+        .bmAttributes         = USB_EP_ATTR_BULK,
+        .wMaxPacketSize       = USB_CDC_DATA_PACKET_SIZE,
+        .bInterval            = 0x00U
+    }
+};
+
+/* USB language ID Descriptor */
+static __ALIGN_BEGIN const usb_desc_LANGID usbd_language_id_desc __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = sizeof(usb_desc_LANGID),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .wLANGID              = ENG_LANGID
+};
+
+/* USB manufacture string */
+static __ALIGN_BEGIN const usb_desc_str manufacturer_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(10),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'i', 'g', 'a', 'D', 'e', 'v', 'i', 'c', 'e'}
+};
+
+/* USB product string */
+static __ALIGN_BEGIN const usb_desc_str product_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(12),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'D', '3', '2', '-', 'C', 'D', 'C', '_', 'A', 'C', 'M'}
+};
+
+/* USBD serial string */
+static __ALIGN_BEGIN usb_desc_str serial_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(12),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    }
+};
+
+/* USB string descriptor set */
+void *const usbd_cdc_strings[] = 
+{
+    [STR_IDX_LANGID]  = (uint8_t *) &usbd_language_id_desc,
+    [STR_IDX_MFC]     = (uint8_t *) &manufacturer_string,
+    [STR_IDX_PRODUCT] = (uint8_t *) &product_string,
+    [STR_IDX_SERIAL]  = (uint8_t *) &serial_string
+};
+
+usb_desc cdc_desc = 
+{
+    .dev_desc    = (uint8_t *) &cdc_dev_desc,
+    .config_desc = (uint8_t *) &cdc_config_desc,
+    .strings     = usbd_cdc_strings
+};
+
+/* local function prototypes ('static') */
+static uint8_t cdc_acm_init     (usb_dev *udev, uint8_t config_index);
+static uint8_t cdc_acm_deinit   (usb_dev *udev, uint8_t config_index);
+static uint8_t cdc_acm_req      (usb_dev *udev, usb_req *req);
+static uint8_t cdc_acm_ctlx_out (usb_dev *udev);
+static uint8_t cdc_acm_in       (usb_dev *udev, uint8_t ep_num);
+static uint8_t cdc_acm_out      (usb_dev *udev, uint8_t ep_num);
+
+/* USB CDC device class callbacks structure */
+usb_class_core cdc_class =
+{
+    .command   = NO_CMD,
+    .alter_set = 0U,
+
+    .init      = cdc_acm_init,
+    .deinit    = cdc_acm_deinit,
+    .req_proc  = cdc_acm_req,
+    .ctlx_out  = cdc_acm_ctlx_out,
+    .data_in   = cdc_acm_in,
+    .data_out  = cdc_acm_out
+};
+
+/*!
+    \brief      check CDC ACM is ready for data transfer
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     0 if CDC is ready, 5 else
+*/
+uint8_t cdc_acm_check_ready(usb_dev *udev)
+{
+    if (udev->dev.class_data[CDC_COM_INTERFACE] != NULL) {
+        usb_cdc_handler *cdc = (usb_cdc_handler *)udev->dev.class_data[CDC_COM_INTERFACE];
+
+        if ((1U == cdc->packet_receive) && (1U == cdc->packet_sent)) {
+            return 0U;
+        }
+    }
+
+    return 1U;
+}
+
+/*!
+    \brief      send CDC ACM data
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation status
+*/
+void cdc_acm_data_send (usb_dev *udev)
+{
+    usb_cdc_handler *cdc = (usb_cdc_handler *)udev->dev.class_data[CDC_COM_INTERFACE];
+
+    if (0U != cdc->receive_length) {
+        cdc->packet_sent = 0U;
+
+        usbd_ep_send (udev, CDC_DATA_IN_EP, (uint8_t*)(cdc->data), cdc->receive_length);
+
+        cdc->receive_length = 0U;
+    }
+}
+
+/*!
+    \brief      receive CDC ACM data
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation status
+*/
+void cdc_acm_data_receive (usb_dev *udev)
+{
+    usb_cdc_handler *cdc = (usb_cdc_handler *)udev->dev.class_data[CDC_COM_INTERFACE];
+
+    cdc->packet_receive = 0U;
+    cdc->packet_sent = 0U;
+
+    usbd_ep_recev (udev, CDC_DATA_OUT_EP, (uint8_t*)(cdc->data), USB_CDC_DATA_PACKET_SIZE);
+}
+
+/*!
+    \brief      initialize the CDC ACM device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t cdc_acm_init (usb_dev *udev, uint8_t config_index)
+{
+    static __ALIGN_BEGIN usb_cdc_handler cdc_handler __ALIGN_END;
+
+    /* initialize the data Tx endpoint */
+    usbd_ep_setup (udev, &(cdc_config_desc.cdc_in_endpoint));
+
+    /* initialize the data Rx endpoint */
+    usbd_ep_setup (udev, &(cdc_config_desc.cdc_out_endpoint));
+
+    /* initialize the command Tx endpoint */
+    usbd_ep_setup (udev, &(cdc_config_desc.cdc_cmd_endpoint));
+
+    /* initialize CDC handler structure */
+    cdc_handler.packet_receive = 1U;
+    cdc_handler.packet_sent = 1U;
+    cdc_handler.receive_length = 0U;
+
+    cdc_handler.line_coding = (acm_line){
+        .dwDTERate   = 115200U,
+        .bCharFormat = 0U,
+        .bParityType = 0U,
+        .bDataBits   = 0x08U
+    };
+
+    udev->dev.class_data[CDC_COM_INTERFACE] = (void *)&cdc_handler;
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      deinitialize the CDC ACM device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t cdc_acm_deinit (usb_dev *udev, uint8_t config_index)
+{
+    /* deinitialize the data Tx/Rx endpoint */
+    usbd_ep_clear (udev, CDC_DATA_IN_EP);
+    usbd_ep_clear (udev, CDC_DATA_OUT_EP);
+
+    /* deinitialize the command Tx endpoint */
+    usbd_ep_clear (udev, CDC_CMD_EP);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle the CDC ACM class-specific requests
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: device class-specific request
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t cdc_acm_req (usb_dev *udev, usb_req *req)
+{
+    usb_cdc_handler *cdc = (usb_cdc_handler *)udev->dev.class_data[CDC_COM_INTERFACE];
+
+    usb_transc *transc = NULL;
+
+    switch (req->bRequest) {
+    case SEND_ENCAPSULATED_COMMAND:
+        /* no operation for this driver */
+        break;
+
+    case GET_ENCAPSULATED_RESPONSE:
+        /* no operation for this driver */
+        break;
+
+    case SET_COMM_FEATURE:
+        /* no operation for this driver */
+        break;
+
+    case GET_COMM_FEATURE:
+        /* no operation for this driver */
+        break;
+
+    case CLEAR_COMM_FEATURE:
+        /* no operation for this driver */
+        break;
+
+    case SET_LINE_CODING:
+        transc = &udev->dev.transc_out[0];
+
+        /* set the value of the current command to be processed */
+        udev->dev.class_core->alter_set = req->bRequest;
+
+        /* enable EP0 prepare to receive command data packet */
+        transc->remain_len = req->wLength;
+        transc->xfer_buf = cdc->cmd;
+        break;
+
+    case GET_LINE_CODING:
+        transc = &udev->dev.transc_in[0];
+
+        cdc->cmd[0] = (uint8_t)(cdc->line_coding.dwDTERate);
+        cdc->cmd[1] = (uint8_t)(cdc->line_coding.dwDTERate >> 8);
+        cdc->cmd[2] = (uint8_t)(cdc->line_coding.dwDTERate >> 16);
+        cdc->cmd[3] = (uint8_t)(cdc->line_coding.dwDTERate >> 24);
+        cdc->cmd[4] = cdc->line_coding.bCharFormat;
+        cdc->cmd[5] = cdc->line_coding.bParityType;
+        cdc->cmd[6] = cdc->line_coding.bDataBits;
+
+        transc->xfer_buf = cdc->cmd;
+        transc->remain_len = 7U;
+        break;
+
+    case SET_CONTROL_LINE_STATE:
+        /* no operation for this driver */
+        break;
+
+    case SEND_BREAK:
+        /* no operation for this driver */
+        break;
+
+    default:
+        break;
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      command data received on control endpoint
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t cdc_acm_ctlx_out (usb_dev *udev)
+{
+    usb_cdc_handler *cdc = (usb_cdc_handler *)udev->dev.class_data[CDC_COM_INTERFACE];
+
+    if (udev->dev.class_core->alter_set != NO_CMD) {
+        /* process the command data */
+        cdc->line_coding.dwDTERate = (uint32_t)((uint32_t)cdc->cmd[0] | 
+                                               ((uint32_t)cdc->cmd[1] << 8U) | 
+                                               ((uint32_t)cdc->cmd[2] << 16U) | 
+                                               ((uint32_t)cdc->cmd[3] << 24U));
+
+        cdc->line_coding.bCharFormat = cdc->cmd[4];
+        cdc->line_coding.bParityType = cdc->cmd[5];
+        cdc->line_coding.bDataBits = cdc->cmd[6];
+
+        udev->dev.class_core->alter_set = NO_CMD;
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle CDC ACM data in
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint identifier
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t cdc_acm_in (usb_dev *udev, uint8_t ep_num)
+{
+    usb_transc *transc = &udev->dev.transc_in[EP_ID(ep_num)];
+
+    usb_cdc_handler *cdc = (usb_cdc_handler *)udev->dev.class_data[CDC_COM_INTERFACE];
+
+    if ((0U == transc->xfer_len % transc->max_len) && (0U != transc->xfer_len)) {
+        usbd_ep_send (udev, ep_num, NULL, 0U);
+    } else {
+        cdc->packet_sent = 1U;
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle CDC ACM data out
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint identifier
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t cdc_acm_out (usb_dev *udev, uint8_t ep_num)
+{
+    usb_cdc_handler *cdc = (usb_cdc_handler *)udev->dev.class_data[CDC_COM_INTERFACE];
+
+    cdc->packet_receive = 1U;
+    cdc->receive_length = ((usb_core_driver *)udev)->dev.transc_out[ep_num].xfer_count;
+
+    return USBD_OK;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/dfu/Include/dfu_core.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/dfu/Include/dfu_core.h
@@ -1,0 +1,177 @@
+/*!
+    \file    dfu_core.h
+    \brief   the header file of USB DFU device class core functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __DFU_CORE_H
+#define __DFU_CORE_H
+
+#include "usbd_enum.h"
+
+/* DFU class code */
+#define USB_DFU_CLASS                 0xFEU
+
+/* DFU subclass code */
+#define USB_DFU_SUBCLASS_UPGRADE      0x01U
+
+/* DFU protocol code */
+#define USB_DFU_PROTOCL_RUNTIME       0x01U
+#define USB_DFU_PROTOCL_DFU           0x02U
+
+/* manifestation state */
+#define MANIFEST_COMPLETE             0x00U
+#define MANIFEST_IN_PROGRESS          0x01U
+
+/* DFU attributes code */
+#define USB_DFU_CAN_DOWNLOAD          0x01U
+#define USB_DFU_CAN_UPLOAD            0x02U
+#define USB_DFU_MANIFEST_TOLERANT     0x04U
+#define USB_DFU_WILL_DETACH           0x08U
+
+/* special commands with download request */
+#define GET_COMMANDS                  0x00U
+#define SET_ADDRESS_POINTER           0x21U
+#define ERASE                         0x41U
+
+/* memory operation command */
+#define CMD_ERASE                     0U
+#define CMD_WRITE                     1U
+
+#define _BYTE1(x)                     (uint8_t)((x) & 0xFFU)                /*!< addressing cycle 1st byte */
+#define _BYTE2(x)                     (uint8_t)(((x) & 0xFF00U) >> 8U)      /*!< addressing cycle 2nd byte */
+#define _BYTE3(x)                     (uint8_t)(((x) & 0xFF0000U) >> 16U)   /*!< addressing cycle 3rd byte */
+
+#define FLASH_ERASE_TIMEOUT           60U
+#define FLASH_WRITE_TIMEOUT           80U
+
+/* bit detach capable = bit 3 in bmAttributes field */
+#define DFU_DETACH_MASK               (uint8_t)(0x10U)
+
+#define DFU_DESC_TYPE                 0x21U
+
+/* DFU device state defines */
+typedef enum {
+    STATE_APP_IDLE = 0x00U,
+    STATE_APP_DETACH,
+    STATE_DFU_IDLE,
+    STATE_DFU_DNLOAD_SYNC,
+    STATE_DFU_DNBUSY,
+    STATE_DFU_DNLOAD_IDLE,
+    STATE_DFU_MANIFEST_SYNC,
+    STATE_DFU_MANIFEST,
+    STATE_DFU_MANIFEST_WAIT_RESET,
+    STATE_DFU_UPLOAD_IDLE,
+    STATE_DFU_ERROR
+} dfu_state;
+
+/* DFU device status defines */
+typedef enum {
+    STATUS_OK = 0x00U,
+    STATUS_ERR_TARGET,
+    STATUS_ERR_FILE,
+    STATUS_ERR_WRITE,
+    STATUS_ERR_ERASE,
+    STATUS_ERR_CHECK_ERASED,
+    STATUS_ERR_PROG,
+    STATUS_ERR_VERIFY,
+    STATUS_ERR_ADDRESS,
+    STATUS_ERR_NOTDONE,
+    STATUS_ERR_FIRMWARE,
+    STATUS_ERR_VENDOR,
+    STATUS_ERR_USBR,
+    STATUS_ERR_POR,
+    STATUS_ERR_UNKNOWN,
+    STATUS_ERR_STALLEDPKT
+} dfu_status;
+
+/* DFU class-specific requests */
+typedef enum {
+    DFU_DETACH = 0U,
+    DFU_DNLOAD,
+    DFU_UPLOAD,
+    DFU_GETSTATUS,
+    DFU_CLRSTATUS,
+    DFU_GETSTATE,
+    DFU_ABORT,
+    DFU_REQ_MAX
+} dfu_requests;
+
+#pragma pack(1)
+
+/* USB DFU function descriptor structure */
+typedef struct
+{
+    usb_desc_header header;               /*!< descriptor header, including type and size */
+    uint8_t bmAttributes;                 /*!< DFU attributes */
+    uint16_t wDetachTimeOut;              /*!< time, in milliseconds, that the device will wait after receipt of the DFU_DETACH request. If */ 
+    uint16_t wTransferSize;               /*!< maximum number of bytes that the device can accept per control-write transaction */
+    uint16_t bcdDFUVersion;               /*!< numeric expression identifying the version of the DFU specification release. */
+} usb_desc_dfu_func;
+
+#pragma pack()
+
+/* USB configuration descriptor structure */
+typedef struct
+{
+    usb_desc_config           config;
+    usb_desc_itf              dfu_itf0;
+    usb_desc_itf              dfu_itf1;
+    usb_desc_itf              dfu_itf2;
+    usb_desc_dfu_func         dfu_func;
+} usb_dfu_desc_config_set;
+
+/* USB DFU handler structure */
+typedef struct
+{
+    uint8_t bStatus;
+    uint8_t bwPollTimeout0;
+    uint8_t bwPollTimeout1;
+    uint8_t bwPollTimeout2;
+    uint8_t bState;
+    uint8_t iString;
+
+    uint8_t manifest_state;
+    uint32_t data_len;
+    uint16_t block_num;
+    uint32_t base_addr;
+
+    uint8_t buf[TRANSFER_SIZE];
+} usbd_dfu_handler;
+
+typedef void (*app_func) (void);
+
+extern usb_desc dfu_desc;
+extern usb_class_core dfu_class;
+
+#endif /* DFU_CORE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/dfu/Include/dfu_mem.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/dfu/Include/dfu_mem.h
@@ -1,0 +1,85 @@
+/*!
+    \file    dfu_mem.h
+    \brief   USB DFU device media access layer header file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __DFU_MEM_H
+#define __DFU_MEM_H
+
+#include "usb_conf.h"
+
+typedef struct _dfu_mem_prop
+{
+    const uint8_t* pstr_desc;
+
+    uint8_t  (*mem_init)      (void);
+    uint8_t  (*mem_deinit)    (void);
+    uint8_t  (*mem_erase)     (uint32_t addr);
+    uint8_t  (*mem_write)     (uint8_t *buf, uint32_t addr, uint32_t len);
+    uint8_t* (*mem_read)      (uint8_t *buf, uint32_t addr, uint32_t len);
+    uint8_t  (*mem_checkaddr) (uint32_t addr);
+
+    const uint32_t erase_timeout;
+    const uint32_t write_timeout;
+} dfu_mem_prop;
+
+typedef enum
+{
+    MEM_OK = 0,
+    MEM_FAIL
+} mem_status;
+
+#define _1ST_BYTE(x)              (uint8_t)((x) & 0xFF)               /*!< addressing cycle 1st byte */
+#define _2ND_BYTE(x)              (uint8_t)(((x) & 0xFF00) >> 8)      /*!< addressing cycle 2nd byte */
+#define _3RD_BYTE(x)              (uint8_t)(((x) & 0xFF0000) >> 16)   /*!< addressing cycle 3rd byte */
+
+#define POLLING_TIMEOUT_SET(x)    buffer[0] = _1ST_BYTE(x);\
+                                  buffer[1] = _2ND_BYTE(x);\
+                                  buffer[2] = _3RD_BYTE(x);
+
+/* function declarations */
+/* initialize the memory media on the GD32 */
+uint8_t dfu_mem_init(void);
+/* deinitialize the memory media on the GD32 */
+uint8_t dfu_mem_deinit(void);
+/* erase a memory sector */
+uint8_t dfu_mem_erase(uint32_t addr);
+/* write data to sectors of memory */
+uint8_t dfu_mem_write(uint8_t *buf, uint32_t addr, uint32_t len);
+/* read data from sectors of memory */
+uint8_t* dfu_mem_read(uint8_t *buf, uint32_t addr, uint32_t len);
+/* get the status of a given memory and store in buffer */
+uint8_t dfu_mem_getstatus(uint32_t addr, uint8_t cmd, uint8_t *buffer);
+
+#endif /* __DFU_MEM_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/dfu/Source/dfu_core.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/dfu/Source/dfu_core.c
@@ -1,0 +1,735 @@
+/*!
+    \file    dfu_core.c
+    \brief   USB DFU device class core functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "dfu_core.h"
+#include "dfu_mem.h"
+#include "drv_usb_hw.h"
+#include <string.h>
+
+#define USBD_VID                     0x28E9U
+#define USBD_PID                     0x0189U
+
+/* local function prototypes ('static') */
+static uint8_t dfu_init(usb_dev *udev, uint8_t config_index);
+static uint8_t dfu_deinit(usb_dev *udev, uint8_t config_index);
+static uint8_t dfu_req_handler(usb_dev *udev, usb_req *req);
+static uint8_t dfu_ctlx_in(usb_dev *udev);
+
+static void dfu_mode_leave(usb_dev *udev);
+static uint8_t dfu_getstatus_complete (usb_dev *udev);
+
+/* DFU requests management functions */
+static void dfu_detach(usb_dev *udev, usb_req *req);
+static void dfu_dnload(usb_dev *udev, usb_req *req);
+static void dfu_upload(usb_dev *udev, usb_req *req);
+static void dfu_getstatus(usb_dev *udev, usb_req *req);
+static void dfu_clrstatus(usb_dev *udev, usb_req *req);
+static void dfu_getstate(usb_dev *udev, usb_req *req);
+static void dfu_abort(usb_dev *udev, usb_req *req);
+
+static void string_to_unicode (uint8_t *str, uint16_t *pbuf);
+
+static void (*dfu_request_process[])(usb_dev *udev, usb_req *req) = 
+{
+    [DFU_DETACH]    = dfu_detach,
+    [DFU_DNLOAD]    = dfu_dnload,
+    [DFU_UPLOAD]    = dfu_upload,
+    [DFU_GETSTATUS] = dfu_getstatus,
+    [DFU_CLRSTATUS] = dfu_clrstatus,
+    [DFU_GETSTATE]  = dfu_getstate,
+    [DFU_ABORT]     = dfu_abort
+};
+
+/* note:it should use the c99 standard when compiling the below codes */
+/* USB standard device descriptor */
+__ALIGN_BEGIN const usb_desc_dev dfu_dev_desc __ALIGN_END =
+{
+    .header = 
+     {
+         .bLength          = USB_DEV_DESC_LEN, 
+         .bDescriptorType  = USB_DESCTYPE_DEV
+     },
+    .bcdUSB                = 0x0200U,
+    .bDeviceClass          = 0x00U,
+    .bDeviceSubClass       = 0x00U,
+    .bDeviceProtocol       = 0x00U,
+    .bMaxPacketSize0       = USB_FS_EP0_MAX_LEN,
+    .idVendor              = USBD_VID,
+    .idProduct             = USBD_PID,
+    .bcdDevice             = 0x0100U,
+    .iManufacturer         = STR_IDX_MFC,
+    .iProduct              = STR_IDX_PRODUCT,
+    .iSerialNumber         = STR_IDX_SERIAL,
+    .bNumberConfigurations = USBD_CFG_MAX_NUM
+};
+
+/* USB device configuration descriptor */
+__ALIGN_BEGIN const usb_dfu_desc_config_set dfu_config_desc __ALIGN_END = 
+{
+    .config = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_config), 
+             .bDescriptorType = USB_DESCTYPE_CONFIG 
+         },
+        .wTotalLength         = sizeof(usb_dfu_desc_config_set),
+        .bNumInterfaces       = 0x01U,
+        .bConfigurationValue  = 0x01U,
+        .iConfiguration       = 0x00U,
+        .bmAttributes         = 0x80U,
+        .bMaxPower            = 0x32U
+    },
+
+    .dfu_itf0 = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_itf), 
+             .bDescriptorType = USB_DESCTYPE_ITF 
+         },
+        .bInterfaceNumber     = 0x00U,
+        .bAlternateSetting    = 0x00U,
+        .bNumEndpoints        = 0x00U,
+        .bInterfaceClass      = USB_DFU_CLASS,
+        .bInterfaceSubClass   = USB_DFU_SUBCLASS_UPGRADE,
+        .bInterfaceProtocol   = USB_DFU_PROTOCL_DFU,
+        .iInterface           = STR_IDX_ALT_ITF0
+    },
+
+    .dfu_itf1 = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_itf), 
+             .bDescriptorType = USB_DESCTYPE_ITF 
+         },
+        .bInterfaceNumber     = 0x00U,
+        .bAlternateSetting    = 0x01U,
+        .bNumEndpoints        = 0x00U,
+        .bInterfaceClass      = USB_DFU_CLASS,
+        .bInterfaceSubClass   = USB_DFU_SUBCLASS_UPGRADE,
+        .bInterfaceProtocol   = USB_DFU_PROTOCL_DFU,
+        .iInterface           = STR_IDX_ALT_ITF1
+    },
+
+    .dfu_itf2 = 
+    {
+        .header = 
+         {
+             .bLength         = sizeof(usb_desc_itf), 
+             .bDescriptorType = USB_DESCTYPE_ITF 
+         },
+        .bInterfaceNumber     = 0x00U,
+        .bAlternateSetting    = 0x02U,
+        .bNumEndpoints        = 0x00U,
+        .bInterfaceClass      = USB_DFU_CLASS,
+        .bInterfaceSubClass   = USB_DFU_SUBCLASS_UPGRADE,
+        .bInterfaceProtocol   = USB_DFU_PROTOCL_DFU,
+        .iInterface           = STR_IDX_ALT_ITF2
+    },
+
+    .dfu_func= 
+    {
+        .header = 
+         {
+            .bLength          = sizeof(usb_desc_dfu_func), 
+            .bDescriptorType  = DFU_DESC_TYPE 
+         },
+        .bmAttributes         = USB_DFU_CAN_DOWNLOAD | USB_DFU_CAN_UPLOAD | USB_DFU_WILL_DETACH,
+        .wDetachTimeOut       = 0x00FFU,
+        .wTransferSize        = TRANSFER_SIZE,
+        .bcdDFUVersion        = 0x0110U,
+    },
+};
+
+/* USB language ID descriptor */
+static __ALIGN_BEGIN const usb_desc_LANGID usbd_language_id_desc __ALIGN_END = 
+{
+    .header = 
+    {
+         .bLength         = sizeof(usb_desc_LANGID), 
+         .bDescriptorType = USB_DESCTYPE_STR
+    },
+    .wLANGID              = ENG_LANGID
+};
+
+/* USB manufacture string */
+static __ALIGN_BEGIN const usb_desc_str manufacturer_string __ALIGN_END = 
+{
+    .header = 
+    {
+         .bLength         = USB_STRING_LEN(10U), 
+         .bDescriptorType = USB_DESCTYPE_STR,
+     },
+    .unicode_string = {'G', 'i', 'g', 'a', 'D', 'e', 'v', 'i', 'c', 'e'}
+};
+
+/* USB product string */
+static __ALIGN_BEGIN const usb_desc_str product_string __ALIGN_END = 
+{
+    .header = 
+    {
+         .bLength         = USB_STRING_LEN(12U), 
+         .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'D', '3', '2', '-', 'U', 'S', 'B', '_', 'D', 'F', 'U'}
+};
+
+/* USB serial string */
+static __ALIGN_BEGIN usb_desc_str serial_string __ALIGN_END = 
+{
+    .header = 
+    {
+         .bLength         = USB_STRING_LEN(2U), 
+         .bDescriptorType = USB_DESCTYPE_STR,
+    }
+};
+
+/* USB configure string */
+static __ALIGN_BEGIN const usb_desc_str config_string __ALIGN_END = 
+{
+    .header = 
+    {
+         .bLength         = USB_STRING_LEN(15U), 
+         .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'D', '3', '2', ' ', 'U', 'S', 'B', ' ', 'C', 'O', 'N', 'F', 'I', 'G'}
+};
+
+/* alternate interface 0 string */
+static __ALIGN_BEGIN usb_desc_str interface_string0 __ALIGN_END = 
+{
+    .header = 
+    {
+         .bLength         = USB_STRING_LEN(2U), 
+         .bDescriptorType = USB_DESCTYPE_STR,
+    },
+};
+
+/* alternate interface 1 string */
+static __ALIGN_BEGIN usb_desc_str interface_string1 __ALIGN_END = 
+{
+    .header = 
+    {
+         .bLength         = USB_STRING_LEN(2U), 
+         .bDescriptorType = USB_DESCTYPE_STR,
+    },
+};
+
+/* alternate interface 2 string */
+static __ALIGN_BEGIN usb_desc_str interface_string2 __ALIGN_END = 
+{
+    .header = 
+    {
+         .bLength         = USB_STRING_LEN(2U), 
+         .bDescriptorType = USB_DESCTYPE_STR,
+    },
+};
+
+void *const usbd_dfu_strings[] = 
+{
+    [STR_IDX_LANGID]   = (uint8_t *)&usbd_language_id_desc,
+    [STR_IDX_MFC]      = (uint8_t *)&manufacturer_string,
+    [STR_IDX_PRODUCT]  = (uint8_t *)&product_string,
+    [STR_IDX_SERIAL]   = (uint8_t *)&serial_string,
+    [STR_IDX_CONFIG]   = (uint8_t *)&config_string,
+    [STR_IDX_ALT_ITF0] = (uint8_t *)&interface_string0,
+    [STR_IDX_ALT_ITF1] = (uint8_t *)&interface_string1,
+    [STR_IDX_ALT_ITF2] = (uint8_t *)&interface_string2,
+};
+
+usb_desc dfu_desc = {
+    .dev_desc    = (uint8_t *)&dfu_dev_desc,
+    .config_desc = (uint8_t *)&dfu_config_desc,
+    .strings     = usbd_dfu_strings
+};
+
+usb_class_core dfu_class = {
+    .init            = dfu_init,
+    .deinit          = dfu_deinit,
+    .req_proc        = dfu_req_handler,
+    .ctlx_in         = dfu_ctlx_in
+};
+
+/*!
+    \brief      initialize the DFU device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t dfu_init (usb_dev *udev, uint8_t config_index)
+{
+    static __ALIGN_BEGIN usbd_dfu_handler dfu_handler __ALIGN_END;
+
+    /* unlock the internal flash */
+    dfu_mem_init();
+
+    memset((void *)&dfu_handler, 0, sizeof(usbd_dfu_handler));
+
+    dfu_handler.manifest_state = MANIFEST_COMPLETE;
+    dfu_handler.bState = STATE_DFU_IDLE;
+    dfu_handler.bStatus = STATUS_OK;
+
+    udev->dev.class_data[USBD_DFU_INTERFACE] = (void *)&dfu_handler;
+
+    /* create interface string */
+    string_to_unicode((uint8_t *)dfu_inter_flash_cb.pstr_desc, udev->dev.desc->strings[STR_IDX_ALT_ITF0]);
+    string_to_unicode((uint8_t *)dfu_nor_flash_cb.pstr_desc, udev->dev.desc->strings[STR_IDX_ALT_ITF1]);
+    string_to_unicode((uint8_t *)dfu_nand_flash_cb.pstr_desc, udev->dev.desc->strings[STR_IDX_ALT_ITF2]);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      deinitialize the DFU device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t dfu_deinit (usb_dev *udev, uint8_t config_index)
+{
+    usbd_dfu_handler *dfu = (usbd_dfu_handler *)udev->dev.class_data[USBD_DFU_INTERFACE];
+
+    /* restore device default state */
+    memset(udev->dev.class_data[USBD_DFU_INTERFACE], 0, sizeof(usbd_dfu_handler));
+
+    dfu->bState = STATE_DFU_IDLE;
+    dfu->bStatus = STATUS_OK;
+
+    /* deinit the memory */
+    dfu_mem_deinit();
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle the DFU class-specific requests
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: device class-specific request
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t dfu_req_handler (usb_dev *udev, usb_req *req)
+{
+    if (req->bRequest < DFU_REQ_MAX) {
+        dfu_request_process[req->bRequest](udev, req);
+    } else {
+        return USBD_FAIL;
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle data stage
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t dfu_ctlx_in (usb_dev *udev)
+{
+    dfu_getstatus_complete(udev);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      leave DFU mode and reset device to jump to user loaded code
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     none
+*/
+static void dfu_mode_leave (usb_dev *udev)
+{
+    usbd_dfu_handler *dfu = (usbd_dfu_handler *)udev->dev.class_data[USBD_DFU_INTERFACE];
+
+    dfu->manifest_state = MANIFEST_COMPLETE;
+
+    if (dfu_config_desc.dfu_func.bmAttributes & 0x04U) {
+        dfu->bState = STATE_DFU_MANIFEST_SYNC;
+    } else {
+        dfu->bState = STATE_DFU_MANIFEST_WAIT_RESET;
+
+        /* deinit the memory */
+        dfu_mem_deinit();
+
+        /* generate system reset to allow jumping to the user code */
+        NVIC_SystemReset();
+    }
+}
+
+/*!
+    \brief      handle data IN stage in control endpoint 0
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation status
+  */
+static uint8_t dfu_getstatus_complete (usb_dev *udev)
+{
+    uint32_t addr;
+
+    usbd_dfu_handler *dfu = (usbd_dfu_handler *)udev->dev.class_data[USBD_DFU_INTERFACE];
+
+    if (STATE_DFU_DNBUSY == dfu->bState) {
+        /* decode the special command */
+        if (0U == dfu->block_num) {
+            if (1U == dfu->data_len){
+                if (GET_COMMANDS == dfu->buf[0]) {
+                    /* no operation */
+                }
+            } else if (5U == dfu->data_len) {
+                if (SET_ADDRESS_POINTER == dfu->buf[0]) {
+                    /* set flash operation address */
+                    dfu->base_addr = *(uint32_t *)(dfu->buf + 1U);
+                } else if (ERASE == dfu->buf[0]) {
+                    dfu->base_addr = *(uint32_t *)(dfu->buf + 1U);
+
+                    dfu_mem_erase(dfu->base_addr);
+                } else {
+                    /* no operation */
+                }
+            } else {
+                /* no operation */
+            }
+        } else if (dfu->block_num > 1U) {  /* regular download command */
+            /* decode the required address */
+            addr = (dfu->block_num - 2U) * TRANSFER_SIZE + dfu->base_addr;
+
+            dfu_mem_write (dfu->buf, addr, dfu->data_len);
+
+            dfu->block_num = 0U;
+        } else {
+            /* no operation */
+        }
+
+        dfu->data_len = 0U;
+
+        /* update the device state and poll timeout */
+        dfu->bState = STATE_DFU_DNLOAD_SYNC;
+
+        return USBD_OK;
+    } else if (dfu->bState == STATE_DFU_MANIFEST) { /* manifestation in progress */
+        /* start leaving DFU mode */
+        dfu_mode_leave(udev);
+    } else {
+        /* no operation */
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle the DFU_DETACH request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: DFU class request
+    \param[out] none
+    \retval     none.
+*/
+static void dfu_detach(usb_dev *udev, usb_req *req)
+{
+    usbd_dfu_handler *dfu = (usbd_dfu_handler *)udev->dev.class_data[USBD_DFU_INTERFACE];
+
+    switch (dfu->bState) {
+    case STATE_DFU_IDLE:
+    case STATE_DFU_DNLOAD_SYNC:
+    case STATE_DFU_DNLOAD_IDLE:
+    case STATE_DFU_MANIFEST_SYNC:
+    case STATE_DFU_UPLOAD_IDLE:
+        dfu->bStatus = STATUS_OK;
+        dfu->bState = STATE_DFU_IDLE;
+        dfu->iString = 0U; /* iString */
+
+        dfu->block_num = 0U;
+        dfu->data_len = 0U;
+        break;
+ 
+    default:
+        break;
+    }
+
+    /* check the detach capability in the DFU functional descriptor */
+    if (dfu_config_desc.dfu_func.wDetachTimeOut & DFU_DETACH_MASK) {
+        usbd_disconnect (udev);
+
+        usbd_connect (udev);
+    } else {
+        /* wait for the period of time specified in detach request */
+        usb_mdelay (4U);
+    }
+}
+
+/*!
+    \brief      handle the DFU_DNLOAD request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: DFU class request
+    \param[out] none
+    \retval     none
+*/
+static void dfu_dnload(usb_dev *udev, usb_req *req)
+{
+    usb_transc *transc = &udev->dev.transc_out[0];
+    usbd_dfu_handler *dfu = (usbd_dfu_handler *)udev->dev.class_data[USBD_DFU_INTERFACE];
+
+    switch (dfu->bState) {
+    case STATE_DFU_IDLE:
+    case STATE_DFU_DNLOAD_IDLE:
+        if (req->wLength > 0U) {
+            /* update the global length and block number */
+            dfu->block_num = req->wValue;
+            dfu->data_len = req->wLength;
+
+            dfu->bState = STATE_DFU_DNLOAD_SYNC;
+
+            transc->remain_len = dfu->data_len;
+            transc->xfer_buf = dfu->buf;
+        } else {
+            dfu->manifest_state = MANIFEST_IN_PROGRESS;
+            dfu->bState = STATE_DFU_MANIFEST_SYNC;
+        }
+        break;
+
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      handles the DFU UPLOAD request.
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: DFU class request
+    \param[out] none
+    \retval     none
+*/
+static void  dfu_upload (usb_dev *udev, usb_req *req)
+{
+    uint8_t *phy_addr = NULL;
+    uint32_t addr = 0U;
+    usbd_dfu_handler *dfu = (usbd_dfu_handler *)udev->dev.class_data[USBD_DFU_INTERFACE];
+
+    usb_transc *transc = &udev->dev.transc_in[0];
+
+    if(req->wLength <= 0U) {
+        dfu->bState = STATE_DFU_IDLE;
+        return;
+    }
+
+    switch (dfu->bState) {
+    case STATE_DFU_IDLE:
+    case STATE_DFU_UPLOAD_IDLE:
+        /* update the global length and block number */
+        dfu->block_num = req->wValue;
+        dfu->data_len = req->wLength;
+
+        /* DFU get command */
+        if (0U == dfu->block_num) {
+            /* update the state machine */
+            dfu->bState = (dfu->data_len > 3U) ? STATE_DFU_IDLE : STATE_DFU_UPLOAD_IDLE;
+
+            /* store the values of all supported commands */
+            dfu->buf[0] = GET_COMMANDS;
+            dfu->buf[1] = SET_ADDRESS_POINTER;
+            dfu->buf[2] = ERASE;
+
+            /* send the status data over EP0 */
+            transc->xfer_buf = &(dfu->buf[0]);
+            transc->remain_len = 3U;
+        } else if (dfu->block_num > 1U) {
+            dfu->bState = STATE_DFU_UPLOAD_IDLE;
+
+            /* change is accelerated */
+            addr = (dfu->block_num - 2U) * TRANSFER_SIZE + dfu->base_addr;
+
+            /* return the physical address where data are stored */
+            phy_addr = dfu_mem_read (dfu->buf, addr, dfu->data_len);
+
+            /* send the status data over EP0 */
+            transc->xfer_buf = phy_addr;
+            transc->remain_len = dfu->data_len;
+        } else {
+            dfu->bState = STATUS_ERR_STALLEDPKT;
+        }
+        break;
+
+    default:
+        dfu->data_len = 0U;
+        dfu->block_num = 0U;
+        break;
+    }
+}
+
+/*!
+    \brief      handle the DFU_GETSTATUS request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: DFU class request
+    \param[out] none
+    \retval     none
+*/
+static void dfu_getstatus (usb_dev *udev, usb_req *req)
+{
+    usb_transc *transc = &udev->dev.transc_in[0];
+    usbd_dfu_handler *dfu = (usbd_dfu_handler *)udev->dev.class_data[USBD_DFU_INTERFACE];
+
+    switch (dfu->bState) {
+    case STATE_DFU_DNLOAD_SYNC:
+        if (0U != dfu->data_len) {
+            dfu->bState = STATE_DFU_DNBUSY;
+
+            if (0U == dfu->block_num) {
+                if (ERASE == dfu->buf[0]) {
+                    dfu_mem_getstatus (dfu->base_addr, CMD_ERASE, (uint8_t *)&dfu->bwPollTimeout0);
+                } else {
+                    dfu_mem_getstatus (dfu->base_addr, CMD_WRITE, (uint8_t *)&dfu->bwPollTimeout0);
+                }
+            }
+        } else {
+            dfu->bState = STATE_DFU_DNLOAD_IDLE;
+        }
+        break;
+
+    case STATE_DFU_MANIFEST_SYNC:
+        if (MANIFEST_IN_PROGRESS == dfu->manifest_state) {
+            dfu->bState = STATE_DFU_MANIFEST;
+            dfu->bwPollTimeout0 = 1U;
+        } else if ((MANIFEST_COMPLETE == dfu->manifest_state) && \
+            (dfu_config_desc.dfu_func.bmAttributes & 0x04U)){
+            dfu->bState = STATE_DFU_IDLE;
+            dfu->bwPollTimeout0 = 0U;
+        } else {
+            /* no operation */
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    /* send the status data of DFU interface to host over EP0 */
+    transc->xfer_buf = (uint8_t *)&(dfu->bStatus);
+    transc->remain_len = 6U;
+}
+
+/*!
+    \brief      handle the DFU_CLRSTATUS request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: DFU class request
+    \param[out] none
+    \retval     none
+*/
+static void  dfu_clrstatus (usb_dev *udev, usb_req *req)
+{
+    usbd_dfu_handler *dfu = (usbd_dfu_handler *)udev->dev.class_data[USBD_DFU_INTERFACE];
+
+    if (STATE_DFU_ERROR == dfu->bState) {
+        dfu->bStatus = STATUS_OK;
+        dfu->bState = STATE_DFU_IDLE;
+    } else {
+        /* state error */
+        dfu->bStatus = STATUS_ERR_UNKNOWN;
+        dfu->bState = STATE_DFU_ERROR;
+    }
+
+    dfu->iString = 0U; /* iString: index = 0 */
+}
+
+/*!
+    \brief      handle the DFU_GETSTATE request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: DFU class request
+    \param[out] none
+    \retval     none
+*/
+static void  dfu_getstate (usb_dev *udev, usb_req *req)
+{
+    usb_transc *transc = &udev->dev.transc_in[0];
+    usbd_dfu_handler *dfu = (usbd_dfu_handler *)udev->dev.class_data[USBD_DFU_INTERFACE];
+
+    /* send the current state of the DFU interface to host */
+    transc->xfer_buf = &(dfu->bState);
+    transc->remain_len = 1U;
+}
+
+/*!
+    \brief      handle the DFU_ABORT request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: DFU class request
+    \param[out] none
+    \retval     none
+*/
+static void dfu_abort (usb_dev *udev, usb_req *req)
+{
+    usbd_dfu_handler *dfu = (usbd_dfu_handler *)udev->dev.class_data[USBD_DFU_INTERFACE];
+
+    switch (dfu->bState){
+    case STATE_DFU_IDLE:
+    case STATE_DFU_DNLOAD_SYNC:
+    case STATE_DFU_DNLOAD_IDLE:
+    case STATE_DFU_MANIFEST_SYNC:
+    case STATE_DFU_UPLOAD_IDLE:
+        dfu->bStatus = STATUS_OK;
+        dfu->bState = STATE_DFU_IDLE;
+        dfu->iString = 0U; /* iString: index = 0 */
+
+        dfu->block_num = 0U;
+        dfu->data_len = 0U;
+        break;
+
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      convert string value into unicode char
+    \param[in]  str: pointer to plain string
+    \param[in]  pbuf: buffer pointer to store unicode char
+    \param[out] none
+    \retval     none
+*/
+static void string_to_unicode (uint8_t *str, uint16_t *pbuf)
+{
+    uint8_t index = 0;
+
+    if (str != NULL) {
+        pbuf[index++] = ((strlen((const char *)str) * 2U + 2U) & 0x00FFU) | ((USB_DESCTYPE_STR << 8U) & 0xFF00);
+
+        while (*str != '\0') {
+            pbuf[index++] = *str++;
+        }
+    }
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/dfu/Source/dfu_mem.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/dfu/Source/dfu_mem.c
@@ -1,0 +1,245 @@
+/*!
+    \file    dfu_mem.c
+    \brief   USB DFU device media access layer functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "dfu_mem.h"
+#include "drv_usb_hw.h"
+#include "usbd_transc.h"
+
+extern usb_core_driver usb_dfu_dev;
+
+extern struct {
+    uint8_t buf[TRANSFER_SIZE];
+    uint16_t data_len;
+    uint16_t block_num;
+    uint32_t base_addr;
+} prog;
+
+dfu_mem_prop* mem_tab[MAX_USED_MEMORY_MEDIA] = {
+    &dfu_inter_flash_cb,
+    &dfu_nor_flash_cb,
+    &dfu_nand_flash_cb,
+};
+
+/* The list of memory interface string descriptor pointers. This list
+   can be updated whenever a memory has to be added or removed */
+const uint8_t* USBD_DFU_StringDesc[MAX_USED_MEMORY_MEDIA] = 
+{
+    (const uint8_t *)INTER_FLASH_IF_STR,
+    (const uint8_t *)NOR_FLASH_IF_STR,
+    (const uint8_t *)NAND_FLASH_IF_STR
+};
+
+static uint8_t dfu_mem_checkaddr (uint32_t addr);
+
+/*!
+    \brief      initialize the memory media on the GD32
+    \param[in]  none
+    \param[out] none
+    \retval     MEM_OK
+*/
+uint8_t dfu_mem_init (void)
+{
+    uint32_t mem_index = 0U;
+
+    /* initialize all supported memory medias */
+    for (mem_index = 0U; mem_index < MAX_USED_MEMORY_MEDIA; mem_index++) {
+        /* check if the memory media exists */
+        if (NULL != mem_tab[mem_index]->mem_init) {
+            mem_tab[mem_index]->mem_init();
+        }
+    }
+
+    return MEM_OK;
+}
+
+/*!
+    \brief      deinitialize the memory media on the GD32
+    \param[in]  none
+    \param[out] none
+    \retval     MEM_OK
+*/
+uint8_t dfu_mem_deinit (void)
+{
+    uint32_t mem_index = 0U;
+
+    /* deinitialize all supported memory medias */
+    for (mem_index = 0U; mem_index < MAX_USED_MEMORY_MEDIA; mem_index++) {
+        /* check if the memory media exists */
+        if (NULL != mem_tab[mem_index]->mem_deinit) {
+            mem_tab[mem_index]->mem_deinit();
+        }
+    }
+
+    return MEM_OK;
+}
+
+/*!
+    \brief      erase a memory sector
+    \param[in]  addr: memory sector address/code
+    \param[out] none
+    \retval     MEM_OK
+*/
+uint8_t dfu_mem_erase (uint32_t addr)
+{
+    uint32_t mem_index = dfu_mem_checkaddr(addr);
+
+    /* check if the address is in protected area */
+    if (IS_PROTECTED_AREA(addr)) {
+        return MEM_FAIL;
+    }
+
+    if (mem_index < MAX_USED_MEMORY_MEDIA) {
+        /* check if the operation is supported */
+        if (NULL != mem_tab[mem_index]->mem_erase) {
+            return mem_tab[mem_index]->mem_erase(addr);
+        } else {
+            return MEM_FAIL;
+        }
+    } else {
+        return MEM_FAIL;
+    }
+}
+
+/*!
+    \brief      write data to sectors of memory
+    \param[in]  buf: the data buffer to be write
+    \param[in]  addr: memory sector address/code
+    \param[in]  len: data length
+    \param[out] none
+    \retval     MEM_OK
+*/
+uint8_t dfu_mem_write (uint8_t *buf, uint32_t addr, uint32_t len)
+{
+    uint32_t mem_index = dfu_mem_checkaddr(addr);
+
+    /* check if the address is in protected area */
+    if (IS_PROTECTED_AREA(addr)) {
+        return MEM_FAIL;
+    }
+
+    if ((addr & MAL_MASK_OB) == OB_RDPT0) {
+        option_byte_write(addr, buf);
+        NVIC_SystemReset();
+
+        return MEM_OK;
+    }
+
+    if (mem_index < MAX_USED_MEMORY_MEDIA) {
+        /* check if the operation is supported */
+        if (NULL != mem_tab[mem_index]->mem_write) {
+            return mem_tab[mem_index]->mem_write(buf, addr, len);
+        } else {
+            return MEM_FAIL;
+        }
+    } else {
+        return MEM_FAIL;
+    }
+}
+
+/*!
+    \brief      read data from sectors of memory
+    \param[in]  buf: the data buffer to be write
+    \param[in]  addr: memory sector address/code
+    \param[in]  len: data length
+    \param[out] none
+    \retval     pointer to buffer
+*/
+uint8_t* dfu_mem_read (uint8_t *buf, uint32_t addr, uint32_t len)
+{
+    uint32_t mem_index = 0U;
+
+    if ((OB_RDPT0 != addr) && (OB_RDPT1 != addr)) {
+        mem_index = dfu_mem_checkaddr(addr);
+    }
+
+    if (mem_index < MAX_USED_MEMORY_MEDIA) {
+        /* check if the operation is supported */
+        if (NULL != mem_tab[mem_index]->mem_read) {
+            return mem_tab[mem_index]->mem_read(buf, addr, len);
+        } else {
+            return buf;
+        }
+    } else {
+        return buf;
+    }
+}
+
+/*!
+    \brief      get the status of a given memory and store in buffer
+    \param[in]  addr: memory sector address/code
+    \param[in]  cmd: 0 for erase and 1 for write
+    \param[in]  buffer: pointer to the buffer where the status data will be stored
+    \param[out] none
+    \retval     MEM_OK if all operations are OK, MEM_FAIL else
+*/
+uint8_t dfu_mem_getstatus (uint32_t addr, uint8_t cmd, uint8_t *buffer)
+{
+    uint32_t mem_index = dfu_mem_checkaddr(addr);
+
+    if (mem_index < MAX_USED_MEMORY_MEDIA) {
+        if (cmd & 0x01U) {
+            POLLING_TIMEOUT_SET(mem_tab[mem_index]->write_timeout);
+        } else {
+            POLLING_TIMEOUT_SET(mem_tab[mem_index]->erase_timeout);
+        }
+
+        return MEM_OK;
+    } else {
+        return MEM_FAIL;
+    }
+}
+
+/*!
+    \brief      check the address is supported
+    \param[in]  addr: memory sector address/code
+    \param[out] none
+    \retval     index of the addressed memory
+*/
+static uint8_t dfu_mem_checkaddr (uint32_t addr)
+{
+    uint8_t mem_index = 0U;
+
+    /* check with all supported memories */
+    for (mem_index = 0U; mem_index < MAX_USED_MEMORY_MEDIA; mem_index++) {
+        /* if the check address is supported, return the memory index */
+        if (MEM_OK == mem_tab[mem_index]->mem_checkaddr(addr)) {
+            return mem_index;
+        }
+    }
+
+    /* if there is no memory found, return MAX_USED_MEMORY_MEDIA */
+    return (MAX_USED_MEMORY_MEDIA);
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/hid/Include/custom_hid_core.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/hid/Include/custom_hid_core.h
@@ -1,0 +1,71 @@
+/*!
+    \file    custom_hid_core.h
+    \brief   definitions for HID core
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __CUSTOM_HID_CORE_H
+#define __CUSTOM_HID_CORE_H
+
+#include "usbd_enum.h"
+#include "usb_hid.h"
+
+#define DESC_LEN_REPORT             96U
+#define DESC_LEN_CONFIG             41U
+
+#define NO_CMD                      0xFFU
+
+#define MAX_PERIPH_NUM              4U
+
+typedef struct {
+    uint8_t data[2];
+
+    uint8_t reportID;
+    uint8_t idlestate;
+    uint8_t protocol;
+} custom_hid_handler;
+
+typedef struct {
+    void (*periph_config[MAX_PERIPH_NUM])(void);
+} hid_fop_handler;
+
+extern usb_desc custom_hid_desc;
+extern usb_class_core usbd_custom_hid_cb;
+
+/* function declarations */
+/* register HID interface operation functions */
+uint8_t custom_hid_itfop_register (usb_dev *udev, hid_fop_handler *hid_fop);
+/* send custom HID report */
+uint8_t custom_hid_report_send (usb_dev *udev, uint8_t *report, uint32_t len);
+
+#endif /* __CUSTOM_HID_CORE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/hid/Include/standard_hid_core.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/hid/Include/standard_hid_core.h
@@ -1,0 +1,70 @@
+/*!
+    \file    standard_hid_core.h
+    \brief   definitions for HID core
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __STANDARD_HID_CORE_H
+#define __STANDARD_HID_CORE_H
+
+#include "usbd_enum.h"
+#include "usb_hid.h"
+
+#define USB_HID_CONFIG_DESC_LEN          0x22U
+#define USB_HID_REPORT_DESC_LEN          0x2EU
+
+#define NO_CMD                           0xFFU
+
+typedef struct {
+    uint32_t protocol;
+    uint32_t idle_state;
+
+    uint8_t data[HID_IN_PACKET];
+    __IO uint8_t prev_transfer_complete;
+} standard_hid_handler;
+
+typedef struct {
+    void (*hid_itf_config) (void);
+    void (*hid_itf_data_process) (usb_dev *udev);
+} hid_fop_handler;
+
+extern usb_desc hid_desc;
+extern usb_class_core usbd_hid_cb;
+
+/* function declarations */
+/* register HID interface operation functions */
+uint8_t hid_itfop_register (usb_dev *udev, hid_fop_handler *hid_fop);
+/* send keyboard report */
+uint8_t hid_report_send (usb_dev *udev, uint8_t *report, uint32_t len);
+
+#endif /* __STANDARD_HID_CORE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/hid/Source/custom_hid_core.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/hid/Source/custom_hid_core.c
@@ -1,0 +1,485 @@
+/*!
+    \file    custom_hid_core.c
+    \brief   custom HID class driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "custom_hid_core.h"
+#include "usbd_enum.h"
+#include <string.h>
+
+#define USBD_VID                     0x28E9U
+#define USBD_PID                     0x028AU
+
+/* Note:it should use the C99 standard when compiling the below codes */
+/* USB standard device descriptor */
+__ALIGN_BEGIN const usb_desc_dev custom_hid_dev_desc __ALIGN_END =
+{
+    .header =
+    {
+        .bLength          = USB_DEV_DESC_LEN,
+        .bDescriptorType  = USB_DESCTYPE_DEV,
+    },
+    .bcdUSB                = 0x0200U,
+    .bDeviceClass          = 0x00U,
+    .bDeviceSubClass       = 0x00U,
+    .bDeviceProtocol       = 0x00U,
+    .bMaxPacketSize0       = USB_FS_EP0_MAX_LEN,
+    .idVendor              = USBD_VID,
+    .idProduct             = USBD_PID,
+    .bcdDevice             = 0x0100U,
+    .iManufacturer         = STR_IDX_MFC,
+    .iProduct              = STR_IDX_PRODUCT,
+    .iSerialNumber         = STR_IDX_SERIAL,
+    .bNumberConfigurations = USBD_CFG_MAX_NUM,
+};
+
+/* USB device configuration descriptor */
+__ALIGN_BEGIN const usb_hid_desc_config_set custom_hid_config_desc __ALIGN_END = 
+{
+    .config =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_config),
+            .bDescriptorType = USB_DESCTYPE_CONFIG
+        },
+        .wTotalLength         = DESC_LEN_CONFIG,
+        .bNumInterfaces       = 0x01U,
+        .bConfigurationValue  = 0x01U,
+        .iConfiguration       = 0x00U,
+        .bmAttributes         = 0x80U,
+        .bMaxPower            = 0x32U
+    },
+
+    .hid_itf =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_itf),
+            .bDescriptorType = USB_DESCTYPE_ITF
+        },
+        .bInterfaceNumber     = 0x00U,
+        .bAlternateSetting    = 0x00U,
+        .bNumEndpoints        = 0x02U,
+        .bInterfaceClass      = USB_HID_CLASS,
+        .bInterfaceSubClass   = 0x00U,
+        .bInterfaceProtocol   = 0x00U,
+        .iInterface           = 0x00U
+    },
+
+    .hid_vendor =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_hid),
+            .bDescriptorType = USB_DESCTYPE_HID
+        },
+        .bcdHID               = 0x0111U,
+        .bCountryCode         = 0x00U,
+        .bNumDescriptors      = 0x01U,
+        .bDescriptorType      = USB_DESCTYPE_REPORT,
+        .wDescriptorLength    = DESC_LEN_REPORT,
+    },
+
+    .hid_epin =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_ep),
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress     = CUSTOMHID_IN_EP,
+        .bmAttributes         = USB_EP_ATTR_INT,
+        .wMaxPacketSize       = CUSTOMHID_IN_PACKET,
+        .bInterval            = 0x20U
+    },
+
+    .hid_epout =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_ep),
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress     = CUSTOMHID_OUT_EP,
+        .bmAttributes         = USB_EP_ATTR_INT,
+        .wMaxPacketSize       = CUSTOMHID_OUT_PACKET,
+        .bInterval            = 0x20U
+    }
+};
+
+/* USB language ID descriptor */
+static __ALIGN_BEGIN const usb_desc_LANGID usbd_language_id_desc __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = sizeof(usb_desc_LANGID),
+        .bDescriptorType = USB_DESCTYPE_STR
+    },
+    .wLANGID = ENG_LANGID
+};
+
+/* USB manufacture string */
+static __ALIGN_BEGIN const usb_desc_str manufacturer_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(10U),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'i', 'g', 'a', 'D', 'e', 'v', 'i', 'c', 'e'}
+};
+
+/* USB product string */
+static __ALIGN_BEGIN const usb_desc_str product_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(14U),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'D', '3', '2', '-', 'C', 'u', 's', 't', 'o', 'm', 'H', 'I', 'D'}
+};
+
+/* USBD serial string */
+static __ALIGN_BEGIN usb_desc_str serial_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(12U),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    }
+};
+
+/* USB string descriptor set */
+void *const usbd_hid_strings[] = 
+{
+    [STR_IDX_LANGID]  = (uint8_t *)&usbd_language_id_desc,
+    [STR_IDX_MFC]     = (uint8_t *)&manufacturer_string,
+    [STR_IDX_PRODUCT] = (uint8_t *)&product_string,
+    [STR_IDX_SERIAL]  = (uint8_t *)&serial_string
+};
+
+usb_desc custom_hid_desc = {
+    .dev_desc    = (uint8_t *)&custom_hid_dev_desc,
+    .config_desc = (uint8_t *)&custom_hid_config_desc,
+    .strings     = usbd_hid_strings
+};
+
+__ALIGN_BEGIN const uint8_t customhid_report_descriptor[DESC_LEN_REPORT] __ALIGN_END =
+{
+    0x06, 0x00, 0xFF,  /* USAGE_PAGE (Vendor Defined: 0xFF00) */
+    0x09, 0x00,        /* USAGE (Custom Device)               */
+    0xa1, 0x01,        /* COLLECTION (Application)            */
+
+    /* led 1 */
+    0x85, 0x11,     /* REPORT_ID (0x11)          */
+    0x09, 0x01,     /* USAGE (LED 1)             */
+    0x15, 0x00,     /* LOGICAL_MINIMUM (0)       */
+    0x25, 0x01,     /* LOGICAL_MAXIMUM (1)       */
+    0x75, 0x08,     /* REPORT_SIZE (8)           */
+    0x95, 0x01,     /* REPORT_COUNT (1)          */
+    0x91, 0x82,     /* OUTPUT (Data,Var,Abs,Vol) */
+
+    /* led 2 */
+    0x85, 0x12,     /* REPORT_ID (0x12)          */
+    0x09, 0x02,     /* USAGE (LED 2)             */
+    0x15, 0x00,     /* LOGICAL_MINIMUM (0)       */
+    0x25, 0x01,     /* LOGICAL_MAXIMUM (1)       */
+    0x75, 0x08,     /* REPORT_SIZE (8)           */
+    0x95, 0x01,     /* REPORT_COUNT (1)          */
+    0x91, 0x82,     /* OUTPUT (Data,Var,Abs,Vol) */
+
+    /* led 3 */
+    0x85, 0x13,     /* REPORT_ID (0x13)          */
+    0x09, 0x03,     /* USAGE (LED 3)             */
+    0x15, 0x00,     /* LOGICAL_MINIMUM (0)       */
+    0x25, 0x01,     /* LOGICAL_MAXIMUM (1)       */
+    0x75, 0x08,     /* REPORT_SIZE (8)           */
+    0x95, 0x01,     /* REPORT_COUNT (1)          */
+    0x91, 0x82,     /* OUTPUT (Data,Var,Abs,Vol) */
+
+    /* led 4 */
+    0x85, 0x14,     /* REPORT_ID (0x14)          */
+    0x09, 0x04,     /* USAGE (LED 4)             */
+    0x15, 0x00,     /* LOGICAL_MINIMUM (0)       */
+    0x25, 0x01,     /* LOGICAL_MAXIMUM (1)       */
+    0x75, 0x08,     /* REPORT_SIZE (8)           */
+    0x95, 0x01,     /* REPORT_COUNT (1)          */
+    0x91, 0x82,     /* OUTPUT (Data,Var,Abs,Vol) */
+
+    /* wakeup key */
+    0x85, 0x15,     /* REPORT_ID (0x15)          */
+    0x09, 0x05,     /* USAGE (Push Button)       */
+    0x15, 0x00,     /* LOGICAL_MINIMUM (0)       */
+    0x25, 0x01,     /* LOGICAL_MAXIMUM (1)       */
+    0x75, 0x01,     /* REPORT_SIZE (1)           */
+    0x81, 0x02,     /* INPUT (Data,Var,Abs,Vol)  */
+
+    0x75, 0x07,     /* REPORT_SIZE (7)           */
+    0x81, 0x03,     /* INPUT (Cnst,Var,Abs,Vol)  */
+
+    /* tamper key */
+    0x85, 0x16,     /* REPORT_ID (0x16)          */
+    0x09, 0x06,     /* USAGE (Push Button)       */
+    0x15, 0x00,     /* LOGICAL_MINIMUM (0)       */
+    0x25, 0x01,     /* LOGICAL_MAXIMUM (1)       */
+    0x75, 0x01,     /* REPORT_SIZE (1)           */
+    0x81, 0x02,     /* INPUT (Data,Var,Abs,Vol)  */
+
+    0x75, 0x07,     /* REPORT_SIZE (7)           */
+    0x81, 0x03,     /* INPUT (Cnst,Var,Abs,Vol)  */
+
+    0xc0            /* END_COLLECTION            */
+};
+
+/* local function prototypes ('static') */
+static uint8_t custom_hid_init        (usb_dev *udev, uint8_t config_index);
+static uint8_t custom_hid_deinit      (usb_dev *udev, uint8_t config_index);
+static uint8_t custom_hid_req_handler (usb_dev *udev, usb_req *req);
+
+static uint8_t custom_hid_data_in     (usb_dev *udev, uint8_t ep_num);
+static uint8_t custom_hid_data_out    (usb_dev *udev, uint8_t ep_num);
+
+usb_class_core usbd_custom_hid_cb = 
+{
+    .command   = NO_CMD,
+    .alter_set = 0U,
+
+    .init      = custom_hid_init,
+    .deinit    = custom_hid_deinit,
+
+    .req_proc  = custom_hid_req_handler,
+
+    .data_in   = custom_hid_data_in,
+    .data_out  = custom_hid_data_out
+};
+
+/*!
+    \brief      register HID interface operation functions
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  hid_fop: HID operation functions structure
+    \param[out] none
+    \retval     USB device operation status
+*/
+uint8_t custom_hid_itfop_register (usb_dev *udev, hid_fop_handler *hid_fop)
+{
+    if (NULL != hid_fop) {
+        udev->dev.user_data = hid_fop;
+
+        return USBD_OK;
+    }
+
+    return USBD_FAIL;
+}
+
+/*!
+    \brief      send custom HID report
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  report: pointer to HID report
+    \param[in]  len: data length
+    \param[out] none
+    \retval     USB device operation status
+*/
+uint8_t custom_hid_report_send (usb_dev *udev, uint8_t *report, uint32_t len)
+{
+    usbd_ep_send (udev, CUSTOMHID_IN_EP, report, len);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      initialize the HID device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t custom_hid_init (usb_dev *udev, uint8_t config_index)
+{
+    static __ALIGN_BEGIN custom_hid_handler hid_handler __ALIGN_END;
+
+    memset((void *)&hid_handler, 0U, sizeof(custom_hid_handler));
+
+    /* initialize the data Tx endpoint */
+    usbd_ep_setup (udev, &(custom_hid_config_desc.hid_epin));
+
+    /* initialize the data Rx endpoint */
+    usbd_ep_setup (udev, &(custom_hid_config_desc.hid_epout));
+
+    /* prepare receive data */
+    usbd_ep_recev (udev, CUSTOMHID_OUT_EP, hid_handler.data, 2U);
+
+    udev->dev.class_data[CUSTOM_HID_INTERFACE] = (void *)&hid_handler;
+
+    if (udev->dev.user_data != NULL) {
+        for (uint8_t i = 0U; i < MAX_PERIPH_NUM; i++) {
+            if (((hid_fop_handler *)udev->dev.user_data)->periph_config[i] != NULL) {
+                ((hid_fop_handler *)udev->dev.user_data)->periph_config[i]();
+            }
+        }
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      deinitialize the HID device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t custom_hid_deinit (usb_dev *udev, uint8_t config_index)
+{
+    /* deinitialize HID endpoints */
+    usbd_ep_clear(udev, CUSTOMHID_IN_EP);
+    usbd_ep_clear(udev, CUSTOMHID_OUT_EP);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle the HID class-specific requests
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: device class-specific request
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t custom_hid_req_handler (usb_dev *udev, usb_req *req)
+{
+    usb_transc *transc = &udev->dev.transc_in[0];
+
+    custom_hid_handler *hid = (custom_hid_handler *)udev->dev.class_data[CUSTOM_HID_INTERFACE];
+
+    switch (req->bRequest) {
+    case GET_REPORT:
+        break;
+
+    case GET_IDLE:
+        transc->xfer_buf = (uint8_t *)&hid->idlestate;
+        transc->remain_len = 1U;
+        break;
+
+    case GET_PROTOCOL:
+        transc->xfer_buf = (uint8_t *)&hid->protocol;
+        transc->remain_len = 1U;
+        break;
+
+    case SET_REPORT:
+        hid->reportID = (uint8_t)(req->wValue);
+        break;
+
+    case SET_IDLE:
+        hid->idlestate = (uint8_t)(req->wValue >> 8U);
+        break;
+
+    case SET_PROTOCOL:
+        hid->protocol = (uint8_t)(req->wValue);
+        break;
+
+    case USB_GET_DESCRIPTOR:
+        if (USB_DESCTYPE_REPORT == (req->wValue >> 8U)) {
+            transc->remain_len = USB_MIN(DESC_LEN_REPORT, req->wLength);
+            transc->xfer_buf = (uint8_t *)customhid_report_descriptor;
+        }
+        break;
+
+    default:
+        return USBD_FAIL;
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle custom HID data
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint identifier
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t custom_hid_data_in (usb_dev *udev, uint8_t ep_num)
+{
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle custom HID data
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint identifier
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t custom_hid_data_out (usb_dev *udev, uint8_t ep_num)
+{
+    custom_hid_handler *hid = (custom_hid_handler *)udev->dev.class_data[CUSTOM_HID_INTERFACE];
+
+    /* light the LED */
+    switch (hid->data[0]){
+    case 0x11U:
+        if (RESET != hid->data[1]) {
+            gd_eval_led_on(LED1);
+        } else {
+            gd_eval_led_off(LED1);
+        }
+        break;
+
+    case 0x12U:
+        if (RESET != hid->data[1]) {
+            gd_eval_led_on(LED2);
+        } else {
+            gd_eval_led_off(LED2);
+        }
+        break;
+
+    case 0x13U:
+        if (RESET != hid->data[1]) {
+            gd_eval_led_on(LED3);
+        } else {
+            gd_eval_led_off(LED3);
+        }
+        break;
+
+    case 0x14U:
+        break;
+
+    default:
+        break;
+    }
+
+    usbd_ep_recev (udev, CUSTOMHID_OUT_EP, hid->data, 2U);
+
+    return USBD_OK;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/hid/Source/standard_hid_core.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/hid/Source/standard_hid_core.c
@@ -1,0 +1,470 @@
+/*!
+    \file    standard_hid_core.c
+    \brief   HID class driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "standard_hid_core.h"
+#include <string.h>
+
+#define USBD_VID                     0x28e9U
+#define USBD_PID                     0x0380U
+
+/* Note:it should use the C99 standard when compiling the below codes */
+/* USB standard device descriptor */
+__ALIGN_BEGIN const usb_desc_dev hid_dev_desc __ALIGN_END =
+{
+    .header =
+    {
+        .bLength          = USB_DEV_DESC_LEN,
+        .bDescriptorType  = USB_DESCTYPE_DEV
+    },
+    .bcdUSB                = 0x0200U,
+    .bDeviceClass          = 0x00U,
+    .bDeviceSubClass       = 0x00U,
+    .bDeviceProtocol       = 0x00U,
+    .bMaxPacketSize0       = USB_FS_EP0_MAX_LEN,
+    .idVendor              = USBD_VID,
+    .idProduct             = USBD_PID,
+    .bcdDevice             = 0x0100U,
+    .iManufacturer         = STR_IDX_MFC,
+    .iProduct              = STR_IDX_PRODUCT,
+    .iSerialNumber         = STR_IDX_SERIAL,
+    .bNumberConfigurations = USBD_CFG_MAX_NUM
+};
+
+__ALIGN_BEGIN const usb_hid_desc_config_set hid_config_desc __ALIGN_END = 
+{
+    .config =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_config),
+            .bDescriptorType = USB_DESCTYPE_CONFIG
+        },
+        .wTotalLength         = USB_HID_CONFIG_DESC_LEN,
+        .bNumInterfaces       = 0x01U,
+        .bConfigurationValue  = 0x01U,
+        .iConfiguration       = 0x00U,
+        .bmAttributes         = 0xA0U,
+        .bMaxPower            = 0x32U
+    },
+
+    .hid_itf =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_itf),
+            .bDescriptorType = USB_DESCTYPE_ITF
+        },
+        .bInterfaceNumber     = 0x00U,
+        .bAlternateSetting    = 0x00U,
+        .bNumEndpoints        = 0x01U,
+        .bInterfaceClass      = USB_HID_CLASS,
+        .bInterfaceSubClass   = USB_HID_SUBCLASS_BOOT_ITF,
+        .bInterfaceProtocol   = USB_HID_PROTOCOL_KEYBOARD,
+        .iInterface           = 0x00U
+    },
+
+    .hid_vendor =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_hid),
+            .bDescriptorType = USB_DESCTYPE_HID
+        },
+        .bcdHID               = 0x0111U,
+        .bCountryCode         = 0x00U,
+        .bNumDescriptors      = 0x01U,
+        .bDescriptorType      = USB_DESCTYPE_REPORT,
+        .wDescriptorLength    = USB_HID_REPORT_DESC_LEN,
+    },
+
+    .hid_epin =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_ep),
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress     = HID_IN_EP,
+        .bmAttributes         = USB_EP_ATTR_INT,
+        .wMaxPacketSize       = HID_IN_PACKET,
+        .bInterval            = 0x10U
+    }
+};
+
+__ALIGN_BEGIN const usb_hid_desc_config_set other_speed_hid_config_desc __ALIGN_END = 
+{
+    .config = 
+    {
+        .header = 
+        {
+            .bLength         = sizeof(usb_desc_config), 
+            .bDescriptorType = USB_DESCTYPE_OTHER_SPD_CONFIG 
+        },
+        .wTotalLength         = USB_HID_CONFIG_DESC_LEN,
+        .bNumInterfaces       = 0x01U,
+        .bConfigurationValue  = 0x01U,
+        .iConfiguration       = 0x00U,
+        .bmAttributes         = 0xA0U,
+        .bMaxPower            = 0x32U
+    },
+
+    .hid_itf = 
+    {
+        .header = 
+        {
+            .bLength         = sizeof(usb_desc_itf), 
+            .bDescriptorType = USB_DESCTYPE_ITF
+        },
+        .bInterfaceNumber     = 0x00U,
+        .bAlternateSetting    = 0x00U,
+        .bNumEndpoints        = 0x01U,
+        .bInterfaceClass      = USB_HID_CLASS,
+        .bInterfaceSubClass   = USB_HID_SUBCLASS_BOOT_ITF,
+        .bInterfaceProtocol   = USB_HID_PROTOCOL_KEYBOARD,
+        .iInterface           = 0x00U
+    },
+
+    .hid_vendor = 
+    {
+        .header = 
+        {
+            .bLength         = sizeof(usb_desc_hid), 
+            .bDescriptorType = USB_DESCTYPE_HID 
+        },
+        .bcdHID               = 0x0111U,
+        .bCountryCode         = 0x00U,
+        .bNumDescriptors      = 0x01U,
+        .bDescriptorType      = USB_DESCTYPE_REPORT,
+        .wDescriptorLength    = USB_HID_REPORT_DESC_LEN,
+    },
+
+    .hid_epin = 
+    {
+        .header = 
+        {
+            .bLength         = sizeof(usb_desc_ep), 
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress     = HID_IN_EP,
+        .bmAttributes         = USB_EP_ATTR_INT,
+        .wMaxPacketSize       = HID_IN_PACKET,
+        .bInterval            = 0x40U
+    }
+};
+
+__ALIGN_BEGIN const uint8_t usbd_qualifier_desc[10] __ALIGN_END = 
+{
+    0x0A, 
+    0x06,
+    0x00, 
+    0x02,
+    0x00, 
+    0x00,
+    0x00, 
+    0x40,
+    0x01, 
+    0x00
+};
+
+/* USB language ID Descriptor */
+static __ALIGN_BEGIN const usb_desc_LANGID usbd_language_id_desc __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = sizeof(usb_desc_LANGID),
+        .bDescriptorType = USB_DESCTYPE_STR
+    },
+    .wLANGID              = ENG_LANGID
+};
+
+/* USB manufacture string */
+static __ALIGN_BEGIN const usb_desc_str manufacturer_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(10U),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'i', 'g', 'a', 'D', 'e', 'v', 'i', 'c', 'e'}
+};
+
+/* USB product string */
+static __ALIGN_BEGIN const usb_desc_str product_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(17U),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'D', '3', '2', '-', 'U', 'S', 'B', '_', 'K', 'e', 'y', 'b', 'o', 'a', 'r', 'd'}
+};
+
+/* USBD serial string */
+static __ALIGN_BEGIN usb_desc_str serial_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(12U),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    }
+};
+
+void *const usbd_hid_strings[] = 
+{
+    [STR_IDX_LANGID]  = (uint8_t *)&usbd_language_id_desc,
+    [STR_IDX_MFC]     = (uint8_t *)&manufacturer_string,
+    [STR_IDX_PRODUCT] = (uint8_t *)&product_string,
+    [STR_IDX_SERIAL]  = (uint8_t *)&serial_string
+};
+
+usb_desc hid_desc = {
+    .dev_desc    = (uint8_t *)&hid_dev_desc,
+    .config_desc = (uint8_t *)&hid_config_desc,
+#if defined(USE_USB_HS) && defined(USE_ULPI_PHY)
+    .other_speed_config_desc = (uint8_t *)&other_speed_hid_config_desc,
+    .qualifier_desc = (uint8_t *)&usbd_qualifier_desc,
+#endif
+    .strings     = usbd_hid_strings
+};
+
+__ALIGN_BEGIN const uint8_t hid_report_desc[USB_HID_REPORT_DESC_LEN] __ALIGN_END =
+{
+    0x05, 0x01,  /* USAGE_PAGE (Generic Desktop) */
+    0x09, 0x06,  /* USAGE (Keyboard) */
+    0xa1, 0x01,  /* COLLECTION (Application) */
+
+    0x05, 0x07,  /* USAGE_PAGE (Keyboard/Keypad) */
+    0x19, 0xe0,  /* USAGE_MINIMUM (Keyboard LeftControl) */
+    0x29, 0xe7,  /* USAGE_MAXIMUM (Keyboard Right GUI) */
+    0x15, 0x00,  /* LOGICAL_MINIMUM (0) */
+    0x25, 0x01,  /* LOGICAL_MAXIMUM (1) */
+    0x95, 0x08,  /* REPORT_COUNT (8) */
+    0x75, 0x01,  /* REPORT_SIZE (1) */
+    0x81, 0x02,  /* INPUT (Data,Var,Abs) */
+
+    0x95, 0x01,  /* REPORT_COUNT (1) */
+    0x75, 0x08,  /* REPORT_SIZE (8) */
+    0x81, 0x03,  /* INPUT (Cnst,Var,Abs) */
+
+    0x95, 0x06,  /* REPORT_COUNT (6) */
+    0x75, 0x08,  /* REPORT_SIZE (8) */
+    0x15, 0x00,  /* LOGICAL_MINIMUM (0) */
+    0x26, 0xFF, 0x00,  /* LOGICAL_MAXIMUM (255) */
+    0x05, 0x07,  /* USAGE_PAGE (Keyboard/Keypad) */
+    0x19, 0x00,  /* USAGE_MINIMUM (Reserved (no event indicated)) */
+    0x29, 0x65,  /* USAGE_MAXIMUM (Keyboard Application) */
+    0x81, 0x00,  /* INPUT (Data,Ary,Abs) */
+
+    0xc0         /* END_COLLECTION */
+};
+
+/* local function prototypes ('static') */
+static uint8_t hid_init    (usb_dev *udev, uint8_t config_index);
+static uint8_t hid_deinit  (usb_dev *udev, uint8_t config_index);
+static uint8_t hid_req     (usb_dev *udev, usb_req *req);
+static uint8_t hid_data_in (usb_dev *udev, uint8_t ep_num);
+
+usb_class_core usbd_hid_cb = {
+    .command         = NO_CMD,
+    .alter_set       = 0U,
+
+    .init            = hid_init,
+    .deinit          = hid_deinit,
+    .req_proc        = hid_req,
+    .data_in         = hid_data_in
+};
+
+/*!
+    \brief      register HID interface operation functions
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  hid_fop: HID operation function structure
+    \param[out] none
+    \retval     USB device operation status
+*/
+uint8_t hid_itfop_register (usb_dev *udev, hid_fop_handler *hid_fop)
+{
+    if (NULL != hid_fop) {
+        udev->dev.user_data = (void *)hid_fop;
+
+        return USBD_OK;
+    }
+
+    return USBD_FAIL;
+}
+
+/*!
+    \brief      send keyboard report
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  report: pointer to HID report
+    \param[in]  len: data length
+    \param[out] none
+    \retval     USB device operation status
+*/
+uint8_t hid_report_send (usb_dev *udev, uint8_t *report, uint32_t len)
+{
+    standard_hid_handler *hid = (standard_hid_handler *)udev->dev.class_data[USBD_HID_INTERFACE];
+
+    hid->prev_transfer_complete = 0U;
+
+    usbd_ep_send(udev, HID_IN_EP, report, len);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      initialize the HID device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t hid_init (usb_dev *udev, uint8_t config_index)
+{
+    static __ALIGN_BEGIN standard_hid_handler hid_handler __ALIGN_END;
+
+    memset((void *)&hid_handler, 0U, sizeof(standard_hid_handler));
+
+    /* initialize the data TX endpoint */
+    usbd_ep_setup (udev, &(hid_config_desc.hid_epin));
+
+    hid_handler.prev_transfer_complete = 1U;
+
+    udev->dev.class_data[USBD_HID_INTERFACE] = (void *)&hid_handler;
+
+    if (NULL != udev->dev.user_data) {
+        ((hid_fop_handler *)udev->dev.user_data)->hid_itf_config();
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      deinitialize the HID device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t hid_deinit (usb_dev *udev, uint8_t config_index)
+{
+    /* deinitialize HID endpoints */
+    usbd_ep_clear(udev, HID_IN_EP);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle the HID class-specific requests
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: device class-specific request
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t hid_req (usb_dev *udev, usb_req *req)
+{
+    usb_transc *transc = &udev->dev.transc_in[0];
+
+    standard_hid_handler *hid = (standard_hid_handler *)udev->dev.class_data[USBD_HID_INTERFACE];
+
+    switch (req->bRequest) {
+    case GET_REPORT:
+        /* no use for this driver */
+        break;
+
+    case GET_IDLE:
+        transc->xfer_buf = (uint8_t *)&hid->idle_state;
+
+        transc->remain_len = 1U;
+        break;
+
+    case GET_PROTOCOL:
+        transc->xfer_buf = (uint8_t *)&hid->protocol;
+
+        transc->remain_len = 1U;
+        break;
+
+    case SET_REPORT:
+        /* no use for this driver */
+        break;
+
+    case SET_IDLE:
+        hid->idle_state = (uint8_t)(req->wValue >> 8U);
+        break;
+
+    case SET_PROTOCOL:
+        hid->protocol = (uint8_t)(req->wValue);
+        break;
+
+    case USB_GET_DESCRIPTOR:
+        if (USB_DESCTYPE_REPORT == (req->wValue >> 8U)) {
+            transc->remain_len = USB_MIN(USB_HID_REPORT_DESC_LEN, req->wLength);
+            transc->xfer_buf = (uint8_t *)hid_report_desc;
+
+            return REQ_SUPP;
+        } else if (USB_DESCTYPE_HID == (req->wValue >> 8U)) {
+            transc->remain_len = USB_MIN(9U, req->wLength);
+            transc->xfer_buf = (uint8_t *)(&(hid_config_desc.hid_vendor));
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle data stage
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint identifier
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t hid_data_in (usb_dev *udev, uint8_t ep_num)
+{
+    standard_hid_handler *hid = (standard_hid_handler *)udev->dev.class_data[USBD_HID_INTERFACE];
+
+    if (0U != hid->data[2]) {
+        hid->data[2] = 0x00U;
+
+        usbd_ep_send(udev, HID_IN_EP, hid->data, HID_IN_PACKET);
+    } else {
+        hid->prev_transfer_complete = 1U;
+    }
+
+    return USBD_OK;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/iap/Include/usb_iap_core.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/iap/Include/usb_iap_core.h
@@ -1,0 +1,99 @@
+/*!
+    \file    usb_iap_core.h
+    \brief   the header file of IAP driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USB_IAP_CORE_H
+#define __USB_IAP_CORE_H
+
+#include "usbd_enum.h"
+#include "usb_hid.h"
+
+#define USB_SERIAL_STRING_SIZE              0x06U
+
+#ifdef USE_USB_FS
+    #define USB_DESC_LEN_IAP_REPORT         35U
+#elif defined(USE_USB_HS)
+    #ifdef USE_ULPI_PHY
+        #define USB_DESC_LEN_IAP_REPORT     36U
+    #else
+        #define USB_DESC_LEN_IAP_REPORT     35U
+    #endif
+#else
+    #error "please select 'USE_USB_FS' or 'USE_USB_HS'"
+#endif
+
+#define USB_DESC_LEN_IAP_CONFIG_SET         41U
+
+/* special commands with download request */
+#define IAP_OPTION_BYTE1                    0x01U
+#define IAP_ERASE                           0x02U
+#define IAP_DNLOAD                          0x03U
+#define IAP_LEAVE                           0x04U
+#define IAP_GETBIN_ADDRESS                  0x05U
+#define IAP_OPTION_BYTE2                    0x06U
+
+typedef struct
+{
+    uint8_t option_byte[IAP_IN_PACKET];
+
+    /* state machine variables */
+    uint8_t dev_status[IAP_IN_PACKET];
+    uint8_t bin_addr[IAP_IN_PACKET];
+
+    uint8_t report_buf[IAP_OUT_PACKET + 1U];
+
+    uint8_t reportID;
+    uint8_t flag;
+
+    uint32_t protocol;
+    uint32_t idlestate;
+
+    uint16_t transfer_times;
+    uint16_t page_count;
+    uint16_t lps;           /* last packet size */
+    uint32_t file_length;
+    uint32_t base_address;
+} usbd_iap_handler;
+
+typedef void (*app_func) (void);
+
+extern usb_desc iap_desc;
+extern usb_class_core iap_class;
+
+/* function declarations */
+/* send IAP report */
+uint8_t iap_report_send (usb_dev *udev, uint8_t *report, uint32_t len);
+
+#endif /* __USB_IAP_CORE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/iap/Source/usb_iap_core.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/iap/Source/usb_iap_core.c
@@ -1,0 +1,571 @@
+/*!
+    \file    usb_iap_core.c
+    \brief   IAP driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usb_iap_core.h"
+#include "flash_operation.h"
+#include <string.h>
+
+#define USBD_VID                     0x28E9U
+#define USBD_PID                     0x0228U
+
+/* Note:it should use the C99 standard when compiling the below codes */
+/* USB standard device descriptor */
+__ALIGN_BEGIN const usb_desc_dev iap_dev_desc __ALIGN_END =
+{
+    .header =
+    {
+        .bLength          = USB_DEV_DESC_LEN,
+        .bDescriptorType  = USB_DESCTYPE_DEV
+    },
+    .bcdUSB                = 0x0200U,
+    .bDeviceClass          = 0x00U,
+    .bDeviceSubClass       = 0x00U,
+    .bDeviceProtocol       = 0x00U,
+    .bMaxPacketSize0       = USB_FS_EP0_MAX_LEN,
+    .idVendor              = USBD_VID,
+    .idProduct             = USBD_PID,
+    .bcdDevice             = 0x0100U,
+    .iManufacturer         = STR_IDX_MFC,
+    .iProduct              = STR_IDX_PRODUCT,
+    .iSerialNumber         = STR_IDX_SERIAL,
+    .bNumberConfigurations = USBD_CFG_MAX_NUM
+};
+
+__ALIGN_BEGIN const usb_hid_desc_config_set iap_config_desc __ALIGN_END = 
+{
+    .config =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_config),
+            .bDescriptorType = USB_DESCTYPE_CONFIG
+        },
+        .wTotalLength         = USB_DESC_LEN_IAP_CONFIG_SET,
+        .bNumInterfaces       = 0x01U,
+        .bConfigurationValue  = 0x01U,
+        .iConfiguration       = 0x00U,
+        .bmAttributes         = 0x80U,
+        .bMaxPower            = 0x32U
+    },
+
+    .hid_itf =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_itf),
+            .bDescriptorType = USB_DESCTYPE_ITF
+        },
+        .bInterfaceNumber     = 0x00U,
+        .bAlternateSetting    = 0x00U,
+        .bNumEndpoints        = 0x02U,
+        .bInterfaceClass      = USB_HID_CLASS,
+        .bInterfaceSubClass   = 0x00U,
+        .bInterfaceProtocol   = 0x00U,
+        .iInterface           = 0x00U
+    },
+
+    .hid_vendor =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_hid),
+            .bDescriptorType = USB_DESCTYPE_HID
+        },
+        .bcdHID               = 0x0111U,
+        .bCountryCode         = 0x00U,
+        .bNumDescriptors      = 0x01U,
+        .bDescriptorType      = USB_DESCTYPE_REPORT,
+        .wDescriptorLength    = USB_DESC_LEN_IAP_REPORT,
+    },
+
+    .hid_epin =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_ep),
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress     = IAP_IN_EP,
+        .bmAttributes         = USB_EP_ATTR_INT,
+        .wMaxPacketSize       = IAP_IN_PACKET,
+        .bInterval            = 0x01U
+    },
+
+    .hid_epout =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_ep),
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress     = IAP_OUT_EP,
+        .bmAttributes         = USB_EP_ATTR_INT,
+        .wMaxPacketSize       = IAP_OUT_PACKET,
+        .bInterval            = 0x01U
+    }
+};
+
+/* USB language ID Descriptor */
+static __ALIGN_BEGIN const usb_desc_LANGID usbd_language_id_desc __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = sizeof(usb_desc_LANGID),
+        .bDescriptorType = USB_DESCTYPE_STR
+    },
+    .wLANGID              = ENG_LANGID
+};
+
+/* USB manufacture string */
+static __ALIGN_BEGIN const usb_desc_str manufacturer_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(10U),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'i', 'g', 'a', 'D', 'e', 'v', 'i', 'c', 'e'}
+};
+
+/* USB product string */
+static __ALIGN_BEGIN const usb_desc_str product_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(12U),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'D', '3', '2', '-', 'U', 'S', 'B', '_', 'I', 'A', 'P'}
+};
+
+/* USBD serial string */
+static __ALIGN_BEGIN usb_desc_str serial_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(2U),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    }
+};
+
+void *const usbd_iap_strings[] = 
+{
+    [STR_IDX_LANGID]  = (uint8_t *)&usbd_language_id_desc,
+    [STR_IDX_MFC]     = (uint8_t *)&manufacturer_string,
+    [STR_IDX_PRODUCT] = (uint8_t *)&product_string,
+    [STR_IDX_SERIAL]  = (uint8_t *)&serial_string
+};
+
+usb_desc iap_desc = {
+    .dev_desc    = (uint8_t *)&iap_dev_desc,
+    .config_desc = (uint8_t *)&iap_config_desc,
+    .strings     = usbd_iap_strings
+};
+
+/* local function prototypes ('static') */
+static uint8_t iap_init         (usb_dev *udev, uint8_t config_index);
+static uint8_t iap_deinit       (usb_dev *udev, uint8_t config_index);
+static uint8_t iap_req_handler  (usb_dev *udev, usb_req *req);
+static uint8_t iap_data_out     (usb_dev *udev, uint8_t ep_num);
+
+/* IAP requests management functions */
+static void iap_req_erase       (usb_dev *udev);
+static void iap_req_dnload      (usb_dev *udev);
+static void iap_req_optionbyte  (usb_dev *udev, uint8_t option_num);
+static void iap_req_leave       (usb_dev *udev);
+static void iap_address_send    (usb_dev *udev);
+
+usb_class_core iap_class = {
+    .init            = iap_init,
+    .deinit          = iap_deinit,
+    .req_proc        = iap_req_handler,
+    .data_out        = iap_data_out
+};
+
+/* USB custom HID device report descriptor */
+__ALIGN_BEGIN const uint8_t iap_report_desc[USB_DESC_LEN_IAP_REPORT] __ALIGN_END =
+{
+    0x05, 0x01,     /* USAGE_PAGE (Generic Desktop) */
+    0x09, 0x00,     /* USAGE (Custom Device)        */
+    0xa1, 0x01,     /* COLLECTION (Application)     */
+
+    /* IAP command and data */
+    0x85, 0x01,     /* REPORT_ID (0x01)          */
+    0x09, 0x01,     /* USAGE (IAP command)       */
+    0x15, 0x00,     /* LOGICAL_MINIMUM (0)       */
+    0x25, 0xff,     /* LOGICAL_MAXIMUM (255)     */
+    0x75, 0x08,     /* REPORT_SIZE (8)           */
+#ifdef USE_USB_FS
+    0x95, REPORT_OUT_COUNT,
+#else
+    #ifdef USE_ULPI_PHY
+        0x96, BYTE_LOW(REPORT_OUT_COUNT), BYTE_HIGH(REPORT_OUT_COUNT),
+    #elif defined(USE_EMBEDDED_PHY)
+        0x95, REPORT_OUT_COUNT,
+    #endif
+#endif
+    0x91, 0x82,     /* OUTPUT (Data,Var,Abs,Vol) */
+
+    /* device status and option byte */
+    0x85, 0x02,     /* REPORT_ID (0x02)               */
+    0x09, 0x02,     /* USAGE (Status and option byte) */
+    0x15, 0x00,     /* LOGICAL_MINIMUM (0)            */
+    0x25, 0xff,     /* LOGICAL_MAXIMUM (255)          */
+    0x75, 0x08,     /* REPORT_SIZE (8)                */
+    0x95, REPORT_IN_COUNT,     /* REPORT_COUNT (23)         */
+    0x81, 0x82,     /* INPUT (Data,Var,Abs,Vol)       */
+
+    0xc0            /* END_COLLECTION            */
+};
+
+/*!
+    \brief      send IAP report
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  report: pointer to HID report
+    \param[in]  len: data length
+    \param[out] none
+    \retval     USB device operation status
+*/
+uint8_t iap_report_send (usb_dev *udev, uint8_t *report, uint32_t len)
+{
+    usbd_ep_send (udev, IAP_IN_EP, report, len);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      initialize the IAP device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t iap_init (usb_dev *udev, uint8_t config_index)
+{
+    static __ALIGN_BEGIN usbd_iap_handler iap_handler __ALIGN_END;
+
+    /* initialize Tx endpoint */
+    usbd_ep_setup(udev, &(iap_config_desc.hid_epin));
+
+    /* initialize Rx endpoint */
+    usbd_ep_setup(udev, &(iap_config_desc.hid_epout));
+
+    /* unlock the internal flash */
+    fmc_unlock();
+
+    memset((void *)&iap_handler, 0U, sizeof(usbd_iap_handler));
+
+    /* prepare receive data */
+    usbd_ep_recev(udev, IAP_OUT_EP, iap_handler.report_buf, IAP_OUT_PACKET);
+
+    iap_handler.base_address = APP_LOADED_ADDR;
+
+    udev->dev.class_data[USBD_IAP_INTERFACE] = (void *)&iap_handler;
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      deinitialize the IAP device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t iap_deinit (usb_dev *udev, uint8_t config_index)
+{
+    /* deinitialize IAP endpoints */
+    usbd_ep_clear (udev, IAP_IN_EP);
+    usbd_ep_clear (udev, IAP_OUT_EP);
+
+    /* lock the internal flash */
+    fmc_lock();
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle the IAP class-specific requests
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: device class-specific request
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t iap_req_handler (usb_dev *udev, usb_req *req)
+{
+    usb_transc *transc = &udev->dev.transc_in[0];
+
+    usbd_iap_handler *iap = (usbd_iap_handler *)udev->dev.class_data[USBD_IAP_INTERFACE];
+
+    switch (req->bRequest) {
+    case GET_REPORT:
+        /* no use for this driver */
+        break;
+
+    case GET_IDLE:
+        transc->xfer_buf = (uint8_t *)&iap->idlestate;
+        transc->remain_len = 1U;
+        break;
+
+    case GET_PROTOCOL:
+        transc->xfer_buf = (uint8_t *)&iap->protocol;
+        transc->remain_len = 1U;
+        break;
+
+    case SET_REPORT:
+        iap->reportID = (uint8_t)(req->wValue);
+        break;
+
+    case SET_IDLE:
+        iap->idlestate = (uint8_t)(req->wValue >> 8U);
+        break;
+
+    case SET_PROTOCOL:
+        iap->protocol = (uint8_t)(req->wValue);
+        break;
+
+    case USB_GET_DESCRIPTOR:
+        if (USB_DESCTYPE_REPORT == (req->wValue >> 8U)) {
+            transc->remain_len = USB_MIN(USB_DESC_LEN_IAP_REPORT, req->wLength);
+            transc->xfer_buf = (uint8_t *)iap_report_desc;
+        }
+        break;
+
+    default:
+        return USBD_FAIL;
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle data out stage
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint identifier
+    \param[out] none
+    \retval     none
+*/
+static uint8_t iap_data_out (usb_dev *udev ,uint8_t ep_num)
+{
+    usbd_iap_handler *iap = (usbd_iap_handler *)udev->dev.class_data[USBD_IAP_INTERFACE];
+
+    if (0x01U == iap->report_buf[0]) {
+        switch (iap->report_buf[1]) {
+        case IAP_DNLOAD:
+            iap_req_dnload(udev);
+            break;
+
+        case IAP_ERASE:
+            iap_req_erase(udev);
+            break;
+
+        case IAP_OPTION_BYTE1:
+            iap_req_optionbyte(udev, 0x01U);
+            break;
+
+        case IAP_LEAVE:
+            iap_req_leave(udev);
+            break;
+
+        case IAP_GETBIN_ADDRESS:
+            iap_address_send(udev);
+            break;
+
+        case IAP_OPTION_BYTE2:
+            iap_req_optionbyte(udev, 0x02U);
+            break;
+
+        default:
+            break;
+        }
+    }
+
+    usbd_ep_recev(udev, IAP_OUT_EP, iap->report_buf, IAP_OUT_PACKET);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle the IAP_DNLOAD request
+    \param[in]  udev: pointer to usb device instance
+    \param[out] none
+    \retval     none
+*/
+static void iap_req_dnload(usb_dev *udev)
+{
+    usbd_iap_handler *iap = (usbd_iap_handler *)udev->dev.class_data[USBD_IAP_INTERFACE];
+
+    if (0U != iap->transfer_times) {
+        if (1U == iap->transfer_times) {
+            if (0U == iap->lps) {
+                iap_data_write(&iap->report_buf[2], iap->base_address, TRANSFER_SIZE);
+            } else {
+                iap_data_write(&iap->report_buf[2], iap->base_address, iap->file_length % TRANSFER_SIZE);
+                iap->lps = 0U;
+            }
+
+            iap->dev_status[0] = 0x02U;
+            iap->dev_status[1] = 0x02U;
+            iap_report_send (udev, iap->dev_status, IAP_IN_PACKET);
+        } else {
+            iap_data_write(&iap->report_buf[2], iap->base_address, TRANSFER_SIZE);
+
+            iap->base_address += TRANSFER_SIZE;
+        }
+
+        iap->transfer_times--;
+    }
+}
+
+/*!
+    \brief      handle the IAP_ERASE request
+    \param[in]  udev: pointer to usb device instance
+    \param[out] none
+    \retval     none
+*/
+static void iap_req_erase(usb_dev *udev)
+{
+    uint32_t addr = 0U;
+
+    usbd_iap_handler *iap = (usbd_iap_handler *)udev->dev.class_data[USBD_IAP_INTERFACE];
+
+    /* get base address to erase */
+    iap->base_address  = iap->report_buf[2];
+    iap->base_address |= iap->report_buf[3] << 8U;
+    iap->base_address |= iap->report_buf[4] << 16U;
+    iap->base_address |= iap->report_buf[5] << 24U;
+
+    /* get file length */
+    iap->file_length = iap->report_buf[7];
+    iap->file_length |= iap->report_buf[8] << 8U;
+    iap->file_length |= iap->report_buf[9] << 16U;
+    iap->file_length |= iap->report_buf[10] << 24U;
+
+    iap->lps = iap->file_length % TRANSFER_SIZE;
+    if (0U == iap->lps) {
+        iap->transfer_times = iap->file_length / TRANSFER_SIZE;
+    } else {
+        iap->transfer_times = iap->file_length / TRANSFER_SIZE + 1U;
+    }
+
+    /* check if the address is in protected area */
+    if (IS_PROTECTED_AREA(iap->base_address)) {
+        return;
+    }
+
+    addr = iap->base_address;
+
+    /* unlock the flash program erase controller */
+    fmc_unlock();
+
+    flash_erase(addr, iap->file_length, iap->report_buf);
+
+    fmc_lock();
+
+    iap->dev_status[0] = 0x02U;
+    iap->dev_status[1] = 0x01U;
+
+    usbd_ep_send(udev, IAP_IN_EP, iap->dev_status, IAP_IN_PACKET);
+}
+
+/*!
+    \brief      handle the IAP_OPTION_BYTE request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  option_num: number of option byte
+    \param[out] none
+    \retval     none
+*/
+static void iap_req_optionbyte(usb_dev *udev, uint8_t option_num)
+{
+    uint8_t i = 0U;
+    uint32_t address = 0U;
+
+    usbd_iap_handler *iap = (usbd_iap_handler *)udev->dev.class_data[USBD_IAP_INTERFACE];
+
+    iap->option_byte[0] = 0x02U;
+
+    if (0x01U == option_num) {
+        address = OPT_BYTE_ADDR1;
+#ifdef OPT_BYTE_ADDR2
+    } else if (0x02U == option_num) {
+        address = OPT_BYTE_ADDR2;
+#endif
+    } else {
+        return;
+    }
+
+    for (i = 1U; i < 17U; i++) {
+        iap->option_byte[i] = *(uint8_t *)address;
+        address++;
+    }
+
+    iap_report_send (udev, iap->option_byte, IAP_IN_PACKET);
+}
+
+/*!
+    \brief      handle the IAP_LEAVE request
+    \param[in]  udev: pointer to usb device instance
+    \param[out] none
+    \retval     none
+*/
+static void iap_req_leave(usb_dev *udev)
+{
+    /* lock the internal flash */
+    fmc_lock();
+
+    /* generate system reset to allow jumping to the user code */
+    NVIC_SystemReset();
+}
+
+/*!
+    \brief      handle the IAP_SEND_ADDRESS request
+    \param[in]  udev: pointer to usb device instance
+    \param[out] none
+    \retval     none
+*/
+static void iap_address_send(usb_dev *udev)
+{
+    usbd_iap_handler *iap = (usbd_iap_handler *)udev->dev.class_data[USBD_IAP_INTERFACE];
+
+    iap->bin_addr[0] = 0x02U;
+
+    iap->bin_addr[1] = (uint8_t)(APP_LOADED_ADDR);
+    iap->bin_addr[2] = (uint8_t)(APP_LOADED_ADDR >> 8U);
+    iap->bin_addr[3] = (uint8_t)(APP_LOADED_ADDR >> 16U);
+    iap->bin_addr[4] = (uint8_t)(APP_LOADED_ADDR >> 24U);
+
+    iap_report_send (udev, iap->bin_addr, IAP_IN_PACKET);
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Include/usbd_msc_bbb.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Include/usbd_msc_bbb.h
@@ -1,0 +1,103 @@
+/*!
+    \file    usbd_msc_bbb.h
+    \brief   the header file of the usbd_msc_bbb.c file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBD_MSC_BBB_H
+#define __USBD_MSC_BBB_H
+
+#include "usbd_core.h"
+#include "msc_bbb.h"
+#include "usbd_msc_mem.h"
+#include "usbd_msc_scsi.h"
+
+/* MSC BBB state */
+enum msc_bbb_state {
+    BBB_IDLE = 0U,          /*!< idle state  */
+    BBB_DATA_OUT,           /*!< data OUT state */
+    BBB_DATA_IN,            /*!< data IN state */
+    BBB_LAST_DATA_IN,       /*!< last data IN state */
+    BBB_SEND_DATA           /*!< send immediate data state */
+};
+
+/* MSC BBB status */
+enum msc_bbb_status {
+    BBB_STATUS_NORMAL = 0U, /*!< normal status */
+    BBB_STATUS_RECOVERY,    /*!< recovery status*/
+    BBB_STATUS_ERROR        /*!< error status */
+};
+
+typedef struct
+{
+    uint8_t bbb_data[MSC_MEDIA_PACKET_SIZE];
+
+    uint8_t max_lun;
+    uint8_t bbb_state;
+    uint8_t bbb_status;
+
+    uint32_t bbb_datalen;
+
+    msc_bbb_cbw bbb_cbw;
+    msc_bbb_csw bbb_csw;
+
+    uint8_t scsi_sense_head;
+    uint8_t scsi_sense_tail;
+
+    uint32_t scsi_blk_size[MEM_LUN_NUM];
+    uint32_t scsi_blk_nbr[MEM_LUN_NUM];
+
+    uint32_t scsi_blk_addr;
+    uint32_t scsi_blk_len;
+    uint32_t scsi_disk_pop;
+
+    msc_scsi_sense scsi_sense[SENSE_LIST_DEEPTH];
+} usbd_msc_handler;
+
+/* function declarations */
+/* initialize the BBB process */
+void msc_bbb_init (usb_core_driver *udev);
+/* reset the BBB machine */
+void msc_bbb_reset (usb_core_driver *udev);
+/* deinitialize the BBB machine */
+void msc_bbb_deinit (usb_core_driver *udev);
+/* handle BBB data IN stage */
+void msc_bbb_data_in (usb_core_driver *udev, uint8_t ep_num);
+/* handle BBB data OUT stage */
+void msc_bbb_data_out (usb_core_driver *udev, uint8_t ep_num);
+/* send the CSW(command status wrapper) */
+void msc_bbb_csw_send (usb_core_driver *udev, uint8_t csw_status);
+/* complete the clear feature request */
+void msc_bbb_clrfeature (usb_core_driver *udev, uint8_t ep_num);
+
+#endif /* __USBD_MSC_BBB_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Include/usbd_msc_core.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Include/usbd_msc_core.h
@@ -1,0 +1,61 @@
+/*!
+    \file    usbd_msc_core.h
+    \brief   the header file of USB MSC device class core functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBD_MSC_CORE_H
+#define __USBD_MSC_CORE_H
+
+#include "usbd_core.h"
+#include "usb_msc.h"
+
+#define USB_MSC_CONFIG_DESC_SIZE          32U
+
+#define MSC_EPIN_SIZE                     MSC_DATA_PACKET_SIZE
+#define MSC_EPOUT_SIZE                    MSC_DATA_PACKET_SIZE
+
+/* USB configuration descriptor structure */
+typedef struct
+{
+    usb_desc_config         config;
+
+    usb_desc_itf            msc_itf;
+    usb_desc_ep             msc_epin;
+    usb_desc_ep             msc_epout;
+} usb_desc_config_set;
+
+extern usb_desc msc_desc;
+extern usb_class_core msc_class;
+
+#endif /* __USBD_MSC_CORE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Include/usbd_msc_mem.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Include/usbd_msc_mem.h
@@ -1,0 +1,61 @@
+/*!
+    \file    usbd_msc_mem.h
+    \brief   header file for storage memory
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBD_MSC_MEM_H
+#define __USBD_MSC_MEM_H
+
+#include "usbd_conf.h"
+
+#define USBD_STD_INQUIRY_LENGTH     36U
+
+typedef struct
+{
+    int8_t (*mem_init)         (uint8_t lun);
+    int8_t (*mem_ready)        (uint8_t lun);
+    int8_t (*mem_protected)    (uint8_t lun);
+    int8_t (*mem_read)         (uint8_t lun, uint8_t *buf, uint32_t block_addr, uint16_t block_len);
+    int8_t (*mem_write)        (uint8_t lun, uint8_t *buf, uint32_t block_addr, uint16_t block_len);
+    int8_t (*mem_maxlun)       (void);
+
+    uint8_t *mem_toc_data;
+    uint8_t *mem_inquiry_data[MEM_LUN_NUM];
+    uint32_t mem_block_size[MEM_LUN_NUM];
+    uint32_t mem_block_len[MEM_LUN_NUM];
+} usbd_mem_cb;
+
+extern usbd_mem_cb *usbd_mem_fops;
+
+#endif /* __USBD_MSC_MEM_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Include/usbd_msc_scsi.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Include/usbd_msc_scsi.h
@@ -1,0 +1,60 @@
+/*!
+    \file    usbd_msc_scsi.h
+    \brief   the header file of the usbd_msc_scsi.c file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBD_MSC_SCSI_H
+#define __USBD_MSC_SCSI_H
+
+#include "usbd_msc_bbb.h"
+#include "msc_scsi.h"
+
+#define SENSE_LIST_DEEPTH                           4U
+
+#define MODE_SENSE6_LENGTH                          8U
+#define MODE_SENSE10_LENGTH                         8U
+#define INQUIRY_PAGE00_LENGTH                       96U
+#define FORMAT_CAPACITIES_LENGTH                    20U
+
+extern const uint8_t msc_page00_inquiry_data[];
+extern const uint8_t msc_mode_sense6_data[];
+extern const uint8_t msc_mode_sense10_data[];
+
+/* function declarations */
+/* process SCSI commands */
+int8_t scsi_process_cmd (usb_core_driver *udev, uint8_t lun, uint8_t *cmd);
+/* load the last error code in the error list */
+void scsi_sense_code (usb_core_driver *udev, uint8_t lun, uint8_t skey, uint8_t asc);
+
+#endif /* __USBD_MSC_SCSI_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Source/usbd_msc_bbb.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Source/usbd_msc_bbb.c
@@ -1,0 +1,289 @@
+/*!
+    \file    usbd_msc_bbb.c
+    \brief   USB BBB(Bulk/Bulk/Bulk) protocol core functions
+    \note    BBB means Bulk-only transport protocol for USB MSC
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usbd_enum.h"
+#include "usbd_msc_bbb.h"
+
+/* local function prototypes ('static') */
+static void msc_bbb_cbw_decode (usb_core_driver *udev);
+static void msc_bbb_data_send  (usb_core_driver *udev, uint8_t *pbuf, uint32_t Len);
+static void msc_bbb_abort      (usb_core_driver *udev);
+
+/*!
+    \brief      initialize the BBB process
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     none
+*/
+void msc_bbb_init (usb_core_driver *udev)
+{
+    uint8_t lun_num;
+
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    msc->bbb_state = BBB_IDLE;
+    msc->bbb_status = BBB_STATUS_NORMAL;
+
+    /* initializes the storage logic unit */
+    for(lun_num = 0U; lun_num < MEM_LUN_NUM; lun_num++) {
+        usbd_mem_fops->mem_init(lun_num);
+    }
+
+    /* flush the Rx FIFO */
+    usbd_fifo_flush (udev, MSC_OUT_EP);
+
+    /* flush the Tx FIFO */
+    usbd_fifo_flush (udev, MSC_IN_EP);
+
+    /* prepare endpoint to receive the first BBB CBW */
+    usbd_ep_recev (udev, MSC_OUT_EP, (uint8_t *)&msc->bbb_cbw, BBB_CBW_LENGTH);
+}
+
+/*!
+    \brief      reset the BBB machine
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     none
+*/
+void msc_bbb_reset (usb_core_driver *udev)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    msc->bbb_state = BBB_IDLE;
+    msc->bbb_status = BBB_STATUS_RECOVERY;
+
+    /* prepare endpoint to receive the first BBB command */
+    usbd_ep_recev (udev, MSC_OUT_EP, (uint8_t *)&msc->bbb_cbw, BBB_CBW_LENGTH);
+}
+
+/*!
+    \brief      deinitialize the BBB machine
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     none
+*/
+void msc_bbb_deinit (usb_core_driver *udev)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    msc->bbb_state = BBB_IDLE;
+}
+
+/*!
+    \brief      handle BBB data IN stage
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint number
+    \param[out] none
+    \retval     none
+*/
+void msc_bbb_data_in (usb_core_driver *udev, uint8_t ep_num)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    switch (msc->bbb_state) {
+    case BBB_DATA_IN:
+        if (scsi_process_cmd (udev, msc->bbb_cbw.bCBWLUN, &msc->bbb_cbw.CBWCB[0]) < 0) {
+            msc_bbb_csw_send (udev, CSW_CMD_FAILED);
+        }
+        break;
+
+    case BBB_SEND_DATA:
+    case BBB_LAST_DATA_IN:
+        msc_bbb_csw_send (udev, CSW_CMD_PASSED);
+        break;
+
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      handle BBB data OUT stage
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint number
+    \param[out] none
+    \retval     none
+*/
+void msc_bbb_data_out (usb_core_driver *udev, uint8_t ep_num)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    switch (msc->bbb_state) {
+    case BBB_IDLE:
+        msc_bbb_cbw_decode (udev);
+        break;
+
+    case BBB_DATA_OUT:
+        if (scsi_process_cmd (udev, msc->bbb_cbw.bCBWLUN, &msc->bbb_cbw.CBWCB[0]) < 0) {
+            msc_bbb_csw_send (udev, CSW_CMD_FAILED);
+        }
+        break;
+
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      send the CSW(command status wrapper)
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  csw_status: CSW status
+    \param[out] none
+    \retval     none
+*/
+void msc_bbb_csw_send (usb_core_driver *udev, uint8_t csw_status)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    msc->bbb_csw.dCSWSignature = BBB_CSW_SIGNATURE;
+    msc->bbb_csw.bCSWStatus = csw_status;
+    msc->bbb_state = BBB_IDLE;
+
+    usbd_ep_send (udev, MSC_IN_EP, (uint8_t *)&msc->bbb_csw, BBB_CSW_LENGTH);
+
+    /* prepare endpoint to receive next command */
+    usbd_ep_recev (udev, MSC_OUT_EP, (uint8_t *)&msc->bbb_cbw, BBB_CBW_LENGTH);
+}
+
+/*!
+    \brief      complete the clear feature request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint number
+    \param[out] none
+    \retval     none
+*/
+void msc_bbb_clrfeature (usb_core_driver *udev, uint8_t ep_num)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    if (msc->bbb_status == BBB_STATUS_ERROR) { /* bad CBW signature */ 
+        usbd_ep_stall(udev, MSC_IN_EP);
+
+        msc->bbb_status = BBB_STATUS_NORMAL;
+    } else if(((ep_num & 0x80U) == 0x80U) && (msc->bbb_status != BBB_STATUS_RECOVERY)) {
+        msc_bbb_csw_send (udev, CSW_CMD_FAILED);
+    } else {
+
+    }
+}
+
+/*!
+    \brief      decode the CBW command and set the BBB state machine accordingly
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     none
+*/
+static void msc_bbb_cbw_decode (usb_core_driver *udev)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    msc->bbb_csw.dCSWTag = msc->bbb_cbw.dCBWTag;
+    msc->bbb_csw.dCSWDataResidue = msc->bbb_cbw.dCBWDataTransferLength;
+
+    if((BBB_CBW_LENGTH != usbd_rxcount_get(udev, MSC_OUT_EP)) ||
+            (BBB_CBW_SIGNATURE != msc->bbb_cbw.dCBWSignature) ||
+            (msc->bbb_cbw.bCBWLUN > 1U) ||
+            (msc->bbb_cbw.bCBWCBLength < 1U) ||
+            (msc->bbb_cbw.bCBWCBLength > 16U)) {
+        /* illegal command handler */
+        scsi_sense_code (udev, msc->bbb_cbw.bCBWLUN, ILLEGAL_REQUEST, INVALID_CDB);
+
+        msc->bbb_status = BBB_STATUS_ERROR;
+
+        msc_bbb_abort (udev);
+    } else {
+        if (scsi_process_cmd (udev, msc->bbb_cbw.bCBWLUN, &msc->bbb_cbw.CBWCB[0]) < 0) {
+            msc_bbb_abort (udev);
+        } else if ((BBB_DATA_IN != msc->bbb_state) && 
+                    (BBB_DATA_OUT != msc->bbb_state) &&
+                      (BBB_LAST_DATA_IN != msc->bbb_state)) { /* burst xfer handled internally */
+            if (msc->bbb_datalen > 0U) {
+                msc_bbb_data_send (udev, msc->bbb_data, msc->bbb_datalen);
+            } else if (0U == msc->bbb_datalen) {
+                msc_bbb_csw_send (udev, CSW_CMD_PASSED);
+            } else {
+
+            }
+        } else {
+
+        }
+    }
+}
+
+/*!
+    \brief      send the requested data
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  buf: pointer to data buffer
+    \param[in]  len: data length
+    \param[out] none
+    \retval     none
+*/
+static void msc_bbb_data_send (usb_core_driver *udev, uint8_t *buf, uint32_t len)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    len = USB_MIN (msc->bbb_cbw.dCBWDataTransferLength, len);
+
+    msc->bbb_csw.dCSWDataResidue -= len;
+    msc->bbb_csw.bCSWStatus = CSW_CMD_PASSED;
+    msc->bbb_state = BBB_SEND_DATA;
+
+    usbd_ep_send (udev, MSC_IN_EP, buf, len);
+}
+
+/*!
+    \brief      abort the current transfer
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     none
+*/
+static void msc_bbb_abort (usb_core_driver *udev)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    if ((0U == msc->bbb_cbw.bmCBWFlags) && 
+        (0U != msc->bbb_cbw.dCBWDataTransferLength) &&
+        (BBB_STATUS_NORMAL == msc->bbb_status)) {
+        usbd_ep_stall(udev, MSC_OUT_EP);
+    }
+
+    usbd_ep_stall(udev, MSC_IN_EP);
+
+    if (msc->bbb_status == BBB_STATUS_ERROR) {
+        usbd_ep_recev (udev, MSC_OUT_EP, (uint8_t *)&msc->bbb_cbw, BBB_CBW_LENGTH);
+    }
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Source/usbd_msc_core.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Source/usbd_msc_core.c
@@ -1,0 +1,406 @@
+/*!
+    \file    usbd_msc_core.c
+    \brief   USB MSC device class core functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usbd_enum.h"
+#include "usbd_msc_bbb.h"
+#include "usbd_msc_core.h"
+#include <string.h>
+
+#define USBD_VID                    0x28E9U
+#define USBD_PID                    0x028FU
+
+/* local function prototypes ('static') */
+static uint8_t msc_core_init   (usb_dev *udev, uint8_t config_index);
+static uint8_t msc_core_deinit (usb_dev *udev, uint8_t config_index);
+static uint8_t msc_core_req    (usb_dev *udev, usb_req *req);
+static uint8_t msc_core_in     (usb_dev *udev, uint8_t ep_num);
+static uint8_t msc_core_out    (usb_dev *udev, uint8_t ep_num);
+
+usb_class_core msc_class = 
+{
+    .init     = msc_core_init,
+    .deinit   = msc_core_deinit,
+
+    .req_proc = msc_core_req,
+
+    .data_in  = msc_core_in,
+    .data_out = msc_core_out
+};
+
+/* note: it should use the C99 standard when compiling the below codes */
+/* USB standard device descriptor */
+__ALIGN_BEGIN const usb_desc_dev msc_dev_desc __ALIGN_END =
+{
+    .header = 
+    {
+        .bLength           = USB_DEV_DESC_LEN, 
+        .bDescriptorType   = USB_DESCTYPE_DEV
+    },
+    .bcdUSB                = 0x0200U,
+    .bDeviceClass          = 0x00U,
+    .bDeviceSubClass       = 0x00U,
+    .bDeviceProtocol       = 0x00U,
+    .bMaxPacketSize0       = USB_FS_EP0_MAX_LEN,
+    .idVendor              = USBD_VID,
+    .idProduct             = USBD_PID,
+    .bcdDevice             = 0x0100U,
+    .iManufacturer         = STR_IDX_MFC,
+    .iProduct              = STR_IDX_PRODUCT,
+    .iSerialNumber         = STR_IDX_SERIAL,
+    .bNumberConfigurations = USBD_CFG_MAX_NUM
+};
+
+/* USB device configuration descriptor */
+__ALIGN_BEGIN const usb_desc_config_set msc_config_desc __ALIGN_END = 
+{
+    .config = 
+    {
+        .header = 
+        {
+            .bLength         = sizeof(usb_desc_config), 
+            .bDescriptorType = USB_DESCTYPE_CONFIG
+        },
+        .wTotalLength        = USB_MSC_CONFIG_DESC_SIZE,
+        .bNumInterfaces      = 0x01U,
+        .bConfigurationValue = 0x01U,
+        .iConfiguration      = 0x00U,
+        .bmAttributes        = 0xC0U,
+        .bMaxPower           = 0x32U
+    },
+
+    .msc_itf = 
+    {
+        .header = 
+        {
+            .bLength         = sizeof(usb_desc_itf), 
+            .bDescriptorType = USB_DESCTYPE_ITF
+        },
+        .bInterfaceNumber    = 0x00U,
+        .bAlternateSetting   = 0x00U,
+        .bNumEndpoints       = 0x02U,
+        .bInterfaceClass     = USB_CLASS_MSC,
+        .bInterfaceSubClass  = USB_MSC_SUBCLASS_SCSI,
+        .bInterfaceProtocol  = USB_MSC_PROTOCOL_BBB,
+        .iInterface          = 0x00U
+    },
+
+    .msc_epin = 
+    {
+        .header = 
+        {
+            .bLength         = sizeof(usb_desc_ep), 
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress    = MSC_IN_EP,
+        .bmAttributes        = USB_EP_ATTR_BULK,
+        .wMaxPacketSize      = MSC_EPIN_SIZE,
+        .bInterval           = 0x00U
+    },
+
+    .msc_epout = 
+    {
+        .header = 
+        {
+            .bLength         = sizeof(usb_desc_ep), 
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress    = MSC_OUT_EP,
+        .bmAttributes        = USB_EP_ATTR_BULK,
+        .wMaxPacketSize      = MSC_EPOUT_SIZE,
+        .bInterval           = 0x00U
+    }
+};
+
+/* USB device configuration descriptor */
+__ALIGN_BEGIN const usb_desc_config_set other_speed_msc_config_desc __ALIGN_END = 
+{
+    .config = 
+    {
+        .header = 
+        {
+            .bLength         = sizeof(usb_desc_config), 
+            .bDescriptorType = USB_DESCTYPE_OTHER_SPD_CONFIG
+        },
+        .wTotalLength        = USB_MSC_CONFIG_DESC_SIZE,
+        .bNumInterfaces      = 0x01U,
+        .bConfigurationValue = 0x01U,
+        .iConfiguration      = 0x00U,
+        .bmAttributes        = 0xC0U,
+        .bMaxPower           = 0x32U
+    },
+
+    .msc_itf = 
+    {
+        .header = 
+        {
+            .bLength         = sizeof(usb_desc_itf), 
+            .bDescriptorType = USB_DESCTYPE_ITF
+        },
+        .bInterfaceNumber    = 0x00U,
+        .bAlternateSetting   = 0x00U,
+        .bNumEndpoints       = 0x02U,
+        .bInterfaceClass     = USB_CLASS_MSC,
+        .bInterfaceSubClass  = USB_MSC_SUBCLASS_SCSI,
+        .bInterfaceProtocol  = USB_MSC_PROTOCOL_BBB,
+        .iInterface          = 0x00U
+    },
+
+    .msc_epin = 
+    {
+        .header = 
+        {
+            .bLength         = sizeof(usb_desc_ep), 
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress    = MSC_IN_EP,
+        .bmAttributes        = USB_EP_ATTR_BULK,
+        .wMaxPacketSize      = 64U,
+        .bInterval           = 0x00U
+    },
+
+    .msc_epout = 
+    {
+        .header = 
+        {
+            .bLength         = sizeof(usb_desc_ep), 
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress    = MSC_OUT_EP,
+        .bmAttributes        = USB_EP_ATTR_BULK,
+        .wMaxPacketSize      = 64U,
+        .bInterval           = 0x00U
+    }
+};
+
+__ALIGN_BEGIN const uint8_t usbd_qualifier_desc[10] __ALIGN_END = 
+{
+    0x0A, 
+    0x06,
+    0x00, 
+    0x02,
+    0x00, 
+    0x00,
+    0x00, 
+    0x40,
+    0x01, 
+    0x00
+};
+
+/* USB language ID descriptor */
+static __ALIGN_BEGIN const usb_desc_LANGID usbd_language_id_desc __ALIGN_END = 
+{
+    .header = 
+    {
+        .bLength            = sizeof(usb_desc_LANGID), 
+        .bDescriptorType    = USB_DESCTYPE_STR
+    },
+    .wLANGID                 = ENG_LANGID
+};
+
+/* USB manufacture string */
+static __ALIGN_BEGIN const usb_desc_str manufacturer_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(10U),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'i', 'g', 'a', 'D', 'e', 'v', 'i', 'c', 'e'}
+};
+
+/* USB product string */
+static __ALIGN_BEGIN const usb_desc_str product_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(12U),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'D', '3', '2', '-', 'U', 'S', 'B', '_', 'M', 'S', 'C'}
+};
+
+/* USBD serial string */
+static __ALIGN_BEGIN usb_desc_str serial_string __ALIGN_END = 
+{
+    .header =
+    {
+        .bLength         = USB_STRING_LEN(12U),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    }
+};
+
+/* USB string descriptor */
+static void *const usbd_msc_strings[] = 
+{
+    [STR_IDX_LANGID]  = (uint8_t *)&usbd_language_id_desc,
+    [STR_IDX_MFC]     = (uint8_t *)&manufacturer_string,
+    [STR_IDX_PRODUCT] = (uint8_t *)&product_string,
+    [STR_IDX_SERIAL]  = (uint8_t *)&serial_string
+};
+
+usb_desc msc_desc = {
+    .dev_desc    = (uint8_t *)&msc_dev_desc,
+    .config_desc = (uint8_t *)&msc_config_desc,
+
+#if defined(USE_USB_HS) && defined(USE_ULPI_PHY)
+    .other_speed_config_desc = (uint8_t *)&other_speed_msc_config_desc,
+    .qualifier_desc = (uint8_t *)&usbd_qualifier_desc,
+#endif /* USE_USB_HS && USE_ULPI_PHY */
+
+    .strings     = usbd_msc_strings
+};
+
+static __ALIGN_BEGIN uint8_t usbd_msc_maxlun = 0U __ALIGN_END;
+
+/*!
+    \brief      initialize the MSC device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t msc_core_init (usb_dev *udev, uint8_t config_index)
+{
+    static __ALIGN_BEGIN usbd_msc_handler msc_handler __ALIGN_END;
+
+    memset((void *)&msc_handler, 0U, sizeof(usbd_msc_handler));
+
+    udev->dev.class_data[USBD_MSC_INTERFACE] = (void *)&msc_handler;
+
+    /* configure MSC Tx endpoint */
+    usbd_ep_setup (udev, &(msc_config_desc.msc_epin));
+
+    /* configure MSC Rx endpoint */
+    usbd_ep_setup (udev, &(msc_config_desc.msc_epout));
+
+    /* initialize the BBB layer */
+    msc_bbb_init(udev);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      deinitialize the MSC device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t msc_core_deinit (usb_dev *udev, uint8_t config_index)
+{
+    /* clear MSC endpoints */
+    usbd_ep_clear (udev, MSC_IN_EP);
+    usbd_ep_clear (udev, MSC_OUT_EP);
+
+    /* deinitialize the BBB layer */
+    msc_bbb_deinit(udev);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle the MSC class-specific and standard requests
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: device class-specific request
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t msc_core_req (usb_dev *udev, usb_req *req)
+{
+    usb_transc *transc = &udev->dev.transc_in[0];
+
+    switch (req->bRequest) {
+    case BBB_GET_MAX_LUN :
+        if((0U == req->wValue) && 
+            (1U == req->wLength) &&
+            (0x80U == (req->bmRequestType & 0x80U))) {
+            usbd_msc_maxlun = (uint8_t)usbd_mem_fops->mem_maxlun();
+
+            transc->xfer_buf = &usbd_msc_maxlun;
+            transc->remain_len = 1U;
+        } else {
+            return USBD_FAIL;
+        }
+        break;
+
+    case BBB_RESET :
+        if((0U == req->wValue) && 
+            (0U == req->wLength) &&
+             (0x80U != (req->bmRequestType & 0x80U))) {
+            msc_bbb_reset(udev);
+        } else {
+            return USBD_FAIL;
+        }
+        break;
+
+    case USB_CLEAR_FEATURE:
+        msc_bbb_clrfeature (udev, (uint8_t)req->wIndex);
+        break;
+
+    default:
+        return USBD_FAIL;
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle data in stage
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: the endpoint number
+    \param[out] none
+    \retval     none
+*/
+static uint8_t msc_core_in (usb_dev *udev, uint8_t ep_num)
+{
+    msc_bbb_data_in (udev, ep_num);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle data out stage
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: the endpoint number
+    \param[out] none
+    \retval     none
+*/
+static uint8_t msc_core_out (usb_dev *udev, uint8_t ep_num)
+{
+    msc_bbb_data_out (udev, ep_num);
+
+    return USBD_OK;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Source/usbd_msc_scsi.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/msc/Source/usbd_msc_scsi.c
@@ -1,0 +1,763 @@
+/*!
+    \file    usbd_msc_scsi.c
+    \brief   USB SCSI layer functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usbd_enum.h"
+#include "usbd_msc_bbb.h"
+#include "usbd_msc_scsi.h"
+
+/* USB mass storage page 0 inquiry data */
+const uint8_t msc_page00_inquiry_data[] = 
+{
+    0x00U,
+    0x00U,
+    0x00U,
+    0x00U,
+    (INQUIRY_PAGE00_LENGTH - 4U),
+    0x80U,
+    0x83U,
+};
+
+/* USB mass storage sense 6 data */
+const uint8_t msc_mode_sense6_data[] = 
+{
+    0x00U,
+    0x00U,
+    0x00U,
+    0x00U,
+    0x00U,
+    0x00U,
+    0x00U,
+    0x00U
+};
+
+/* USB mass storage sense 10 data */
+const uint8_t msc_mode_sense10_data[] = 
+{
+    0x00U,
+    0x06U,
+    0x00U,
+    0x00U,
+    0x00U,
+    0x00U,
+    0x00U,
+    0x00U
+};
+
+/* local function prototypes ('static') */
+static int8_t scsi_test_unit_ready      (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+static int8_t scsi_mode_select6         (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+static int8_t scsi_mode_select10        (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+static int8_t scsi_inquiry              (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+static int8_t scsi_read_format_capacity (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+static int8_t scsi_read_capacity10      (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+static int8_t scsi_request_sense        (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+static int8_t scsi_mode_sense6          (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+static int8_t scsi_toc_cmd_read         (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+static int8_t scsi_mode_sense10         (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+static int8_t scsi_write10              (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+static int8_t scsi_read10               (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+static int8_t scsi_verify10             (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+
+static int8_t scsi_process_read         (usb_core_driver *udev, uint8_t lun);
+static int8_t scsi_process_write        (usb_core_driver *udev, uint8_t lun);
+
+static inline int8_t scsi_check_address_range  (usb_core_driver *udev, uint8_t lun, uint32_t blk_offset, uint16_t blk_nbr);
+static inline int8_t scsi_format_cmd           (usb_core_driver *udev, uint8_t lun);
+static inline int8_t scsi_start_stop_unit      (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+static inline int8_t scsi_allow_medium_removal (usb_core_driver *udev, uint8_t lun, uint8_t *params);
+
+/*!
+    \brief      process SCSI commands
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+int8_t scsi_process_cmd(usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    switch (params[0]) {
+    case SCSI_TEST_UNIT_READY:
+        return scsi_test_unit_ready (udev, lun, params);
+
+    case SCSI_REQUEST_SENSE:
+        return scsi_request_sense (udev, lun, params);
+
+    case SCSI_INQUIRY:
+        return scsi_inquiry (udev, lun, params);
+
+    case SCSI_START_STOP_UNIT:
+        return scsi_start_stop_unit (udev, lun, params);
+
+    case SCSI_ALLOW_MEDIUM_REMOVAL:
+        return scsi_allow_medium_removal (udev, lun, params);
+
+    case SCSI_MODE_SENSE6:
+        return scsi_mode_sense6 (udev, lun, params);
+
+    case SCSI_MODE_SENSE10:
+        return scsi_mode_sense10 (udev, lun, params);
+
+    case SCSI_READ_FORMAT_CAPACITIES:
+        return scsi_read_format_capacity (udev, lun, params);
+
+    case SCSI_READ_CAPACITY10:
+        return scsi_read_capacity10 (udev, lun, params);
+
+    case SCSI_READ10:
+        return scsi_read10 (udev, lun, params); 
+
+    case SCSI_WRITE10:
+        return scsi_write10 (udev, lun, params);
+
+    case SCSI_VERIFY10:
+        return scsi_verify10 (udev, lun, params);
+
+    case SCSI_FORMAT_UNIT:
+        return scsi_format_cmd (udev, lun);
+
+    case SCSI_READ_TOC_DATA:
+        return scsi_toc_cmd_read (udev, lun, params);
+
+    case SCSI_MODE_SELECT6:
+        return scsi_mode_select6 (udev, lun, params);
+
+    case SCSI_MODE_SELECT10:
+        return scsi_mode_select10 (udev, lun, params);
+
+    default:
+        scsi_sense_code (udev, lun, ILLEGAL_REQUEST, INVALID_CDB);
+        return -1;
+    }
+}
+
+/*!
+    \brief      load the last error code in the error list
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  skey: sense key
+    \param[in]  asc: additional sense key
+    \param[out] none
+    \retval     none
+*/
+void scsi_sense_code (usb_core_driver *udev, uint8_t lun, uint8_t skey, uint8_t asc)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    msc->scsi_sense[msc->scsi_sense_tail].SenseKey = skey;
+    msc->scsi_sense[msc->scsi_sense_tail].ASC = asc << 8U;
+    msc->scsi_sense_tail++;
+
+    if (SENSE_LIST_DEEPTH == msc->scsi_sense_tail) {
+        msc->scsi_sense_tail = 0U;
+    }
+}
+
+/*!
+    \brief      process SCSI Test Unit Ready command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_test_unit_ready (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    /* case 9 : Hi > D0 */
+    if (0U != msc->bbb_cbw.dCBWDataTransferLength) {
+        scsi_sense_code (udev, msc->bbb_cbw.bCBWLUN, ILLEGAL_REQUEST, INVALID_CDB);
+
+        return -1;
+    }
+
+    if (0 != usbd_mem_fops->mem_ready(lun)) {
+        scsi_sense_code(udev, lun, NOT_READY, MEDIUM_NOT_PRESENT);
+
+        return -1;
+    }
+
+    msc->bbb_datalen = 0U;
+
+    return 0;
+}
+
+/*!
+    \brief      process Inquiry command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_mode_select6 (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    msc->bbb_datalen = 0U;
+
+    return 0;
+}
+
+/*!
+    \brief      process Inquiry command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_mode_select10 (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    msc->bbb_datalen = 0U;
+
+    return 0;
+}
+
+/*!
+    \brief      process Inquiry command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_inquiry (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    uint8_t *page = NULL;
+    uint16_t len = 0U;
+
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    if (params[1] & 0x01U) {
+        page = (uint8_t *)msc_page00_inquiry_data;
+
+        len = INQUIRY_PAGE00_LENGTH;
+    } else {
+        page = (uint8_t *)usbd_mem_fops->mem_inquiry_data[lun];
+
+        len = (uint16_t)(page[4] + 5U);
+
+        if (params[4] <= len) {
+            len = params[4];
+        }
+    }
+
+    msc->bbb_datalen = len;
+
+    while (len) {
+        len--;
+        msc->bbb_data[len] = page[len];
+    }
+
+    return 0;
+}
+
+/*!
+    \brief      process Read Capacity 10 command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_read_capacity10 (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    uint32_t blk_num = usbd_mem_fops->mem_block_len[lun] - 1U;
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    msc->scsi_blk_nbr[lun] = usbd_mem_fops->mem_block_len[lun];
+    msc->scsi_blk_size[lun] = usbd_mem_fops->mem_block_size[lun];
+
+    msc->bbb_data[0] = (uint8_t)(blk_num >> 24U);
+    msc->bbb_data[1] = (uint8_t)(blk_num >> 16U);
+    msc->bbb_data[2] = (uint8_t)(blk_num >> 8U);
+    msc->bbb_data[3] = (uint8_t)(blk_num);
+
+    msc->bbb_data[4] = (uint8_t)(msc->scsi_blk_size[lun] >> 24U);
+    msc->bbb_data[5] = (uint8_t)(msc->scsi_blk_size[lun] >> 16U);
+    msc->bbb_data[6] = (uint8_t)(msc->scsi_blk_size[lun] >> 8U);
+    msc->bbb_data[7] = (uint8_t)(msc->scsi_blk_size[lun]);
+
+    msc->bbb_datalen = 8U;
+
+    return 0;
+}
+
+/*!
+    \brief      process Read Format Capacity command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_read_format_capacity (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    uint16_t i = 0U;
+    uint32_t blk_size = usbd_mem_fops->mem_block_size[lun];
+    uint32_t blk_num = usbd_mem_fops->mem_block_len[lun];
+    uint32_t blk_nbr = blk_num - 1U;
+
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    for (i = 0U; i < 12U; i++) {
+        msc->bbb_data[i] = 0U;
+    }
+
+    msc->bbb_data[3] = 0x08U;
+    msc->bbb_data[4] = (uint8_t)(blk_nbr >> 24U);
+    msc->bbb_data[5] = (uint8_t)(blk_nbr >> 16U);
+    msc->bbb_data[6] = (uint8_t)(blk_nbr >>  8U);
+    msc->bbb_data[7] = (uint8_t)(blk_nbr);
+
+    msc->bbb_data[8] = 0x02U;
+    msc->bbb_data[9] = (uint8_t)(blk_size >> 16U);
+    msc->bbb_data[10] = (uint8_t)(blk_size >> 8U);
+    msc->bbb_data[11] = (uint8_t)(blk_size);
+
+    msc->bbb_datalen = 12U;
+
+    return 0;
+}
+
+/*!
+    \brief      process Mode Sense6 command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_mode_sense6 (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    uint16_t len = 8U;
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    msc->bbb_datalen = len;
+
+    while (len) {
+        len--;
+        msc->bbb_data[len] = msc_mode_sense6_data[len];
+    }
+
+    return 0;
+}
+
+/*!
+    \brief      process Mode Sense10 command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_mode_sense10 (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    uint16_t len = 8U;
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    msc->bbb_datalen = len;
+
+    while (len) {
+        len--;
+        msc->bbb_data[len] = msc_mode_sense10_data[len];
+    }
+
+    return 0;
+}
+
+/*!
+    \brief      process Request Sense command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_request_sense (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    uint8_t i = 0U;
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    for (i = 0U; i < REQUEST_SENSE_DATA_LEN; i++) {
+        msc->bbb_data[i] = 0U;
+    }
+
+    msc->bbb_data[0] = 0x70U;
+    msc->bbb_data[7] = REQUEST_SENSE_DATA_LEN - 6U;
+
+    if ((msc->scsi_sense_head != msc->scsi_sense_tail)) {
+        msc->bbb_data[2] = msc->scsi_sense[msc->scsi_sense_head].SenseKey;
+        msc->bbb_data[12] = msc->scsi_sense[msc->scsi_sense_head].ASCQ;
+        msc->bbb_data[13] = msc->scsi_sense[msc->scsi_sense_head].ASC;
+        msc->scsi_sense_head++;
+
+        if (msc->scsi_sense_head == SENSE_LIST_DEEPTH) {
+            msc->scsi_sense_head = 0U;
+        }
+    }
+
+    msc->bbb_datalen = USB_MIN(REQUEST_SENSE_DATA_LEN, params[4]);
+
+    return 0;
+}
+
+/*!
+    \brief      process Start Stop Unit command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static inline int8_t scsi_start_stop_unit (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    msc->bbb_datalen = 0U;
+    msc->scsi_disk_pop = 1U;
+
+    return 0;
+}
+
+/*!
+    \brief      process Allow Medium Removal command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static inline int8_t scsi_allow_medium_removal (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    msc->bbb_datalen = 0U;
+
+    return 0;
+}
+
+/*!
+    \brief      process Read10 command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_read10 (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    if (msc->bbb_state == BBB_IDLE) {
+        /* direction is from device to host */
+        if (0x80U != (msc->bbb_cbw.bmCBWFlags & 0x80U)) {
+            scsi_sense_code (udev, msc->bbb_cbw.bCBWLUN, ILLEGAL_REQUEST, INVALID_CDB);
+
+            return -1;
+        }
+
+        if (0 != usbd_mem_fops->mem_ready(lun)) {
+            scsi_sense_code (udev, lun, NOT_READY, MEDIUM_NOT_PRESENT);
+
+            return -1;
+        }
+
+        msc->scsi_blk_addr = (params[2] << 24U) | (params[3] << 16U) | \
+                             (params[4] << 8U) |  params[5];
+
+        msc->scsi_blk_len = (params[7] << 8U) | params[8];
+
+        if (scsi_check_address_range (udev, lun, msc->scsi_blk_addr, (uint16_t)msc->scsi_blk_len) < 0) {
+            return -1; /* error */
+        }
+
+        msc->bbb_state = BBB_DATA_IN;
+
+        msc->scsi_blk_addr *= msc->scsi_blk_size[lun];
+        msc->scsi_blk_len  *= msc->scsi_blk_size[lun];
+
+        /* cases 4,5 : Hi <> Dn */
+        if (msc->bbb_cbw.dCBWDataTransferLength != msc->scsi_blk_len) {
+            scsi_sense_code (udev, msc->bbb_cbw.bCBWLUN, ILLEGAL_REQUEST, INVALID_CDB);
+
+            return -1;
+        }
+    }
+
+    msc->bbb_datalen = MSC_MEDIA_PACKET_SIZE;
+
+    return scsi_process_read (udev, lun);
+}
+
+/*!
+    \brief      process Write10 command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_write10 (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    if (BBB_IDLE == msc->bbb_state) {
+        /* case 8 : Hi <> Do */
+        if (0x80U == (msc->bbb_cbw.bmCBWFlags & 0x80U)) {
+            scsi_sense_code (udev, msc->bbb_cbw.bCBWLUN, ILLEGAL_REQUEST, INVALID_CDB);
+
+            return -1;
+        }
+
+        /* check whether media is ready */
+        if (0 != usbd_mem_fops->mem_ready(lun)) {
+            scsi_sense_code (udev, lun, NOT_READY, MEDIUM_NOT_PRESENT);
+
+            return -1;
+        }
+
+        /* check if media is write-protected */
+        if (0 != usbd_mem_fops->mem_protected(lun)) {
+            scsi_sense_code (udev, lun, NOT_READY, WRITE_PROTECTED);
+
+            return -1;
+        }
+
+        msc->scsi_blk_addr = (params[2] << 24U) | (params[3] << 16U) | \
+                             (params[4] << 8U) |  params[5];
+
+        msc->scsi_blk_len = (params[7] << 8U) | params[8];
+
+        /* check if LBA address is in the right range */
+        if (scsi_check_address_range (udev, lun, msc->scsi_blk_addr, (uint16_t)msc->scsi_blk_len) < 0) {
+            return -1; /* error */
+        }
+
+        msc->scsi_blk_addr *= msc->scsi_blk_size[lun];
+        msc->scsi_blk_len  *= msc->scsi_blk_size[lun];
+
+        /* cases 3,11,13 : Hn,Ho <> D0 */
+        if (msc->bbb_cbw.dCBWDataTransferLength != msc->scsi_blk_len) {
+            scsi_sense_code (udev, msc->bbb_cbw.bCBWLUN, ILLEGAL_REQUEST, INVALID_CDB);
+
+            return -1;
+        }
+
+        /* prepare endpoint to receive first data packet */
+        msc->bbb_state = BBB_DATA_OUT;
+
+        usbd_ep_recev (udev, 
+                       MSC_OUT_EP, 
+                       msc->bbb_data, 
+                       USB_MIN (msc->scsi_blk_len, MSC_MEDIA_PACKET_SIZE));
+    } else { /* write process ongoing */
+        return scsi_process_write (udev, lun);
+    }
+
+    return 0;
+}
+
+/*!
+    \brief      process Verify10 command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_verify10 (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    if (0x02U == (params[1] & 0x02U)) {
+        scsi_sense_code (udev, lun, ILLEGAL_REQUEST, INVALID_FIELED_IN_COMMAND);
+
+        return -1; /* error, verify mode not supported*/
+    }
+
+    if (scsi_check_address_range (udev, lun, msc->scsi_blk_addr, (uint16_t)msc->scsi_blk_len) < 0) {
+        return -1; /* error */
+    }
+
+    msc->bbb_datalen = 0U;
+
+    return 0;
+}
+
+/*!
+    \brief      check address range
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  blk_offset: block offset
+    \param[in]  blk_nbr: number of block to be processed
+    \param[out] none
+    \retval     status
+*/
+static inline int8_t scsi_check_address_range (usb_core_driver *udev, uint8_t lun, uint32_t blk_offset, uint16_t blk_nbr)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    if ((blk_offset + blk_nbr) > msc->scsi_blk_nbr[lun]) {
+        scsi_sense_code (udev, lun, ILLEGAL_REQUEST, ADDRESS_OUT_OF_RANGE);
+
+        return -1;
+    }
+
+    return 0;
+}
+
+/*!
+    \brief      handle read process
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_process_read (usb_core_driver *udev, uint8_t lun)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    uint32_t len = USB_MIN(msc->scsi_blk_len, MSC_MEDIA_PACKET_SIZE);
+
+    if (usbd_mem_fops->mem_read(lun,
+                                msc->bbb_data, 
+                                msc->scsi_blk_addr, 
+                                (uint16_t)(len / msc->scsi_blk_size[lun])) < 0) {
+        scsi_sense_code(udev, lun, HARDWARE_ERROR, UNRECOVERED_READ_ERROR);
+
+        return -1; 
+    }
+
+    usbd_ep_send (udev, MSC_IN_EP, msc->bbb_data, len);
+
+    msc->scsi_blk_addr += len;
+    msc->scsi_blk_len  -= len;
+
+    /* case 6 : Hi = Di */
+    msc->bbb_csw.dCSWDataResidue -= len;
+
+    if (0U == msc->scsi_blk_len) {
+        msc->bbb_state = BBB_LAST_DATA_IN;
+    }
+
+    return 0;
+}
+
+/*!
+    \brief      handle write process
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_process_write (usb_core_driver *udev, uint8_t lun)
+{
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    uint32_t len = USB_MIN(msc->scsi_blk_len, MSC_MEDIA_PACKET_SIZE);
+
+    if (usbd_mem_fops->mem_write (lun,
+                                  msc->bbb_data, 
+                                  msc->scsi_blk_addr, 
+                                  (uint16_t)(len / msc->scsi_blk_size[lun])) < 0) {
+        scsi_sense_code(udev, lun, HARDWARE_ERROR, WRITE_FAULT);
+
+        return -1;
+    }
+
+    msc->scsi_blk_addr += len;
+    msc->scsi_blk_len  -= len;
+
+    /* case 12 : Ho = Do */
+    msc->bbb_csw.dCSWDataResidue -= len;
+
+    if (0U == msc->scsi_blk_len) {
+        msc_bbb_csw_send (udev, CSW_CMD_PASSED);
+    } else {
+        /* prepare endpoint to receive next packet */
+        usbd_ep_recev (udev, 
+                       MSC_OUT_EP, 
+                       msc->bbb_data, 
+                       USB_MIN (msc->scsi_blk_len, MSC_MEDIA_PACKET_SIZE));
+    }
+
+    return 0;
+}
+
+/*!
+    \brief      process Format Unit command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[out] none
+    \retval     status
+*/
+static inline int8_t scsi_format_cmd (usb_core_driver *udev, uint8_t lun)
+{
+    return 0;
+}
+
+/*!
+    \brief      process Read_Toc command
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  lun: logical unit number
+    \param[in]  params: command parameters
+    \param[out] none
+    \retval     status
+*/
+static int8_t scsi_toc_cmd_read (usb_core_driver *udev, uint8_t lun, uint8_t *params)
+{
+    uint8_t* pPage;
+    uint16_t len;
+
+    usbd_msc_handler *msc = (usbd_msc_handler *)udev->dev.class_data[USBD_MSC_INTERFACE];
+
+    pPage = (uint8_t *)&usbd_mem_fops->mem_toc_data[lun * READ_TOC_CMD_LEN];
+    len = (uint16_t)pPage[1] + 2U;
+
+    msc->bbb_datalen = len;
+
+    while (len) {
+        len--;
+        msc->bbb_data[len] = pPage[len];
+    }
+
+    return 0;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/printer/Include/printer_core.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/printer/Include/printer_core.h
@@ -1,0 +1,80 @@
+/*!
+    \file    printer_core.h
+    \brief   the header file of USB printer device class core functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __PRINTER_CORE_H
+#define __PRINTER_CORE_H
+
+#include "usbd_enum.h"
+#include "usb_ch9_std.h"
+
+/* USB printing device class code */
+#define USB_CLASS_PRINTER               0x07U
+
+/* printing device subclass code */
+#define USB_SUBCLASS_PRINTER            0x01U
+
+/* printing device protocol code */
+#define PROTOCOL_UNIDIRECTIONAL_ITF     0x01U
+#define PROTOCOL_BI_DIRECTIONAL_ITF     0x02U
+#define PROTOCOL_1284_4_ITF             0x03U
+#define PROTOCOL_VENDOR                 0xFFU
+
+#define DEVICE_ID_LEN                   103U
+
+#define USB_PRINTER_CONFIG_DESC_LEN     32U
+
+/* printing device specific-class request */
+#define GET_DEVICE_ID                   0x00U
+#define GET_PORT_STATUS                 0x01U
+#define SOFT_RESET                      0x02U
+
+#pragma pack(1)
+
+/* USB configuration descriptor structure */
+typedef struct
+{
+    usb_desc_config         config;
+    usb_desc_itf            printer_itf;
+    usb_desc_ep             printer_epin;
+    usb_desc_ep             printer_epout;
+} usb_printer_desc_config_set;
+
+#pragma pack()
+
+extern usb_desc printer_desc;
+extern usb_class_core usbd_printer_cb;
+
+#endif /* __PRINTER_CORE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/printer/Source/printer_core.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/class/printer/Source/printer_core.c
@@ -1,0 +1,312 @@
+/*!
+    \file    printer_core.c
+    \brief   USB printer device class core functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "printer_core.h"
+
+#define USBD_VID                     0x28E9U
+#define USBD_PID                     0x028DU
+
+/* printer port status: paper not empty/selected/no error */
+static uint8_t g_port_status = 0x18U;
+
+uint8_t g_printer_data_buf[PRINTER_OUT_PACKET];
+
+__ALIGN_BEGIN uint8_t PRINTER_DEVICE_ID[DEVICE_ID_LEN] __ALIGN_END =
+{
+    0x00, 0x67,
+    'M', 'A', 'N', 'U', 'F', 'A', 'C', 'T', 'U', 'R', 'E', 'R', ':',
+    'G', 'I', 'G', 'A', ' ', 'D', 'E', 'V', 'I', 'C', 'E', '-', ';',
+    'C', 'O', 'M', 'M', 'A', 'N', 'D', ' ', 'S', 'E', 'T', ':',
+    'P', 'C', 'L', ',', 'M', 'P', 'L', ';',
+    'M', 'O', 'D', 'E', 'L', ':',
+    'L', 'a', 's', 'e', 'r', 'B', 'e', 'a', 'm', '?', ';',
+    'C', 'O', 'M', 'M', 'E', 'N', 'T', ':',
+    'G', 'o', 'o', 'd', ' ', '!', ';',
+    'A', 'C', 'T', 'I', 'V', 'E', ' ', 'C', 'O', 'M', 'M', 'A', 'N', 'D', ' ', 'S', 'E', 'T', ':',
+    'P', 'C', 'L', ';'
+};
+
+/* USB standard device descriptor */
+__ALIGN_BEGIN const usb_desc_dev printer_dev_desc __ALIGN_END =
+{
+    .header =
+    {
+        .bLength          = USB_DEV_DESC_LEN,
+        .bDescriptorType  = USB_DESCTYPE_DEV,
+    },
+    .bcdUSB                = 0x0200U,
+    .bDeviceClass          = 0x00U,
+    .bDeviceSubClass       = 0x00U,
+    .bDeviceProtocol       = 0x00U,
+    .bMaxPacketSize0       = USB_FS_EP0_MAX_LEN,
+    .idVendor              = USBD_VID,
+    .idProduct             = USBD_PID,
+    .bcdDevice             = 0x0100U,
+    .iManufacturer         = STR_IDX_MFC,
+    .iProduct              = STR_IDX_PRODUCT,
+    .iSerialNumber         = STR_IDX_SERIAL,
+    .bNumberConfigurations = USBD_CFG_MAX_NUM,
+};
+
+/* USB device configuration descriptor */
+__ALIGN_BEGIN const usb_printer_desc_config_set printer_config_desc __ALIGN_END = 
+{
+    .config = 
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_config),
+            .bDescriptorType = USB_DESCTYPE_CONFIG
+        },
+        .wTotalLength         = USB_PRINTER_CONFIG_DESC_LEN,
+        .bNumInterfaces       = 0x01U,
+        .bConfigurationValue  = 0x01U,
+        .iConfiguration       = 0x00U,
+        .bmAttributes         = 0xA0U,
+        .bMaxPower            = 0x32U
+    },
+
+    .printer_itf =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_itf),
+            .bDescriptorType =  USB_DESCTYPE_ITF
+        },
+        .bInterfaceNumber     = 0x00U,
+        .bAlternateSetting    = 0x00U,
+        .bNumEndpoints        = 0x02U,
+        .bInterfaceClass      = USB_CLASS_PRINTER,
+        .bInterfaceSubClass   = USB_SUBCLASS_PRINTER,
+        .bInterfaceProtocol   = PROTOCOL_BI_DIRECTIONAL_ITF,
+        .iInterface           = 0x00U
+    },
+
+    .printer_epin =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_ep),
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress     = PRINTER_IN_EP,
+        .bmAttributes         = USB_EP_ATTR_BULK,
+        .wMaxPacketSize       = PRINTER_IN_PACKET,
+        .bInterval            = 0x00U
+    },
+
+    .printer_epout =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_ep),
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress     = PRINTER_OUT_EP,
+        .bmAttributes         = USB_EP_ATTR_BULK,
+        .wMaxPacketSize       = PRINTER_OUT_PACKET,
+        .bInterval            = 0x00U
+    },
+};
+
+/* USB language ID Descriptor */
+static __ALIGN_BEGIN const usb_desc_LANGID usbd_language_id_desc __ALIGN_END = 
+{
+    .header = 
+    {
+        .bLength         = sizeof(usb_desc_LANGID), 
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .wLANGID              = ENG_LANGID
+};
+
+/* USB manufacture string */
+static __ALIGN_BEGIN const usb_desc_str manufacturer_string __ALIGN_END = 
+{
+    .header = 
+    {
+        .bLength         = USB_STRING_LEN(10U), 
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'i', 'g', 'a', 'D', 'e', 'v', 'i', 'c', 'e'}
+};
+
+/* USB product string */
+static __ALIGN_BEGIN const usb_desc_str product_string __ALIGN_END = 
+{
+    .header = 
+    {
+        .bLength         = USB_STRING_LEN(16U), 
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .unicode_string = {'G', 'D', '3', '2', '-', 'U', 'S', 'B', '_', 'P', 'r', 'i', 'n', 't', 'e', 'r'}
+};
+
+/* USBD serial string */
+static __ALIGN_BEGIN usb_desc_str serial_string __ALIGN_END = 
+{
+    .header = 
+    {
+        .bLength         = USB_STRING_LEN(12U), 
+        .bDescriptorType = USB_DESCTYPE_STR,
+    }
+};
+
+/* USB string descriptor */
+static void *const usbd_msc_strings[] = 
+{
+    [STR_IDX_LANGID]  = (uint8_t *)&usbd_language_id_desc,
+    [STR_IDX_MFC]     = (uint8_t *)&manufacturer_string,
+    [STR_IDX_PRODUCT] = (uint8_t *)&product_string,
+    [STR_IDX_SERIAL]  = (uint8_t *)&serial_string
+};
+
+usb_desc printer_desc = {
+    .dev_desc    = (uint8_t *)&printer_dev_desc,
+    .config_desc = (uint8_t *)&printer_config_desc,
+    .strings     = usbd_msc_strings
+};
+
+/* local function prototypes ('static') */
+static uint8_t printer_init         (usb_dev *udev, uint8_t config_index);
+static uint8_t printer_deinit       (usb_dev *udev, uint8_t config_index);
+static uint8_t printer_req          (usb_dev *udev, usb_req *req);
+static uint8_t printer_in           (usb_dev *udev, uint8_t ep_num);
+static uint8_t printer_out          (usb_dev *udev, uint8_t ep_num);
+
+usb_class_core usbd_printer_cb = {
+    .init          = printer_init,
+    .deinit        = printer_deinit,
+
+    .req_proc      = printer_req,
+
+    .data_in       = printer_in,
+    .data_out      = printer_out
+};
+
+/*!
+    \brief      initialize the printer device
+    \param[in]  udev: pointer to usb device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     usb device operation status
+*/
+static uint8_t printer_init (usb_dev *udev, uint8_t config_index)
+{
+    /* initialize the data Tx endpoint */
+    usbd_ep_setup (udev, &(printer_config_desc.printer_epin));
+
+    /* initialize the data Rx endpoint */
+    usbd_ep_setup (udev, &(printer_config_desc.printer_epout));
+
+    /* prepare to receive data */
+    usbd_ep_recev(udev, PRINTER_OUT_EP, g_printer_data_buf, PRINTER_OUT_PACKET);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      deinitialize the printer device
+    \param[in]  udev: pointer to usb device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     usb device operation status
+*/
+static uint8_t printer_deinit (usb_dev *udev, uint8_t config_index)
+{
+    /* deinitialize the data Tx/Rx endpoint */
+    usbd_ep_clear (udev, PRINTER_IN_EP);
+    usbd_ep_clear (udev, PRINTER_OUT_EP);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle the printer class-specific requests
+    \param[in]  udev: pointer to usb device instance
+    \param[in]  req: device class-specific request
+    \param[out] none
+    \retval     usb device operation status
+*/
+static uint8_t printer_req(usb_dev *udev, usb_req *req)
+{
+    usb_transc *transc = &udev->dev.transc_in[0];
+
+    switch (req->bRequest) {
+    case GET_DEVICE_ID:
+        transc->xfer_buf = (uint8_t *)PRINTER_DEVICE_ID;
+        transc->remain_len = DEVICE_ID_LEN;
+        break;
+
+    case GET_PORT_STATUS:
+        transc->xfer_buf = (uint8_t *)&g_port_status;
+        transc->remain_len = 1U;
+        break;
+
+    case SOFT_RESET:
+        usbd_ep_recev(udev, PRINTER_OUT_EP, g_printer_data_buf, PRINTER_OUT_PACKET);
+        break;
+
+    default:
+        return USBD_FAIL;
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle printer data
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint number
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t printer_in (usb_dev *udev, uint8_t ep_num)
+{
+    return USBD_OK;
+}
+
+/*!
+    \brief      handle printer data
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint number
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t printer_out (usb_dev *udev, uint8_t ep_num)
+{
+    return USBD_OK;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/core/Include/usbd_core.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/core/Include/usbd_core.h
@@ -1,0 +1,105 @@
+/*!
+    \file    usbd_core.h
+    \brief   USB device mode core functions prototype
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBD_CORE_H
+#define __USBD_CORE_H
+
+#include "drv_usb_core.h"
+#include "drv_usb_dev.h"
+
+typedef enum
+{
+    USBD_OK = 0U,                           /*!< status OK */
+    USBD_BUSY,                              /*!< status busy */
+    USBD_FAIL                               /*!< status fail */
+} usbd_status;
+
+enum _usbd_status {
+    USBD_DEFAULT    = 1U,                    /*!< default status */
+    USBD_ADDRESSED  = 2U,                    /*!< address send status */
+    USBD_CONFIGURED = 3U,                    /*!< configured status */
+    USBD_SUSPENDED  = 4U                     /*!< suspended status */
+};
+
+/* static inline function definitions */
+
+/*!
+    \brief      set USB device address
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  addr: device address to set
+    \param[out] none
+    \retval     none
+*/
+__STATIC_INLINE void usbd_addr_set (usb_core_driver *udev, uint8_t addr)
+{
+    usb_devaddr_set(udev, addr);
+}
+
+/*!
+    \brief      get the received data length
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint number
+    \param[out] none
+    \retval     USB device operation cur_status
+*/
+__STATIC_INLINE uint16_t usbd_rxcount_get (usb_core_driver *udev, uint8_t ep_num)
+{
+    return (uint16_t)udev->dev.transc_out[ep_num].xfer_count;
+}
+
+/* function declarations */
+/* initializes the USB device-mode stack and load the class driver */
+void usbd_init (usb_core_driver *udev, usb_core_enum core, usb_desc *desc, usb_class_core *class_core);
+/* endpoint initialization */
+uint32_t usbd_ep_setup (usb_core_driver *udev, const usb_desc_ep *ep_desc);
+/* configure the endpoint when it is disabled */
+uint32_t usbd_ep_clear (usb_core_driver *udev, uint8_t ep_addr);
+/* endpoint prepare to receive data */
+uint32_t usbd_ep_recev (usb_core_driver *udev, uint8_t ep_addr, uint8_t *pbuf, uint32_t len);
+/* endpoint prepare to transmit data */
+uint32_t usbd_ep_send (usb_core_driver *udev, uint8_t ep_addr, uint8_t *pbuf, uint32_t len);
+/* set an endpoint to STALL status */
+uint32_t usbd_ep_stall (usb_core_driver *udev, uint8_t ep_addr);
+/* clear endpoint STALLed status */
+uint32_t usbd_ep_stall_clear (usb_core_driver *udev, uint8_t ep_addr);
+/* flush the endpoint FIFOs */
+uint32_t usbd_fifo_flush (usb_core_driver *udev, uint8_t ep_addr);
+/* device connect */
+void usbd_connect (usb_core_driver *udev);
+/* device disconnect */
+void usbd_disconnect (usb_core_driver *udev);
+
+#endif /* __USBD_CORE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/core/Include/usbd_enum.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/core/Include/usbd_enum.h
@@ -1,0 +1,103 @@
+/*!
+    \file    usbd_enum.h
+    \brief   USB enumeration definitions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBD_ENUM_H
+#define __USBD_ENUM_H
+
+#include "usbd_core.h"
+#include "usbd_conf.h"
+#include <wchar.h>
+
+#ifndef NULL
+    #define NULL                0U
+#endif
+
+typedef enum _usb_reqsta {
+    REQ_SUPP     = 0x0U,                   /* request support */
+    REQ_NOTSUPP  = 0x1U,                   /* request not support */
+} usb_reqsta;
+
+/* string descriptor index */
+enum _str_index
+{
+    STR_IDX_LANGID                = 0x0U,  /* language ID string index */
+    STR_IDX_MFC                   = 0x1U,  /* manufacturer string index */
+    STR_IDX_PRODUCT               = 0x2U,  /* product string index */
+    STR_IDX_SERIAL                = 0x3U,  /* serial string index */
+    STR_IDX_CONFIG                = 0x4U,  /* configuration string index */
+    STR_IDX_ITF                   = 0x5U,  /* interface string index */
+    STR_IDX_MAX                   = 0xEFU, /* string maximum index */
+};
+
+typedef enum _usb_pwrsta {
+    USB_PWRSTA_SELF_POWERED       = 0x1U,  /* USB is in self powered status */
+    USB_PWRSTA_REMOTE_WAKEUP      = 0x2U,  /* USB is in remote wakeup status */
+} usb_pwrsta;
+
+typedef enum _usb_feature
+{
+    USB_FEATURE_EP_HALT           = 0x0U,  /* USB has endpoint halt feature */
+    USB_FEATURE_REMOTE_WAKEUP     = 0x1U,  /* USB has endpoint remote wakeup feature */
+    USB_FEATURE_TEST_MODE         = 0x2U,  /* USB has endpoint test mode feature */
+} usb_feature;
+
+#define ENG_LANGID                0x0409U  /* english language ID */
+#define CHN_LANGID                0x0804U  /* chinese language ID */
+
+/* USB device exported macros */
+#define CTL_EP(ep)                (((ep) == 0x00U) || ((ep) == 0x80U))
+
+#define DEVICE_ID1                (0x1FFF7A10U)  /* device ID1 */
+#define DEVICE_ID2                (0x1FFF7A14U)  /* device ID2 */
+#define DEVICE_ID3                (0x1FFF7A18U)  /* device ID3 */
+
+#define DEVICE_ID                 (0x40023D00U)
+
+/* function declarations */
+/* handle USB standard device request */
+usb_reqsta usbd_standard_request (usb_core_driver *udev, usb_req *req);
+/* handle USB device class request */
+usb_reqsta usbd_class_request (usb_core_driver *udev, usb_req *req);
+/* handle USB vendor request */
+usb_reqsta usbd_vendor_request (usb_core_driver *udev, usb_req *req);
+/* handle USB enumeration error */
+void usbd_enum_error (usb_core_driver *udev, usb_req *req);
+/* convert hex 32bits value into unicode char */
+void int_to_unicode (uint32_t value, uint8_t *pbuf, uint8_t len);
+/* get serial string */
+void serial_string_get (uint16_t *unicode_str);
+
+#endif /* __USBD_ENUM_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/core/Include/usbd_transc.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/core/Include/usbd_transc.h
@@ -1,0 +1,58 @@
+/*!
+    \file    usbd_transc.h
+    \brief   USB transaction core functions prototype
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBD_TRANSC_H
+#define __USBD_TRANSC_H
+
+#include "usbd_core.h"
+
+/* function declarations */
+/* USB send data in the control transaction */
+usbd_status usbd_ctl_send (usb_core_driver *udev);
+/* USB receive data in control transaction */
+usbd_status usbd_ctl_recev (usb_core_driver *udev);
+/* USB send control transaction status */
+usbd_status usbd_ctl_status_send (usb_core_driver *udev);
+/* USB control receive status */
+usbd_status usbd_ctl_status_recev (usb_core_driver *udev);
+/* USB setup stage processing */
+uint8_t usbd_setup_transc (usb_core_driver *udev);
+/* data out stage processing */
+uint8_t usbd_out_transc (usb_core_driver *udev, uint8_t ep_num);
+/* data in stage processing */
+uint8_t usbd_in_transc (usb_core_driver *udev, uint8_t ep_num);
+
+#endif /* __USBD_TRANSC_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/core/Source/usbd_core.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/core/Source/usbd_core.c
@@ -1,0 +1,322 @@
+/*!
+    \file    usbd_core.c
+    \brief   USB device mode core functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usbd_core.h"
+#include "usbd_enum.h"
+#include "drv_usb_hw.h"
+
+/* endpoint type */
+const uint32_t ep_type[] = {
+    [USB_EP_ATTR_CTL]  = (uint32_t)USB_EPTYPE_CTRL,
+    [USB_EP_ATTR_BULK] = (uint32_t)USB_EPTYPE_BULK,
+    [USB_EP_ATTR_INT]  = (uint32_t)USB_EPTYPE_INTR,
+    [USB_EP_ATTR_ISO]  = (uint32_t)USB_EPTYPE_ISOC
+};
+
+/*!
+    \brief      initializes the USB device-mode stack and load the class driver
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  core: USB core type
+    \param[in]  desc: pointer to USB descriptor
+    \param[in]  class_core: class driver
+    \param[out] none
+    \retval     none
+*/
+void usbd_init (usb_core_driver *udev, usb_core_enum core, usb_desc *desc, usb_class_core *class_core)
+{
+    udev->dev.desc = desc;
+
+    /* class callbacks */
+    udev->dev.class_core = class_core;
+
+    /* create serial string */
+    serial_string_get(udev->dev.desc->strings[STR_IDX_SERIAL]);
+
+    /* configure USB capabilities */
+    (void)usb_basic_init (&udev->bp, &udev->regs, core);
+
+    usb_globalint_disable(&udev->regs);
+
+    /* initializes the USB core*/
+    (void)usb_core_init (udev->bp, &udev->regs);
+
+    /* set device disconnect */
+    usbd_disconnect (udev);
+
+#ifndef USE_OTG_MODE
+    usb_curmode_set(&udev->regs, DEVICE_MODE);
+#endif /* USE_OTG_MODE */
+
+    /* initializes device mode */
+    (void)usb_devcore_init (udev);
+
+    usb_globalint_enable(&udev->regs);
+
+    /* set device connect */
+    usbd_connect (udev);
+
+    udev->dev.cur_status = (uint8_t)USBD_DEFAULT;
+}
+
+/*!
+    \brief      endpoint initialization
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  ep_desc: pointer to endpoint descriptor
+    \param[out] none
+    \retval     none
+*/
+uint32_t usbd_ep_setup (usb_core_driver *udev, const usb_desc_ep *ep_desc)
+{
+    usb_transc *transc;
+
+    uint8_t ep_addr = ep_desc->bEndpointAddress;
+    uint16_t max_len = ep_desc->wMaxPacketSize;
+
+    /* set endpoint direction */
+    if (EP_DIR(ep_addr)) {
+        transc = &udev->dev.transc_in[EP_ID(ep_addr)];
+
+        transc->ep_addr.dir = 1U;
+    } else {
+        transc = &udev->dev.transc_out[ep_addr];
+
+        transc->ep_addr.dir = 0U;
+    }
+
+    transc->ep_addr.num = EP_ID(ep_addr);
+    transc->max_len = max_len;
+    transc->ep_type = (uint8_t)ep_type[ep_desc->bmAttributes & (uint8_t)USB_EPTYPE_MASK];
+
+    /* active USB endpoint function */
+    (void)usb_transc_active (udev, transc);
+
+    return 0U;
+}
+
+/*!
+    \brief      configure the endpoint when it is disabled
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  ep_addr: endpoint address
+                  in this parameter:
+                    bit0..bit6: endpoint number (0..7)
+                    bit7: endpoint direction which can be IN(1) or OUT(0)
+    \param[out] none
+    \retval     none
+*/
+uint32_t usbd_ep_clear (usb_core_driver *udev, uint8_t ep_addr)
+{
+    usb_transc *transc;
+
+    if (EP_DIR(ep_addr)) {
+        transc = &udev->dev.transc_in[EP_ID(ep_addr)];
+    } else {
+        transc = &udev->dev.transc_out[ep_addr];
+    }
+
+    /* deactivate USB endpoint function */
+    (void)usb_transc_deactivate (udev, transc);
+
+    return 0U;
+}
+
+/*!
+    \brief      endpoint prepare to receive data
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  ep_addr: endpoint address
+                  in this parameter:
+                    bit0..bit6: endpoint number (0..7)
+                    bit7: endpoint direction which can be IN(1) or OUT(0)
+    \param[in]  pbuf: user buffer address pointer
+    \param[in]  len: buffer length
+    \param[out] none
+    \retval     none
+*/
+uint32_t usbd_ep_recev (usb_core_driver *udev, uint8_t ep_addr, uint8_t *pbuf, uint32_t len)
+{
+    usb_transc *transc = &udev->dev.transc_out[EP_ID(ep_addr)];
+
+    /* setup the transfer */
+    transc->xfer_buf = pbuf;
+    transc->xfer_len = len;
+    transc->xfer_count = 0U;
+
+    if ((uint8_t)USB_USE_DMA == udev->bp.transfer_mode) {
+        transc->dma_addr = (uint32_t)pbuf;
+    }
+
+    /* start the transfer */
+    (void)usb_transc_outxfer (udev, transc);
+
+    return 0U;
+}
+
+/*!
+    \brief      endpoint prepare to transmit data
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  ep_addr: endpoint address
+                  in this parameter:
+                    bit0..bit6: endpoint number (0..7)
+                    bit7: endpoint direction which can be IN(1) or OUT(0)
+    \param[in]  pbuf: transmit buffer address pointer
+    \param[in]  len: buffer length
+    \param[out] none
+    \retval     none
+*/
+uint32_t usbd_ep_send (usb_core_driver *udev, uint8_t ep_addr, uint8_t *pbuf, uint32_t len)
+{
+    usb_transc *transc = &udev->dev.transc_in[EP_ID(ep_addr)];
+
+    /* setup the transfer */
+    transc->xfer_buf = pbuf;
+    transc->xfer_len = len;
+    transc->xfer_count = 0U;
+
+    if ((uint8_t)USB_USE_DMA == udev->bp.transfer_mode) {
+        transc->dma_addr = (uint32_t)pbuf;
+    }
+
+    /* start the transfer */
+    (void)usb_transc_inxfer (udev, transc);
+
+    return 0U;
+}
+
+/*!
+    \brief      set an endpoint to STALL status
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  ep_addr: endpoint address
+                  in this parameter:
+                    bit0..bit6: endpoint number (0..7)
+                    bit7: endpoint direction which can be IN(1) or OUT(0)
+    \param[out] none
+    \retval     none
+*/
+uint32_t usbd_ep_stall (usb_core_driver *udev, uint8_t ep_addr)
+{
+    usb_transc *transc = NULL;
+
+    if (EP_DIR(ep_addr)) {
+        transc = &udev->dev.transc_in[EP_ID(ep_addr)];
+    } else {
+        transc = &udev->dev.transc_out[ep_addr];
+    }
+
+    transc->ep_stall = 1U;
+
+    (void)usb_transc_stall (udev, transc);
+
+    return (0U);
+}
+
+/*!
+    \brief      clear endpoint STALLed status
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  ep_addr: endpoint address
+                  in this parameter:
+                    bit0..bit6: endpoint number (0..7)
+                    bit7: endpoint direction which can be IN(1) or OUT(0)
+    \param[out] none
+    \retval     none
+*/
+uint32_t usbd_ep_stall_clear (usb_core_driver *udev, uint8_t ep_addr)
+{
+    usb_transc *transc = NULL;
+
+    if (EP_DIR(ep_addr)) {
+        transc = &udev->dev.transc_in[EP_ID(ep_addr)];
+    } else {
+        transc = &udev->dev.transc_out[ep_addr];
+    }
+
+    transc->ep_stall = 0U;
+
+    (void)usb_transc_clrstall (udev, transc);
+
+    return (0U);
+}
+
+/*!
+    \brief      flush the endpoint FIFOs
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  ep_addr: endpoint address
+                  in this parameter:
+                    bit0..bit6: endpoint number (0..7)
+                    bit7: endpoint direction which can be IN(1) or OUT(0)
+    \param[out] none
+    \retval     none
+*/
+uint32_t usbd_fifo_flush (usb_core_driver *udev, uint8_t ep_addr)
+{
+    if (EP_DIR(ep_addr)) {
+        (void)usb_txfifo_flush (&udev->regs, EP_ID(ep_addr));
+    } else {
+        (void)usb_rxfifo_flush (&udev->regs);
+    }
+
+    return (0U);
+}
+
+/*!
+    \brief      device connect
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     none
+*/
+void usbd_connect (usb_core_driver *udev)
+{
+#ifndef USE_OTG_MODE
+    /* connect device */
+    usb_dev_connect (udev);
+
+    usb_mdelay(3U);
+#endif /* USE_OTG_MODE */
+}
+
+/*!
+    \brief      device disconnect
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     none
+*/
+void usbd_disconnect (usb_core_driver *udev)
+{
+#ifndef USE_OTG_MODE
+    /* disconnect device for 3ms */
+    usb_dev_disconnect (udev);
+
+    usb_mdelay(3U);
+#endif /* USE_OTG_MODE */
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/core/Source/usbd_enum.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/core/Source/usbd_enum.c
@@ -1,0 +1,820 @@
+/*!
+    \file    usbd_enum.c
+    \brief   USB enumeration function
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usbd_enum.h"
+#include "usb_ch9_std.h"
+
+#ifdef WINUSB_EXEMPT_DRIVER
+
+extern usbd_status usbd_OEM_req(usb_dev *udev, usb_req *req);
+
+#endif /* WINUSB_EXEMPT_DRIVER */
+
+/* local function prototypes ('static') */
+static usb_reqsta _usb_std_reserved                     (usb_core_driver *udev, usb_req *req);
+static uint8_t* _usb_dev_desc_get                       (usb_core_driver *udev, uint8_t index, uint16_t *len);
+static uint8_t* _usb_config_desc_get                    (usb_core_driver *udev, uint8_t index, uint16_t *len);
+#if defined(USE_USB_HS) && defined(USE_ULPI_PHY)
+static uint8_t* _usb_other_speed_config_desc_get        (usb_core_driver *udev, uint8_t index, uint16_t *len);
+static uint8_t* _usb_qualifier_desc_get                 (usb_core_driver *udev, uint8_t index, uint16_t *len);
+#endif
+static uint8_t* _usb_bos_desc_get                       (usb_core_driver *udev, uint8_t index, uint16_t *len);
+static uint8_t* _usb_str_desc_get                       (usb_core_driver *udev, uint8_t index, uint16_t *len);
+static usb_reqsta _usb_std_getstatus                    (usb_core_driver *udev, usb_req *req);
+static usb_reqsta _usb_std_clearfeature                 (usb_core_driver *udev, usb_req *req);
+static usb_reqsta _usb_std_setfeature                   (usb_core_driver *udev, usb_req *req);
+static usb_reqsta _usb_std_setaddress                   (usb_core_driver *udev, usb_req *req);
+static usb_reqsta _usb_std_getdescriptor                (usb_core_driver *udev, usb_req *req);
+static usb_reqsta _usb_std_setdescriptor                (usb_core_driver *udev, usb_req *req);
+static usb_reqsta _usb_std_getconfiguration             (usb_core_driver *udev, usb_req *req);
+static usb_reqsta _usb_std_setconfiguration             (usb_core_driver *udev, usb_req *req);
+static usb_reqsta _usb_std_getinterface                 (usb_core_driver *udev, usb_req *req);
+static usb_reqsta _usb_std_setinterface                 (usb_core_driver *udev, usb_req *req);
+static usb_reqsta _usb_std_synchframe                   (usb_core_driver *udev, usb_req *req);
+
+static usb_reqsta (*_std_dev_req[])(usb_core_driver *udev, usb_req *req) =
+{
+    [USB_GET_STATUS]        = _usb_std_getstatus,
+    [USB_CLEAR_FEATURE]     = _usb_std_clearfeature,
+    [USB_RESERVED2]         = _usb_std_reserved,
+    [USB_SET_FEATURE]       = _usb_std_setfeature,
+    [USB_RESERVED4]         = _usb_std_reserved,
+    [USB_SET_ADDRESS]       = _usb_std_setaddress,
+    [USB_GET_DESCRIPTOR]    = _usb_std_getdescriptor,
+    [USB_SET_DESCRIPTOR]    = _usb_std_setdescriptor,
+    [USB_GET_CONFIGURATION] = _usb_std_getconfiguration,
+    [USB_SET_CONFIGURATION] = _usb_std_setconfiguration,
+    [USB_GET_INTERFACE]     = _usb_std_getinterface,
+    [USB_SET_INTERFACE]     = _usb_std_setinterface,
+    [USB_SYNCH_FRAME]       = _usb_std_synchframe,
+};
+
+/* get standard descriptor handler */
+static uint8_t* (*std_desc_get[])(usb_core_driver *udev, uint8_t index, uint16_t *len) = {
+    [(uint8_t)USB_DESCTYPE_DEV - 1U]              = _usb_dev_desc_get,
+    [(uint8_t)USB_DESCTYPE_CONFIG - 1U]           = _usb_config_desc_get,
+    [(uint8_t)USB_DESCTYPE_STR - 1U]              = _usb_str_desc_get,
+#if defined(USE_USB_HS) && defined(USE_ULPI_PHY)
+    [(uint8_t)USB_DESCTYPE_DEV_QUALIFIER - 3U]    = _usb_qualifier_desc_get,
+    [(uint8_t)USB_DESCTYPE_OTHER_SPD_CONFIG - 3U] = _usb_other_speed_config_desc_get,
+#endif
+};
+
+/*!
+    \brief      handle USB standard device request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB device request
+    \param[out] none
+    \retval     USB device request status
+*/
+usb_reqsta usbd_standard_request (usb_core_driver *udev, usb_req *req)
+{
+    return (*_std_dev_req[req->bRequest])(udev, req);
+}
+
+/*!
+    \brief      handle USB device class request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB device class request
+    \param[out] none
+    \retval     USB device request status
+*/
+usb_reqsta usbd_class_request (usb_core_driver *udev, usb_req *req)
+{
+    if ((uint8_t)USBD_CONFIGURED == udev->dev.cur_status) {
+        if (BYTE_LOW(req->wIndex) <= USBD_ITF_MAX_NUM) {
+            /* call device class handle function */
+            return (usb_reqsta)udev->dev.class_core->req_proc(udev, req);
+        }
+    }
+
+    return REQ_NOTSUPP;
+}
+
+/*!
+    \brief      handle USB vendor request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB vendor request
+    \param[out] none
+    \retval     USB device request status
+*/
+usb_reqsta usbd_vendor_request (usb_core_driver *udev, usb_req *req)
+{
+    (void)udev;
+    (void)req;
+
+    /* added by user... */
+#ifdef WINUSB_EXEMPT_DRIVER
+   usbd_OEM_req(udev, req);
+#endif
+
+    return REQ_SUPP;
+}
+
+/*!
+    \brief      handle USB enumeration error
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB device request
+    \param[out] none
+    \retval     none
+*/
+void usbd_enum_error (usb_core_driver *udev, usb_req *req)
+{
+    (void)req;
+
+    (void)usbd_ep_stall (udev, 0x80U);
+    (void)usbd_ep_stall (udev, 0x00U);
+
+    usb_ctlep_startout(udev);
+}
+
+/*!
+    \brief      convert hex 32bits value into unicode char
+    \param[in]  value: hex 32bits value
+    \param[in]  pbuf: buffer pointer to store unicode char
+    \param[in]  len: value length
+    \param[out] none
+    \retval     none
+*/
+void int_to_unicode (uint32_t value, uint8_t *pbuf, uint8_t len)
+{
+    uint8_t index;
+
+    for (index = 0U; index < len; index++) {
+        if ((value >> 28U) < 0x0AU) {
+            pbuf[2U * index] = (uint8_t)((value >> 28U) + '0');
+        } else {
+            pbuf[2U * index] = (uint8_t)((value >> 28U) + 'A' - 10U); 
+        }
+
+        value = value << 4U;
+
+        pbuf[2U * index + 1U] = 0U;
+    }
+}
+
+/*!
+    \brief      convert hex 32bits value into unicode char
+    \param[in]  unicode_str: pointer to unicode string
+    \param[out] none
+    \retval     none
+*/
+void serial_string_get (uint16_t *unicode_str)
+{
+    if ((unicode_str[0] & 0x00FFU) != 6U) {
+        uint32_t DeviceSerial0, DeviceSerial1, DeviceSerial2;
+
+        DeviceSerial0 = *(uint32_t*)DEVICE_ID1;
+        DeviceSerial1 = *(uint32_t*)DEVICE_ID2;
+        DeviceSerial2 = *(uint32_t*)DEVICE_ID3;
+
+        DeviceSerial0 += DeviceSerial2;
+
+        if (0U != DeviceSerial0) {
+            int_to_unicode(DeviceSerial0, (uint8_t*)&(unicode_str[1]), 8U);
+            int_to_unicode(DeviceSerial1, (uint8_t*)&(unicode_str[9]), 4U);
+        }
+    } else {
+        uint32_t device_serial = *(uint32_t*)DEVICE_ID;
+
+        if(0U != device_serial) {
+            unicode_str[1] = (uint16_t)(device_serial & 0x0000FFFFU);
+            unicode_str[2] = (uint16_t)((device_serial & 0xFFFF0000U) >> 16U);
+
+        }
+    }
+}
+
+/*!
+    \brief      no operation, just for reserved
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB vendor request
+    \param[out] none
+    \retval     USB device request status
+*/
+static usb_reqsta _usb_std_reserved (usb_core_driver *udev, usb_req *req)
+{
+    (void)udev;
+    (void)req;
+
+    /* no operation... */
+
+    return REQ_NOTSUPP;
+}
+
+/*!
+    \brief      get the device descriptor
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  index: no use
+    \param[out] len: data length pointer
+    \retval     descriptor buffer pointer
+*/
+static uint8_t* _usb_dev_desc_get (usb_core_driver *udev, uint8_t index, uint16_t *len)
+{
+    (void)index;
+
+    *len = udev->dev.desc->dev_desc[0];
+
+    return udev->dev.desc->dev_desc;
+}
+
+/*!
+    \brief      get the configuration descriptor
+    \brief[in]  udev: pointer to USB device instance
+    \brief[in]  index: no use
+    \param[out] len: data length pointer
+    \retval     descriptor buffer pointer
+*/
+static uint8_t* _usb_config_desc_get (usb_core_driver *udev, uint8_t index, uint16_t *len)
+{
+    (void)index;
+
+    *len = udev->dev.desc->config_desc[2] | (udev->dev.desc->config_desc[3]<< 8U);
+
+    return udev->dev.desc->config_desc;
+}
+
+#if defined(USE_USB_HS) && defined(USE_ULPI_PHY)
+
+/*!
+    \brief      get the other speed configuration descriptor
+    \brief[in]  udev: pointer to USB device instance
+    \brief[in]  index: no use
+    \param[out] len: data length pointer
+    \retval     descriptor buffer pointer
+*/
+static uint8_t* _usb_other_speed_config_desc_get (usb_core_driver *udev, uint8_t index, uint16_t *len)
+{
+    (void)index;
+
+    *len = udev->dev.desc->other_speed_config_desc[2];
+
+    return udev->dev.desc->other_speed_config_desc;
+}
+
+/*!
+    \brief      get the other speed configuration descriptor
+    \brief[in]  udev: pointer to USB device instance
+    \brief[in]  index: no use
+    \param[out] len: data length pointer
+    \retval     descriptor buffer pointer
+*/
+static uint8_t* _usb_qualifier_desc_get (usb_core_driver *udev, uint8_t index, uint16_t *len)
+{
+    (void)index;
+
+    *len = udev->dev.desc->qualifier_desc[0];
+
+    return udev->dev.desc->qualifier_desc;
+}
+
+#endif /* USE_USB_HS && USE_ULPI_PHY */
+
+/*!
+    \brief      get the BOS descriptor
+    \brief[in]  udev: pointer to USB device instance
+    \brief[in]  index: no use
+    \param[out] len: data length pointer
+    \retval     descriptor buffer pointer
+*/
+static uint8_t* _usb_bos_desc_get (usb_core_driver *udev, uint8_t index, uint16_t *len)
+{
+    (void)index;
+
+    *len = udev->dev.desc->bos_desc[2];
+
+    return udev->dev.desc->bos_desc;
+}
+
+/*!
+    \brief      get string descriptor
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  index: string descriptor index
+    \param[out] len: pointer to string length
+    \retval     descriptor buffer pointer
+*/
+static uint8_t* _usb_str_desc_get (usb_core_driver *udev, uint8_t index, uint16_t *len)
+{
+    uint8_t *desc = udev->dev.desc->strings[index];
+
+    *len = desc[0];
+
+    return desc;
+}
+
+/*!
+    \brief      handle Get_Status request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB device request
+    \param[out] none
+    \retval     USB device request status
+*/
+static usb_reqsta _usb_std_getstatus (usb_core_driver *udev, usb_req *req)
+{
+    uint8_t recp = BYTE_LOW(req->wIndex);
+    usb_reqsta req_status = REQ_NOTSUPP;
+    usb_transc *transc = &udev->dev.transc_in[0];
+
+    static uint8_t status[2] = {0};
+
+    switch(req->bmRequestType & (uint8_t)USB_RECPTYPE_MASK) {
+    case USB_RECPTYPE_DEV:
+        if (((uint8_t)USBD_ADDRESSED == udev->dev.cur_status) || \
+            ((uint8_t)USBD_CONFIGURED == udev->dev.cur_status)) {
+
+            if (udev->dev.pm.power_mode) {
+                status[0] = USB_STATUS_SELF_POWERED;
+            } else {
+                status[0] = 0U;
+            }
+
+            if (udev->dev.pm.dev_remote_wakeup) {
+                status[0] |= USB_STATUS_REMOTE_WAKEUP;
+            } else {
+                status[0] = 0U;
+            }
+
+            req_status = REQ_SUPP;
+        }
+        break;
+
+    case USB_RECPTYPE_ITF:
+        if (((uint8_t)USBD_CONFIGURED == udev->dev.cur_status) && (recp <= USBD_ITF_MAX_NUM)) {
+            req_status = REQ_SUPP;
+        }
+        break;
+
+    case USB_RECPTYPE_EP:
+        if ((uint8_t)USBD_CONFIGURED == udev->dev.cur_status) {
+            if (0x80U == (recp & 0x80U)) {
+                status[0] = udev->dev.transc_in[EP_ID(recp)].ep_stall;
+            } else {
+                status[0] = udev->dev.transc_out[recp].ep_stall;
+            }
+
+            req_status = REQ_SUPP;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    if (REQ_SUPP == req_status) {
+        transc->xfer_buf = status;
+        transc->remain_len = 2U;
+    }
+
+    return req_status;
+}
+
+/*!
+    \brief      handle USB Clear_Feature request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: USB device request
+    \param[out] none
+    \retval     USB device request status
+*/
+static usb_reqsta _usb_std_clearfeature (usb_core_driver *udev, usb_req *req)
+{
+    uint8_t ep = 0U;
+
+    switch(req->bmRequestType & (uint8_t)USB_RECPTYPE_MASK) {
+    case USB_RECPTYPE_DEV:
+        if (((uint8_t)USBD_ADDRESSED == udev->dev.cur_status) || \
+            ((uint8_t)USBD_CONFIGURED == udev->dev.cur_status)) {
+
+            /* clear device remote wakeup feature */
+            if ((uint16_t)USB_FEATURE_REMOTE_WAKEUP == req->wValue) {
+                udev->dev.pm.dev_remote_wakeup = 0U;
+
+                return REQ_SUPP;
+            }
+        }
+        break;
+
+    case USB_RECPTYPE_ITF:
+        break;
+
+    case USB_RECPTYPE_EP:
+        /* get endpoint address */
+        ep = BYTE_LOW(req->wIndex);
+
+        if ((uint8_t)USBD_CONFIGURED == udev->dev.cur_status) {
+            /* clear endpoint halt feature */
+            if (((uint16_t)USB_FEATURE_EP_HALT == req->wValue) && (!CTL_EP(ep))) {
+                (void)usbd_ep_stall_clear (udev, ep);
+
+                (void)udev->dev.class_core->req_proc (udev, req);
+            }
+
+            return REQ_SUPP;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return REQ_NOTSUPP;
+}
+
+/*!
+    \brief      handle USB Set_Feature request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB device request
+    \param[out] none
+    \retval     USB device request status
+*/
+static usb_reqsta _usb_std_setfeature (usb_core_driver *udev, usb_req *req)
+{
+    uint8_t ep = 0U;
+
+    switch (req->bmRequestType & (uint8_t)USB_RECPTYPE_MASK) {
+    case USB_RECPTYPE_DEV:
+        if (((uint8_t)USBD_ADDRESSED == udev->dev.cur_status) || \
+            ((uint8_t)USBD_CONFIGURED == udev->dev.cur_status)) {
+            /* set device remote wakeup feature */
+            if ((uint16_t)USB_FEATURE_REMOTE_WAKEUP == req->wValue) {
+                udev->dev.pm.dev_remote_wakeup = 1U;
+            }
+
+            return REQ_SUPP;
+        }
+        break;
+
+    case USB_RECPTYPE_ITF:
+        break;
+
+    case USB_RECPTYPE_EP:
+        /* get endpoint address */
+        ep = BYTE_LOW(req->wIndex);
+
+        if ((uint8_t)USBD_CONFIGURED == udev->dev.cur_status) {
+            /* set endpoint halt feature */
+            if (((uint16_t)USB_FEATURE_EP_HALT == req->wValue) && (!CTL_EP(ep))) {
+                (void)usbd_ep_stall (udev, ep);
+            }
+
+            return REQ_SUPP;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return REQ_NOTSUPP;
+}
+
+/*!
+    \brief      handle USB Set_Address request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB device request
+    \param[out] none
+    \retval     USB device request status
+*/
+static usb_reqsta _usb_std_setaddress (usb_core_driver *udev, usb_req *req)
+{
+    if ((0U == req->wIndex) && (0U == req->wLength)) {
+        udev->dev.dev_addr = (uint8_t)(req->wValue) & 0x7FU;
+
+        if (udev->dev.cur_status != (uint8_t)USBD_CONFIGURED) {
+            usbd_addr_set (udev, udev->dev.dev_addr);
+
+            if (udev->dev.dev_addr) {
+                udev->dev.cur_status = (uint8_t)USBD_ADDRESSED;
+            } else {
+                udev->dev.cur_status = (uint8_t)USBD_DEFAULT;
+            }
+
+            return REQ_SUPP;
+        }
+    }
+
+    return REQ_NOTSUPP;
+}
+
+/*!
+    \brief      handle USB Get_Descriptor request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB device request
+    \param[out] none
+    \retval     USB device request status
+*/
+static usb_reqsta _usb_std_getdescriptor (usb_core_driver *udev, usb_req *req)
+{
+    uint8_t desc_type = 0U;
+    uint8_t desc_index = 0U;
+
+    usb_reqsta status = REQ_NOTSUPP;
+
+    usb_transc *transc = &udev->dev.transc_in[0];
+
+    /* get device standard descriptor */
+    switch (req->bmRequestType & USB_RECPTYPE_MASK) {
+    case USB_RECPTYPE_DEV:
+        desc_type = BYTE_HIGH(req->wValue);
+        desc_index = BYTE_LOW(req->wValue);
+
+        switch (desc_type) {
+        case USB_DESCTYPE_DEV:
+            transc->xfer_buf = std_desc_get[desc_type - 1U](udev, desc_index, (uint16_t *)&(transc->remain_len));
+
+            if (64U == req->wLength) {
+                transc->remain_len = 8U;
+            }
+            break;
+
+        case USB_DESCTYPE_CONFIG:
+            transc->xfer_buf = std_desc_get[desc_type - 1U](udev, desc_index, (uint16_t *)&(transc->remain_len));
+            break;
+
+        case USB_DESCTYPE_STR:
+            if (desc_index < (uint8_t)STR_IDX_MAX) {
+                transc->xfer_buf = std_desc_get[desc_type - 1U](udev, desc_index, (uint16_t *)&(transc->remain_len));
+            }
+            break;
+
+        case USB_DESCTYPE_ITF:
+        case USB_DESCTYPE_EP:
+            break;
+
+#if defined(USE_USB_HS) && defined(USE_ULPI_PHY)
+        case USB_DESCTYPE_DEV_QUALIFIER:
+            transc->xfer_buf = std_desc_get[desc_type - 3U](udev, desc_index, (uint16_t *)&(transc->remain_len));
+            break;
+
+        case USB_DESCTYPE_OTHER_SPD_CONFIG:
+            transc->xfer_buf = std_desc_get[desc_type - 3U](udev, desc_index, (uint16_t *)&(transc->remain_len));
+            break;
+#endif
+
+        case USB_DESCTYPE_ITF_POWER:
+            break;
+
+        case USB_DESCTYPE_BOS:
+            transc->xfer_buf = _usb_bos_desc_get(udev, desc_index, (uint16_t *)&(transc->remain_len));
+            break;
+
+        default:
+            break;
+        }
+        break;
+
+    case USB_RECPTYPE_ITF:
+        /* get device class special descriptor */
+        status = (usb_reqsta)(udev->dev.class_core->req_proc(udev, req));
+        break;
+
+    case USB_RECPTYPE_EP:
+        break;
+
+    default:
+        break;
+    }
+
+    if ((0U != transc->remain_len) && (0U != req->wLength)) {
+        if (transc->remain_len < req->wLength) {
+            if ((transc->remain_len >= transc->max_len) && (0U == (transc->remain_len % transc->max_len))) {
+                udev->dev.control.ctl_zlp = 1U;
+            }
+        } else {
+            transc->remain_len = req->wLength;
+        }
+
+        status = REQ_SUPP;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      handle USB Set_Descriptor request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB device request
+    \param[out] none
+    \retval     USB device request status
+*/
+static usb_reqsta _usb_std_setdescriptor (usb_core_driver *udev, usb_req *req)
+{
+    (void)udev;
+    (void)req;
+
+    /* no handle... */
+    return REQ_SUPP;
+}
+
+/*!
+    \brief      handle USB Get_Configuration request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB device request
+    \param[out] none
+    \retval     USB device request status
+*/
+static usb_reqsta _usb_std_getconfiguration (usb_core_driver *udev, usb_req *req)
+{
+    (void)req;
+
+    usb_reqsta req_status = REQ_NOTSUPP;
+    usb_transc *transc = &udev->dev.transc_in[0];
+
+    switch (udev->dev.cur_status) {
+    case USBD_ADDRESSED:
+        if (USB_DEFAULT_CONFIG == udev->dev.config) {
+            req_status = REQ_SUPP;
+        }
+        break;
+
+    case USBD_CONFIGURED:
+        if (udev->dev.config != USB_DEFAULT_CONFIG) {
+            req_status = REQ_SUPP;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    if (REQ_SUPP == req_status) {
+        transc->xfer_buf = &(udev->dev.config);
+        transc->remain_len = 1U;
+    }
+
+    return req_status;
+}
+
+/*!
+    \brief      handle USB Set_Configuration request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB device request
+    \param[out] none
+    \retval     USB device request status
+*/
+static usb_reqsta _usb_std_setconfiguration (usb_core_driver *udev, usb_req *req)
+{
+    static uint8_t config;
+    usb_reqsta status = REQ_NOTSUPP;
+
+    config = (uint8_t)(req->wValue);
+
+    if (config <= USBD_CFG_MAX_NUM) {
+        switch (udev->dev.cur_status) {
+        case USBD_ADDRESSED:
+            if (config){
+                (void)udev->dev.class_core->init(udev, config);
+
+                udev->dev.config = config;
+                udev->dev.cur_status = (uint8_t)USBD_CONFIGURED;
+            }
+
+            status = REQ_SUPP;
+            break;
+
+        case USBD_CONFIGURED:
+            if (USB_DEFAULT_CONFIG == config) {
+                (void)udev->dev.class_core->deinit(udev, config);
+
+                udev->dev.config = config;
+                udev->dev.cur_status = (uint8_t)USBD_ADDRESSED;
+            } else if (config != udev->dev.config) {
+                /* clear old configuration */
+                (void)udev->dev.class_core->deinit(udev, config);
+
+                /* set new configuration */
+                udev->dev.config = config;
+
+                (void)udev->dev.class_core->init(udev, config);
+            } else {
+                /* no operation */
+            }
+
+            status = REQ_SUPP;
+            break;
+
+        case USBD_DEFAULT:
+            break;
+
+        default:
+            break;
+        }
+    }
+
+    return status;
+}
+
+/*!
+    \brief      handle USB Get_Interface request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB device request
+    \param[out] none
+    \retval     USB device request status
+*/
+static usb_reqsta _usb_std_getinterface (usb_core_driver *udev, usb_req *req)
+{
+    switch (udev->dev.cur_status) {
+    case USBD_DEFAULT:
+        break;
+
+    case USBD_ADDRESSED:
+        break;
+
+    case USBD_CONFIGURED:
+        if (BYTE_LOW(req->wIndex) <= USBD_ITF_MAX_NUM) {
+            usb_transc *transc = &udev->dev.transc_in[0];
+
+            transc->xfer_buf = &(udev->dev.class_core->alter_set);
+            transc->remain_len = 1U;
+
+            return REQ_SUPP;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return REQ_NOTSUPP;
+}
+
+/*!
+    \brief      handle USB Set_Interface request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB device request
+    \param[out] none
+    \retval     USB device request status
+*/
+static usb_reqsta _usb_std_setinterface (usb_core_driver *udev, usb_req *req)
+{
+    switch (udev->dev.cur_status) {
+    case USBD_DEFAULT:
+        break;
+
+    case USBD_ADDRESSED:
+        break;
+
+    case USBD_CONFIGURED:
+        if (BYTE_LOW(req->wIndex) <= USBD_ITF_MAX_NUM) {
+            if (NULL != udev->dev.class_core->set_intf) {
+                (void)udev->dev.class_core->set_intf (udev, req);
+            }
+
+            return REQ_SUPP;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return REQ_NOTSUPP;
+}
+
+/*!
+    \brief      handle USB SynchFrame request
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: pointer to USB device request
+    \param[out] none
+    \retval     USB device request status
+*/
+static usb_reqsta _usb_std_synchframe (usb_core_driver *udev, usb_req *req)
+{
+    (void)udev;
+    (void)req;
+
+    /* no handle */
+    return REQ_SUPP;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/core/Source/usbd_transc.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/device/core/Source/usbd_transc.c
@@ -1,0 +1,266 @@
+/*!
+    \file    usbd_transc.c
+    \brief   USB transaction core functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usbd_enum.h"
+#include "usbd_transc.h"
+
+/*!
+    \brief      USB send data in the control transaction
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation cur_status
+*/
+usbd_status usbd_ctl_send (usb_core_driver *udev)
+{
+    usb_transc *transc = &udev->dev.transc_in[0];
+
+    (void)usbd_ep_send(udev, 0U, transc->xfer_buf, transc->remain_len);
+
+    if (transc->remain_len > transc->max_len) {
+        udev->dev.control.ctl_state = (uint8_t)USB_CTL_DATA_IN;
+    } else {
+        udev->dev.control.ctl_state = (uint8_t)USB_CTL_LAST_DATA_IN;
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      USB receive data in control transaction
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation cur_status
+*/
+usbd_status usbd_ctl_recev (usb_core_driver *udev)
+{
+    usb_transc *transc = &udev->dev.transc_out[0];
+
+    (void)usbd_ep_recev (udev, 0U, transc->xfer_buf, transc->remain_len);
+
+    if (transc->remain_len > transc->max_len) {
+        udev->dev.control.ctl_state = (uint8_t)USB_CTL_DATA_OUT;
+    } else {
+        udev->dev.control.ctl_state = (uint8_t)USB_CTL_LAST_DATA_OUT;
+    }
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      USB send control transaction status
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation cur_status
+*/
+usbd_status  usbd_ctl_status_send (usb_core_driver *udev)
+{
+    udev->dev.control.ctl_state = (uint8_t)USB_CTL_STATUS_IN;
+
+    (void)usbd_ep_send (udev, 0U, NULL, 0U);
+
+    usb_ctlep_startout(udev);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      USB control receive status
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation cur_status
+*/
+usbd_status usbd_ctl_status_recev (usb_core_driver *udev)
+{
+    udev->dev.control.ctl_state = (uint8_t)USB_CTL_STATUS_OUT;
+
+    (void)usbd_ep_recev (udev, 0U, NULL, 0U);
+
+    usb_ctlep_startout(udev);
+
+    return USBD_OK;
+}
+
+/*!
+    \brief      USB setup stage processing
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation cur_status
+*/
+uint8_t usbd_setup_transc (usb_core_driver *udev)
+{
+    usb_reqsta reqstat = REQ_NOTSUPP;
+
+    usb_req req = udev->dev.control.req;
+
+    switch (req.bmRequestType & USB_REQTYPE_MASK) {
+    /* standard device request */
+    case USB_REQTYPE_STRD:
+        reqstat = usbd_standard_request (udev, &req);
+        break;
+
+    /* device class request */
+    case USB_REQTYPE_CLASS:
+        reqstat = usbd_class_request (udev, &req);
+        break;
+
+    /* vendor defined request */
+    case USB_REQTYPE_VENDOR:
+        reqstat = usbd_vendor_request (udev, &req);
+        break;
+
+    default:
+        break;
+    }
+
+    if (REQ_SUPP == reqstat) {
+        if (0U == req.wLength) {
+            (void)usbd_ctl_status_send (udev);
+        } else {
+            if (req.bmRequestType & 0x80U) {
+                (void)usbd_ctl_send (udev);
+            } else {
+                (void)usbd_ctl_recev (udev);
+            }
+        }
+    } else {
+        usbd_enum_error (udev, &req);
+    }
+
+    return (uint8_t)USBD_OK;
+}
+
+/*!
+    \brief      data out stage processing
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint identifier(0..7)
+    \param[out] none
+    \retval     USB device operation cur_status
+*/
+uint8_t usbd_out_transc (usb_core_driver *udev, uint8_t ep_num)
+{
+    if (0U == ep_num) {
+        usb_transc *transc = &udev->dev.transc_out[0];
+
+        switch (udev->dev.control.ctl_state) {
+        case USB_CTL_DATA_OUT:
+            /* update transfer length */
+            transc->remain_len -= transc->max_len;
+
+            if ((uint8_t)USB_USE_DMA == udev->bp.transfer_mode) {
+                transc->xfer_buf += transc->max_len;
+            }
+
+            (void)usbd_ctl_recev (udev);
+            break;
+
+        case USB_CTL_LAST_DATA_OUT:
+            if (udev->dev.cur_status == (uint8_t)USBD_CONFIGURED) {
+                if (udev->dev.class_core->ctlx_out != NULL) {
+                    (void)udev->dev.class_core->ctlx_out (udev);
+                }
+            }
+
+            transc->remain_len = 0U;
+
+            (void)usbd_ctl_status_send (udev);
+            break;
+
+        default:
+            break;
+        }
+    } else if ((udev->dev.class_core->data_out != NULL) && (udev->dev.cur_status == (uint8_t)USBD_CONFIGURED)) {
+        (void)udev->dev.class_core->data_out (udev, ep_num);
+    } else {
+        /* no operation */
+    }
+
+    return (uint8_t)USBD_OK;
+}
+
+/*!
+    \brief      data in stage processing
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint identifier(0..7)
+    \param[out] none
+    \retval     USB device operation cur_status
+*/
+uint8_t usbd_in_transc (usb_core_driver *udev, uint8_t ep_num)
+{
+    if (0U == ep_num) {
+        usb_transc *transc = &udev->dev.transc_in[0];
+
+        switch (udev->dev.control.ctl_state) {
+        case USB_CTL_DATA_IN:
+            /* update transfer length */
+            transc->remain_len -= transc->max_len;
+
+            if ((uint8_t)USB_USE_DMA == udev->bp.transfer_mode) {
+                transc->xfer_buf += transc->max_len;
+            }
+
+            (void)usbd_ctl_send (udev);
+            break;
+
+        case USB_CTL_LAST_DATA_IN:
+            /* last packet is MPS multiple, so send ZLP packet */
+            if (udev->dev.control.ctl_zlp) {
+                (void)usbd_ep_send (udev, 0U, NULL, 0U);
+
+                udev->dev.control.ctl_zlp = 0U;
+            } else {
+                if (udev->dev.cur_status == (uint8_t)USBD_CONFIGURED) {
+                    if (udev->dev.class_core->ctlx_in != NULL) {
+                        (void)udev->dev.class_core->ctlx_in (udev);
+                    }
+                }
+
+                transc->remain_len = 0U;
+
+                (void)usbd_ctl_status_recev (udev);
+            }
+            break;
+
+        default:
+            break;
+        }
+    } else {
+        if ((udev->dev.cur_status == (uint8_t)USBD_CONFIGURED) && (udev->dev.class_core->data_in != NULL)) {
+            (void)udev->dev.class_core->data_in (udev, ep_num);
+        }
+    }
+
+    return (uint8_t)USBD_OK;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usb_core.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usb_core.h
@@ -1,0 +1,354 @@
+/*!
+    \file    drv_usb_core.h
+    \brief   USB core low level driver header file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __DRV_USB_CORE_H
+#define __DRV_USB_CORE_H
+
+#include "drv_usb_regs.h"
+#include "usb_ch9_std.h"
+
+#ifdef USE_DEVICE_MODE
+    #include "usbd_conf.h"
+#endif /* USE_DEVICE_MODE */
+
+#define USB_FS_EP0_MAX_LEN                  64U                                 /*!< maximum packet size of endpoint 0 */
+#define HC_MAX_PACKET_COUNT                 140U                                /*!< maximum packet count */
+
+#define EP_ID(x)                            ((uint8_t)((x) & 0x7FU))            /*!< endpoint number */
+#define EP_DIR(x)                           ((uint8_t)((x) >> 7))               /*!< endpoint direction */
+
+enum _usb_mode {
+    DEVICE_MODE = 0U,                                                           /*!< device mode */
+    HOST_MODE,                                                                  /*!< host mode */
+    OTG_MODE                                                                    /*!< OTG mode */
+};
+
+enum _usb_eptype {
+    USB_EPTYPE_CTRL = 0U,                                                       /*!< control endpoint type */
+    USB_EPTYPE_ISOC = 1U,                                                       /*!< isochronous endpoint type */
+    USB_EPTYPE_BULK = 2U,                                                       /*!< bulk endpoint type */
+    USB_EPTYPE_INTR = 3U,                                                       /*!< interrupt endpoint type */
+    USB_EPTYPE_MASK = 3U                                                        /*!< endpoint type mask */
+};
+
+typedef enum
+{
+    USB_OTG_OK = 0U,                                                            /*!< USB OTG status OK*/
+    USB_OTG_FAIL                                                                /*!< USB OTG status fail*/
+} usb_otg_status;
+
+typedef enum
+{
+    USB_OK = 0U,                                                                /*!< USB status OK*/
+    USB_FAIL                                                                    /*!< USB status fail*/
+} usb_status;
+
+typedef enum
+{
+    USB_USE_FIFO,                                                               /*!< USB use FIFO transfer mode */
+    USB_USE_DMA                                                                 /*!< USB use DMA transfer mode */
+} usb_transfer_mode;
+
+typedef struct
+{
+    uint8_t        core_enum;                                                   /*!< USB core type */
+    uint8_t        core_speed;                                                  /*!< USB core speed */
+    uint8_t        num_pipe;                                                    /*!< USB host channel numbers */
+    uint8_t        num_ep;                                                      /*!< USB device endpoint numbers */
+    uint8_t        transfer_mode;                                               /*!< USB transfer mode */
+    uint8_t        phy_itf;                                                     /*!< USB core PHY interface */
+    uint8_t        sof_enable;                                                  /*!< USB SOF output */
+    uint8_t        low_power;                                                   /*!< USB low power */
+    uint8_t        lpm_enable;                                                  /*!< USB link power mode(LPM) */
+    uint8_t        vbus_sensing_enable;                                         /*!< USB VBUS sensing feature */
+    uint8_t        use_dedicated_ep1;                                           /*!< USB dedicated endpoint1 interrupt */
+    uint8_t        use_external_vbus;                                           /*!< enable or disable the use of the external VBUS */
+    uint32_t       base_reg;                                                    /*!< base register address */
+} usb_core_basic;
+
+#ifdef USE_DEVICE_MODE
+
+/* USB descriptor */
+typedef struct _usb_desc {
+    uint8_t *dev_desc;                                                          /*!< device descriptor */
+    uint8_t *config_desc;                                                       /*!< configure descriptor */
+    uint8_t *bos_desc;                                                          /*!< BOS descriptor */
+
+#if defined(USE_USB_HS) && defined(USE_ULPI_PHY)
+    uint8_t *other_speed_config_desc;                                           /*!< other speed configuration descriptor */
+    uint8_t *qualifier_desc;                                                    /*!< qualifier descriptor */
+#endif
+
+    void* const *strings;                                                       /*!< string descriptor */
+} usb_desc;
+
+/* USB power management */
+typedef struct _usb_pm {
+    uint8_t  power_mode;                                                        /*!< power mode */
+    uint8_t  power_low;                                                         /*!< power low */
+    uint8_t  dev_remote_wakeup;                                                 /*!< remote wakeup */
+    uint8_t  remote_wakeup_on;                                                  /*!< remote wakeup on */
+} usb_pm;
+
+/* USB control information */
+typedef struct _usb_control {
+    usb_req    req;                                                             /*!< USB standard device request */
+
+    uint8_t    ctl_state;                                                       /*!< USB control transfer state */
+    uint8_t    ctl_zlp;                                                         /*!< zero length package */
+} usb_control;
+
+typedef struct
+{
+    struct {
+        uint8_t num: 4;                                                         /*!< the endpoint number.it can be from 0 to 6 */
+        uint8_t pad: 3;                                                         /*!< padding between number and direction */
+        uint8_t dir: 1;                                                         /*!< the endpoint direction */
+    } ep_addr;
+
+    uint8_t        ep_type;                                                     /*!< USB endpoint type */
+    uint8_t        ep_stall;                                                    /*!< USB endpoint stall status */
+
+    uint8_t        frame_num;                                                   /*!< number of frame */
+    uint16_t       max_len;                                                     /*!< Maximum packet length */
+
+    /* transaction level variables */
+    uint8_t       *xfer_buf;                                                    /*!< transmit buffer */
+    uint32_t       xfer_len;                                                    /*!< transmit buffer length */
+    uint32_t       xfer_count;                                                  /*!< transmit buffer count */
+
+    uint32_t       remain_len;                                                  /*!< remain packet length */
+
+    uint32_t       dma_addr;                                                    /*!< DMA address */
+} usb_transc;
+
+typedef struct _usb_core_driver usb_dev;
+
+typedef struct _usb_class_core
+{
+    uint8_t  command;                                                           /*!< device class request command */
+    uint8_t  alter_set;                                                         /*!< alternative set */
+
+    uint8_t  (*init)                  (usb_dev *udev, uint8_t config_index);    /*!< initialize handler */
+    uint8_t  (*deinit)                (usb_dev *udev, uint8_t config_index);    /*!< de-initialize handler */
+
+    uint8_t  (*req_proc)              (usb_dev *udev, usb_req *req);            /*!< device request handler */
+
+    uint8_t  (*set_intf)              (usb_dev *udev, usb_req *req);            /*!< device set interface callback */
+
+    uint8_t  (*ctlx_in)               (usb_dev *udev);                          /*!< device contrl in callback */
+    uint8_t  (*ctlx_out)              (usb_dev *udev); 
+
+    uint8_t  (*data_in)               (usb_dev *udev, uint8_t ep_num);          /*!< device data in handler */
+    uint8_t  (*data_out)              (usb_dev *udev, uint8_t ep_num);          /*!< device data out handler */
+
+    uint8_t  (*SOF)                   (usb_dev *udev);                          /*!< Start of frame handler */
+
+    uint8_t  (*incomplete_isoc_in)    (usb_dev *udev);                          /*!< Incomplete synchronization IN transfer handler */
+    uint8_t  (*incomplete_isoc_out)   (usb_dev *udev);                          /*!< Incomplete synchronization OUT transfer handler */
+} usb_class_core;
+
+typedef struct _usb_perp_dev
+{
+    uint8_t            config;                                                  /*!< configuration */
+    uint8_t            dev_addr;                                                /*!< device address */
+
+    __IO uint8_t       cur_status;                                              /*!< current status */
+    __IO uint8_t       backup_status;                                           /*!< backup status */
+
+    usb_transc         transc_in[USBFS_MAX_TX_FIFOS];                           /*!< endpoint IN transaction */
+    usb_transc         transc_out[USBFS_MAX_TX_FIFOS];                          /*!< endpoint OUT transaction */
+
+    usb_pm             pm;                                                      /*!< power management */
+    usb_control        control;                                                 /*!< USB control information */
+    usb_desc          *desc;                                                    /*!< USB descriptors pointer */
+    usb_class_core    *class_core;                                              /*!< class driver */
+    void              *class_data[USBD_ITF_MAX_NUM];                            /*!< class data pointer */
+    void              *user_data;                                               /*!< user data pointer */
+    void              *pdata;                                                   /*!< reserved data pointer */
+} usb_perp_dev;
+
+#endif /* USE_DEVICE_MODE */
+
+#ifdef USE_HOST_MODE
+
+typedef enum _usb_pipe_status
+{
+    PIPE_IDLE = 0U,
+    PIPE_XF,
+    PIPE_HALTED,
+    PIPE_NAK,
+    PIPE_NYET,
+    PIPE_STALL,
+    PIPE_TRACERR,
+    PIPE_BBERR,
+    PIPE_REQOVR,
+    PIPE_DTGERR,
+} usb_pipe_staus;
+
+typedef enum _usb_urb_state
+{
+    URB_IDLE = 0U,
+    URB_DONE,
+    URB_NOTREADY,
+    URB_ERROR,
+    URB_STALL,
+    URB_PING
+} usb_urb_state;
+
+typedef struct _usb_pipe
+{
+    uint8_t              in_used;
+    uint8_t              dev_addr;
+    uint32_t             dev_speed;
+
+    struct {
+        uint8_t          num;
+        uint8_t          dir;
+        uint8_t          type;
+        uint16_t         mps;
+    } ep;
+
+    __IO uint8_t         supp_ping;
+    __IO uint8_t         do_ping;
+    __IO uint32_t        DPID;
+
+    uint8_t             *xfer_buf;
+    uint32_t             xfer_len;
+    uint32_t             xfer_count;
+
+    uint8_t              data_toggle_in;
+    uint8_t              data_toggle_out;
+
+    __IO uint32_t        err_count;
+    __IO usb_pipe_staus  pp_status;
+    __IO usb_urb_state   urb_state;
+} usb_pipe;
+
+typedef struct _usb_host_drv
+{
+    __IO uint32_t            connect_status;
+    __IO uint32_t            port_enabled;
+    __IO uint32_t            backup_xfercount[USBFS_MAX_TX_FIFOS];
+
+    usb_pipe                 pipe[USBFS_MAX_TX_FIFOS];
+    void                    *data;
+} usb_host_drv;
+
+#endif /* USE_HOST_MODE */
+
+typedef struct _usb_core_driver
+{
+    usb_core_basic     bp;                                              /*!< USB basic parameters */
+    usb_core_regs      regs;                                            /*!< USB registers */
+
+#ifdef USE_DEVICE_MODE
+    usb_perp_dev       dev;                                             /*!< USB peripheral device */
+#endif /* USE_DEVICE_MODE */
+
+#ifdef USE_HOST_MODE
+    usb_host_drv         host;
+#endif /* USE_HOST_MODE */
+} usb_core_driver;
+
+/* static inline function definitions */
+
+/*!
+    \brief      get the global interrupts
+    \param[in]  usb_regs: pointer to USB core registers
+    \param[out] none
+    \retval     interrupt status
+*/
+__STATIC_INLINE uint32_t usb_coreintr_get(usb_core_regs *usb_regs)
+{
+    return usb_regs->gr->GINTEN & usb_regs->gr->GINTF;
+}
+
+/*!
+    \brief      set USB RX FIFO size
+    \param[in]  usb_regs: pointer to USB core registers
+    \param[in]  size: assigned FIFO size
+    \param[out] none
+    \retval     none
+*/
+__STATIC_INLINE void usb_set_rxfifo(usb_core_regs *usb_regs, uint16_t size)
+{
+    usb_regs->gr->GRFLEN = size;
+}
+
+/*!
+    \brief      enable the global interrupts
+    \param[in]  usb_regs: pointer to USB core registers
+    \param[out] none
+    \retval     none
+*/
+__STATIC_INLINE void usb_globalint_enable(usb_core_regs *usb_regs)
+{
+    /* enable USB global interrupt */
+    usb_regs->gr->GAHBCS |= GAHBCS_GINTEN;
+}
+
+/*!
+    \brief      disable the global interrupts
+    \param[in]  usb_regs: pointer to USB core registers
+    \param[out] none
+    \retval     none
+*/
+__STATIC_INLINE void usb_globalint_disable(usb_core_regs *usb_regs)
+{
+    /* disable USB global interrupt */
+    usb_regs->gr->GAHBCS &= ~GAHBCS_GINTEN;
+}
+
+/* function declarations */
+/* configure core capabilities */
+usb_status usb_basic_init (usb_core_basic *usb_basic, usb_core_regs *usb_regs, usb_core_enum usb_core);
+/* initializes the USB controller registers and prepares the core device mode or host mode operation */
+usb_status usb_core_init (usb_core_basic usb_basic, usb_core_regs *usb_regs);
+/* write a packet into the Tx FIFO associated with the endpoint */
+usb_status usb_txfifo_write (usb_core_regs *usb_regs, uint8_t *src_buf, uint8_t  fifo_num, uint16_t byte_count);
+/* read a packet from the Rx FIFO associated with the endpoint */
+void *usb_rxfifo_read (usb_core_regs *usb_regs, uint8_t *dest_buf, uint16_t byte_count);
+/* flush a Tx FIFO or all Tx FIFOs */
+usb_status usb_txfifo_flush (usb_core_regs *usb_regs, uint8_t fifo_num);
+/* flush the entire Rx FIFO */
+usb_status usb_rxfifo_flush (usb_core_regs *usb_regs);
+/* set endpoint or channel TX FIFO size */
+void usb_set_txfifo(usb_core_regs *usb_regs, uint8_t fifo, uint16_t size);
+/* set USB current mode */
+void usb_curmode_set(usb_core_regs *usb_regs, uint8_t mode);
+
+#endif /* __DRV_USB_CORE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usb_dev.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usb_dev.h
@@ -1,0 +1,199 @@
+/*!
+    \file    drv_usb_dev.h
+    \brief   USB device low level driver header file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __DRV_USB_DEV_H
+#define __DRV_USB_DEV_H
+
+#include "usbd_conf.h"
+#include "drv_usb_core.h"
+
+#define EP_IN(x)                            ((uint8_t)(0x80U | (x)))    /*!< device IN endpoint */
+#define EP_OUT(x)                           ((uint8_t)(x))              /*!< device OUT endpoint */
+
+enum usb_ctl_status {
+    USB_CTL_IDLE = 0U,                                                  /*!< USB control transfer idle state */
+    USB_CTL_DATA_IN,                                                    /*!< USB control transfer data in state */
+    USB_CTL_LAST_DATA_IN,                                               /*!< USB control transfer last data in state */
+    USB_CTL_DATA_OUT,                                                   /*!< USB control transfer data out state */
+    USB_CTL_LAST_DATA_OUT,                                              /*!< USB control transfer last data out state */
+    USB_CTL_STATUS_IN,                                                  /*!< USB control transfer status in state*/
+    USB_CTL_STATUS_OUT                                                  /*!< USB control transfer status out state */
+};
+
+/* static inline function definitions */
+
+/*!
+    \brief      configure the USB device to be disconnected
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     operation status
+*/
+__STATIC_INLINE void usb_dev_disconnect (usb_core_driver *udev)
+{
+    udev->regs.dr->DCTL |= DCTL_SD;
+}
+
+/*!
+    \brief      configure the USB device to be connected
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     operation status
+*/
+__STATIC_INLINE void usb_dev_connect (usb_core_driver *udev)
+{
+    udev->regs.dr->DCTL &= ~DCTL_SD;
+}
+
+/*!
+    \brief      set the USB device address
+    \param[in]  udev: pointer to USB device
+    \param[in]  dev_addr: device address for setting
+    \param[out] none
+    \retval     operation status
+*/
+__STATIC_INLINE void usb_devaddr_set (usb_core_driver *udev, uint8_t dev_addr)
+{
+    udev->regs.dr->DCFG &= ~DCFG_DAR;
+    udev->regs.dr->DCFG |= (uint32_t)dev_addr << 4U;
+}
+
+/*!
+    \brief      read device all OUT endpoint interrupt register
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     interrupt status
+*/
+__STATIC_INLINE uint32_t usb_oepintnum_read (usb_core_driver *udev)
+{
+    uint32_t value = udev->regs.dr->DAEPINT;
+
+    value &= udev->regs.dr->DAEPINTEN;
+
+    return (value & DAEPINT_OEPITB) >> 16U;
+}
+
+/*!
+    \brief      read device OUT endpoint interrupt flag register
+    \param[in]  udev: pointer to USB device
+    \param[in]  ep_num: endpoint number
+    \param[out] none
+    \retval     interrupt status
+*/
+__STATIC_INLINE uint32_t usb_oepintr_read (usb_core_driver *udev, uint8_t ep_num)
+{
+    uint32_t value = udev->regs.er_out[ep_num]->DOEPINTF;
+
+    value &= udev->regs.dr->DOEPINTEN;
+
+    return value;
+}
+
+/*!
+    \brief      read device all IN endpoint interrupt register
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     interrupt status
+*/
+__STATIC_INLINE uint32_t usb_iepintnum_read (usb_core_driver *udev)
+{
+    uint32_t value = udev->regs.dr->DAEPINT;
+
+    value &= udev->regs.dr->DAEPINTEN;
+    
+    return value & DAEPINT_IEPITB;
+}
+
+/*!
+    \brief      set remote wakeup signaling
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     none
+*/
+__STATIC_INLINE void usb_rwkup_set (usb_core_driver *udev)
+{
+    if (udev->dev.pm.dev_remote_wakeup) {
+        /* enable remote wakeup signaling */
+        udev->regs.dr->DCTL |= DCTL_RWKUP;
+    }
+}
+
+/*!
+    \brief      reset remote wakeup signaling
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     none
+*/
+__STATIC_INLINE void usb_rwkup_reset (usb_core_driver *udev)
+{
+    if (udev->dev.pm.dev_remote_wakeup) {
+        /* disable remote wakeup signaling */
+        udev->regs.dr->DCTL &= ~DCTL_RWKUP;
+    }
+}
+
+/* function declarations */
+/* initialize USB core registers for device mode */
+usb_status usb_devcore_init (usb_core_driver *udev);
+/* enable the USB device mode interrupts */
+usb_status usb_devint_enable (usb_core_driver *udev);
+/* active the USB endpoint 0 transaction */
+usb_status usb_transc0_active (usb_core_driver *udev, usb_transc *transc);
+/* active the USB transaction */
+usb_status usb_transc_active (usb_core_driver *udev, usb_transc *transc);
+/* deactivate the USB transaction */
+usb_status usb_transc_deactivate (usb_core_driver *udev, usb_transc *transc);
+/* configure USB transaction to start IN transfer */
+usb_status usb_transc_inxfer (usb_core_driver *udev, usb_transc *transc);
+/* configure USB transaction to start OUT transfer */
+usb_status usb_transc_outxfer (usb_core_driver *udev, usb_transc *transc);
+/* set the USB transaction STALL status */
+usb_status usb_transc_stall (usb_core_driver *udev, usb_transc *transc);
+/* clear the USB transaction STALL status */
+usb_status usb_transc_clrstall (usb_core_driver *udev, usb_transc *transc);
+/* read device IN endpoint interrupt flag register */
+uint32_t usb_iepintr_read (usb_core_driver *udev, uint8_t ep_num);
+/* configures OUT endpoint 0 to receive SETUP packets */
+void usb_ctlep_startout (usb_core_driver *udev);
+/* active remote wakeup signaling */
+void usb_rwkup_active (usb_core_driver *udev);
+/* active USB core clock */
+void usb_clock_active (usb_core_driver *udev);
+/* USB device suspend */
+void usb_dev_suspend (usb_core_driver *udev);
+/* stop the device and clean up FIFOs */
+void usb_dev_stop (usb_core_driver *udev);
+
+#endif /* __DRV_USB_DEV_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usb_host.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usb_host.h
@@ -1,0 +1,125 @@
+/*!
+    \file    drv_usb_host.h
+    \brief   USB host mode low level driver header file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __DRV_USB_HOST_H
+#define __DRV_USB_HOST_H
+
+#include "drv_usb_regs.h"
+#include "usb_ch9_std.h"
+#include "drv_usb_core.h"
+
+typedef enum _usb_pipe_mode
+{
+    PIPE_PERIOD     = 0U,
+    PIPE_NON_PERIOD = 1U
+} usb_pipe_mode;
+
+/*!
+    \brief      get USB even frame
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     none
+*/
+__STATIC_INLINE uint8_t usb_frame_even (usb_core_driver *udev)
+{
+    return (uint8_t)!(udev->regs.hr->HFINFR & 0x01U);
+}
+
+/*!
+    \brief      configure USB clock of PHY
+    \param[in]  udev: pointer to USB device
+    \param[in]  clock: PHY clock
+    \param[out] none
+    \retval     none
+*/
+__STATIC_INLINE void usb_phyclock_config (usb_core_driver *udev, uint8_t clock)
+{
+    udev->regs.hr->HCTL &= ~HCTL_CLKSEL;
+    udev->regs.hr->HCTL |= clock;
+}
+
+/*!
+    \brief      read USB port
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     port status
+*/
+__STATIC_INLINE uint32_t usb_port_read (usb_core_driver *udev)
+{
+    return *udev->regs.HPCS & ~(HPCS_PE | HPCS_PCD | HPCS_PEDC);
+}
+
+/*!
+    \brief      get USB current speed
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     USB current speed
+*/
+__STATIC_INLINE uint32_t usb_curspeed_get (usb_core_driver *udev)
+{
+    return *udev->regs.HPCS & HPCS_PS;
+}
+
+/*!
+    \brief      get USB current frame
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     USB current frame
+*/
+__STATIC_INLINE uint32_t usb_curframe_get (usb_core_driver *udev)
+{
+    return (udev->regs.hr->HFINFR & 0xFFFFU);
+}
+
+/* function declarations */
+/* initializes USB core for host mode */
+usb_status usb_host_init (usb_core_driver *udev);
+/* control the VBUS to power */
+void usb_portvbus_switch (usb_core_driver *udev, uint8_t state);
+/* reset host port */
+uint32_t usb_port_reset (usb_core_driver *udev);
+/* initialize host pipe */
+usb_status usb_pipe_init (usb_core_driver *udev, uint8_t pipe_num);
+/* prepare host pipe for transferring packets */
+usb_status usb_pipe_xfer (usb_core_driver *udev, uint8_t pipe_num);
+/* halt host pipe */
+usb_status usb_pipe_halt (usb_core_driver *udev, uint8_t pipe_num);
+/* configure host pipe to do ping operation */
+usb_status usb_pipe_ping (usb_core_driver *udev, uint8_t pipe_num);
+/* stop the USB host and clean up FIFO */
+void usb_host_stop (usb_core_driver *udev);
+
+#endif /* __DRV_USB_HOST_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usb_hw.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usb_hw.h
@@ -1,0 +1,64 @@
+/*!
+    \file    drv_usb_hw.h
+    \brief   usb hardware configuration header file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __DRV_USB_HW_H
+#define __DRV_USB_HW_H
+
+#include "usb_conf.h"
+
+/* function declarations */
+/* configure USB clock */
+void usb_rcu_config (void);
+/* configure USB data line gpio */
+void usb_gpio_config (void);
+/* configure USB interrupt */
+void usb_intr_config (void);
+/* initializes delay unit using Timer2 */
+void usb_timer_init (void);
+/* delay in micro seconds */
+void usb_udelay (const uint32_t usec);
+/* delay in milliseconds */
+void usb_mdelay (const uint32_t msec);
+/* configures system clock after wakeup from STOP mode */
+void system_clk_config_stop(void);
+#ifdef USE_HOST_MODE
+/* configure USB VBus */
+void usb_vbus_config (void);
+/* drive USB VBus */
+void usb_vbus_drive (uint8_t State);
+#endif /* USE_HOST_MODE */
+
+#endif /* __DRV_USB_HW_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usb_regs.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usb_regs.h
@@ -1,0 +1,664 @@
+/*!
+    \file    drv_usb_regs.h
+    \brief   USB cell registers definition and handle macros
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __DRV_USB_REGS_H
+#define __DRV_USB_REGS_H
+
+#include "usb_conf.h"
+
+#define USBHS_REG_BASE                0x40040000L   /*!< base address of USBHS registers */
+#define USBFS_REG_BASE                0x50000000L   /*!< base address of USBFS registers */
+
+#define USBFS_MAX_TX_FIFOS            15U           /*!< FIFO number */
+
+#define USBFS_MAX_PACKET_SIZE         64U           /*!< USBFS max packet size */
+#define USBFS_MAX_CHANNEL_COUNT       8U            /*!< USBFS host channel count */
+#define USBFS_MAX_EP_COUNT            4U            /*!< USBFS device endpoint count */
+#define USBFS_MAX_FIFO_WORDLEN        320U          /*!< USBFS max fifo size in words */
+
+#define USBHS_MAX_PACKET_SIZE         512U          /*!< USBHS max packet size */
+#define USBHS_MAX_CHANNEL_COUNT       12U           /*!< USBHS host channel count */
+#define USBHS_MAX_EP_COUNT            6U            /*!< USBHS device endpoint count */
+#define USBHS_MAX_FIFO_WORDLEN        1280U         /*!< USBHS max fifo size in words */
+
+#define USB_DATA_FIFO_OFFSET          0x1000U       /*!< USB data fifo offset */
+#define USB_DATA_FIFO_SIZE            0x1000U       /*!< USB data fifo size */
+
+typedef enum
+{
+    USB_CORE_ENUM_HS = 0,                           /*!< USB core type is HS */
+    USB_CORE_ENUM_FS = 1                            /*!< USB core type is FS */
+} usb_core_enum;
+
+enum USB_SPEED {
+    USB_SPEED_UNKNOWN = 0,                          /*!< USB speed unknown */
+    USB_SPEED_LOW,                                  /*!< USB speed low */
+    USB_SPEED_FULL,                                 /*!< USB speed full */
+    USB_SPEED_HIGH,                                 /*!< USB speed high */
+};
+
+enum usb_reg_offset {
+    USB_REG_OFFSET_CORE      = 0x0000U,             /*!< global OTG control and status register */
+    USB_REG_OFFSET_DEV       = 0x0800U,             /*!< device mode control and status registers */
+    USB_REG_OFFSET_EP        = 0x0020U,
+    USB_REG_OFFSET_EP_IN     = 0x0900U,             /*!< device IN endpoint 0 control register */
+    USB_REG_OFFSET_EP_OUT    = 0x0B00U,             /*!< device OUT endpoint 0 control register */
+    USB_REG_OFFSET_HOST      = 0x0400U,             /*!< host control register */
+    USB_REG_OFFSET_CH        = 0x0020U,
+    USB_REG_OFFSET_PORT      = 0x0440U,             /*!< host port control and status register */
+    USB_REG_OFFSET_CH_INOUT  = 0x0500U,             /*!< Host channel-x control registers */
+    USB_REG_OFFSET_PWRCLKCTL = 0x0E00U,             /*!< power and clock register */
+};
+
+typedef struct
+{
+    __IO uint32_t GOTGCS;                           /*!< USB global OTG control and status register       000h */
+    __IO uint32_t GOTGINTF;                         /*!< USB global OTG interrupt flag register           004h */
+    __IO uint32_t GAHBCS;                           /*!< USB global AHB control and status register       008h */
+    __IO uint32_t GUSBCS;                           /*!< USB global USB control and status register       00Ch */
+    __IO uint32_t GRSTCTL;                          /*!< USB global reset control register                010h */
+    __IO uint32_t GINTF;                            /*!< USB global interrupt flag register               014h */
+    __IO uint32_t GINTEN;                           /*!< USB global interrupt enable register             018h */
+    __IO uint32_t GRSTATR;                          /*!< USB receive status debug read register           01Ch */
+    __IO uint32_t GRSTATP;                          /*!< USB receive status and pop register              020h */
+    __IO uint32_t GRFLEN;                           /*!< USB global receive FIFO length register          024h */
+    __IO uint32_t DIEP0TFLEN_HNPTFLEN;              /*!< USB device IN endpoint 0/host non-periodic transmit FIFO length register 028h */
+    __IO uint32_t HNPTFQSTAT;                       /*!< USB host non-periodic FIFO/queue status register 02Ch */
+    uint32_t Reserved30[2];                         /*!< Reserved                                         030h */
+    __IO uint32_t GCCFG;                            /*!< USB global core configuration register           038h */
+    __IO uint32_t CID;                              /*!< USB core ID register                             03Ch */
+    uint32_t Reserved40[48];                        /*!< Reserved                                         040h-0FFh */
+    __IO uint32_t HPTFLEN;                          /*!< USB host periodic transmit FIFO length register  100h */
+    __IO uint32_t DIEPTFLEN[15];                    /*!< USB device IN endpoint transmit FIFO length register 104h */
+} usb_gr;
+
+
+typedef struct
+{
+    __IO uint32_t HCTL;                             /*!< USB host control register                             400h */
+    __IO uint32_t HFT;                              /*!< USB host frame interval register                      404h */
+    __IO uint32_t HFINFR;                           /*!< USB host frame information remaining register         408h */
+    uint32_t Reserved40C;                           /*!< Reserved                                              40Ch */
+    __IO uint32_t HPTFQSTAT;                        /*!< USB host periodic transmit FIFO/queue status register 410h */
+    __IO uint32_t HACHINT;                          /*!< USB host all channels interrupt register              414h */
+    __IO uint32_t HACHINTEN;                        /*!< USB host all channels interrupt enable register       418h */
+} usb_hr;
+
+typedef struct
+{
+    __IO uint32_t HCHCTL;                           /*!< USB host channel control register          500h */
+    __IO uint32_t HCHSTCTL;                         /*!< Reserved                                   504h */
+    __IO uint32_t HCHINTF;                          /*!< USB host channel interrupt flag register   508h */
+    __IO uint32_t HCHINTEN;                         /*!< USB host channel interrupt enable register 50Ch */
+    __IO uint32_t HCHLEN;                           /*!< USB host channel transfer length register  510h */
+    __IO uint32_t HCHDMAADDR;                       /*!< USB host channel-x DMA address register    514h*/
+    uint32_t Reserved[2];
+} usb_pr;
+
+typedef struct
+{
+    __IO uint32_t DCFG;                             /*!< USB device configuration register                           800h */
+    __IO uint32_t DCTL;                             /*!< USB device control register                                 804h */
+    __IO uint32_t DSTAT;                            /*!< USB device status register                                  808h */
+    uint32_t Reserved0C;                            /*!< Reserved                                                    80Ch */
+    __IO uint32_t DIEPINTEN;                        /*!< USB device IN endpoint common interrupt enable register     810h */
+    __IO uint32_t DOEPINTEN;                        /*!< USB device OUT endpoint common interrupt enable register    814h */
+    __IO uint32_t DAEPINT;                          /*!< USB device all endpoints interrupt register                 818h */
+    __IO uint32_t DAEPINTEN;                        /*!< USB device all endpoints interrupt enable register          81Ch */
+    uint32_t Reserved20;                            /*!< Reserved                                                    820h */
+    uint32_t Reserved24;                            /*!< Reserved                                                    824h */
+    __IO uint32_t DVBUSDT;                          /*!< USB device VBUS discharge time register                     828h */
+    __IO uint32_t DVBUSPT;                          /*!< USB device VBUS pulsing time register                       82Ch */
+    __IO uint32_t DTHRCTL;                          /*!< device threshold control                                    830h */
+    __IO uint32_t DIEPFEINTEN;                      /*!< USB Device IN endpoint FIFO empty interrupt enable register 834h */
+    __IO uint32_t DEP1INT;                          /*!< USB device endpoint 1 interrupt register                    838h */
+    __IO uint32_t DEP1INTEN;                        /*!< USB device endpoint 1 interrupt enable register             83Ch */
+    uint32_t Reserved40;                            /*!< Reserved                                                    840h */
+    __IO uint32_t DIEP1INTEN;                       /*!< USB device IN endpoint-1 interrupt enable register          844h */
+    uint32_t Reserved48[15];                        /*!< Reserved                                                848-880h */
+    __IO uint32_t DOEP1INTEN;                       /*!< USB device OUT endpoint-1 interrupt enable register         884h */
+} usb_dr;
+
+typedef struct
+{
+    __IO uint32_t DIEPCTL;                          /*!< USB device IN endpoint control register         900h + (EpNum * 20h) + 00h */
+    uint32_t Reserved04;                            /*!< Reserved                                        900h + (EpNum * 20h) + 04h */
+    __IO uint32_t DIEPINTF;                         /*!< USB device IN endpoint interrupt flag register  900h + (EpNum * 20h) + 08h */
+    uint32_t Reserved0C;                            /*!< Reserved                                        900h + (EpNum * 20h) + 0Ch */
+    __IO uint32_t DIEPLEN;                          /*!< USB device IN endpoint transfer length register 900h + (EpNum * 20h) + 10h */
+    __IO uint32_t DIEPDMAADDR;                      /*!< Device IN endpoint-x DMA address register       900h + (EpNum * 20h) + 14h */
+    __IO uint32_t DIEPTFSTAT;                       /*!< USB device IN endpoint transmit FIFO status register 900h + (EpNum * 20h) + 18h */
+} usb_erin;
+
+typedef struct
+{
+    __IO uint32_t DOEPCTL;                          /*!< USB device IN endpoint control register         B00h + (EpNum * 20h) + 00h */
+    uint32_t Reserved04;                            /*!< Reserved                                        B00h + (EpNum * 20h) + 04h */
+    __IO uint32_t DOEPINTF;                         /*!< USB device IN endpoint interrupt flag register  B00h + (EpNum * 20h) + 08h */
+    uint32_t Reserved0C;                            /*!< Reserved                                        B00h + (EpNum * 20h) + 0Ch */
+    __IO uint32_t DOEPLEN;                          /*!< USB device IN endpoint transfer length register B00h + (EpNum * 20h) + 10h */
+    __IO uint32_t DOEPDMAADDR;                      /*!< Device OUT endpoint-x DMA address register      B00h + (EpNum * 20h) + 0Ch */
+} usb_erout;
+
+typedef struct _usb_regs
+{
+    usb_gr       *gr;                               /*!< USBFS global registers */
+    usb_dr       *dr;                               /*!< Device control and status registers */
+    usb_hr       *hr;                               /*!< Host control and status registers */
+    usb_erin     *er_in[6];                         /*!< USB device IN endpoint register */
+    usb_erout    *er_out[6];                        /*!< USB device OUT endpoint register */
+    usb_pr       *pr[15];                           /*!< USB Host channel-x control register */
+
+    __IO uint32_t     *HPCS;                        /*!< USB host port control and status register */
+    __IO uint32_t     *DFIFO[USBFS_MAX_TX_FIFOS];
+    __IO uint32_t     *PWRCLKCTL;                   /*!< USB power and clock control register */
+} usb_core_regs;
+
+/* global OTG control and status register bits definitions */
+#define GOTGCS_BSV                BIT(19)             /*!< B-Session Valid */
+#define GOTGCS_ASV                BIT(18)             /*!< A-session valid */
+#define GOTGCS_DI                 BIT(17)             /*!< debounce interval */
+#define GOTGCS_CIDPS              BIT(16)             /*!< id pin status */
+#define GOTGCS_DHNPEN             BIT(11)             /*!< device HNP enable */
+#define GOTGCS_HHNPEN             BIT(10)             /*!< host HNP enable */
+#define GOTGCS_HNPREQ             BIT(9)              /*!< HNP request */
+#define GOTGCS_HNPS               BIT(8)              /*!< HNP successes */
+#define GOTGCS_SRPREQ             BIT(1)              /*!< SRP request */
+#define GOTGCS_SRPS               BIT(0)              /*!< SRP successes */
+
+/* global OTG interrupt flag register bits definitions */
+#define GOTGINTF_DF               BIT(19)             /*!< debounce finish */
+#define GOTGINTF_ADTO             BIT(18)             /*!< A-device timeout */
+#define GOTGINTF_HNPDET           BIT(17)             /*!< host negotiation request detected */
+#define GOTGINTF_HNPEND           BIT(9)              /*!< HNP end */
+#define GOTGINTF_SRPEND           BIT(8)              /*!< SRP end */
+#define GOTGINTF_SESEND           BIT(2)              /*!< session end */
+
+/* global AHB control and status register bits definitions */
+#define GAHBCS_PTXFTH             BIT(8)              /*!< periodic Tx FIFO threshold */
+#define GAHBCS_TXFTH              BIT(7)              /*!< tx FIFO threshold */
+#define GAHBCS_DMAEN              BIT(5)              /*!< DMA function Enable */
+#define GAHBCS_BURST              BITS(1, 4)          /*!< the AHB burst type used by DMA */
+#define GAHBCS_GINTEN             BIT(0)              /*!< global interrupt enable */
+
+/* global USB control and status register bits definitions */
+#define GUSBCS_FDM                BIT(30)             /*!< force device mode */
+#define GUSBCS_FHM                BIT(29)             /*!< force host mode */
+#define GUSBCS_ULPIEOI            BIT(21)             /*!< ULPI external over-current indicator */
+#define GUSBCS_ULPIEVD            BIT(20)             /*!< ULPI external VBUS driver */
+#define GUSBCS_UTT                BITS(10, 13)        /*!< USB turnaround time */
+#define GUSBCS_HNPCEN             BIT(9)              /*!< HNP capability enable */
+#define GUSBCS_SRPCEN             BIT(8)              /*!< SRP capability enable */
+#define GUSBCS_EMBPHY             BIT(6)              /*!< embedded PHY selected */
+#define GUSBCS_TOC                BITS(0, 2)          /*!< timeout calibration */
+
+/* global reset control register bits definitions */
+#define GRSTCTL_DMAIDL            BIT(31)             /*!< DMA idle state */
+#define GRSTCTL_DMABSY            BIT(30)             /*!< DMA busy */
+#define GRSTCTL_TXFNUM            BITS(6, 10)         /*!< tx FIFO number */
+#define GRSTCTL_TXFF              BIT(5)              /*!< tx FIFO flush */
+#define GRSTCTL_RXFF              BIT(4)              /*!< rx FIFO flush */
+#define GRSTCTL_HFCRST            BIT(2)              /*!< host frame counter reset */
+#define GRSTCTL_HCSRST            BIT(1)              /*!< HCLK soft reset */
+#define GRSTCTL_CSRST             BIT(0)              /*!< core soft reset */
+
+/* global interrupt flag register bits definitions */
+#define GINTF_WKUPIF              BIT(31)             /*!< wakeup interrupt flag */
+#define GINTF_SESIF               BIT(30)             /*!< session interrupt flag */
+#define GINTF_DISCIF              BIT(29)             /*!< disconnect interrupt flag */
+#define GINTF_IDPSC               BIT(28)             /*!< id pin status change */
+#define GINTF_PTXFEIF             BIT(26)             /*!< periodic tx FIFO empty interrupt flag */
+#define GINTF_HCIF                BIT(25)             /*!< host channels interrupt flag */
+#define GINTF_HPIF                BIT(24)             /*!< host port interrupt flag */
+#define GINTF_PXNCIF              BIT(21)             /*!< periodic transfer not complete interrupt flag */
+#define GINTF_ISOONCIF            BIT(21)             /*!< isochronous OUT transfer not complete interrupt flag */
+#define GINTF_ISOINCIF            BIT(20)             /*!< isochronous IN transfer not complete interrupt flag */
+#define GINTF_OEPIF               BIT(19)             /*!< OUT endpoint interrupt flag */
+#define GINTF_IEPIF               BIT(18)             /*!< IN endpoint interrupt flag */
+#define GINTF_EOPFIF              BIT(15)             /*!< end of periodic frame interrupt flag */
+#define GINTF_ISOOPDIF            BIT(14)             /*!< isochronous OUT packet dropped interrupt flag */
+#define GINTF_ENUMFIF             BIT(13)             /*!< enumeration finished */
+#define GINTF_RST                 BIT(12)             /*!< USB reset */
+#define GINTF_SP                  BIT(11)             /*!< USB suspend */
+#define GINTF_ESP                 BIT(10)             /*!< early suspend */
+#define GINTF_GONAK               BIT(7)              /*!< global OUT NAK effective */
+#define GINTF_GNPINAK             BIT(6)              /*!< global IN non-periodic NAK effective */
+#define GINTF_NPTXFEIF            BIT(5)              /*!< non-periodic tx FIFO empty interrupt flag */
+#define GINTF_RXFNEIF             BIT(4)              /*!< rx FIFO non-empty interrupt flag */
+#define GINTF_SOF                 BIT(3)              /*!< start of frame */
+#define GINTF_OTGIF               BIT(2)              /*!< OTG interrupt flag */
+#define GINTF_MFIF                BIT(1)              /*!< mode fault interrupt flag */
+#define GINTF_COPM                BIT(0)              /*!< current operation mode */
+
+/* global interrupt enable register bits definitions */
+#define GINTEN_WKUPIE             BIT(31)             /*!< wakeup interrupt enable */
+#define GINTEN_SESIE              BIT(30)             /*!< session interrupt enable */
+#define GINTEN_DISCIE             BIT(29)             /*!< disconnect interrupt enable */
+#define GINTEN_IDPSCIE            BIT(28)             /*!< id pin status change interrupt enable */
+#define GINTEN_PTXFEIE            BIT(26)             /*!< periodic tx FIFO empty interrupt enable */
+#define GINTEN_HCIE               BIT(25)             /*!< host channels interrupt enable */
+#define GINTEN_HPIE               BIT(24)             /*!< host port interrupt enable */
+#define GINTEN_IPXIE              BIT(21)             /*!< periodic transfer not complete interrupt enable */
+#define GINTEN_ISOONCIE           BIT(21)             /*!< isochronous OUT transfer not complete interrupt enable */
+#define GINTEN_ISOINCIE           BIT(20)             /*!< isochronous IN transfer not complete interrupt enable */
+#define GINTEN_OEPIE              BIT(19)             /*!< OUT endpoints interrupt enable */
+#define GINTEN_IEPIE              BIT(18)             /*!< IN endpoints interrupt enable */
+#define GINTEN_EOPFIE             BIT(15)             /*!< end of periodic frame interrupt enable */
+#define GINTEN_ISOOPDIE           BIT(14)             /*!< isochronous OUT packet dropped interrupt enable */
+#define GINTEN_ENUMFIE            BIT(13)             /*!< enumeration finish enable */
+#define GINTEN_RSTIE              BIT(12)             /*!< USB reset interrupt enable */
+#define GINTEN_SPIE               BIT(11)             /*!< USB suspend interrupt enable */
+#define GINTEN_ESPIE              BIT(10)             /*!< early suspend interrupt enable */
+#define GINTEN_GONAKIE            BIT(7)              /*!< global OUT NAK effective interrupt enable */
+#define GINTEN_GNPINAKIE          BIT(6)              /*!< global non-periodic IN NAK effective interrupt enable */
+#define GINTEN_NPTXFEIE           BIT(5)              /*!< non-periodic Tx FIFO empty interrupt enable */
+#define GINTEN_RXFNEIE            BIT(4)              /*!< receive FIFO non-empty interrupt enable */
+#define GINTEN_SOFIE              BIT(3)              /*!< start of frame interrupt enable */
+#define GINTEN_OTGIE              BIT(2)              /*!< OTG interrupt enable */
+#define GINTEN_MFIE               BIT(1)              /*!< mode fault interrupt enable */
+
+/* global receive status read and pop register bits definitions */
+#define GRSTATRP_RPCKST           BITS(17, 20)        /*!< received packet status */
+#define GRSTATRP_DPID             BITS(15, 16)        /*!< data PID */
+#define GRSTATRP_BCOUNT           BITS(4, 14)         /*!< byte count */
+#define GRSTATRP_CNUM             BITS(0, 3)          /*!< channel number */
+#define GRSTATRP_EPNUM            BITS(0, 3)          /*!< endpoint number */
+
+/* global receive FIFO length register bits definitions */
+#define GRFLEN_RXFD               BITS(0, 15)         /*!< rx FIFO depth */
+
+/* host non-periodic transmit FIFO length register bits definitions */
+#define HNPTFLEN_HNPTXFD          BITS(16, 31)        /*!< non-periodic Tx FIFO depth */
+#define HNPTFLEN_HNPTXRSAR        BITS(0, 15)         /*!< non-periodic Tx RAM start address */
+
+/* USB IN endpoint 0 transmit FIFO length register bits definitions */
+#define DIEP0TFLEN_IEP0TXFD       BITS(16, 31)        /*!< IN Endpoint 0 Tx FIFO depth */
+#define DIEP0TFLEN_IEP0TXRSAR     BITS(0, 15)         /*!< IN Endpoint 0 TX RAM start address */
+
+/* host non-periodic transmit FIFO/queue status register bits definitions */
+#define HNPTFQSTAT_NPTXRQTOP      BITS(24, 30)        /*!< top entry of the non-periodic Tx request queue */
+#define HNPTFQSTAT_NPTXRQS        BITS(16, 23)        /*!< non-periodic Tx request queue space */
+#define HNPTFQSTAT_NPTXFS         BITS(0, 15)         /*!< non-periodic Tx FIFO space */
+#define HNPTFQSTAT_CNUM           BITS(27, 30)        /*!< channel number*/
+#define HNPTFQSTAT_EPNUM          BITS(27, 30)        /*!< endpoint number */
+#define HNPTFQSTAT_TYPE           BITS(25, 26)        /*!< token type */
+#define HNPTFQSTAT_TMF            BIT(24)             /*!< terminate flag */
+
+/* global core configuration register bits definitions */
+#define GCCFG_VBUSIG              BIT(21)             /*!< vbus ignored */
+#define GCCFG_SOFOEN              BIT(20)             /*!< SOF output enable */
+#define GCCFG_VBUSBCEN            BIT(19)             /*!< the VBUS B-device comparer enable */
+#define GCCFG_VBUSACEN            BIT(18)             /*!< the VBUS A-device comparer enable */
+#define GCCFG_PWRON               BIT(16)             /*!< power on */
+
+/* core ID register bits definitions */
+#define CID_CID                   BITS(0, 31)         /*!< core ID */
+
+/* host periodic transmit FIFO length register bits definitions */
+#define HPTFLEN_HPTXFD            BITS(16, 31)        /*!< host periodic Tx FIFO depth */
+#define HPTFLEN_HPTXFSAR          BITS(0, 15)         /*!< host periodic Tx RAM start address */
+
+/* device IN endpoint transmit FIFO length register bits definitions */
+#define DIEPTFLEN_IEPTXFD         BITS(16, 31)        /*!< IN endpoint Tx FIFO x depth */
+#define DIEPTFLEN_IEPTXRSAR       BITS(0, 15)         /*!< IN endpoint FIFOx Tx x RAM start address */
+
+/* host control register bits definitions */
+#define HCTL_SPDFSLS              BIT(2)              /*!< speed limited to FS and LS */
+#define HCTL_CLKSEL               BITS(0, 1)          /*!< clock select for USB clock */
+
+/* host frame interval register bits definitions */
+#define HFT_FRI                   BITS(0, 15)         /*!< frame interval */
+
+/* host frame information remaining register bits definitions */
+#define HFINFR_FRT                BITS(16, 31)        /*!< frame remaining time */
+#define HFINFR_FRNUM              BITS(0, 15)         /*!< frame number */
+
+/* host periodic transmit FIFO/queue status register bits definitions */
+#define HPTFQSTAT_PTXREQT         BITS(24, 31)        /*!< top entry of the periodic Tx request queue */
+#define HPTFQSTAT_PTXREQS         BITS(16, 23)        /*!< periodic Tx request queue space */
+#define HPTFQSTAT_PTXFS           BITS(0, 15)         /*!< periodic Tx FIFO space */
+#define HPTFQSTAT_OEFRM           BIT(31)             /*!< odd/eveb frame */
+#define HPTFQSTAT_CNUM            BITS(27, 30)        /*!< channel number */
+#define HPTFQSTAT_EPNUM           BITS(27, 30)        /*!< endpoint number */
+#define HPTFQSTAT_TYPE            BITS(25, 26)        /*!< token type */
+#define HPTFQSTAT_TMF             BIT(24)             /*!< terminate flag */
+
+#define TFQSTAT_TXFS              BITS(0, 15)
+#define TFQSTAT_CNUM              BITS(27, 30)
+
+/* host all channels interrupt register bits definitions */
+#define HACHINT_HACHINT           BITS(0, 11)         /*!< host all channel interrupts */
+
+/* host all channels interrupt enable register bits definitions */
+#define HACHINTEN_CINTEN          BITS(0, 11)         /*!< channel interrupt enable */
+
+/* host port control and status register bits definitions */
+#define HPCS_PS                   BITS(17, 18)        /*!< port speed */
+#define HPCS_PP                   BIT(12)             /*!< port power */
+#define HPCS_PLST                 BITS(10, 11)        /*!< port line status */
+#define HPCS_PRST                 BIT(8)              /*!< port reset */
+#define HPCS_PSP                  BIT(7)              /*!< port suspend */
+#define HPCS_PREM                 BIT(6)              /*!< port resume */
+#define HPCS_PEDC                 BIT(3)              /*!< port enable/disable change */
+#define HPCS_PE                   BIT(2)              /*!< port enable */
+#define HPCS_PCD                  BIT(1)              /*!< port connect detected */
+#define HPCS_PCST                 BIT(0)              /*!< port connect status */
+
+/* host channel-x control register bits definitions */
+#define HCHCTL_CEN                BIT(31)             /*!< channel enable */
+#define HCHCTL_CDIS               BIT(30)             /*!< channel disable */
+#define HCHCTL_ODDFRM             BIT(29)             /*!< odd frame */
+#define HCHCTL_DAR                BITS(22, 28)        /*!< device address */
+#define HCHCTL_MPC                BITS(20, 21)        /*!< multiple packet count */
+#define HCHCTL_EPTYPE             BITS(18, 19)        /*!< endpoint type */
+#define HCHCTL_LSD                BIT(17)             /*!< low-speed device */
+#define HCHCTL_EPDIR              BIT(15)             /*!< endpoint direction */
+#define HCHCTL_EPNUM              BITS(11, 14)        /*!< endpoint number */
+#define HCHCTL_MPL                BITS(0, 10)         /*!< maximum packet length */
+
+/* host channel-x split transaction register bits definitions */
+#define HCHSTCTL_SPLEN            BIT(31)             /*!< enable high-speed split transaction */
+#define HCHSTCTL_CSPLT            BIT(16)             /*!< complete-split enable */
+#define HCHSTCTL_ISOPCE           BITS(14, 15)        /*!< isochronous OUT payload continuation encoding */
+#define HCHSTCTL_HADDR            BITS(7, 13)         /*!< HUB address */
+#define HCHSTCTL_PADDR            BITS(0, 6)          /*!< port address */
+
+/* host channel-x interrupt flag register bits definitions */
+#define HCHINTF_DTER              BIT(10)             /*!< data toggle error */
+#define HCHINTF_REQOVR            BIT(9)              /*!< request queue overrun */
+#define HCHINTF_BBER              BIT(8)              /*!< babble error */
+#define HCHINTF_USBER             BIT(7)              /*!< USB bus Error */
+#define HCHINTF_NYET              BIT(6)              /*!< NYET */
+#define HCHINTF_ACK               BIT(5)              /*!< ACK */
+#define HCHINTF_NAK               BIT(4)              /*!< NAK */
+#define HCHINTF_STALL             BIT(3)              /*!< STALL */
+#define HCHINTF_DMAER             BIT(2)              /*!< DMA error */
+#define HCHINTF_CH                BIT(1)              /*!< channel halted */
+#define HCHINTF_TF                BIT(0)              /*!< transfer finished */
+
+/* host channel-x interrupt enable register bits definitions */
+#define HCHINTEN_DTERIE           BIT(10)             /*!< data toggle error interrupt enable */
+#define HCHINTEN_REQOVRIE         BIT(9)              /*!< request queue overrun interrupt enable */
+#define HCHINTEN_BBERIE           BIT(8)              /*!< babble error interrupt enable */
+#define HCHINTEN_USBERIE          BIT(7)              /*!< USB bus error interrupt enable */
+#define HCHINTEN_NYETIE           BIT(6)              /*!< NYET interrupt enable */
+#define HCHINTEN_ACKIE            BIT(5)              /*!< ACK interrupt enable */
+#define HCHINTEN_NAKIE            BIT(4)              /*!< NAK interrupt enable */
+#define HCHINTEN_STALLIE          BIT(3)              /*!< STALL interrupt enable */
+#define HCHINTEN_DMAERIE          BIT(2)              /*!< DMA error interrupt enable */
+#define HCHINTEN_CHIE             BIT(1)              /*!< channel halted interrupt enable */
+#define HCHINTEN_TFIE             BIT(0)              /*!< transfer finished interrupt enable */
+
+/* host channel-x transfer length register bits definitions */
+#define HCHLEN_PING               BIT(31)             /*!< PING token request */
+#define HCHLEN_DPID               BITS(29, 30)        /*!< data PID */
+#define HCHLEN_PCNT               BITS(19, 28)        /*!< packet count */
+#define HCHLEN_TLEN               BITS(0, 18)         /*!< transfer length */
+
+/* host channel-x DMA address register bits definitions */
+#define HCHDMAADDR_DMAADDR        BITS(0, 31)         /*!< DMA address */
+
+#define PORT_SPEED(x)             (((uint32_t)(x) << 17) & HPCS_PS)         /*!< Port speed */
+
+#define PORT_SPEED_HIGH           PORT_SPEED(0U)                            /*!< high speed */
+#define PORT_SPEED_FULL           PORT_SPEED(1U)                            /*!< full speed */
+#define PORT_SPEED_LOW            PORT_SPEED(2U)                            /*!< low speed */
+
+#define PIPE_CTL_DAR(x)           (((uint32_t)(x) << 22) & HCHCTL_DAR)      /*!< device address */
+#define PIPE_CTL_EPTYPE(x)        (((uint32_t)(x) << 18) & HCHCTL_EPTYPE)   /*!< endpoint type */
+#define PIPE_CTL_EPNUM(x)         (((uint32_t)(x) << 11) & HCHCTL_EPNUM)    /*!< endpoint number */
+#define PIPE_CTL_EPDIR(x)         (((uint32_t)(x) << 15) & HCHCTL_EPDIR)    /*!< endpoint direction */
+#define PIPE_CTL_EPMPL(x)         (((uint32_t)(x) <<  0) & HCHCTL_MPL)      /*!< maximum packet length */
+#define PIPE_CTL_LSD(x)           (((uint32_t)(x) << 17) & HCHCTL_LSD)      /*!< low-Speed device */
+
+#define PIPE_XFER_PCNT(x)         (((uint32_t)(x) << 19) & HCHLEN_PCNT)     /*!< packet count */
+#define PIPE_XFER_DPID(x)         (((uint32_t)(x) << 29) & HCHLEN_DPID)     /*!< data PID */
+
+#define PIPE_DPID_DATA0           PIPE_XFER_DPID(0)                         /*!< DATA0 */
+#define PIPE_DPID_DATA1           PIPE_XFER_DPID(2)                         /*!< DATA1 */
+#define PIPE_DPID_DATA2           PIPE_XFER_DPID(1)                         /*!< DATA2 */
+#define PIPE_DPID_SETUP           PIPE_XFER_DPID(3)                         /*!< MDATA (non-control)/SETUP (control) */
+
+extern const uint32_t PIPE_DPID[2];
+
+/* device configuration registers bits definitions */
+#define DCFG_EOPFT                BITS(11, 12)        /*!< end of periodic frame time */
+#define DCFG_DAR                  BITS(4, 10)         /*!< device address */
+#define DCFG_NZLSOH               BIT(2)              /*!< non-zero-length status OUT handshake */
+#define DCFG_DS                   BITS(0, 1)          /*!< device speed */
+
+/* device control registers bits definitions */
+#define DCTL_POIF                 BIT(11)             /*!< power-on initialization finished */
+#define DCTL_CGONAK               BIT(10)             /*!< clear global OUT NAK */
+#define DCTL_SGONAK               BIT(9)              /*!< set global OUT NAK */
+#define DCTL_CGINAK               BIT(8)              /*!< clear global IN NAK */
+#define DCTL_SGINAK               BIT(7)              /*!< set global IN NAK */
+#define DCTL_GONS                 BIT(3)              /*!< global OUT NAK status */
+#define DCTL_GINS                 BIT(2)              /*!< global IN NAK status */
+#define DCTL_SD                   BIT(1)              /*!< soft disconnect */
+#define DCTL_RWKUP                BIT(0)              /*!< remote wakeup */
+
+/* device status registers bits definitions */
+#define DSTAT_FNRSOF              BITS(8, 21)         /*!< the frame number of the received SOF. */
+#define DSTAT_ES                  BITS(1, 2)          /*!< enumerated speed */
+#define DSTAT_SPST                BIT(0)              /*!< suspend status */
+
+/* device IN endpoint common interrupt enable registers bits definitions */
+#define DIEPINTEN_NAKEN           BIT(13)             /*!< NAK handshake sent by USBHS interrupt enable bit */
+#define DIEPINTEN_TXFEEN          BIT(7)              /*!< transmit FIFO empty interrupt enable bit */
+#define DIEPINTEN_IEPNEEN         BIT(6)              /*!< IN endpoint NAK effective interrupt enable bit */
+#define DIEPINTEN_EPTXFUDEN       BIT(4)              /*!< endpoint Tx FIFO underrun interrupt enable bit */
+#define DIEPINTEN_CITOEN          BIT(3)              /*!< control In Timeout interrupt enable bit */
+#define DIEPINTEN_EPDISEN         BIT(1)              /*!< endpoint disabled interrupt enable bit */
+#define DIEPINTEN_TFEN            BIT(0)              /*!< transfer finished interrupt enable bit */
+
+/* device OUT endpoint common interrupt enable registers bits definitions */
+#define DOEPINTEN_NYETEN          BIT(14)             /*!< NYET handshake is sent interrupt enable bit */
+#define DOEPINTEN_BTBSTPEN        BIT(6)              /*!< back-to-back SETUP packets interrupt enable bit */
+#define DOEPINTEN_EPRXFOVREN      BIT(4)              /*!< endpoint Rx FIFO overrun interrupt enable bit */
+#define DOEPINTEN_STPFEN          BIT(3)              /*!< SETUP phase finished interrupt enable bit */
+#define DOEPINTEN_EPDISEN         BIT(1)              /*!< endpoint disabled interrupt enable bit */
+#define DOEPINTEN_TFEN            BIT(0)              /*!< transfer finished interrupt enable bit */
+
+/* device all endpoints interrupt registers bits definitions */
+#define DAEPINT_OEPITB            BITS(16, 21)        /*!< device all OUT endpoint interrupt bits */
+#define DAEPINT_IEPITB            BITS(0, 5)          /*!< device all IN endpoint interrupt bits */
+
+/* device all endpoints interrupt enable registers bits definitions */
+#define DAEPINTEN_OEPIE           BITS(16, 21)        /*!< OUT endpoint interrupt enable */
+#define DAEPINTEN_IEPIE           BITS(0, 3)          /*!< IN endpoint interrupt enable */
+
+/* device Vbus discharge time registers bits definitions */
+#define DVBUSDT_DVBUSDT           BITS(0, 15)         /*!< device VBUS discharge time */
+
+/* device Vbus pulsing time registers bits definitions */
+#define DVBUSPT_DVBUSPT           BITS(0, 11)         /*!< device VBUS pulsing time */
+
+/* device IN endpoint FIFO empty interrupt enable register bits definitions */
+#define DIEPFEINTEN_IEPTXFEIE     BITS(0, 5)          /*!< IN endpoint Tx FIFO empty interrupt enable bits */
+
+/* device endpoint 0 control register bits definitions */
+#define DEP0CTL_EPEN              BIT(31)             /*!< endpoint enable */
+#define DEP0CTL_EPD               BIT(30)             /*!< endpoint disable */
+#define DEP0CTL_SNAK              BIT(27)             /*!< set NAK */
+#define DEP0CTL_CNAK              BIT(26)             /*!< clear NAK */
+#define DIEP0CTL_TXFNUM           BITS(22, 25)        /*!< tx FIFO number */
+#define DEP0CTL_STALL             BIT(21)             /*!< STALL handshake */
+#define DOEP0CTL_SNOOP            BIT(20)             /*!< snoop mode */
+#define DEP0CTL_EPTYPE            BITS(18, 19)        /*!< endpoint type */
+#define DEP0CTL_NAKS              BIT(17)             /*!< NAK status */
+#define DEP0CTL_EPACT             BIT(15)             /*!< endpoint active */
+#define DEP0CTL_MPL               BITS(0, 1)          /*!< maximum packet length */
+
+/* device endpoint x control register bits definitions */
+#define DEPCTL_EPEN               BIT(31)             /*!< endpoint enable */
+#define DEPCTL_EPD                BIT(30)             /*!< endpoint disable */
+#define DEPCTL_SODDFRM            BIT(29)             /*!< set odd frame */
+#define DEPCTL_SD1PID             BIT(29)             /*!< set DATA1 PID */
+#define DEPCTL_SEVNFRM            BIT(28)             /*!< set even frame */
+#define DEPCTL_SD0PID             BIT(28)             /*!< set DATA0 PID */
+#define DEPCTL_SNAK               BIT(27)             /*!< set NAK */
+#define DEPCTL_CNAK               BIT(26)             /*!< clear NAK */
+#define DIEPCTL_TXFNUM            BITS(22, 25)        /*!< tx FIFO number */
+#define DEPCTL_STALL              BIT(21)             /*!< STALL handshake */
+#define DOEPCTL_SNOOP             BIT(20)             /*!< snoop mode */
+#define DEPCTL_EPTYPE             BITS(18, 19)        /*!< endpoint type */
+#define DEPCTL_NAKS               BIT(17)             /*!< NAK status */
+#define DEPCTL_EOFRM              BIT(16)             /*!< even/odd frame */
+#define DEPCTL_DPID               BIT(16)             /*!< endpoint data PID */
+#define DEPCTL_EPACT              BIT(15)             /*!< endpoint active */
+#define DEPCTL_MPL                BITS(0, 10)         /*!< maximum packet length */
+
+/* device IN endpoint-x interrupt flag register bits definitions */
+#define DIEPINTF_NAK              BIT(13)             /*!< NAK handshake sent by USBHS */
+#define DIEPINTF_TXFE             BIT(7)              /*!< transmit FIFO empty */
+#define DIEPINTF_IEPNE            BIT(6)              /*!< IN endpoint NAK effective */
+#define DIEPINTF_EPTXFUD          BIT(4)              /*!< endpoint Tx FIFO underrun */
+#define DIEPINTF_CITO             BIT(3)              /*!< control In Timeout interrupt */
+#define DIEPINTF_EPDIS            BIT(1)              /*!< endpoint disabled */
+#define DIEPINTF_TF               BIT(0)              /*!< transfer finished */
+
+/* device OUT endpoint-x interrupt flag register bits definitions */
+#define DOEPINTF_NYET             BIT(14)             /*!< NYET handshake is sent */
+#define DOEPINTF_BTBSTP           BIT(6)              /*!< back-to-back SETUP packets */
+#define DOEPINTF_EPRXFOVR         BIT(4)              /*!< endpoint Rx FIFO overrun */
+#define DOEPINTF_STPF             BIT(3)              /*!< SETUP phase finished */
+#define DOEPINTF_EPDIS            BIT(1)              /*!< endpoint disabled */
+#define DOEPINTF_TF               BIT(0)              /*!< transfer finished */
+
+/* device IN endpoint 0 transfer length register bits definitions */
+#define DIEP0LEN_PCNT             BITS(19, 20)        /*!< packet count */
+#define DIEP0LEN_TLEN             BITS(0, 6)          /*!< transfer length */
+
+/* device OUT endpoint 0 transfer length register bits definitions */
+#define DOEP0LEN_STPCNT           BITS(29, 30)        /*!< SETUP packet count */
+#define DOEP0LEN_PCNT             BIT(19)             /*!< packet count */
+#define DOEP0LEN_TLEN             BITS(0, 6)          /*!< transfer length */
+
+/* device OUT endpoint-x transfer length register bits definitions */
+#define DOEPLEN_RXDPID            BITS(29, 30)        /*!< received data PID */
+#define DOEPLEN_STPCNT            BITS(29, 30)        /*!< SETUP packet count */
+#define DIEPLEN_MCNT              BITS(29, 30)        /*!< multi count */
+#define DEPLEN_PCNT               BITS(19, 28)        /*!< packet count */
+#define DEPLEN_TLEN               BITS(0, 18)         /*!< transfer length */
+
+/* device IN endpoint-x DMA address register bits definitions */
+#define DIEPDMAADDR_DMAADDR       BITS(0, 31)         /*!< DMA address */
+
+/* device OUT endpoint-x DMA address register bits definitions */
+#define DOEPDMAADDR_DMAADDR       BITS(0, 31)         /*!< DMA address */
+
+/* device IN endpoint-x transmit FIFO status register bits definitions */
+#define DIEPTFSTAT_IEPTFS         BITS(0, 15)         /*!< IN endpoint Tx FIFO space remaining */
+
+/* USB power and clock registers bits definition */
+#define PWRCLKCTL_SHCLK           BIT(1)              /*!< stop HCLK */
+#define PWRCLKCTL_SUCLK           BIT(0)              /*!< stop the USB clock */
+
+#define RSTAT_GOUT_NAK                  1U    /* global OUT NAK (triggers an interrupt) */
+#define RSTAT_DATA_UPDT                 2U    /* OUT data packet received */
+#define RSTAT_XFER_COMP                 3U    /* OUT transfer completed (triggers an interrupt) */
+#define RSTAT_SETUP_COMP                4U    /* SETUP transaction completed (triggers an interrupt) */
+#define RSTAT_SETUP_UPDT                6U    /* SETUP data packet received */
+
+#define DSTAT_EM_HS_PHY_30MHZ_60MHZ     0U    /* USB enumerate speed use high-speed PHY clock in 30MHz or 60MHz */
+#define DSTAT_EM_FS_PHY_30MHZ_60MHZ     1U    /* USB enumerate speed use full-speed PHY clock in 30MHz or 60MHz */
+#define DSTAT_EM_LS_PHY_6MHZ            2U    /* USB enumerate speed use low-speed PHY clock in 6MHz */
+#define DSTAT_EM_FS_PHY_48MHZ           3U    /* USB enumerate speed use full-speed PHY clock in 48MHz */
+
+#define DPID_DATA0                      0U    /* device endpoint data PID is DATA0 */
+#define DPID_DATA1                      2U    /* device endpoint data PID is DATA1 */
+#define DPID_DATA2                      1U    /* device endpoint data PID is DATA2 */
+#define DPID_MDATA                      3U    /* device endpoint data PID is MDATA */
+
+#define GAHBCS_DMAINCR(regval)    (GAHBCS_BURST & ((regval) << 1)) /*!< AHB burst type used by DMA*/
+
+#define DMA_INCR0                 GAHBCS_DMAINCR(0U)                /*!< single burst type used by DMA*/
+#define DMA_INCR1                 GAHBCS_DMAINCR(1U)                /*!< 4-beat incrementing burst type used by DMA*/
+#define DMA_INCR4                 GAHBCS_DMAINCR(3U)                /*!< 8-beat incrementing burst type used by DMA*/
+#define DMA_INCR8                 GAHBCS_DMAINCR(5U)                /*!< 16-beat incrementing burst type used by DMA*/
+#define DMA_INCR16                GAHBCS_DMAINCR(7U)                /*!< 32-beat incrementing burst type used by DMA*/
+
+#define DCFG_PFRI(regval)         (DCFG_EOPFT & ((regval) << 11))  /*!< end of periodic frame time configuration */
+
+#define FRAME_INTERVAL_80         DCFG_PFRI(0U)                     /*!< 80% of the frame time */
+#define FRAME_INTERVAL_85         DCFG_PFRI(1U)                     /*!< 85% of the frame time */
+#define FRAME_INTERVAL_90         DCFG_PFRI(2U)                     /*!< 90% of the frame time */
+#define FRAME_INTERVAL_95         DCFG_PFRI(3U)                     /*!< 95% of the frame time */
+
+#define DCFG_DEVSPEED(regval)     (DCFG_DS & ((regval) << 0))       /*!< device speed configuration */
+
+#define USB_SPEED_EXP_HIGH        DCFG_DEVSPEED(0U)                 /*!< device external PHY high speed */
+#define USB_SPEED_EXP_FULL        DCFG_DEVSPEED(1U)                 /*!< device external PHY full speed */
+#define USB_SPEED_INP_FULL        DCFG_DEVSPEED(3U)                 /*!< device internal PHY full speed */
+
+#define DEP0_MPL(regval)          (DEP0CTL_MPL & ((regval) << 0))   /*!< maximum packet length configuration */
+
+#define EP0MPL_64                 DEP0_MPL(0U)                      /*!< maximum packet length 64 bytes */
+#define EP0MPL_32                 DEP0_MPL(1U)                      /*!< maximum packet length 32 bytes */
+#define EP0MPL_16                 DEP0_MPL(2U)                      /*!< maximum packet length 16 bytes */
+#define EP0MPL_8                  DEP0_MPL(3U)                      /*!< maximum packet length 8 bytes */
+
+#define DOEP0_TLEN(regval)        (DOEP0LEN_TLEN & ((regval) << 0))     /*!< transfer length */
+#define DOEP0_PCNT(regval)        (DOEP0LEN_PCNT & ((regval) << 19))    /*!< packet count */
+#define DOEP0_STPCNT(regval)      (DOEP0LEN_STPCNT & ((regval) << 29))  /*!< SETUP packet count */
+
+#define USB_ULPI_PHY                            1U                      /*!< ULPI interface external PHY */
+#define USB_EMBEDDED_PHY                        2U                      /*!< embedded PHY */
+
+#define GRXSTS_PKTSTS_IN                        2U
+#define GRXSTS_PKTSTS_IN_XFER_COMP              3U
+#define GRXSTS_PKTSTS_DATA_TOGGLE_ERR           5U
+#define GRXSTS_PKTSTS_CH_HALTED                 7U
+
+#define HCTL_30_60MHZ                           0U                      /*!< USB clock 30-60MHZ */
+#define HCTL_48MHZ                              1U                      /*!< USB clock 48MHZ */
+#define HCTL_6MHZ                               2U                      /*!< USB clock 6MHZ */
+
+#define EP0_OUT                   ((uint8_t)0x00)                       /*!< endpoint out 0 */
+#define EP0_IN                    ((uint8_t)0x80)                       /*!< endpoint in 0 */
+#define EP1_OUT                   ((uint8_t)0x01)                       /*!< endpoint out 1 */
+#define EP1_IN                    ((uint8_t)0x81)                       /*!< endpoint in 1 */
+#define EP2_OUT                   ((uint8_t)0x02)                       /*!< endpoint out 2 */
+#define EP2_IN                    ((uint8_t)0x82)                       /*!< endpoint in 2 */
+#define EP3_OUT                   ((uint8_t)0x03)                       /*!< endpoint out 3 */
+#define EP3_IN                    ((uint8_t)0x83)                       /*!< endpoint in 3 */
+#define EP4_OUT                   ((uint8_t)0x04)                       /*!< endpoint out 4 */
+#define EP4_IN                    ((uint8_t)0x84)                       /*!< endpoint in 4 */
+#define EP5_OUT                   ((uint8_t)0x05)                       /*!< endpoint out 5 */
+#define EP5_IN                    ((uint8_t)0x85)                       /*!< endpoint in 5 */
+
+#endif /* __DRV_USB_REGS_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usbd_int.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usbd_int.h
@@ -1,0 +1,54 @@
+/*!
+    \file    drv_usbd_int.h
+    \brief   USB device mode interrupt header file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __DRV_USBD_INT_H
+#define __DRV_USBD_INT_H
+
+#include "drv_usb_core.h"
+#include "drv_usb_dev.h"
+
+/* function declarations */
+/* USB device-mode interrupts global service routine handler */
+void usbd_isr (usb_core_driver *udev);
+
+#ifdef USB_HS_DEDICATED_EP1_ENABLED
+/* USB dedicated IN endpoint 1 interrupt service routine handler */
+uint32_t usbd_int_dedicated_ep1in (usb_core_driver *udev);
+/* USB dedicated OUT endpoint 1 interrupt service routine handler */
+uint32_t usbd_int_dedicated_ep1out (usb_core_driver *udev);
+#endif /* USB_HS_DEDICATED_EP1_ENABLED */
+
+#endif /* __DRV_USBD_INT_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usbh_int.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Include/drv_usbh_int.h
@@ -1,0 +1,56 @@
+/*!
+    \file    drv_usbh_int.h.h
+    \brief   USB host mode interrupt management header file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __DRV_USBH_INT_H
+#define __DRV_USBH_INT_H
+
+#include "drv_usb_host.h"
+#include "usbh_core.h"
+
+typedef struct _usbh_ev_cb
+{
+    uint8_t (*connect)          (usbh_host *uhost);
+    uint8_t (*disconnect)       (usbh_host *uhost);
+    uint8_t (*SOF)              (usbh_host *uhost);
+} usbh_ev_cb;
+
+extern usbh_ev_cb *usbh_int_fop;
+
+/* function declarations */
+/* handle global host interrupt */
+uint32_t usbh_isr (usb_core_driver *udev);
+
+#endif /* __DRV_USBH_INT_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Source/drv_usb_core.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Source/drv_usb_core.c
@@ -1,0 +1,374 @@
+/*!
+    \file    drv_usb_core.c
+    \brief   USB core driver which can operate in host and device mode
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "drv_usb_core.h"
+#include "drv_usb_hw.h"
+
+/* local function prototypes ('static') */
+static void usb_core_reset (usb_core_regs *usb_regs);
+
+/*!
+    \brief      configure USB core basic 
+    \param[in]  usb_basic: pointer to USB capabilities
+    \param[in]  usb_regs: USB core registers
+    \param[in]  usb_core: USB core
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_basic_init (usb_core_basic *usb_basic, 
+                           usb_core_regs  *usb_regs, 
+                           usb_core_enum   usb_core)
+{
+    /* configure USB default transfer mode as FIFO mode */
+    usb_basic->transfer_mode = (uint8_t)USB_USE_FIFO;
+
+    /* USB default speed is full-speed */
+    usb_basic->core_speed = (uint8_t)USB_SPEED_FULL;
+
+    usb_basic->core_enum = (uint8_t)usb_core;
+
+    switch (usb_core) {
+    case USB_CORE_ENUM_HS:
+        usb_basic->base_reg = (uint32_t)USBHS_REG_BASE;
+
+        /* set the host channel numbers */
+        usb_basic->num_pipe = USBHS_MAX_CHANNEL_COUNT;
+
+        /* set the device endpoint numbers */
+        usb_basic->num_ep = USBHS_MAX_EP_COUNT;
+
+#ifdef USB_ULPI_PHY_ENABLED
+        usb_basic->phy_itf = USB_ULPI_PHY;
+#else
+        usb_basic->phy_itf = USB_EMBEDDED_PHY;
+#endif /* USB_ULPI_PHY_ENABLED */
+
+#ifdef USB_HS_INTERNAL_DMA_ENABLED
+        usb_basic->transfer_mode = USB_USE_DMA;
+#endif /* USB_HS_INTERNAL_DMA_ENABLED */
+
+#ifdef USB_HS_CORE
+        /* configure the SOF output and the low power support */
+        usb_basic->sof_enable = USBHS_SOF_OUTPUT;
+        usb_basic->low_power = USBHS_LOW_POWER;
+#endif /* USB_HS_CORE */
+        break;
+
+    case USB_CORE_ENUM_FS:
+        usb_basic->base_reg = (uint32_t)USBFS_REG_BASE;
+
+        /* set the host channel numbers */
+        usb_basic->num_pipe = USBFS_MAX_CHANNEL_COUNT;
+
+        /* set the device endpoint numbers */
+        usb_basic->num_ep = USBFS_MAX_EP_COUNT;
+
+        /* USBFS core use embedded physical layer */
+        usb_basic->phy_itf = USB_EMBEDDED_PHY;
+
+#ifdef USB_FS_CORE
+        /* configure the SOF output and the low power support */
+        usb_basic->sof_enable = USBFS_SOF_OUTPUT;
+        usb_basic->low_power = USBFS_LOW_POWER;
+#endif /* USB_FS_CORE */
+        break;
+
+    default:
+        return USB_FAIL;
+    }
+
+    /* assign main registers address */
+    *usb_regs = (usb_core_regs) {
+        .gr          = (usb_gr*) (usb_basic->base_reg + USB_REG_OFFSET_CORE),
+        .hr          = (usb_hr*) (usb_basic->base_reg + USB_REG_OFFSET_HOST),
+        .dr          = (usb_dr*) (usb_basic->base_reg + USB_REG_OFFSET_DEV),
+
+        .HPCS        = (uint32_t*) (usb_basic->base_reg + USB_REG_OFFSET_PORT),
+        .PWRCLKCTL   = (uint32_t*) (usb_basic->base_reg + USB_REG_OFFSET_PWRCLKCTL)
+    };
+
+    /* assign device endpoint registers address */
+    for (uint8_t i = 0U; i < usb_basic->num_ep; i++) {
+        usb_regs->er_in[i] = (usb_erin *) \
+            (usb_basic->base_reg + USB_REG_OFFSET_EP_IN + (i * USB_REG_OFFSET_EP));
+
+        usb_regs->er_out[i] = (usb_erout *)\
+            (usb_basic->base_reg + USB_REG_OFFSET_EP_OUT + (i * USB_REG_OFFSET_EP));
+    }
+
+    /* assign host pipe registers address */
+    for (uint8_t i = 0U; i < usb_basic->num_pipe; i++) {
+        usb_regs->pr[i] = (usb_pr *) \
+            (usb_basic->base_reg + USB_REG_OFFSET_CH_INOUT + (i * USB_REG_OFFSET_CH));
+
+        usb_regs->DFIFO[i] = (uint32_t *) \
+            (usb_basic->base_reg + USB_DATA_FIFO_OFFSET + (i * USB_DATA_FIFO_SIZE));
+    }
+
+    return USB_OK;
+}
+
+/*!
+    \brief      initializes the USB controller registers and 
+                prepares the core device mode or host mode operation
+    \param[in]  usb_basic: pointer to USB capabilities
+    \param[in]  usb_regs: pointer to USB core registers
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_core_init (usb_core_basic usb_basic, usb_core_regs *usb_regs)
+{
+    if (USB_ULPI_PHY == usb_basic.phy_itf) {
+        usb_regs->gr->GCCFG &= ~GCCFG_PWRON;
+
+        if (usb_basic.sof_enable) {
+            usb_regs->gr->GCCFG |= GCCFG_SOFOEN;
+        }
+
+        /* initialize the ULPI interface */
+        usb_regs->gr->GUSBCS &= ~(GUSBCS_EMBPHY | GUSBCS_ULPIEOI);
+
+#ifdef USBHS_EXTERNAL_VBUS_ENABLED
+        /* use external VBUS driver */
+        usb_regs->gr->GUSBCS |= GUSBCS_ULPIEVD;
+#else
+        /* use internal VBUS driver */
+        usb_regs->gr->GUSBCS &= ~GUSBCS_ULPIEVD;
+#endif /* USBHS_EXTERNAL_VBUS_ENABLED */
+
+        /* soft reset the core */
+        usb_core_reset (usb_regs);
+    } else {
+        usb_regs->gr->GUSBCS |= GUSBCS_EMBPHY;
+
+        /* soft reset the core */
+        usb_core_reset (usb_regs);
+
+        /* active the transceiver and enable VBUS sensing */
+        usb_regs->gr->GCCFG |= GCCFG_PWRON | GCCFG_VBUSACEN | GCCFG_VBUSBCEN;
+
+#ifndef VBUS_SENSING_ENABLED
+        usb_regs->gr->GCCFG |= GCCFG_VBUSIG;
+#endif /* VBUS_SENSING_ENABLED */
+
+        /* enable SOF output */
+        if (usb_basic.sof_enable) {
+            usb_regs->gr->GCCFG |= GCCFG_SOFOEN;
+        }
+
+        usb_mdelay(20U);
+    }
+
+    if ((uint8_t)USB_USE_DMA == usb_basic.transfer_mode) {
+        usb_regs->gr->GAHBCS &= ~GAHBCS_BURST;
+        usb_regs->gr->GAHBCS |= DMA_INCR8 | GAHBCS_DMAEN;
+    }
+
+#ifdef USE_OTG_MODE
+
+    /* enable USB OTG features */
+    usb_regs->gr->GUSBCS |= GUSBCS_HNPCEN | GUSBCS_SRPCEN;
+
+    /* enable the USB wakeup and suspend interrupts */
+    usb_regs->gr->GINTF = 0xBFFFFFFFU;
+
+    usb_regs->gr->GINTEN = GINTEN_WKUPIE | GINTEN_SPIE | \
+                           GINTEN_OTGIE | GINTEN_SESIE | GINTEN_CIDPSCIE;
+
+#endif /* USE_OTG_MODE */
+
+    return USB_OK;
+}
+
+/*!
+    \brief      write a packet into the Tx FIFO associated with the endpoint
+    \param[in]  usb_regs: pointer to USB core registers
+    \param[in]  src_buf: pointer to source buffer
+    \param[in]  fifo_num: FIFO number which is in (0..3 or 0..5)
+    \param[in]  byte_count: packet byte count
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_txfifo_write (usb_core_regs *usb_regs, 
+                             uint8_t *src_buf, 
+                             uint8_t  fifo_num, 
+                             uint16_t byte_count)
+{
+    uint32_t word_count = (byte_count + 3U) / 4U;
+
+    __IO uint32_t *fifo = usb_regs->DFIFO[fifo_num];
+
+    while (word_count-- > 0U) {
+        *fifo = *((__packed uint32_t *)src_buf);
+
+        src_buf += 4U;
+    }
+
+    return USB_OK;
+}
+
+/*!
+    \brief      read a packet from the Rx FIFO associated with the endpoint
+    \param[in]  usb_regs: pointer to USB core registers
+    \param[in]  dest_buf: pointer to destination buffer
+    \param[in]  byte_count: packet byte count
+    \param[out] none
+    \retval     void type pointer
+*/
+void *usb_rxfifo_read (usb_core_regs *usb_regs, uint8_t *dest_buf, uint16_t byte_count)
+{
+    uint32_t word_count = (byte_count + 3U) / 4U;
+
+    __IO uint32_t *fifo = usb_regs->DFIFO[0];
+
+    while (word_count-- > 0U) {
+        *(__packed uint32_t *)dest_buf = *fifo;
+
+        dest_buf += 4U;
+    }
+
+    return ((void *)dest_buf);
+}
+
+/*!
+    \brief      flush a Tx FIFO or all Tx FIFOs
+    \param[in]  usb_regs: pointer to USB core registers
+    \param[in]  fifo_num: FIFO number which is in (0..3 or 0..5)
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_txfifo_flush (usb_core_regs *usb_regs, uint8_t fifo_num)
+{
+    usb_regs->gr->GRSTCTL = ((uint32_t)fifo_num << 6U) | GRSTCTL_TXFF;
+
+    /* wait for Tx FIFO flush bit is set */
+    while (usb_regs->gr->GRSTCTL & GRSTCTL_TXFF) {
+        /* no operation */
+    }
+
+    /* wait for 3 PHY clocks*/
+    usb_udelay(3U);
+
+    return USB_OK;
+}
+
+/*!
+    \brief      flush the entire Rx FIFO
+    \param[in]  usb_regs: pointer to USB core registers
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_rxfifo_flush (usb_core_regs *usb_regs)
+{
+    usb_regs->gr->GRSTCTL = GRSTCTL_RXFF;
+
+    /* wait for Rx FIFO flush bit is set */
+    while (usb_regs->gr->GRSTCTL & GRSTCTL_RXFF) {
+        /* no operation */
+    }
+
+    /* wait for 3 PHY clocks */
+    usb_udelay(3U);
+
+    return USB_OK;
+}
+
+/*!
+    \brief      set endpoint or channel TX FIFO size
+    \param[in]  usb_regs: pointer to USB core registers
+    \param[in]  fifo: TX FIFO number
+    \param[in]  size: assigned TX FIFO size
+    \param[out] none
+    \retval     none
+*/
+void usb_set_txfifo(usb_core_regs *usb_regs, uint8_t fifo, uint16_t size)
+{
+    uint32_t tx_offset;
+
+    tx_offset = usb_regs->gr->GRFLEN;
+
+    if(0U == fifo) {
+        usb_regs->gr->DIEP0TFLEN_HNPTFLEN = ((uint32_t)size << 16) | tx_offset;
+    } else {
+        tx_offset += (usb_regs->gr->DIEP0TFLEN_HNPTFLEN) >> 16;
+
+        for (uint8_t i = 0U; i < (fifo - 1U); i++) {
+            tx_offset += (usb_regs->gr->DIEPTFLEN[i] >> 16);
+        }
+
+        /* multiply Tx_Size by 2 to get higher performance */
+        usb_regs->gr->DIEPTFLEN[fifo - 1U] = ((uint32_t)size << 16) | tx_offset;
+    }
+}
+
+/*!
+    \brief      set USB current mode
+    \param[in]  usb_regs: pointer to USB core registers
+    \param[out] none
+    \retval     none
+*/
+void usb_curmode_set(usb_core_regs *usb_regs, uint8_t mode)
+{
+    usb_regs->gr->GUSBCS &= ~(GUSBCS_FDM | GUSBCS_FHM);
+
+    if (DEVICE_MODE == mode) {
+        usb_regs->gr->GUSBCS |= GUSBCS_FDM;
+    } else if (HOST_MODE == mode) {
+        usb_regs->gr->GUSBCS |= GUSBCS_FHM;
+    } else {
+        /* OTG mode and other mode can not be here! */
+    }
+}
+
+/*!
+    \brief      configure USB core to soft reset
+    \param[in]  usb_regs: pointer to USB core registers
+    \param[out] none
+    \retval     none
+*/
+static void usb_core_reset (usb_core_regs *usb_regs)
+{
+    /* enable core soft reset */
+    usb_regs->gr->GRSTCTL |= GRSTCTL_CSRST;
+
+    /* wait for the core to be soft reset */
+    while (usb_regs->gr->GRSTCTL & GRSTCTL_CSRST) {
+        /* no operation */
+    }
+
+    /* wait for additional 3 PHY clocks */
+    usb_udelay(3U);
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Source/drv_usb_dev.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Source/drv_usb_dev.c
@@ -1,0 +1,663 @@
+/*!
+    \file    drv_usb_dev.c
+    \brief   USB device mode low level driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "drv_usb_hw.h"
+#include "drv_usb_core.h"
+#include "drv_usb_dev.h"
+
+/* endpoint 0 max packet length */
+static const uint8_t EP0_MAXLEN[4] = {
+    [DSTAT_EM_HS_PHY_30MHZ_60MHZ] = EP0MPL_64,
+    [DSTAT_EM_FS_PHY_30MHZ_60MHZ] = EP0MPL_64,
+    [DSTAT_EM_FS_PHY_48MHZ] = EP0MPL_64,
+    [DSTAT_EM_LS_PHY_6MHZ] = EP0MPL_8
+};
+
+#ifdef USB_FS_CORE
+
+/* USB endpoint Tx FIFO size */
+static uint16_t USBFS_TX_FIFO_SIZE[USBFS_MAX_EP_COUNT] = 
+{
+    (uint16_t)TX0_FIFO_FS_SIZE,
+    (uint16_t)TX1_FIFO_FS_SIZE,
+    (uint16_t)TX2_FIFO_FS_SIZE,
+    (uint16_t)TX3_FIFO_FS_SIZE
+};
+
+#endif /* USBFS_CORE */
+
+#ifdef USB_HS_CORE
+
+uint16_t USBHS_TX_FIFO_SIZE[USBHS_MAX_EP_COUNT] = 
+{
+    (uint16_t)TX0_FIFO_HS_SIZE,
+    (uint16_t)TX1_FIFO_HS_SIZE,
+    (uint16_t)TX2_FIFO_HS_SIZE,
+    (uint16_t)TX3_FIFO_HS_SIZE,
+    (uint16_t)TX4_FIFO_HS_SIZE,
+    (uint16_t)TX5_FIFO_HS_SIZE
+};
+
+#endif /* USBHS_CORE */
+
+/*!
+    \brief      initialize USB core registers for device mode
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_devcore_init (usb_core_driver *udev)
+{
+    uint8_t i;
+
+    /* restart the PHY clock (maybe don't need to...) */
+    *udev->regs.PWRCLKCTL = 0U;
+
+    /* configure periodic frame interval to default value */
+    udev->regs.dr->DCFG &= ~DCFG_EOPFT;
+    udev->regs.dr->DCFG |= FRAME_INTERVAL_80;
+
+    udev->regs.dr->DCFG &= ~DCFG_DS;
+
+#ifdef USB_FS_CORE
+    if (udev->bp.core_enum == (uint8_t)USB_CORE_ENUM_FS) {
+        /* set full-speed PHY */
+        udev->regs.dr->DCFG |= USB_SPEED_INP_FULL;
+
+        /* set Rx FIFO size */
+        usb_set_rxfifo(&udev->regs, RX_FIFO_FS_SIZE);
+
+        /* set endpoint 0 to 3's Tx FIFO length and RAM address */
+        for (i = 0U; i < USBFS_MAX_EP_COUNT; i++) {
+            usb_set_txfifo(&udev->regs, i, USBFS_TX_FIFO_SIZE[i]);
+        }
+    }
+#endif /* USB_FS_CORE */
+
+#ifdef USB_HS_CORE
+    if (udev->bp.core_enum == USB_CORE_ENUM_HS) {
+        if (udev->bp.phy_itf == USB_ULPI_PHY) {
+            udev->regs.dr->DCFG |= USB_SPEED_EXP_HIGH;
+        } else {/* set High speed PHY in Full speed mode */
+            udev->regs.dr->DCFG |= USB_SPEED_EXP_FULL;
+        }
+
+        /* Set Rx FIFO size */
+        usb_set_rxfifo(&udev->regs, RX_FIFO_HS_SIZE);
+
+        /* Set endpoint 0 to 6's TX FIFO length and RAM address */
+        for (i = 0; i < USBHS_MAX_EP_COUNT; i++) {
+            usb_set_txfifo(&udev->regs, i, USBHS_TX_FIFO_SIZE[i]);
+        }
+    }
+#endif /* USB_FS_CORE */
+
+    /* make sure all FIFOs are flushed */
+
+    /* flush all Tx FIFOs */
+    (void)usb_txfifo_flush (&udev->regs, 0x10U);
+
+    /* flush entire Rx FIFO */
+    (void)usb_rxfifo_flush (&udev->regs);
+
+    /* clear all pending device interrupts */
+    udev->regs.dr->DIEPINTEN = 0U;
+    udev->regs.dr->DOEPINTEN = 0U;
+    udev->regs.dr->DAEPINT = 0xFFFFFFFFU;
+    udev->regs.dr->DAEPINTEN = 0U;
+
+    /* configure all IN/OUT endpoints */
+    for (i = 0U; i < udev->bp.num_ep; i++) {
+        if (udev->regs.er_in[i]->DIEPCTL & DEPCTL_EPEN) {
+            udev->regs.er_in[i]->DIEPCTL |= DEPCTL_EPD | DEPCTL_SNAK;
+        } else {
+            udev->regs.er_in[i]->DIEPCTL = 0U;
+        }
+
+        /* set IN endpoint transfer length to 0 */
+        udev->regs.er_in[i]->DIEPLEN = 0U;
+
+        /* clear all pending IN endpoint interrupts */
+        udev->regs.er_in[i]->DIEPINTF = 0xFFU;
+
+        if (udev->regs.er_out[i]->DOEPCTL & DEPCTL_EPEN) {
+            udev->regs.er_out[i]->DOEPCTL |= DEPCTL_EPD | DEPCTL_SNAK;
+        } else {
+            udev->regs.er_out[i]->DOEPCTL = 0U;
+        }
+
+        /* set OUT endpoint transfer length to 0 */
+        udev->regs.er_out[i]->DOEPLEN = 0U;
+
+        /* clear all pending OUT endpoint interrupts */
+        udev->regs.er_out[i]->DOEPINTF = 0xFFU;
+    }
+
+    udev->regs.dr->DIEPINTEN |= DIEPINTEN_EPTXFUDEN;
+
+    (void)usb_devint_enable (udev);
+
+    return USB_OK;
+}
+
+/*!
+    \brief      enable the USB device mode interrupts
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_devint_enable (usb_core_driver *udev)
+{
+    /* clear any pending USB OTG interrupts */
+    udev->regs.gr->GOTGINTF = 0xFFFFFFFFU;
+
+    /* clear any pending interrupts */
+    udev->regs.gr->GINTF = 0xBFFFFFFFU;
+
+    /* enable the USB wakeup and suspend interrupts */
+    udev->regs.gr->GINTEN = GINTEN_WKUPIE | GINTEN_SPIE;
+
+    /* enable device_mode-related interrupts */
+    if ((uint8_t)USB_USE_FIFO == udev->bp.transfer_mode) {
+        udev->regs.gr->GINTEN |= GINTEN_RXFNEIE;
+    }
+
+    udev->regs.gr->GINTEN |= GINTEN_RSTIE | GINTEN_ENUMFIE | GINTEN_IEPIE |\
+                             GINTEN_OEPIE | GINTEN_SOFIE | GINTEN_ISOONCIE | GINTEN_ISOINCIE;
+
+#ifdef VBUS_SENSING_ENABLED
+    udev->regs.gr->GINTEN |= GINTEN_SESIE | GINTEN_OTGIE;
+#endif /* VBUS_SENSING_ENABLED */
+
+    return USB_OK;
+}
+
+/*!
+    \brief      active the USB endpoint0 transaction
+    \param[in]  udev: pointer to USB device
+    \param[in]  transc: the USB endpoint0 transaction
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_transc0_active (usb_core_driver *udev, usb_transc *transc)
+{
+    __IO uint32_t *reg_addr = NULL;
+
+    /* get the endpoint number */
+    uint8_t ep_num = transc->ep_addr.num;
+
+    if (ep_num) {
+        /* not endpoint 0 */
+        return USB_FAIL;
+    }
+
+    if (transc->ep_addr.dir) {
+        reg_addr = &udev->regs.er_in[0]->DIEPCTL;
+    } else {
+        reg_addr = &udev->regs.er_out[0]->DOEPCTL;
+    }
+
+    /* endpoint 0 is activated after USB clock is enabled */
+    *reg_addr &= ~(DEPCTL_MPL | DEPCTL_EPTYPE | DIEPCTL_TXFNUM);
+
+    /* set endpoint 0 maximum packet length */
+    *reg_addr |= EP0_MAXLEN[udev->regs.dr->DSTAT & DSTAT_ES];
+
+    /* activate endpoint */
+    *reg_addr |= ((uint32_t)transc->ep_type << 18U) | ((uint32_t)ep_num << 22U) | DEPCTL_SD0PID | DEPCTL_EPACT;
+
+    return USB_OK;
+}
+
+/*!
+    \brief      active the USB transaction
+    \param[in]  udev: pointer to USB device
+    \param[in]  transc: the USB transaction
+    \param[out] none
+    \retval     status
+*/
+usb_status usb_transc_active (usb_core_driver *udev, usb_transc *transc)
+{
+    __IO uint32_t *reg_addr = NULL;
+    __IO uint32_t epinten = 0U;
+
+    /* get the endpoint number */
+    uint8_t ep_num = transc->ep_addr.num;
+
+    /* enable endpoint interrupt number */
+    if (transc->ep_addr.dir) {
+        reg_addr = &udev->regs.er_in[ep_num]->DIEPCTL;
+
+        epinten = 1U << ep_num;
+    } else {
+        reg_addr = &udev->regs.er_out[ep_num]->DOEPCTL;
+
+        epinten = 1U << (16U + ep_num);
+    }
+
+    /* if the endpoint is not active, need change the endpoint control register */
+    if (!(*reg_addr & DEPCTL_EPACT)) {
+        *reg_addr &= ~(DEPCTL_MPL | DEPCTL_EPTYPE | DIEPCTL_TXFNUM);
+
+        /* set endpoint maximum packet length */
+        if (0U == ep_num) {
+            *reg_addr |= EP0_MAXLEN[udev->regs.dr->DSTAT & DSTAT_ES];
+        } else {
+            *reg_addr |= transc->max_len;
+        }
+
+        /* activate endpoint */
+        *reg_addr |= ((uint32_t)transc->ep_type << 18U) | ((uint32_t)ep_num << 22U) | DEPCTL_SD0PID | DEPCTL_EPACT;
+    }
+
+#ifdef USB_HS_DEDICATED_EP1_ENABLED
+    if ((ep_num == 1U) && (udev->bp.core_enum == USB_CORE_ENUM_HS)) {
+        udev->regs.dr->DEP1INTEN |= epinten;
+    }
+    else
+#endif /* USB_HS_DEDICATED_EP1_ENABLED */
+    {
+        /* enable the interrupts for this endpoint */
+        udev->regs.dr->DAEPINTEN |= epinten;
+    }
+
+    return USB_OK;
+}
+
+/*!
+    \brief      deactivate the USB transaction
+    \param[in]  udev: pointer to USB device
+    \param[in]  transc: the USB transaction
+    \param[out] none
+    \retval     status
+*/
+usb_status usb_transc_deactivate(usb_core_driver *udev, usb_transc *transc)
+{
+    uint32_t epinten = 0U;
+
+    uint8_t ep_num = transc->ep_addr.num;
+
+    /* disable endpoint interrupt number */
+    if (transc->ep_addr.dir) {
+        epinten = 1U << ep_num;
+
+        udev->regs.er_in[ep_num]->DIEPCTL &= ~DEPCTL_EPACT;
+    } else {
+        epinten = 1U << (ep_num + 16U);
+
+        udev->regs.er_out[ep_num]->DOEPCTL &= ~DEPCTL_EPACT;
+    }
+
+#ifdef USB_HS_DEDICATED_EP1_ENABLED
+    if ((ep_num == 1U) && (udev->bp.core_enum == USB_CORE_ENUM_HS)) {
+        udev->regs.dr->DEP1INTEN &= ~epinten;
+    }
+    else
+#endif /* USB_HS_DEDICATED_EP1_ENABLED */
+    {
+        /* disable the interrupts for this endpoint */
+        udev->regs.dr->DAEPINTEN &= ~epinten;
+    }
+
+    return USB_OK;
+}
+
+/*!
+    \brief      configure USB transaction to start IN transfer
+    \param[in]  udev: pointer to USB device
+    \param[in]  transc: the USB IN transaction
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_transc_inxfer (usb_core_driver *udev, usb_transc *transc)
+{
+    usb_status status = USB_OK;
+
+    uint8_t ep_num = transc->ep_addr.num;
+
+    __IO uint32_t epctl = udev->regs.er_in[ep_num]->DIEPCTL;
+    __IO uint32_t eplen = udev->regs.er_in[ep_num]->DIEPLEN;
+
+    eplen &= ~(DEPLEN_TLEN | DEPLEN_PCNT);
+
+    /* zero length packet or endpoint 0 */
+    if (0U == transc->xfer_len) {
+        /* set transfer packet count to 1 */
+        eplen |= 1U << 19U;
+    } else {
+        /* set transfer packet count */
+        if (0U == ep_num) {
+            transc->xfer_len = USB_MIN(transc->xfer_len, transc->max_len);
+
+            eplen |= 1U << 19U;
+        } else {
+            eplen |= (((transc->xfer_len - 1U) + transc->max_len) / transc->max_len) << 19U;
+        }
+
+        /* set endpoint transfer length */
+        eplen |= transc->xfer_len;
+
+        if (transc->ep_type == (uint8_t)USB_EPTYPE_ISOC) {
+            eplen |= DIEPLEN_MCNT & (1U << 29U);
+        }
+    }
+
+    udev->regs.er_in[ep_num]->DIEPLEN = eplen;
+
+    if (transc->ep_type == (uint8_t)USB_EPTYPE_ISOC) {
+        if (((udev->regs.dr->DSTAT & DSTAT_FNRSOF) >> 8U) & 0x01U) {
+            epctl |= DEPCTL_SEVNFRM;
+        } else {
+            epctl |= DEPCTL_SODDFRM;
+        }
+    }
+
+    if ((uint8_t)USB_USE_DMA == udev->bp.transfer_mode) {
+        udev->regs.er_in[ep_num]->DIEPDMAADDR = transc->dma_addr;
+    }
+
+    /* enable the endpoint and clear the NAK */
+    epctl |= DEPCTL_CNAK | DEPCTL_EPEN;
+
+    udev->regs.er_in[ep_num]->DIEPCTL = epctl;
+
+    if ((uint8_t)USB_USE_FIFO == udev->bp.transfer_mode) {
+        if (transc->ep_type != (uint8_t)USB_EPTYPE_ISOC) {
+            /* enable the Tx FIFO empty interrupt for this endpoint */
+            if (transc->xfer_len > 0U) {
+                udev->regs.dr->DIEPFEINTEN |= 1U << ep_num;
+            }
+        } else {
+            (void)usb_txfifo_write (&udev->regs, transc->xfer_buf, ep_num, (uint16_t)transc->xfer_len);
+        }
+    }
+
+    return status;
+}
+
+/*!
+    \brief      configure USB transaction to start OUT transfer
+    \param[in]  udev: pointer to USB device
+    \param[in]  transc: the USB OUT transaction
+    \param[out] none
+    \retval     status
+*/
+usb_status usb_transc_outxfer (usb_core_driver *udev, usb_transc *transc)
+{
+    usb_status status = USB_OK;
+
+    uint8_t ep_num = transc->ep_addr.num;
+
+    uint32_t epctl = udev->regs.er_out[ep_num]->DOEPCTL;
+    uint32_t eplen = udev->regs.er_out[ep_num]->DOEPLEN;
+
+    eplen &= ~(DEPLEN_TLEN | DEPLEN_PCNT);
+
+    /* zero length packet or endpoint 0 */
+    if ((0U == transc->xfer_len) || (0U == ep_num)) {
+        /* set the transfer length to max packet size */
+        eplen |= transc->max_len;
+
+        /* set the transfer packet count to 1 */
+        eplen |= 1U << 19U;
+    } else {
+        /* configure the transfer size and packet count as follows:
+         * pktcnt = N
+         * xfersize = N * maxpacket
+         */
+        uint32_t packet_count = (transc->xfer_len + transc->max_len - 1U) / transc->max_len;
+
+        eplen |= packet_count << 19U;
+        eplen |= packet_count * transc->max_len;
+
+#ifdef INT_HIGH_BW
+        if (transc->ep_type == (uint8_t)USB_EPTYPE_INTR) {
+            eplen |= DIEPLEN_MCNT & (3U << 29U);
+        }
+#endif /* INT_HIGH_BW */
+    }
+
+    udev->regs.er_out[ep_num]->DOEPLEN = eplen;
+
+    if ((uint8_t)USB_USE_DMA == udev->bp.transfer_mode) {
+        udev->regs.er_out[ep_num]->DOEPDMAADDR = transc->dma_addr;
+    }
+
+    if (transc->ep_type == (uint8_t)USB_EPTYPE_ISOC) {
+        if (transc->frame_num) {
+            epctl |= DEPCTL_SD1PID;
+        } else {
+            epctl |= DEPCTL_SD0PID;
+        }
+    }
+
+    /* enable the endpoint and clear the NAK */
+    epctl |= DEPCTL_EPEN | DEPCTL_CNAK;
+
+    udev->regs.er_out[ep_num]->DOEPCTL = epctl;
+
+    return status;
+}
+
+/*!
+    \brief      set the USB transaction STALL status
+    \param[in]  udev: pointer to USB device
+    \param[in]  transc: the USB transaction
+    \param[out] none
+    \retval     status
+*/
+usb_status usb_transc_stall (usb_core_driver *udev, usb_transc *transc)
+{
+    __IO uint32_t *reg_addr = NULL;
+
+    uint8_t ep_num = transc->ep_addr.num;
+
+    if (transc->ep_addr.dir) {
+        reg_addr = &(udev->regs.er_in[ep_num]->DIEPCTL);
+
+        /* set the endpoint disable bit */
+        if (*reg_addr & DEPCTL_EPEN) {
+            *reg_addr |= DEPCTL_EPD;
+        }
+    } else {
+        /* set the endpoint stall bit */
+        reg_addr = &(udev->regs.er_out[ep_num]->DOEPCTL);
+    }
+
+    /* set the endpoint stall bit */
+    *reg_addr |= DEPCTL_STALL;
+
+    return USB_OK;
+}
+
+/*!
+    \brief      clear the USB transaction STALL status
+    \param[in]  udev: pointer to USB device
+    \param[in]  transc: the USB transaction
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_transc_clrstall(usb_core_driver *udev, usb_transc *transc)
+{
+    __IO uint32_t *reg_addr = NULL;
+
+    uint8_t ep_num = transc->ep_addr.num;
+
+    if (transc->ep_addr.dir) {
+        reg_addr = &(udev->regs.er_in[ep_num]->DIEPCTL);
+    } else {
+        reg_addr = &(udev->regs.er_out[ep_num]->DOEPCTL);
+    }
+
+    /* clear the endpoint stall bits */
+    *reg_addr &= ~DEPCTL_STALL;
+
+    /* reset data PID of the periodic endpoints */
+    if ((transc->ep_type == (uint8_t)USB_EPTYPE_INTR) || (transc->ep_type == (uint8_t)USB_EPTYPE_BULK)) {
+        *reg_addr |= DEPCTL_SD0PID;
+    }
+
+    return USB_OK;
+}
+
+/*!
+    \brief      read device IN endpoint interrupt flag register
+    \param[in]  udev: pointer to USB device
+    \param[in]  ep_num: endpoint number
+    \param[out] none
+    \retval     interrupt value
+*/
+uint32_t usb_iepintr_read (usb_core_driver *udev, uint8_t ep_num)
+{
+    uint32_t value = 0U, fifoemptymask, commonintmask;
+
+    commonintmask = udev->regs.dr->DIEPINTEN;
+    fifoemptymask = udev->regs.dr->DIEPFEINTEN;
+
+    /* check FIFO empty interrupt enable bit */
+    commonintmask |= ((fifoemptymask >> ep_num) & 0x1U) << 7;
+
+    value = udev->regs.er_in[ep_num]->DIEPINTF & commonintmask;
+
+    return value;
+}
+
+/*!
+    \brief      configures OUT endpoint 0 to receive SETUP packets
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     none
+*/
+void usb_ctlep_startout (usb_core_driver *udev)
+{
+    /* set OUT endpoint 0 receive length to 24 bytes, 1 packet and 3 setup packets */
+    udev->regs.er_out[0]->DOEPLEN = DOEP0_TLEN(8U * 3U) | DOEP0_PCNT(1U) | DOEP0_STPCNT(3U);
+
+    if ((uint8_t)USB_USE_DMA == udev->bp.transfer_mode) {
+        udev->regs.er_out[0]->DOEPDMAADDR = (uint32_t)&udev->dev.control.req;
+
+        /* endpoint enable */
+        udev->regs.er_out[0]->DOEPCTL |= DEPCTL_EPACT | DEPCTL_EPEN;
+    }
+}
+
+/*!
+    \brief      active remote wakeup signaling
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     none
+*/
+void usb_rwkup_active (usb_core_driver *udev)
+{
+    if (udev->dev.pm.dev_remote_wakeup)  {
+        if (udev->regs.dr->DSTAT & DSTAT_SPST) {
+            if (udev->bp.low_power) {
+                /* ungate USB core clock */
+                *udev->regs.PWRCLKCTL &= ~(PWRCLKCTL_SHCLK | PWRCLKCTL_SUCLK);
+            }
+
+            /* active remote wakeup signaling */
+            udev->regs.dr->DCTL |= DCTL_RWKUP;
+
+            usb_mdelay(5U);
+
+            udev->regs.dr->DCTL &= ~DCTL_RWKUP;
+        }
+    }
+}
+
+/*!
+    \brief      active USB core clock
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     none
+*/
+void usb_clock_active (usb_core_driver *udev)
+{
+    if (udev->bp.low_power) {
+        if (udev->regs.dr->DSTAT & DSTAT_SPST) {
+            /* ungate USB Core clock */
+            *udev->regs.PWRCLKCTL &= ~(PWRCLKCTL_SHCLK | PWRCLKCTL_SUCLK);
+        }
+    }
+}
+
+/*!
+    \brief      USB device suspend
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     none
+*/
+void usb_dev_suspend (usb_core_driver *udev)
+{
+    __IO uint32_t devstat = udev->regs.dr->DSTAT;
+
+    if ((udev->bp.low_power) && (devstat & DSTAT_SPST)) {
+        /* switch-off the USB clocks */
+        *udev->regs.PWRCLKCTL |= PWRCLKCTL_SHCLK;
+
+        /* enter DEEP_SLEEP mode with LDO in low power mode */
+        pmu_to_deepsleepmode (PMU_LDO_LOWPOWER,PMU_LOWDRIVER_DISABLE,WFI_CMD);
+    }
+}
+
+/*!
+    \brief      stop the device and clean up FIFOs
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     none
+*/
+void usb_dev_stop (usb_core_driver *udev)
+{
+    uint32_t i;
+
+    udev->dev.cur_status = 1U;
+
+    /* clear all interrupt flag and enable bits */
+    for (i = 0U; i < udev->bp.num_ep; i++) {
+        udev->regs.er_in[i]->DIEPINTF = 0xFFU;
+        udev->regs.er_out[i]->DOEPINTF = 0xFFU;
+    }
+
+    udev->regs.dr->DIEPINTEN = 0U;
+    udev->regs.dr->DOEPINTEN = 0U;
+    udev->regs.dr->DAEPINTEN = 0U;
+    udev->regs.dr->DAEPINT = 0xFFFFFFFFU;
+
+    /* flush the FIFO */
+    (void)usb_rxfifo_flush (&udev->regs);
+    (void)usb_txfifo_flush (&udev->regs, 0x10U);
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Source/drv_usb_host.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Source/drv_usb_host.c
@@ -1,0 +1,477 @@
+/*!
+    \file    drv_usb_host.c
+    \brief   USB host mode low level driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "drv_usb_hw.h"
+#include "drv_usb_core.h"
+#include "drv_usb_host.h"
+
+const uint32_t PIPE_DPID[2] = {
+    PIPE_DPID_DATA0,
+    PIPE_DPID_DATA1
+};
+
+/*!
+    \brief      initializes USB core for host mode
+    \param[in]  udev: pointer to selected USB host
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_host_init (usb_core_driver *udev)
+{
+    uint32_t i = 0U, inten = 0U;
+
+    uint32_t nptxfifolen = 0U;
+    uint32_t ptxfifolen = 0U;
+
+    /* restart the PHY Clock */
+    *udev->regs.PWRCLKCTL = 0U;
+
+    /* initialize host configuration register */
+    if (USB_ULPI_PHY == udev->bp.phy_itf) {
+        usb_phyclock_config (udev, HCTL_30_60MHZ); 
+    } else {
+        usb_phyclock_config (udev, HCTL_48MHZ);
+    }
+
+    /* support FS/LS only */
+    udev->regs.hr->HCTL &= ~HCTL_SPDFSLS;
+
+    /* configure data FIFOs size */
+#ifdef USB_FS_CORE
+    if (USB_CORE_ENUM_FS == udev->bp.core_enum) {
+        /* set Rx FIFO size */
+        udev->regs.gr->GRFLEN = USB_RX_FIFO_FS_SIZE;
+
+        /* set non-periodic Tx FIFO size and address */
+        nptxfifolen |= USB_RX_FIFO_FS_SIZE;
+        nptxfifolen |= USB_HTX_NPFIFO_FS_SIZE << 16U;
+        udev->regs.gr->DIEP0TFLEN_HNPTFLEN = nptxfifolen;
+
+        /* set periodic Tx FIFO size and address */
+        ptxfifolen |= USB_RX_FIFO_FS_SIZE + USB_HTX_NPFIFO_FS_SIZE;
+        ptxfifolen |= USB_HTX_PFIFO_FS_SIZE << 16U;
+        udev->regs.gr->HPTFLEN = ptxfifolen;
+    }
+#endif /* USB_FS_CORE */
+
+#ifdef USB_HS_CORE
+    if (USB_CORE_ENUM_HS == udev->bp.core_enum) {
+        /* set Rx FIFO size */
+        udev->regs.gr->GRFLEN = USB_RX_FIFO_HS_SIZE;
+
+        /* set non-periodic Tx FIFO size and address */
+        nptxfifolen |= USB_RX_FIFO_HS_SIZE;
+        nptxfifolen |= USB_HTX_NPFIFO_HS_SIZE << 16U;
+        udev->regs.gr->DIEP0TFLEN_HNPTFLEN = nptxfifolen;
+
+        /* set periodic Tx FIFO size and address */
+        ptxfifolen |= USB_RX_FIFO_HS_SIZE + USB_HTX_NPFIFO_HS_SIZE;
+        ptxfifolen |= USB_HTX_PFIFO_HS_SIZE << 16U;
+        udev->regs.gr->HPTFLEN = ptxfifolen;
+    }
+#endif /* USB_HS_CORE */
+
+#ifdef USE_OTG_MODE
+
+    /* clear host set HNP enable in the usb_otg control register */
+    udev->regs.gr->GOTGCS &= ~GOTGCS_HHNPEN;
+
+#endif /* USE_OTG_MODE */
+
+    /* make sure the FIFOs are flushed */
+
+    /* flush all Tx FIFOs in device or host mode */
+    usb_txfifo_flush (&udev->regs, 0x10U);
+
+    /* flush the entire Rx FIFO */
+    usb_rxfifo_flush (&udev->regs);
+
+    /* disable all interrupts */
+    udev->regs.gr->GINTEN = 0U;
+
+    /* clear any pending USB OTG interrupts */
+    udev->regs.gr->GOTGINTF = 0xFFFFFFFFU;
+
+    /* enable the USB wakeup and suspend interrupts */
+    udev->regs.gr->GINTF = 0xBFFFFFFFU;
+
+    /* clear all pending host channel interrupts */
+    for (i = 0U; i < udev->bp.num_pipe; i++) {
+        udev->regs.pr[i]->HCHINTF = 0xFFFFFFFFU;
+        udev->regs.pr[i]->HCHINTEN = 0U;
+    }
+
+#ifndef USE_OTG_MODE
+    usb_portvbus_switch (udev, 1U);
+#endif /* USE_OTG_MODE */
+
+    udev->regs.gr->GINTEN = GINTEN_WKUPIE | GINTEN_SPIE;
+
+    /* enable host_mode-related interrupts */
+    if (USB_USE_FIFO == udev->bp.transfer_mode) {
+        inten = GINTEN_RXFNEIE;
+    }
+
+    inten |= GINTEN_SESIE | GINTEN_HPIE | GINTEN_HCIE | GINTEN_ISOINCIE;
+
+    udev->regs.gr->GINTEN |= inten;
+
+    inten = GINTEN_DISCIE | GINTEN_SOFIE;
+
+    udev->regs.gr->GINTEN &= ~inten;
+
+    return USB_OK;
+}
+
+/*!
+    \brief      control the VBUS to power
+    \param[in]  udev: pointer to selected usb host
+    \param[in]  state: VBUS state
+    \param[out] none
+    \retval     none
+*/
+void usb_portvbus_switch (usb_core_driver *udev, uint8_t state)
+{
+    uint32_t port = 0U;
+
+    /* enable or disable the external charge pump */
+    usb_vbus_drive (state);
+
+    /* turn on the host port power. */
+    port = usb_port_read (udev);
+
+    if (!(port & HPCS_PP) && (1U == state)) {
+        port |= HPCS_PP;
+    }
+
+    if ((port & HPCS_PP) && (0U == state)) {
+        port &= ~HPCS_PP;
+    }
+
+    *udev->regs.HPCS = port;
+
+    usb_mdelay (200U);
+}
+
+/*!
+    \brief      reset host port
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     operation status
+*/
+uint32_t usb_port_reset (usb_core_driver *udev)
+{
+    __IO uint32_t port = usb_port_read (udev);
+
+    *udev->regs.HPCS = port | HPCS_PRST;
+
+    usb_mdelay(20U); /* see note */
+
+    *udev->regs.HPCS = port & ~HPCS_PRST;
+
+    usb_mdelay(20U);
+
+    return 1U;
+}
+
+/*!
+    \brief      initialize host pipe
+    \param[in]  udev: pointer to USB device
+    \param[in]  pipe_num: host pipe number which is in (0..7)
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_pipe_init (usb_core_driver *udev, uint8_t pipe_num)
+{
+    usb_status status = USB_OK;
+
+    __IO uint32_t pp_ctl = 0U;
+    __IO uint32_t pp_inten = HCHINTEN_TFIE;
+
+    usb_pipe *pp = &udev->host.pipe[pipe_num];
+
+    /* clear old interrupt conditions for this host channel */
+    udev->regs.pr[pipe_num]->HCHINTF = 0xFFFFFFFFU;
+
+    if (USB_USE_DMA == udev->bp.transfer_mode) {
+        pp_inten |= HCHINTEN_DMAERIE;
+    }
+
+    if (pp->ep.dir) {
+        pp_inten |= HCHINTEN_BBERIE;
+    }
+
+    /* enable channel interrupts required for this transfer */
+    switch (pp->ep.type) {
+    case USB_EPTYPE_CTRL:
+    case USB_EPTYPE_BULK:
+        pp_inten |= HCHINTEN_STALLIE | HCHINTEN_USBERIE \
+                    | HCHINTEN_DTERIE | HCHINTEN_NAKIE;
+
+        if (!pp->ep.dir) {
+            if (PORT_SPEED_HIGH == pp->dev_speed) {
+                pp_inten |= HCHINTEN_NYETIE;
+                pp_inten |= HCHINTEN_ACKIE;
+            }
+        }
+        break;
+
+    case USB_EPTYPE_INTR:
+        pp_inten |= HCHINTEN_STALLIE | HCHINTEN_USBERIE | HCHINTEN_DTERIE \
+                     | HCHINTEN_NAKIE | HCHINTEN_REQOVRIE;
+        break;
+
+    case USB_EPTYPE_ISOC:
+        pp_inten |= HCHINTEN_REQOVRIE | HCHINTEN_ACKIE;
+
+        if (pp->ep.dir) {
+            pp_inten |= HCHINTEN_USBERIE;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    udev->regs.pr[pipe_num]->HCHINTEN = pp_inten;
+
+    /* enable the top level host channel interrupt */
+    udev->regs.hr->HACHINTEN |= 1U << pipe_num;
+
+    /* make sure host channel interrupts are enabled */
+    udev->regs.gr->GINTEN |= GINTEN_HCIE;
+
+    /* program the host channel control register */
+    pp_ctl |= PIPE_CTL_DAR(pp->dev_addr);
+    pp_ctl |= PIPE_CTL_EPNUM(pp->ep.num);
+    pp_ctl |= PIPE_CTL_EPDIR(pp->ep.dir);
+    pp_ctl |= PIPE_CTL_EPTYPE(pp->ep.type);
+    pp_ctl |= PIPE_CTL_LSD(pp->dev_speed == PORT_SPEED_LOW);
+
+    pp_ctl |= pp->ep.mps;
+    pp_ctl |= ((uint32_t)(pp->ep.type == USB_EPTYPE_INTR) << 29U) & HCHCTL_ODDFRM;
+
+    udev->regs.pr[pipe_num]->HCHCTL = pp_ctl;
+
+    return status;
+}
+
+/*!
+    \brief      prepare host channel for transferring packets
+    \param[in]  udev: pointer to USB device
+    \param[in]  pipe_num: host pipe number which is in (0..7)
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_pipe_xfer (usb_core_driver *udev, uint8_t pipe_num)
+{
+    usb_status status = USB_OK;
+
+    uint16_t dword_len = 0U;
+    uint16_t packet_count = 0U;
+
+    __IO uint32_t pp_ctl = 0U;
+
+    usb_pipe *pp = &udev->host.pipe[pipe_num];
+
+    uint16_t max_packet_len = pp->ep.mps;
+
+    /* compute the expected number of packets associated to the transfer */
+    if (pp->xfer_len > 0U) {
+        packet_count = (uint16_t)((pp->xfer_len + max_packet_len - 1U) / max_packet_len);
+
+        if (packet_count > HC_MAX_PACKET_COUNT) {
+            packet_count = HC_MAX_PACKET_COUNT;
+            pp->xfer_len = (uint16_t)(packet_count * max_packet_len);
+        }
+    } else {
+        packet_count = 1U;
+    }
+
+    if (pp->ep.dir) {
+        pp->xfer_len = (uint16_t)(packet_count * max_packet_len);
+    }
+
+    /* initialize the host channel transfer information */
+    udev->regs.pr[pipe_num]->HCHLEN = pp->xfer_len | pp->DPID | PIPE_XFER_PCNT(packet_count);
+
+    if (USB_USE_DMA == udev->bp.transfer_mode) {
+        udev->regs.pr[pipe_num]->HCHDMAADDR = (unsigned int)pp->xfer_buf;
+    }
+
+    pp_ctl = udev->regs.pr[pipe_num]->HCHCTL;
+
+    if (usb_frame_even(udev)) {
+        pp_ctl |= HCHCTL_ODDFRM;
+    } else {
+        pp_ctl &= ~HCHCTL_ODDFRM;
+    }
+
+    /* set host channel enabled */
+    pp_ctl |= HCHCTL_CEN;
+    pp_ctl &= ~HCHCTL_CDIS;
+
+    udev->regs.pr[pipe_num]->HCHCTL = pp_ctl;
+
+    if (USB_USE_FIFO == udev->bp.transfer_mode) {
+        if ((0U == pp->ep.dir) && (pp->xfer_len > 0U)) {
+            switch (pp->ep.type) {
+            /* non-periodic transfer */
+            case USB_EPTYPE_CTRL:
+            case USB_EPTYPE_BULK:
+                dword_len = (uint16_t)((pp->xfer_len + 3U) / 4U);
+
+                /* check if there is enough space in FIFO space */
+                if (dword_len > (udev->regs.gr->HNPTFQSTAT & HNPTFQSTAT_NPTXFS)) {
+                    /* need to process data in nptxfempty interrupt */
+                    udev->regs.gr->GINTEN |= GINTEN_NPTXFEIE;
+                }
+                break;
+
+            /* periodic transfer */
+            case USB_EPTYPE_INTR:
+            case USB_EPTYPE_ISOC:
+                dword_len = (uint16_t)((pp->xfer_len + 3U) / 4U);
+
+                /* check if there is enough space in fifo space */
+                if (dword_len > (udev->regs.hr->HPTFQSTAT & HPTFQSTAT_PTXFS)) {
+                    /* need to process data in ptxfempty interrupt */
+                    udev->regs.gr->GINTEN |= GINTEN_PTXFEIE;
+                }
+                break;
+
+            default:
+                break;
+            }
+
+            /* write packet into the Tx fifo. */
+            usb_txfifo_write (&udev->regs, pp->xfer_buf, pipe_num, (uint16_t)pp->xfer_len);
+        }
+    }
+
+    return status;
+}
+
+/*!
+    \brief      halt pipe
+    \param[in]  udev: pointer to USB device
+    \param[in]  pipe_num: host pipe number which is in (0..7)
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_pipe_halt (usb_core_driver *udev, uint8_t pipe_num)
+{
+    __IO uint32_t pp_ctl = udev->regs.pr[pipe_num]->HCHCTL;
+
+    uint8_t ep_type = (uint8_t)((pp_ctl & HCHCTL_EPTYPE) >> 18U);
+
+    pp_ctl |= HCHCTL_CEN | HCHCTL_CDIS;
+
+    switch (ep_type) {
+    case USB_EPTYPE_CTRL:
+    case USB_EPTYPE_BULK:
+        if (0U == (udev->regs.gr->HNPTFQSTAT & HNPTFQSTAT_NPTXFS)) {
+            pp_ctl &= ~HCHCTL_CEN;
+        }
+        break;
+
+    case USB_EPTYPE_INTR:
+    case USB_EPTYPE_ISOC:
+        if (0U == (udev->regs.hr->HPTFQSTAT & HPTFQSTAT_PTXFS)) {
+            pp_ctl &= ~HCHCTL_CEN;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    udev->regs.pr[pipe_num]->HCHCTL = pp_ctl;
+
+    return USB_OK;
+}
+
+/*!
+    \brief      configure host pipe to do ping operation
+    \param[in]  udev: pointer to USB device
+    \param[in]  pipe_num: host pipe number which is in (0..7)
+    \param[out] none
+    \retval     operation status
+*/
+usb_status usb_pipe_ping (usb_core_driver *udev, uint8_t pipe_num)
+{
+    uint32_t pp_ctl = 0U;
+
+    udev->regs.pr[pipe_num]->HCHLEN = HCHLEN_PING | (HCHLEN_PCNT & (1U << 19U));
+
+    pp_ctl = udev->regs.pr[pipe_num]->HCHCTL;
+
+    pp_ctl |= HCHCTL_CEN;
+    pp_ctl &= ~HCHCTL_CDIS;
+
+    udev->regs.pr[pipe_num]->HCHCTL = pp_ctl;
+
+    return USB_OK;
+}
+
+/*!
+    \brief      stop the USB host and clean up FIFO
+    \param[in]  udev: pointer to USB device
+    \param[out] none
+    \retval     none
+*/
+void usb_host_stop (usb_core_driver *udev)
+{
+    uint32_t i;
+    __IO uint32_t pp_ctl = 0U;
+
+    udev->regs.hr->HACHINTEN = 0x0U;
+    udev->regs.hr->HACHINT = 0xFFFFFFFFU;
+
+    /* flush out any leftover queued requests. */
+    for (i = 0U; i < udev->bp.num_pipe; i++) {
+        pp_ctl = udev->regs.pr[i]->HCHCTL;
+
+        pp_ctl &= ~(HCHCTL_CEN | HCHCTL_EPDIR);
+        pp_ctl |= HCHCTL_CDIS;
+
+        udev->regs.pr[i]->HCHCTL = pp_ctl;
+    }
+
+    /* flush the FIFO */
+    usb_rxfifo_flush (&udev->regs);
+    usb_txfifo_flush (&udev->regs, 0x10U);
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Source/drv_usbd_int.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Source/drv_usbd_int.c
@@ -1,0 +1,589 @@
+/*!
+    \file    drv_usbd_int.c
+    \brief   USB device mode interrupt routines
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usbd_conf.h"
+#include "drv_usbd_int.h"
+#include "usbd_transc.h"
+
+/* local function prototypes ('static') */
+static uint32_t usbd_int_epout                 (usb_core_driver *udev);
+static uint32_t usbd_int_epin                  (usb_core_driver *udev);
+static uint32_t usbd_int_rxfifo                (usb_core_driver *udev);
+static uint32_t usbd_int_reset                 (usb_core_driver *udev);
+static uint32_t usbd_int_enumfinish            (usb_core_driver *udev);
+static uint32_t usbd_int_suspend               (usb_core_driver *udev);
+static uint32_t usbd_emptytxfifo_write         (usb_core_driver *udev, uint32_t ep_num);
+
+static const uint8_t USB_SPEED[4] = {
+    [DSTAT_EM_HS_PHY_30MHZ_60MHZ] = (uint8_t)USB_SPEED_HIGH,
+    [DSTAT_EM_FS_PHY_30MHZ_60MHZ] = (uint8_t)USB_SPEED_FULL,
+    [DSTAT_EM_FS_PHY_48MHZ] = (uint8_t)USB_SPEED_FULL,
+    [DSTAT_EM_LS_PHY_6MHZ] = (uint8_t)USB_SPEED_LOW
+};
+
+/*!
+    \brief      USB device-mode interrupts global service routine handler
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     none
+*/
+void usbd_isr (usb_core_driver *udev)
+{
+    if (HOST_MODE != (udev->regs.gr->GINTF & GINTF_COPM)) {
+        uint32_t intr = udev->regs.gr->GINTF & udev->regs.gr->GINTEN;
+
+        /* there are no interrupts, avoid spurious interrupt */
+        if (!intr) {
+            return;
+        }
+
+        /* OUT endpoints interrupts */
+        if (intr & GINTF_OEPIF) {
+            (void)usbd_int_epout (udev);
+        }
+
+        /* IN endpoints interrupts */
+        if (intr & GINTF_IEPIF) {
+            (void)usbd_int_epin (udev);
+        }
+
+        /* suspend interrupt */
+        if (intr & GINTF_SP) {
+            (void)usbd_int_suspend (udev);
+        }
+
+        /* wakeup interrupt */
+        if (intr & GINTF_WKUPIF) {
+            /* inform upper layer by the resume event */
+            udev->dev.cur_status = USBD_CONFIGURED;
+
+            /* clear interrupt */
+            udev->regs.gr->GINTF = GINTF_WKUPIF;
+        }
+
+        /* start of frame interrupt */
+        if (intr & GINTF_SOF) {
+            if (udev->dev.class_core->SOF) {
+                (void)udev->dev.class_core->SOF(udev);
+            }
+
+            /* clear interrupt */
+            udev->regs.gr->GINTF = GINTF_SOF;
+        }
+
+        /* receive FIFO not empty interrupt */
+        if (intr & GINTF_RXFNEIF) {
+            (void)usbd_int_rxfifo (udev);
+        }
+
+        /* USB reset interrupt */
+        if (intr & GINTF_RST) {
+            (void)usbd_int_reset (udev);
+        }
+
+        /* enumeration has been done interrupt */
+        if (intr & GINTF_ENUMFIF) {
+            (void)usbd_int_enumfinish (udev);
+        }
+
+        /* incomplete synchronization IN transfer interrupt*/
+        if (intr & GINTF_ISOINCIF) {
+            if (NULL != udev->dev.class_core->incomplete_isoc_in) {
+                (void)udev->dev.class_core->incomplete_isoc_in(udev);
+            }
+
+            /* Clear interrupt */
+            udev->regs.gr->GINTF = GINTF_ISOINCIF;
+        }
+
+        /* incomplete synchronization OUT transfer interrupt*/
+        if (intr & GINTF_ISOONCIF) {
+            if (NULL != udev->dev.class_core->incomplete_isoc_out) {
+                (void)udev->dev.class_core->incomplete_isoc_out(udev);
+            }
+
+            /* clear interrupt */
+            udev->regs.gr->GINTF = GINTF_ISOONCIF;
+        }
+
+#ifdef VBUS_SENSING_ENABLED
+
+        /* session request interrupt */
+        if (intr & GINTF_SESIF) {
+            udev->regs.gr->GINTF = GINTF_SESIF;
+        }
+
+        /* OTG mode interrupt */
+        if (intr & GINTF_OTGIF) {
+            if(udev->regs.gr->GOTGINTF & GOTGINTF_SESEND) {
+
+            }
+
+            /* clear OTG interrupt */
+            udev->regs.gr->GINTF = GINTF_OTGIF;
+        }
+#endif /* VBUS_SENSING_ENABLED */
+    }
+}
+
+#ifdef USB_HS_DEDICATED_EP1_ENABLED
+
+/*!
+    \brief      USB dedicated OUT endpoint 1 interrupt service routine handler
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     operation status
+*/
+uint32_t usbd_int_dedicated_ep1out (usb_core_driver *udev)
+{
+    uint32_t oepintr = 0U;
+    uint32_t oeplen = 0U;
+
+    oepintr = udev->regs.er_out[1]->DOEPINTF;
+    oepintr &= udev->regs.dr->DOEP1INTEN;
+
+    /* transfer complete */
+    if(oepintr & DOEPINTF_TF){
+        /* clear the bit in DOEPINTn for this interrupt */
+        udev->regs.er_out[1]->DOEPINTF = DOEPINTF_TF;
+
+        if(USB_USE_DMA == udev->bp.transfer_mode){
+            oeplen = udev->regs.er_out[1]->DOEPLEN;
+
+            /* to do : handle more than one single max packet size packet */
+            udev->dev.transc_out[1].xfer_count = udev->dev.transc_out[1].max_len - \
+                                    (oeplen & DEPLEN_TLEN);
+        }
+
+        /* rx complete */
+        usbd_out_transc (udev, 1U);
+    }
+
+    return 1U;
+}
+
+/*!
+    \brief      USB dedicated IN endpoint 1 interrupt service routine handler
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     operation status
+*/
+uint32_t usbd_int_dedicated_ep1in (usb_core_driver *udev)
+{
+    uint32_t inten, intr, emptyen;
+
+    inten = udev->regs.dr->DIEP1INTEN;
+    emptyen = udev->regs.dr->DIEPFEINTEN;
+
+    inten |= ((emptyen >> 1 ) & 0x1) << 7;
+
+    intr = udev->regs.er_in[1]->DIEPINTF & inten;
+
+    if(intr & DIEPINTF_TF){
+        udev->regs.dr->DIEPFEINTEN &= ~(0x1 << 1);
+
+        udev->regs.er_in[1]->DIEPINTF = DIEPINTF_TF;
+
+        /* TX complete */
+        usbd_in_transc (udev, 1);
+    }
+
+    if(intr & DIEPINTF_TXFE){
+        usbd_emptytxfifo_write(udev, 1);
+
+        udev->regs.er_in[1]->DIEPINTF = DIEPINTF_TXFE;
+    }
+
+    return 1;
+}
+
+#endif /* USB_HS_DEDICATED_EP1_ENABLED */
+
+/*!
+    \brief      indicates that an OUT endpoint has a pending interrupt
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     operation status
+*/
+static uint32_t usbd_int_epout (usb_core_driver *udev)
+{
+    uint32_t epintnum = 0U;
+    uint8_t ep_num = 0U;
+
+    for (epintnum = usb_oepintnum_read (udev); epintnum; epintnum >>= 1, ep_num++) {
+        if (epintnum & 0x01U) {
+            __IO uint32_t oepintr = usb_oepintr_read (udev, ep_num);
+
+            /* transfer complete interrupt */
+            if (oepintr & DOEPINTF_TF) {
+                /* clear the bit in DOEPINTF for this interrupt */
+                udev->regs.er_out[ep_num]->DOEPINTF = DOEPINTF_TF;
+
+                if ((uint8_t)USB_USE_DMA == udev->bp.transfer_mode) {
+                    __IO uint32_t eplen = udev->regs.er_out[ep_num]->DOEPLEN;
+
+                    udev->dev.transc_out[ep_num].xfer_count = udev->dev.transc_out[ep_num].max_len - \
+                                                                (eplen & DEPLEN_TLEN);
+                }
+
+                /* inform upper layer: data ready */
+                (void)usbd_out_transc (udev, ep_num);
+
+                if ((uint8_t)USB_USE_DMA == udev->bp.transfer_mode) {
+                    if ((0U == ep_num) && ((uint8_t)USB_CTL_STATUS_OUT == udev->dev.control.ctl_state)) {
+                        usb_ctlep_startout (udev);
+                    }
+                }
+            }
+
+            /* setup phase finished interrupt (control endpoints) */
+            if (oepintr & DOEPINTF_STPF) {
+                /* inform the upper layer that a setup packet is available */
+                (void)usbd_setup_transc (udev);
+
+                udev->regs.er_out[ep_num]->DOEPINTF = DOEPINTF_STPF;
+            }
+        }
+    }
+
+    return 1U;
+}
+
+/*!
+    \brief      indicates that an IN endpoint has a pending interrupt
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     operation status
+*/
+static uint32_t usbd_int_epin (usb_core_driver *udev)
+{
+    uint32_t epintnum = 0U;
+    uint8_t ep_num = 0U;
+
+    for (epintnum = usb_iepintnum_read (udev); epintnum; epintnum >>= 1, ep_num++) {
+        if (epintnum & 0x1U) {
+            __IO uint32_t iepintr = usb_iepintr_read (udev, ep_num);
+
+            if (iepintr & DIEPINTF_TF) {
+                udev->regs.er_in[ep_num]->DIEPINTF = DIEPINTF_TF;
+
+                /* data transmission is completed */
+                (void)usbd_in_transc (udev, ep_num);
+
+                if ((uint8_t)USB_USE_DMA == udev->bp.transfer_mode) {
+                    if ((0U == ep_num) && ((uint8_t)USB_CTL_STATUS_IN == udev->dev.control.ctl_state)) {
+                        usb_ctlep_startout (udev);
+                    }
+                }
+            }
+
+            if (iepintr & DIEPINTF_TXFE) {
+                usbd_emptytxfifo_write (udev, (uint32_t)ep_num);
+
+                udev->regs.er_in[ep_num]->DIEPINTF = DIEPINTF_TXFE;
+            }
+        }
+    }
+
+    return 1U;
+}
+
+/*!
+    \brief      handle the RX status queue level interrupt
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     operation status
+*/
+static uint32_t usbd_int_rxfifo (usb_core_driver *udev)
+{
+    usb_transc *transc = NULL;
+
+    uint8_t data_PID = 0U;
+    uint32_t bcount = 0U;
+
+    __IO uint32_t devrxstat = 0U;
+
+    /* disable the Rx status queue non-empty interrupt */
+    udev->regs.gr->GINTEN &= ~GINTEN_RXFNEIE;
+
+    /* get the status from the top of the FIFO */
+    devrxstat = udev->regs.gr->GRSTATP;
+
+    uint8_t ep_num = (uint8_t)(devrxstat & GRSTATRP_EPNUM);
+
+    transc = &udev->dev.transc_out[ep_num];
+
+    bcount = (devrxstat & GRSTATRP_BCOUNT) >> 4U;
+    data_PID = (uint8_t)((devrxstat & GRSTATRP_DPID) >> 15U);
+
+#if defined(USE_USB_HS) && defined(USE_ULPI_PHY)
+    #ifndef USE_450Z_EVAL
+        /* ensure no-DMA mode can work */
+        if (0U == (udev->regs.er_out[ep_num]->DOEPLEN & DEPLEN_PCNT)) {
+            uint32_t devepctl = udev->regs.er_out[ep_num]->DOEPCTL;
+
+            devepctl |= DEPCTL_SNAK;
+            devepctl &= ~DEPCTL_EPEN;
+            devepctl &= ~DEPCTL_EPD;
+
+            udev->regs.er_out[ep_num]->DOEPCTL = devepctl;
+        }
+    #endif /* USE_450Z_EVAL */
+#endif /* USE_USB_HS && USE_ULPI_PHY */
+
+    switch ((devrxstat & GRSTATRP_RPCKST) >> 17U) {
+    case RSTAT_GOUT_NAK:
+        break;
+
+    case RSTAT_DATA_UPDT:
+        if (bcount > 0U) {
+            (void)usb_rxfifo_read (&udev->regs, transc->xfer_buf, (uint16_t)bcount);
+
+            transc->xfer_buf += bcount;
+            transc->xfer_count += bcount;
+        }
+        break;
+
+    case RSTAT_XFER_COMP:
+        /* trigger the OUT endpoint interrupt */
+        break;
+
+    case RSTAT_SETUP_COMP:
+        /* trigger the OUT endpoint interrupt */
+        break;
+
+    case RSTAT_SETUP_UPDT:
+        if ((0U == transc->ep_addr.num) && (8U == bcount) && (DPID_DATA0 == data_PID)) {
+            /* copy the setup packet received in FIFO into the setup buffer in RAM */
+            (void)usb_rxfifo_read (&udev->regs, (uint8_t *)&udev->dev.control.req, (uint16_t)bcount);
+
+            transc->xfer_count += bcount;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    /* enable the Rx status queue level interrupt */
+    udev->regs.gr->GINTEN |= GINTEN_RXFNEIE;
+
+    return 1U;
+}
+
+/*!
+    \brief      handle USB reset interrupt
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     status
+*/
+static uint32_t usbd_int_reset (usb_core_driver *udev)
+{
+    uint32_t i;
+
+    /* clear the remote wakeup signaling */
+    udev->regs.dr->DCTL &= ~DCTL_RWKUP;
+
+    /* flush the Tx FIFO */
+    (void)usb_txfifo_flush (&udev->regs, 0U);
+
+    for (i = 0U; i < udev->bp.num_ep; i++) {
+        udev->regs.er_in[i]->DIEPINTF = 0xFFU;
+        udev->regs.er_out[i]->DOEPINTF = 0xFFU;
+    }
+
+    /* clear all pending device endpoint interrupts */
+    udev->regs.dr->DAEPINT = 0xFFFFFFFFU;
+
+    /* enable endpoint 0 interrupts */
+    udev->regs.dr->DAEPINTEN = 1U | (1U << 16U);
+
+    /* enable OUT endpoint interrupts */
+    udev->regs.dr->DOEPINTEN = DOEPINTEN_STPFEN | DOEPINTEN_TFEN;
+
+#ifdef USB_HS_DEDICATED_EP1_ENABLED
+    udev->regs.dr->DOEP1INTEN = DOEPINTEN_STPFEN | DOEPINTEN_TFEN;
+#endif /* USB_HS_DEDICATED_EP1_ENABLED */
+
+    /* enable IN endpoint interrupts */
+    udev->regs.dr->DIEPINTEN = DIEPINTEN_TFEN;
+
+#ifdef USB_HS_DEDICATED_EP1_ENABLED
+    udev->regs.dr->DIEP1INTEN = DIEPINTEN_TFEN;
+#endif /* USB_HS_DEDICATED_EP1_ENABLED */
+
+    /* reset device address */
+    udev->regs.dr->DCFG &= ~DCFG_DAR;
+
+    /* configure endpoint 0 to receive SETUP packets */
+    usb_ctlep_startout (udev);
+
+    /* clear USB reset interrupt */
+    udev->regs.gr->GINTF = GINTF_RST;
+
+    udev->dev.transc_out[0] = (usb_transc) {
+        .ep_type = USB_EPTYPE_CTRL,
+        .max_len = USB_FS_EP0_MAX_LEN
+    };
+
+    (void)usb_transc_active (udev, &udev->dev.transc_out[0]);
+
+    udev->dev.transc_in[0] = (usb_transc) {
+        .ep_addr = {
+            .dir = 1U
+        },
+
+        .ep_type = USB_EPTYPE_CTRL,
+        .max_len = USB_FS_EP0_MAX_LEN
+    };
+
+    (void)usb_transc_active (udev, &udev->dev.transc_in[0]);
+
+    /* upon reset call user call back */
+    udev->dev.cur_status = (uint8_t)USBD_DEFAULT;
+
+    return 1U;
+}
+
+/*!
+    \brief      handle USB speed enumeration finish interrupt
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     status
+*/
+static uint32_t usbd_int_enumfinish (usb_core_driver *udev)
+{
+    uint8_t enum_speed = (uint8_t)((udev->regs.dr->DSTAT & DSTAT_ES) >> 1U);
+
+    udev->regs.dr->DCTL &= ~DCTL_CGINAK;
+    udev->regs.dr->DCTL |= DCTL_CGINAK;
+
+    udev->regs.gr->GUSBCS &= ~GUSBCS_UTT;
+
+    /* set USB turn-around time based on device speed and PHY interface */
+    if (USB_SPEED[enum_speed] == (uint8_t)USB_SPEED_HIGH) {
+        udev->bp.core_speed = (uint8_t)USB_SPEED_HIGH;
+
+        udev->regs.gr->GUSBCS |= 0x09U << 10U;
+    } else {
+        udev->bp.core_speed = (uint8_t)USB_SPEED_FULL;
+
+        udev->regs.gr->GUSBCS |= 0x05U << 10U;
+    }
+
+    /* clear interrupt */
+    udev->regs.gr->GINTF = GINTF_ENUMFIF;
+
+    return 1U;
+}
+
+/*!
+    \brief      USB suspend interrupt handler
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     operation status
+*/
+static uint32_t usbd_int_suspend (usb_core_driver *udev)
+{
+    __IO uint8_t low_power = udev->bp.low_power;
+    __IO uint8_t suspend = (uint8_t)(udev->regs.dr->DSTAT & DSTAT_SPST);
+    __IO uint8_t is_configured = (udev->dev.cur_status == (uint8_t)USBD_CONFIGURED) ? 1U : 0U;
+
+    udev->dev.backup_status = udev->dev.cur_status;
+    udev->dev.cur_status = (uint8_t)USBD_SUSPENDED;
+
+    if (low_power && suspend && is_configured) {
+        /* switch-off the OTG clocks */
+        *udev->regs.PWRCLKCTL |= PWRCLKCTL_SUCLK | PWRCLKCTL_SHCLK;
+
+        /* enter DEEP_SLEEP mode with LDO in low power mode */
+        pmu_to_deepsleepmode (PMU_LDO_LOWPOWER, PMU_LOWDRIVER_DISABLE, WFI_CMD);
+    }
+
+    /* clear interrupt */
+    udev->regs.gr->GINTF = GINTF_SP;
+
+    return 1U;
+}
+
+/*!
+    \brief      check FIFO for the next packet to be loaded
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint identifier which is in (0..3)
+    \param[out] none
+    \retval     status
+*/
+static uint32_t usbd_emptytxfifo_write (usb_core_driver *udev, uint32_t ep_num)
+{
+    uint32_t len;
+    uint32_t word_count;
+
+    usb_transc *transc = &udev->dev.transc_in[ep_num];
+
+    len = transc->xfer_len - transc->xfer_count;
+
+    /* get the data length to write */
+    if (len > transc->max_len) {
+        len = transc->max_len;
+    }
+
+    word_count = (len + 3U) / 4U;
+
+    while (((udev->regs.er_in[ep_num]->DIEPTFSTAT & DIEPTFSTAT_IEPTFS) >= word_count) && \
+              (transc->xfer_count < transc->xfer_len)) {
+        len = transc->xfer_len - transc->xfer_count;
+
+        if (len > transc->max_len) {
+            len = transc->max_len;
+        }
+
+        /* write FIFO in word(4bytes) */
+        word_count = (len + 3U) / 4U;
+
+        /* write the FIFO */
+        (void)usb_txfifo_write (&udev->regs, transc->xfer_buf, (uint8_t)ep_num, (uint16_t)len);
+
+        transc->xfer_buf += len;
+        transc->xfer_count += len;
+
+        if (transc->xfer_count == transc->xfer_len) {
+            /* disable the device endpoint FIFO empty interrupt */
+            udev->regs.dr->DIEPFEINTEN &= ~(0x01U << ep_num);
+        }
+    }
+
+    return 1U;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Source/drv_usbh_int.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/driver/Source/drv_usbh_int.c
@@ -1,0 +1,626 @@
+/*!
+    \file    drv_usbh_int.c
+    \brief   USB host mode interrupt handler file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "drv_usbh_int.h"
+
+#if defined   (__CC_ARM)        /*!< ARM compiler */
+    #pragma O0
+#elif defined (__GNUC__)        /*!< GNU compiler */
+    #pragma GCC optimize ("O0")
+#elif defined  (__TASKING__)    /*!< TASKING compiler */ 
+    #pragma optimize=0
+#endif /* __CC_ARM */
+
+/* local function prototypes ('static') */
+static uint32_t usbh_int_port           (usb_core_driver *udev);
+static uint32_t usbh_int_pipe           (usb_core_driver *udev);
+static uint32_t usbh_int_pipe_in        (usb_core_driver *udev, uint32_t pp_num);
+static uint32_t usbh_int_pipe_out       (usb_core_driver *udev, uint32_t pp_num);
+static uint32_t usbh_int_rxfifonoempty  (usb_core_driver *udev);
+static uint32_t usbh_int_txfifoempty    (usb_core_driver *udev, usb_pipe_mode pp_mode);
+
+/*!
+    \brief      handle global host interrupt
+    \param[in]  udev: pointer to USB core instance
+    \param[out] none
+    \retval     operation status
+*/
+uint32_t usbh_isr (usb_core_driver *udev)
+{
+    uint32_t retval = 0U;
+
+    __IO uint32_t intr = 0U;
+
+    /* check if host mode */
+    if (HOST_MODE == (udev->regs.gr->GINTF & GINTF_COPM)) {
+        intr = usb_coreintr_get(&udev->regs);
+
+        if (!intr) {
+            return 0U;
+        }
+
+        if (intr & GINTF_SOF) {
+            usbh_int_fop->SOF(udev->host.data);
+
+            /* clear interrupt */
+            udev->regs.gr->GINTF = GINTF_SOF;
+        }
+
+        if (intr & GINTF_RXFNEIF) {
+            retval |= usbh_int_rxfifonoempty (udev);
+        }
+
+        if (intr & GINTF_NPTXFEIF) {
+            retval |= usbh_int_txfifoempty (udev, PIPE_NON_PERIOD);
+        }
+
+        if (intr & GINTF_PTXFEIF) {
+            retval |= usbh_int_txfifoempty (udev, PIPE_PERIOD);
+        }
+
+        if (intr & GINTF_HCIF) {
+            retval |= usbh_int_pipe (udev);
+        }
+
+        if (intr & GINTF_HPIF) {
+            retval |= usbh_int_port (udev);
+        }
+
+        if (intr & GINTF_DISCIF) {
+            usbh_int_fop->disconnect(udev->host.data);
+
+            /* clear interrupt */
+            udev->regs.gr->GINTF = GINTF_DISCIF;
+        }
+
+        if (intr & GINTF_ISOONCIF) {
+            udev->regs.pr[0]->HCHCTL |= HCHCTL_CEN | HCHCTL_CDIS;
+
+            /* clear interrupt */
+            udev->regs.gr->GINTF = GINTF_ISOONCIF;
+        }
+
+        if (intr & GINTF_SESIF) {
+            usb_portvbus_switch (udev, 1U);
+
+            udev->regs.gr->GINTF = GINTF_SESIF;
+        }
+
+        if (intr & GINTF_WKUPIF) {
+            /* clear interrupt */
+            udev->regs.gr->GINTF = GINTF_WKUPIF;
+        }
+    }
+
+    return retval;
+}
+
+/*!
+    \brief      handle USB pipe halt
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  pp_num: pp_num: host channel number which is in (0..7)
+    \param[in]  pp_int: pipe interrupt
+    \param[in]  pp_status: pipe status
+    \param[out] none
+    \retval     none
+*/
+static inline void usb_pp_halt (usb_core_driver *udev, 
+                                uint8_t pp_num, 
+                                uint32_t pp_int,
+                                usb_pipe_staus pp_status)
+{
+    udev->regs.pr[pp_num]->HCHINTEN |= HCHINTEN_CHIE;
+
+    usb_pipe_halt(udev, pp_num);
+
+    udev->regs.pr[pp_num]->HCHINTF = pp_int;
+
+    udev->host.pipe[pp_num].pp_status = pp_status;
+}
+
+/*!
+    \brief      handle the host port interrupt
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     operation status
+*/
+#if defined (__ICCARM__)      /*!< IAR compiler */
+    #pragma optimize = none
+#endif /* __ICCARM */
+static uint32_t usbh_int_port (usb_core_driver *udev)
+{
+    uint32_t retval = 0U;
+
+    /* note: when the USB PHY use USB HS PHY, the flag is needed */
+    uint8_t port_reset = 0U;
+
+    __IO uint32_t port_state = *udev->regs.HPCS;
+
+    /* clear the interrupt bits in GINTSTS */
+    port_state &= ~(HPCS_PE | HPCS_PCD | HPCS_PEDC);
+
+    /* port connect detected */
+    if (*udev->regs.HPCS & HPCS_PCD) {
+        port_state |= HPCS_PCD;
+
+        usbh_int_fop->connect(udev->host.data);
+
+        retval |= 1U;
+    }
+
+    /* port enable changed */
+    if (*udev->regs.HPCS & HPCS_PEDC) {
+        port_state |= HPCS_PEDC;
+
+        if (*udev->regs.HPCS & HPCS_PE) {
+            uint32_t port_speed = usb_curspeed_get(udev);
+            uint32_t clock_type = udev->regs.hr->HCTL & HCTL_CLKSEL;
+
+            udev->host.connect_status = 1U;
+
+            if (PORT_SPEED_LOW == port_speed) {
+                udev->regs.hr->HFT = 6000U;
+
+                if (HCTL_6MHZ != clock_type) {
+                    if (USB_EMBEDDED_PHY == udev->bp.phy_itf) {
+                        usb_phyclock_config (udev, HCTL_6MHZ);
+                    }
+
+                    port_reset = 1U;
+                }
+            } else if (PORT_SPEED_FULL == port_speed) {
+                udev->regs.hr->HFT = 48000U;
+
+                if (HCTL_48MHZ != clock_type) {
+                    if (USB_EMBEDDED_PHY == udev->bp.phy_itf) {
+                        usb_phyclock_config (udev, HCTL_48MHZ);
+                    }
+
+                    port_reset = 1U;
+                }
+            } else {
+                /* for high speed device and others */
+                port_reset = 1U;
+            }
+
+            udev->host.port_enabled = 1;
+
+            udev->regs.gr->GINTEN |= GINTEN_DISCIE | GINTEN_SOFIE;
+        } else {
+            udev->host.port_enabled = 0;
+        }
+    }
+
+    if (port_reset) {
+        usb_port_reset(udev);
+    }
+
+    /* clear port interrupts */
+    *udev->regs.HPCS = port_state;
+
+    return retval;
+}
+
+/*!
+    \brief      handle all host channels interrupt
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     operation status
+*/
+static uint32_t usbh_int_pipe (usb_core_driver *udev)
+{
+    uint32_t pp_num = 0U;
+    uint32_t retval = 0U;
+
+    for (pp_num = 0U; pp_num < udev->bp.num_pipe; pp_num++) {
+        if ((udev->regs.hr->HACHINT & HACHINT_HACHINT) & (1UL << pp_num)) {
+            if (udev->regs.pr[pp_num]->HCHCTL & HCHCTL_EPDIR) {
+                retval |= usbh_int_pipe_in (udev, pp_num);
+            } else {
+                retval |= usbh_int_pipe_out (udev, pp_num);
+            }
+        }
+    }
+
+    return retval;
+}
+
+/*!
+    \brief      handle the IN channel interrupt
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  pp_num: host channel number which is in (0..7)
+    \param[out] none
+    \retval     operation status
+*/
+#if defined (__ICCARM__)      /*!< IAR compiler */
+    #pragma optimize = none
+#endif /* __ICCARM */
+static uint32_t usbh_int_pipe_in (usb_core_driver *udev, uint32_t pp_num)
+{
+    usb_pr *pp_reg = udev->regs.pr[pp_num];
+
+    usb_pipe *pp = &udev->host.pipe[pp_num];
+
+    __IO uint32_t intr_pp = pp_reg->HCHINTF & pp_reg->HCHINTEN;
+
+    uint8_t ep_type = (uint8_t)((pp_reg->HCHCTL & HCHCTL_EPTYPE) >> 18U);
+
+    if (intr_pp & HCHINTF_ACK) {
+        pp_reg->HCHINTF = HCHINTF_ACK;
+    } else if (intr_pp & HCHINTF_STALL) {
+        usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_STALL, PIPE_STALL);
+        pp_reg->HCHINTF = HCHINTF_NAK;
+
+        /* note: When there is a 'STALL', reset also NAK,
+           else, the udev->host.pp_status = HC_STALL
+           will be overwritten by 'NAK' in code below */
+        intr_pp &= ~HCHINTF_NAK;
+    } else if (intr_pp & HCHINTF_DTER) {
+        usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_DTER, PIPE_DTGERR);
+        pp_reg->HCHINTF = HCHINTF_NAK;
+    } else {
+        /* no operation */
+    }
+
+    if (intr_pp & HCHINTF_REQOVR) {
+        usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_REQOVR, PIPE_REQOVR);
+    } else if (intr_pp & HCHINTF_TF) {
+        if ((uint8_t)USB_USE_DMA == udev->bp.transfer_mode) {
+            udev->host.backup_xfercount[pp_num] = pp->xfer_len - (pp_reg->HCHLEN & HCHLEN_TLEN);
+        }
+
+        pp->pp_status = PIPE_XF;
+        pp->err_count = 0U;
+
+        pp_reg->HCHINTF = HCHINTF_TF;
+
+        switch (ep_type) {
+        case USB_EPTYPE_CTRL:
+        case USB_EPTYPE_BULK:
+            usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_NAK, PIPE_XF);
+
+            pp->data_toggle_in ^= 1U;
+            break;
+
+        case USB_EPTYPE_INTR:
+        case USB_EPTYPE_ISOC:
+            pp_reg->HCHCTL |= HCHCTL_ODDFRM;
+            pp->urb_state = URB_DONE;
+            break;
+
+        default:
+            break;
+        }
+    } else if (intr_pp & HCHINTF_CH) {
+        pp_reg->HCHINTEN &= ~HCHINTEN_CHIE;
+
+        switch (pp->pp_status) {
+        case PIPE_XF:
+            pp->urb_state = URB_DONE;
+            break;
+
+        case PIPE_STALL:
+            pp->urb_state = URB_STALL;
+            break;
+
+        case PIPE_TRACERR:
+        case PIPE_DTGERR:
+            pp->err_count = 0U;
+            pp->urb_state = URB_ERROR;
+
+            pp->data_toggle_in ^= 1U;
+            break;
+
+        case PIPE_IDLE:
+        case PIPE_HALTED:
+        case PIPE_NAK:
+        case PIPE_NYET:
+        case PIPE_BBERR:
+        case PIPE_REQOVR:
+        default:
+            if((uint8_t)USB_EPTYPE_INTR == ep_type) {
+                pp->data_toggle_in ^= 1U;
+            }
+            break;
+        }
+
+        pp_reg->HCHINTF = HCHINTF_CH;
+    } else if (intr_pp & HCHINTF_USBER) {
+        pp->err_count++;
+        usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_USBER, PIPE_TRACERR);
+    } else if (intr_pp & HCHINTF_NAK) {
+        switch (ep_type) {
+        case USB_EPTYPE_CTRL:
+        case USB_EPTYPE_BULK:
+            /* re-activate the channel */
+            pp_reg->HCHCTL = (pp_reg->HCHCTL | HCHCTL_CEN) & ~HCHCTL_CDIS;
+            break;
+
+        case USB_EPTYPE_INTR:
+            pp_reg->HCHINTEN |= HCHINTEN_CHIE;
+
+            (void)usb_pipe_halt(udev, (uint8_t)pp_num);
+            break;
+
+        default:
+            break;
+        }
+
+        pp->pp_status = PIPE_NAK;
+
+        pp_reg->HCHINTF = HCHINTF_NAK;
+    } else {
+        /* no operation */
+    }
+
+    return 1U;
+}
+
+/*!
+    \brief      handle the OUT channel interrupt
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  pp_num: host channel number which is in (0..7)
+    \param[out] none
+    \retval     operation status
+*/
+#if defined (__ICCARM__)      /*!< IAR compiler */
+    #pragma optimize = none
+#endif /* __ICCARM */
+static uint32_t usbh_int_pipe_out (usb_core_driver *udev, uint32_t pp_num)
+{
+    usbh_host *uhost = udev->host.data;
+    usb_pr *pp_reg = udev->regs.pr[pp_num];
+    usb_pipe *pp = &udev->host.pipe[pp_num];
+    uint32_t intr_pp = pp_reg->HCHINTF & pp_reg->HCHINTEN;
+
+    if (intr_pp & HCHINTF_ACK) {
+        if (1U == udev->host.pipe[pp_num].do_ping) {
+            udev->host.pipe[pp_num].do_ping = 0;
+            pp->err_count = 0U;
+            usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_ACK, pp->pp_status);
+        }
+
+        pp_reg->HCHINTF = HCHINTF_ACK;
+    } else if (intr_pp & HCHINTF_STALL) {
+        usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_STALL, PIPE_STALL);
+    } else if (intr_pp & HCHINTF_DTER) {
+        usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_DTER, PIPE_DTGERR);
+        pp_reg->HCHINTF = HCHINTF_NAK;
+    } else if (intr_pp & HCHINTF_REQOVR) {
+        usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_REQOVR, PIPE_REQOVR);
+    } else if (intr_pp & HCHINTF_TF) {
+        pp->err_count = 0U;
+        usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_TF, PIPE_XF);
+    } else if (intr_pp & HCHINTF_NAK) {
+        if (0U == udev->host.pipe[pp_num].do_ping) {
+            if (1U == udev->host.pipe[pp_num].supp_ping) {
+                udev->host.pipe[pp_num].do_ping = 1;
+            }
+        }
+
+        pp->err_count = 0U;
+        usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_NAK, PIPE_NAK);
+    } else if (intr_pp & HCHINTF_USBER) {
+        pp->err_count++;
+        usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_USBER, PIPE_TRACERR);
+    } else if (intr_pp & HCHINTF_NYET) {
+        if (CTL_STATUS_OUT != uhost->control.ctl_state) {
+            if (0U == udev->host.pipe[pp_num].do_ping) {
+                if (1U == udev->host.pipe[pp_num].supp_ping) {
+                    udev->host.pipe[pp_num].do_ping = 1;
+                }
+            }
+
+            usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_NYET, PIPE_NYET);
+        } else {
+            usb_pp_halt (udev, (uint8_t)pp_num, HCHINTF_NYET, PIPE_XF);
+        }
+
+        pp->err_count = 0U;
+    } else if (intr_pp & HCHINTF_CH) {
+        udev->regs.pr[pp_num]->HCHINTEN &= ~HCHINTEN_CHIE;
+
+        switch (pp->pp_status) {
+        case PIPE_XF:
+            pp->urb_state = URB_DONE;
+
+            if ((uint8_t)USB_EPTYPE_BULK == ((pp_reg->HCHCTL & HCHCTL_EPTYPE) >> 18U)) {
+                pp->data_toggle_out ^= 1U; 
+            }
+            break;
+
+        case PIPE_NAK:
+        case PIPE_NYET:
+            pp->urb_state = URB_NOTREADY;
+            break;
+
+        case PIPE_STALL:
+            pp->urb_state = URB_STALL;
+            break;
+
+        case PIPE_TRACERR:
+            if (3U == pp->err_count) {
+                pp->urb_state = URB_ERROR;
+                pp->err_count = 0U;
+            }
+            break;
+
+        case PIPE_IDLE:
+        case PIPE_HALTED:
+        case PIPE_BBERR:
+        case PIPE_REQOVR:
+        case PIPE_DTGERR:
+        default:
+            break;
+        }
+
+        pp_reg->HCHINTF = HCHINTF_CH;
+    } else {
+        /* no operation */
+    }
+
+    return 1U;
+}
+
+/*!
+    \brief      handle the RX FIFO non-empty interrupt
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     operation status
+*/
+#if defined (__ICCARM__)      /*!< IAR compiler */
+    #pragma optimize = none
+#endif /* __ICCARM */
+static uint32_t usbh_int_rxfifonoempty (usb_core_driver *udev)
+{
+    uint32_t count = 0U;
+
+    __IO uint8_t pp_num = 0U;
+    __IO uint32_t rx_stat = 0U;
+
+    /* disable the RX status queue level interrupt */
+    udev->regs.gr->GINTEN &= ~GINTEN_RXFNEIE;
+
+    rx_stat = udev->regs.gr->GRSTATP;
+    pp_num = (uint8_t)(rx_stat & GRSTATRP_CNUM);
+
+    switch ((rx_stat & GRSTATRP_RPCKST) >> 17U) {
+    case GRXSTS_PKTSTS_IN:
+        count = (rx_stat & GRSTATRP_BCOUNT) >> 4U;
+
+        /* read the data into the host buffer. */
+        if ((count > 0U) && (NULL != udev->host.pipe[pp_num].xfer_buf)) {
+            (void)usb_rxfifo_read (&udev->regs, udev->host.pipe[pp_num].xfer_buf, (uint16_t)count);
+
+            /* manage multiple transfer packet */
+            udev->host.pipe[pp_num].xfer_buf += count;
+            udev->host.pipe[pp_num].xfer_count += count;
+
+            udev->host.backup_xfercount[pp_num] = udev->host.pipe[pp_num].xfer_count;
+
+            if (udev->regs.pr[pp_num]->HCHLEN & HCHLEN_PCNT) {
+                /* re-activate the channel when more packets are expected */
+                __IO uint32_t pp_ctl = udev->regs.pr[pp_num]->HCHCTL;
+
+                pp_ctl |= HCHCTL_CEN;
+                pp_ctl &= ~HCHCTL_CDIS;
+
+                udev->regs.pr[pp_num]->HCHCTL = pp_ctl;
+            }
+        }
+        break;
+
+    case GRXSTS_PKTSTS_IN_XFER_COMP:
+        break;
+
+    case GRXSTS_PKTSTS_DATA_TOGGLE_ERR:
+        count = (rx_stat & GRSTATRP_BCOUNT) >> 4U;
+
+        while (count > 0U) {
+            rx_stat = udev->regs.gr->GRSTATP;
+            count--;
+        }
+        break;
+
+    case GRXSTS_PKTSTS_CH_HALTED:
+        break;
+
+    default:
+        break;
+    }
+
+    /* enable the RX status queue level interrupt */
+    udev->regs.gr->GINTEN |= GINTEN_RXFNEIE;
+
+    return 1U;
+}
+
+/*!
+    \brief      handle the TX FIFO empty interrupt
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  pp_mode: pipe mode
+    \param[out] none
+    \retval     operation status
+*/
+#if defined (__ICCARM__)      /*!< IAR compiler */
+    #pragma optimize = none
+#endif /* __ICCARM */
+static uint32_t usbh_int_txfifoempty (usb_core_driver *udev, usb_pipe_mode pp_mode)
+{
+    uint8_t pp_num = 0U;
+    uint16_t word_count = 0U, len = 0U;
+    __IO uint32_t *txfiforeg = 0U, txfifostate = 0U;
+
+    if (PIPE_NON_PERIOD == pp_mode) {
+        txfiforeg = &udev->regs.gr->HNPTFQSTAT;
+    } else if (PIPE_PERIOD == pp_mode) {
+        txfiforeg = &udev->regs.hr->HPTFQSTAT;
+    } else {
+        return 0U;
+    }
+
+    txfifostate = *txfiforeg;
+
+    pp_num = (uint8_t)((txfifostate & TFQSTAT_CNUM) >> 27U);
+
+    word_count = (uint16_t)(udev->host.pipe[pp_num].xfer_len + 3U) / 4U;
+
+    while (((txfifostate & TFQSTAT_TXFS) >= word_count) && (0U != udev->host.pipe[pp_num].xfer_len)) {
+        len = (uint16_t)(txfifostate & TFQSTAT_TXFS) * 4U;
+
+        if (len > udev->host.pipe[pp_num].xfer_len) {
+            /* last packet */
+            len = (uint16_t)udev->host.pipe[pp_num].xfer_len;
+
+            if (PIPE_NON_PERIOD == pp_mode) {
+                udev->regs.gr->GINTEN &= ~GINTEN_NPTXFEIE;
+            } else {
+                udev->regs.gr->GINTEN &= ~GINTEN_PTXFEIE;
+            }
+        }
+
+        word_count = (uint16_t)((udev->host.pipe[pp_num].xfer_len + 3U) / 4U);
+        usb_txfifo_write (&udev->regs, udev->host.pipe[pp_num].xfer_buf, pp_num, len);
+
+        udev->host.pipe[pp_num].xfer_buf += len;
+        udev->host.pipe[pp_num].xfer_len -= len;
+        udev->host.pipe[pp_num].xfer_count += len;
+
+        txfifostate = *txfiforeg;
+    }
+
+    return 1U;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/hid/Include/usbh_hid_core.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/hid/Include/usbh_hid_core.h
@@ -1,0 +1,122 @@
+/*!
+    \file    usbh_hid_core.h
+    \brief   header file for the usbh_hid_core.c
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBH_HID_CORE_H
+#define __USBH_HID_CORE_H
+
+#include "usb_hid.h"
+#include "usbh_enum.h"
+#include "usbh_transc.h"
+
+#define HID_MIN_POLL                                    10U
+#define HID_REPORT_SIZE                                 16U
+#define HID_QUEUE_SIZE                                  10U
+
+#define USB_HID_DESC_SIZE                               9U
+
+/* states for HID state machine */
+typedef enum {
+    HID_INIT = 0U,
+    HID_IDLE,
+    HID_SEND_DATA,
+    HID_BUSY,
+    HID_GET_DATA,
+    HID_SYNC,
+    HID_POLL,
+    HID_ERROR,
+} hid_state;
+
+typedef enum {
+    HID_REQ_INIT = 0U,
+    HID_REQ_IDLE,
+    HID_REQ_GET_REPORT_DESC,
+    HID_REQ_GET_HID_DESC,
+    HID_REQ_SET_IDLE,
+    HID_REQ_SET_PROTOCOL,
+    HID_REQ_SET_REPORT,
+} hid_ctlstate;
+
+typedef enum
+{
+    HID_MOUSE    = 0x01U,
+    HID_KEYBOARD = 0x02U,
+    HID_UNKNOWN  = 0xFFU,
+} hid_type;
+
+typedef struct
+{
+     uint8_t  *buf;
+     uint16_t  head;
+     uint16_t  tail;
+     uint16_t  size;
+     uint8_t   lock;
+} data_fifo;
+
+/* structure for HID process */
+typedef struct _hid_process
+{
+    uint8_t              pipe_in;
+    uint8_t              pipe_out;
+    uint8_t              ep_addr;
+    uint8_t              ep_in;
+    uint8_t              ep_out;
+    uint8_t              *pdata;
+    __IO uint8_t         data_ready;
+    uint16_t             len;
+    uint16_t             poll;
+
+    __IO uint32_t        timer;
+    usb_desc_hid         hid_desc;
+
+    hid_state            state;
+    hid_ctlstate         ctl_state;
+
+    usbh_status          (*init)(usb_core_driver *udev, usbh_host *uhost);
+    usbh_status          (*decode)(uint8_t *data);
+} usbh_hid_handler;
+
+extern usbh_class usbh_hid;
+
+/* function declarations */
+/* set HID report */
+usbh_status usbh_set_report (usb_core_driver *udev,
+                             usbh_host *uhost,
+                             uint8_t  report_type,
+                             uint8_t  report_ID,
+                             uint8_t  report_len,
+                             uint8_t *report_buf);
+
+#endif /* __USBH_HID_CORE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/hid/Include/usbh_standard_hid.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/hid/Include/usbh_standard_hid.h
@@ -1,0 +1,101 @@
+/*!
+    \file    usbh_standard_hid.h
+    \brief   header file for usbh_standard_hid.c
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBH_STANDARD_HID_H
+#define __USBH_STANDARD_HID_H
+
+#include "usb_conf.h"
+#include "usbh_hid_core.h"
+
+//#define AZERTY_KEYBOARD
+#define QWERTY_KEYBOARD
+
+#define MOUSE_BUTTON_1                         0x01U
+#define MOUSE_BUTTON_2                         0x02U
+#define MOUSE_BUTTON_3                         0x04U
+
+#define KBD_LEFT_CTRL                          0x01U
+#define KBD_LEFT_SHIFT                         0x02U
+#define KBD_LEFT_ALT                           0x04U
+#define KBD_LEFT_GUI                           0x08U
+#define KBD_RIGHT_CTRL                         0x10U
+#define KBD_RIGHT_SHIFT                        0x20U
+#define KBD_RIGHT_ALT                          0x40U
+#define KBD_RIGHT_GUI                          0x80U
+
+#define KBD_PRESSED_MAX_NUM                    6U
+
+typedef struct _hid_mouse_info
+{
+    uint8_t x;
+    uint8_t y;
+    uint8_t buttons[3];
+} hid_mouse_info;
+
+typedef struct
+{
+    uint8_t state;
+    uint8_t lctrl;
+    uint8_t lshift;
+    uint8_t lalt;
+    uint8_t lgui;
+    uint8_t rctrl;
+    uint8_t rshift;
+    uint8_t ralt;
+    uint8_t rgui;
+    uint8_t keys[6];
+} hid_keybd_info;
+
+/* function declarations */
+/* initialize mouse */
+void usr_mouse_init (void);
+/* process mouse data */
+void usr_mouse_process_data (hid_mouse_info *data);
+/* initialize mouse function */
+usbh_status usbh_hid_mouse_init (usb_core_driver *udev, usbh_host *uhost);
+/* decode mouse information */
+usbh_status usbh_hid_mouse_decode(uint8_t *data);
+
+/* initialize keyboard */
+void usr_keybrd_init (void);
+/* process keyboard data */
+void usr_keybrd_process_data (uint8_t pbuf);
+/* initialize the keyboard function */
+usbh_status usbh_hid_keybrd_init (usb_core_driver *udev, usbh_host *uhost);
+/* decode keyboard information */
+usbh_status usbh_hid_keybrd_decode (uint8_t *data);
+
+#endif /* __USBH_STANDARD_HID_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/hid/Source/usbh_hid_core.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/hid/Source/usbh_hid_core.c
@@ -1,0 +1,584 @@
+/*!
+    \file    usbh_hid_core.c
+    \brief   USB host HID class driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include <string.h>
+#include <stdbool.h>
+#include "usbh_pipe.h"
+#include "usbh_hid_core.h"
+#include "usbh_standard_hid.h"
+
+/* local function prototypes ('static') */
+static void usbh_hiddesc_parse (usb_desc_hid *hid_desc, uint8_t *buf);
+static void usbh_hid_itf_deinit (usbh_host *uhost);
+static usbh_status usbh_hid_itf_init (usbh_host *uhost);
+static usbh_status usbh_hid_class_req (usbh_host *uhost);
+static usbh_status usbh_hid_handle (usbh_host *uhost);
+static usbh_status usbh_hid_reportdesc_get (usbh_host *uhost, uint16_t len);
+static usbh_status usbh_hid_sof(usbh_host *uhost);
+static usbh_status usbh_hid_desc_get (usbh_host *uhost, uint16_t len);
+static usbh_status usbh_set_idle (usbh_host *uhost, uint8_t duration, uint8_t report_ID);
+static usbh_status usbh_set_protocol (usbh_host *uhost, uint8_t protocol);
+
+usbh_class usbh_hid = 
+{
+    USB_HID_CLASS,
+    usbh_hid_itf_init,
+    usbh_hid_itf_deinit,
+    usbh_hid_class_req,
+    usbh_hid_handle,
+    usbh_hid_sof
+};
+
+/*!
+    \brief      get report
+    \param[in]  uhost: pointer to USB host
+    \param[in]  report_type: duration for HID set idle request
+    \param[in]  report_ID: targeted report ID for HID set idle request
+    \param[in]  report_len: length of data report to be send
+    \param[in]  report_buf: report buffer
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_get_report (usbh_host *uhost,
+                             uint8_t  report_type,
+                             uint8_t  report_ID,
+                             uint8_t  report_len,
+                             uint8_t *report_buf)
+{
+    usbh_status status = USBH_BUSY;
+
+    if (CTL_IDLE == uhost->control.ctl_state) {
+        uhost->control.setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_IN | USB_RECPTYPE_ITF | USB_REQTYPE_CLASS,
+            .bRequest      = GET_REPORT,
+            .wValue        = (report_type << 8U) | report_ID,
+            .wIndex        = 0U,
+            .wLength       = report_len
+        };
+
+        usbh_ctlstate_config (uhost, report_buf, report_len);
+    }
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      set report
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  uhost: pointer to USB host
+    \param[in]  report_type: duration for HID set idle request
+    \param[in]  report_ID: targeted report ID for HID set idle request
+    \param[in]  report_len: length of data report to be send
+    \param[in]  report_buf: report buffer
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_set_report (usb_core_driver *udev, 
+                             usbh_host *uhost,
+                             uint8_t  report_type,
+                             uint8_t  report_ID,
+                             uint8_t  report_len,
+                             uint8_t *report_buf)
+{
+    usbh_status status = USBH_BUSY;
+
+    if (CTL_IDLE == uhost->control.ctl_state) {
+        uhost->control.setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_OUT | USB_RECPTYPE_ITF | USB_REQTYPE_CLASS,
+            .bRequest      = SET_REPORT,
+            .wValue        = (report_type << 8U) | report_ID,
+            .wIndex        = 0U,
+            .wLength       = report_len
+        };
+
+        usbh_ctlstate_config (uhost, report_buf, report_len);
+    }
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      deinitialize the host pipes used for the HID class
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+void usbh_hid_itf_deinit (usbh_host *uhost)
+{
+    usbh_hid_handler *hid = (usbh_hid_handler *)uhost->active_class->class_data;
+
+    if (0x00U != hid->pipe_in) {
+        usb_pipe_halt (uhost->data, hid->pipe_in);
+
+        usbh_pipe_free (uhost->data, hid->pipe_in);
+
+        hid->pipe_in = 0U;     /* reset the pipe as free */
+    }
+
+    if (0x00U != hid->pipe_out) {
+        usb_pipe_halt (uhost->data, hid->pipe_out);
+
+        usbh_pipe_free (uhost->data, hid->pipe_out);
+
+        hid->pipe_out = 0U; /* reset the channel as free */
+    }
+}
+
+/*!
+    \brief      return device type
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     hid_type
+*/
+hid_type usbh_hid_device_type_get(usb_core_driver *udev, usbh_host *uhost)
+{
+    hid_type type = HID_UNKNOWN;
+    uint8_t interface_protocol;
+
+    if (HOST_CLASS_HANDLER == uhost->cur_state) {
+        interface_protocol = uhost->dev_prop.cfg_desc_set.itf_desc_set[uhost->dev_prop.cur_itf][0].itf_desc.bInterfaceProtocol;
+
+        if (USB_HID_PROTOCOL_KEYBOARD == interface_protocol) {
+            type = HID_KEYBOARD;
+        } else {
+            if (USB_HID_PROTOCOL_MOUSE == interface_protocol) {
+                type = HID_MOUSE;
+            }
+        }
+    }
+
+    return type;
+}
+
+/*!
+    \brief      return HID device poll time
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     poll time (ms)
+*/
+uint8_t usbh_hid_poll_interval_get (usb_core_driver *udev, usbh_host *uhost)
+{
+    usbh_hid_handler *hid = (usbh_hid_handler *)uhost->active_class->class_data;
+
+    if ((HOST_CLASS_ENUM == uhost->cur_state) ||
+         (HOST_USER_INPUT == uhost->cur_state) ||
+           (HOST_CLASS_CHECK == uhost->cur_state) ||
+             (HOST_CLASS_HANDLER == uhost->cur_state)) {
+        return (uint8_t)(hid->poll);
+    } else {
+        return 0U;
+    }
+}
+
+/*!
+    \brief      initialize the hid class
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+static usbh_status usbh_hid_itf_init (usbh_host *uhost)
+{
+    uint8_t num = 0U, ep_num = 0U, interface = 0U;
+    usbh_status status = USBH_BUSY;
+
+    interface = usbh_interface_find(&uhost->dev_prop, USB_HID_CLASS, USB_HID_SUBCLASS_BOOT_ITF, 0xFFU);
+
+    if (0xFFU == interface) {
+        uhost->usr_cb->dev_not_supported();
+
+        status = USBH_FAIL;
+    } else {
+        usbh_interface_select(&uhost->dev_prop, interface);
+
+        static usbh_hid_handler hid_handler;
+
+        memset((void*)&hid_handler, 0, sizeof(usbh_hid_handler));
+
+        hid_handler.state = HID_ERROR;
+
+        uint8_t itf_protocol = uhost->dev_prop.cfg_desc_set.itf_desc_set[uhost->dev_prop.cur_itf][0].itf_desc.bInterfaceProtocol;
+        if (USB_HID_PROTOCOL_KEYBOARD == itf_protocol) {
+            hid_handler.init = usbh_hid_keybrd_init;
+            hid_handler.decode = usbh_hid_keybrd_decode;
+        } else if (USB_HID_PROTOCOL_MOUSE == itf_protocol) {
+            hid_handler.init = usbh_hid_mouse_init;
+            hid_handler.decode = usbh_hid_mouse_decode;
+        } else {
+            status = USBH_FAIL;
+        }
+
+        hid_handler.state = HID_INIT;
+        hid_handler.ctl_state = HID_REQ_INIT;
+        hid_handler.ep_addr = uhost->dev_prop.cfg_desc_set.itf_desc_set[uhost->dev_prop.cur_itf][0].ep_desc[0].bEndpointAddress;
+        hid_handler.len = uhost->dev_prop.cfg_desc_set.itf_desc_set[uhost->dev_prop.cur_itf][0].ep_desc[0].wMaxPacketSize;
+        hid_handler.poll = uhost->dev_prop.cfg_desc_set.itf_desc_set[uhost->dev_prop.cur_itf][0].ep_desc[0].bInterval;
+
+        if (hid_handler.poll < HID_MIN_POLL) {
+            hid_handler.poll = HID_MIN_POLL;
+        }
+
+        /* check for available number of endpoints */
+        /* find the number of endpoints in the interface descriptor */
+        /* choose the lower number in order not to overrun the buffer allocated */
+        ep_num = USB_MIN(uhost->dev_prop.cfg_desc_set.itf_desc_set[uhost->dev_prop.cur_itf][0].itf_desc.bNumEndpoints, USBH_MAX_EP_NUM);
+
+        /* decode endpoint IN and OUT address from interface descriptor */
+        for (num = 0U; num < ep_num; num++) {
+            usb_desc_ep *ep_desc = &uhost->dev_prop.cfg_desc_set.itf_desc_set[uhost->dev_prop.cur_itf][0].ep_desc[num];
+
+            uint8_t ep_addr = ep_desc->bEndpointAddress;
+
+            if (ep_addr & 0x80U) {
+                hid_handler.ep_in = ep_addr;
+                hid_handler.pipe_in = usbh_pipe_allocate (uhost->data, ep_addr);
+
+                /* open channel for IN endpoint */
+                usbh_pipe_create (uhost->data,
+                                  &uhost->dev_prop, 
+                                  hid_handler.pipe_in,
+                                  USB_EPTYPE_INTR,
+                                  hid_handler.len);
+
+                usbh_pipe_toggle_set(uhost->data, hid_handler.pipe_in, 0U);
+            } else {
+                hid_handler.ep_out = ep_addr;
+                hid_handler.pipe_out = usbh_pipe_allocate (uhost->data, ep_addr);
+
+                /* open channel for OUT endpoint */
+                usbh_pipe_create (uhost->data,
+                                  &uhost->dev_prop,
+                                  hid_handler.pipe_out,
+                                  USB_EPTYPE_INTR,
+                                  hid_handler.len);
+
+                usbh_pipe_toggle_set(uhost->data, hid_handler.pipe_out, 0U);
+            }
+        }
+
+        uhost->active_class->class_data = (void *)&hid_handler;
+
+        status = USBH_OK;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      handle HID class requests for HID class
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+static usbh_status usbh_hid_class_req (usbh_host *uhost)
+{
+    usbh_status status = USBH_BUSY;
+    usbh_status class_req_status = USBH_BUSY;
+
+    usbh_hid_handler *hid = (usbh_hid_handler *)uhost->active_class->class_data;
+
+    /* handle HID control state machine */
+    switch (hid->ctl_state) {
+    case HID_REQ_INIT:
+    case HID_REQ_GET_HID_DESC:
+        /* get HID descriptor */ 
+        if (USBH_OK == usbh_hid_desc_get (uhost, USB_HID_DESC_SIZE)) {
+            usbh_hiddesc_parse(&hid->hid_desc, uhost->dev_prop.data);
+
+            hid->ctl_state = HID_REQ_GET_REPORT_DESC;
+        }
+        break;
+
+    case HID_REQ_GET_REPORT_DESC:
+        /* get report descriptor */ 
+        if (USBH_OK == usbh_hid_reportdesc_get(uhost, hid->hid_desc.wDescriptorLength)) {
+            hid->ctl_state = HID_REQ_SET_IDLE;
+        }
+        break;
+
+    case HID_REQ_SET_IDLE:
+        class_req_status = usbh_set_idle (uhost, 0U, 0U);
+
+        /* set idle */
+        if (USBH_OK == class_req_status) {
+            hid->ctl_state = HID_REQ_SET_PROTOCOL;
+        } else {
+            if(USBH_NOT_SUPPORTED == class_req_status) {
+                hid->ctl_state = HID_REQ_SET_PROTOCOL;
+            }
+        }
+        break; 
+
+    case HID_REQ_SET_PROTOCOL:
+        /* set protocol */
+        if (USBH_OK == usbh_set_protocol (uhost, 0U)) {
+            hid->ctl_state = HID_REQ_IDLE;
+
+            /* all requests performed */
+            status = USBH_OK;
+        }
+        break;
+
+    case HID_REQ_IDLE:
+    default:
+        break;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      manage state machine for HID data transfers
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+static usbh_status usbh_hid_handle (usbh_host *uhost)
+{
+    usbh_status status = USBH_OK;
+    usbh_hid_handler *hid = (usbh_hid_handler *)uhost->active_class->class_data;
+
+    switch (hid->state) {
+    case HID_INIT:
+        hid->init(uhost->data, uhost);
+        hid->state = HID_IDLE;
+        break;
+
+    case HID_IDLE:
+        hid->state = HID_SYNC;
+        status = USBH_OK;
+        break;
+
+    case HID_SYNC:
+        /* sync with start of even frame */
+        if (true == usb_frame_even(uhost->data)) {
+            hid->state = HID_GET_DATA;
+        }
+        break;
+
+    case HID_GET_DATA:
+        usbh_data_recev (uhost->data, hid->pdata, hid->pipe_in, hid->len);
+
+        hid->state = HID_POLL;
+        hid->timer = usb_curframe_get (uhost->data);
+        hid->data_ready = 0U;
+        break;
+
+    case HID_POLL:
+        if (URB_DONE == usbh_urbstate_get (uhost->data, hid->pipe_in)) {
+            if (0U == hid->data_ready) {
+                hid->data_ready = 1U;
+
+                hid->decode(hid->pdata);
+            }
+        } else {
+            /* check IN endpoint stall status */
+            if (URB_STALL == usbh_urbstate_get (uhost->data, hid->pipe_in)) {
+                /* issue clear feature on interrupt in endpoint */ 
+                if (USBH_OK == (usbh_clrfeature (uhost, hid->ep_addr, hid->pipe_in))) {
+                    /* change state to issue next in token */
+                    hid->state = HID_GET_DATA;
+                }
+            }
+        }
+        break;
+
+    default:
+        break;
+    }
+    return status;
+}
+
+/*!
+    \brief      send get report descriptor command to the device
+    \param[in]  uhost: pointer to USB host
+    \param[in]  len: HID report descriptor length
+    \param[out] none
+    \retval     operation status
+*/
+static usbh_status usbh_hid_reportdesc_get (usbh_host *uhost, uint16_t len)
+{
+    usbh_status status = USBH_BUSY;
+
+    if (CTL_IDLE == uhost->control.ctl_state) {
+        uhost->control.setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_IN | USB_RECPTYPE_ITF | USB_REQTYPE_STRD,
+            .bRequest      = USB_GET_DESCRIPTOR,
+            .wValue        = USBH_DESC(USB_DESCTYPE_REPORT),
+            .wIndex        = 0U,
+            .wLength       = len
+        };
+
+        usbh_ctlstate_config (uhost, uhost->dev_prop.data, len);
+    }
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      managing the SOF process
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+static usbh_status usbh_hid_sof(usbh_host *uhost)
+{
+    usbh_hid_handler *hid = (usbh_hid_handler *)uhost->active_class->class_data;
+
+    if (HID_POLL == hid->state) {
+        uint32_t frame_count = usb_curframe_get (uhost->data);
+
+        if ((frame_count > hid->timer) && ((frame_count - hid->timer) >= hid->poll)) {
+            hid->state = HID_GET_DATA;
+        } else if ((frame_count < hid->timer) && ((frame_count + 0x3FFFU - hid->timer) >= hid->poll)) {
+            hid->state = HID_GET_DATA;
+        } else {
+            /* no operation */
+        }
+    }
+
+    return USBH_OK;
+}
+
+/*!
+    \brief      send the command of get HID descriptor to the device
+    \param[in]  uhost: pointer to USB host
+    \param[in]  len: HID descriptor length
+    \param[out] none
+    \retval     operation status
+*/
+static usbh_status usbh_hid_desc_get (usbh_host *uhost, uint16_t len)
+{
+    usbh_status status = USBH_BUSY;
+
+    if (CTL_IDLE == uhost->control.ctl_state) {
+        uhost->control.setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_IN | USB_RECPTYPE_ITF | USB_REQTYPE_STRD,
+            .bRequest      = USB_GET_DESCRIPTOR,
+            .wValue        = USBH_DESC(USB_DESCTYPE_HID),
+            .wIndex        = 0U,
+            .wLength       = len
+        };
+
+        usbh_ctlstate_config (uhost, uhost->dev_prop.data, len);
+    }
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      set idle state
+    \param[in]  uhost: pointer to USB host
+    \param[in]  duration: duration for HID set idle request
+    \param[in]  report_ID: targeted report ID for HID set idle request
+    \param[out] none
+    \retval     operation status
+*/
+static usbh_status usbh_set_idle (usbh_host *uhost, uint8_t duration, uint8_t report_ID)
+{
+    usbh_status status = USBH_BUSY;
+
+    if (CTL_IDLE == uhost->control.ctl_state) {
+        uhost->control.setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_OUT | USB_RECPTYPE_ITF | USB_REQTYPE_CLASS,
+            .bRequest      = SET_IDLE,
+            .wValue        = (duration << 8U) | report_ID,
+            .wIndex        = 0U,
+            .wLength       = 0U
+        };
+
+        usbh_ctlstate_config (uhost, NULL, 0U);
+    }
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      set protocol state
+    \param[in]  uhost: pointer to USB host
+    \param[in]  protocol: boot/report protocol
+    \param[out] none
+    \retval     operation status
+*/
+static usbh_status usbh_set_protocol (usbh_host *uhost, uint8_t protocol)
+{
+    usbh_status status = USBH_BUSY;
+
+    if (CTL_IDLE == uhost->control.ctl_state) {
+        uhost->control.setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_OUT | USB_RECPTYPE_ITF | USB_REQTYPE_CLASS,
+            .bRequest      = SET_PROTOCOL,
+            .wValue        = !protocol,
+            .wIndex        = 0U,
+            .wLength       = 0U
+        };
+
+        usbh_ctlstate_config (uhost, NULL, 0U);
+    }
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      parse the HID descriptor
+    \param[in]  hid_desc: pointer to HID descriptor
+    \param[in]  buf: pointer to buffer where the source descriptor is available
+    \param[out] none
+    \retval     none
+*/
+static void usbh_hiddesc_parse (usb_desc_hid *hid_desc, uint8_t *buf)
+{
+    hid_desc->header.bLength         = *(uint8_t *)(buf + 0U);
+    hid_desc->header.bDescriptorType = *(uint8_t *)(buf + 1U);
+    hid_desc->bcdHID                 = BYTE_SWAP(buf + 2U);
+    hid_desc->bCountryCode           = *(uint8_t *)(buf + 4U);
+    hid_desc->bNumDescriptors        = *(uint8_t *)(buf + 5U);
+    hid_desc->bDescriptorType        = *(uint8_t *)(buf + 6U);
+    hid_desc->wDescriptorLength      = BYTE_SWAP(buf + 7U);
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/hid/Source/usbh_standard_hid.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/hid/Source/usbh_standard_hid.c
@@ -1,0 +1,276 @@
+/*!
+    \file    usbh_standard_hid.c
+    \brief   USB host HID keyboard and mouse driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usbh_standard_hid.h"
+#include <stdbool.h>
+
+hid_mouse_info mouse_info;
+hid_keybd_info keybd_info;
+
+__ALIGN_BEGIN uint8_t mouse_report_data[4] __ALIGN_END = {0U};
+__ALIGN_BEGIN uint32_t keybd_report_data[2] __ALIGN_END;
+
+/* local constants */
+static const uint8_t kbd_codes[] = 
+{
+    0,      0,      0,      0,      31,     50,     48,     33, 
+    19,     34,     35,     36,     24,     37,     38,     39,         /* 0x00 - 0x0F */
+    52,     51,     25,     26,     17,     20,     32,     21,
+    23,     49,     18,     47,     22,     46,     2,      3,          /* 0x10 - 0x1F */
+    4,      5,      6,      7,      8,      9,      10,     11,
+    43,     110,    15,     16,     61,     12,     13,     27,         /* 0x20 - 0x2F */
+    28,     29,     42,     40,     41,     1,      53,     54,
+    55,     30,     112,    113,    114,    115,    116,    117,        /* 0x30 - 0x3F */
+    118,    119,    120,    121,    122,    123,    124,    125,
+    126,    75,     80,     85,     76,     81,     86,     89,         /* 0x40 - 0x4F */
+    79,     84,     83,     90,     95,     100,    105,    106,
+    108,    93,     98,     103,    92,     97,     102,    91,         /* 0x50 - 0x5F */
+    96,     101,    99,     104,    45,     129,    0,      0,
+    0,      0,      0,      0,      0,      0,      0,      0,          /* 0x60 - 0x6F */
+    0,      0,      0,      0,      0,      0,      0,      0,
+    0,      0,      0,      0,      0,      0,      0,      0,          /* 0x70 - 0x7F */
+    0,      0,      0,      0,      0,      107,    0,      56,
+    0,      0,      0,      0,      0,      0,      0,      0,          /* 0x80 - 0x8F */
+    0,      0,      0,      0,      0,      0,      0,      0,
+    0,      0,      0,      0,      0,      0,      0,      0,          /* 0x90 - 0x9F */
+    0,      0,      0,      0,      0,      0,      0,      0,
+    0,      0,      0,      0,      0,      0,      0,      0,          /* 0xA0 - 0xAF */
+    0,      0,      0,      0,      0,      0,      0,      0,
+    0,      0,      0,      0,      0,      0,      0,      0,          /* 0xB0 - 0xBF */
+    0,      0,      0,      0,      0,      0,      0,      0,
+    0,      0,      0,      0,      0,      0,      0,      0,          /* 0xC0 - 0xCF */
+    0,      0,      0,      0,      0,      0,      0,      0,
+    0,      0,      0,      0,      0,      0,      0,      0,          /* 0xD0 - 0xDF */
+    58,     44,     60,     127,    64,     57,     62,     128         /* 0xE0 - 0xE7 */
+};
+
+#ifdef QWERTY_KEYBOARD
+
+static const int8_t kbd_key[] = 
+{
+    '\0',   '`',    '1',    '2',    '3',    '4',    '5',    '6',
+    '7',    '8',    '9',    '0',    '-',    '=',    '\0',   '\r',
+    '\t',   'q',    'w',    'e',    'r',    't',    'y',    'u',
+    'i',    'o',    'p',    '[',    ']',    '\\',
+    '\0',   'a',    's',    'd',    'f',    'g',    'h',    'j',
+    'k',    'l',    ';',    '\'',   '\0',   '\n',
+    '\0',   '\0',   'z',    'x',    'c',    'v',    'b',    'n',
+    'm',    ',',    '.',    '/',    '\0',   '\0',
+    '\0',   '\0',   '\0',   ' ',    '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\r',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '7',    '4',    '1',
+    '\0',   '/',    '8',    '5',    '2',
+    '0',    '*',    '9',    '6',    '3',
+    '.',    '-',    '+',    '\0',   '\n',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0'
+};
+
+static const int8_t kbd_key_shift[] = {
+    '\0',   '~',    '!',    '@',    '#',    '$',    '%',    '^',    '&',    '*',    '(',    ')',
+    '_',    '+',    '\0',   '\0',   '\0',   'Q',    'W',    'E',    'R',    'T',    'Y',    'U',
+    'I',    'O',    'P',    '{',    '}',    '|',    '\0',   'A',    'S',    'D',    'F',    'G',
+    'H',    'J',    'K',    'L',    ':',    '"',    '\0',   '\n',   '\0',   '\0',   'Z',    'X',
+    'C',    'V',    'B',    'N',    'M',    '<',    '>',    '?',    '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0'
+};
+
+#else
+
+static const int8_t kbd_key[] = {
+    '\0',   '`',    '1',    '2',    '3',    '4',    '5',    '6',    '7',    '8',    '9',    '0',
+    '-',    '=',    '\0',   '\r',   '\t',   'a',    'z',    'e',    'r',    't',    'y',    'u',
+    'i',    'o',    'p',    '[',    ']',    '\\',   '\0',   'q',    's',    'd',    'f',    'g',
+    'h',    'j',    'k',    'l',    'm',    '\0',   '\0',   '\n',   '\0',   '\0',   'w',    'x',
+    'c',    'v',    'b',    'n',    ',',    ';',    ':',    '!',    '\0',   '\0',   '\0',   '\0',
+    '\0',   ' ',    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\r',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '7',    '4',    '1',    '\0',   '/',
+    '8',    '5',    '2',    '0',    '*',    '9',    '6',    '3',    '.',    '-',    '+',    '\0',
+    '\n',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0'
+};
+
+static const int8_t kbd_key_shift[] = {
+    '\0',   '~',    '!',    '@',    '#',    '$',    '%',    '^',    '&',    '*',    '(',    ')',    '_',
+    '+',    '\0',   '\0',   '\0',   'A',    'Z',    'E',    'R',    'T',    'Y',    'U',    'I',    'O',
+    'P',    '{',    '}',    '*',    '\0',   'Q',    'S',    'D',    'F',    'G',    'H',    'J',    'K',
+    'L',    'M',    '%',    '\0',   '\n',   '\0',   '\0',   'W',    'X',    'C',    'V',    'B',    'N',
+    '?',    '.',    '/',    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',
+    '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0',   '\0'
+};
+
+#endif /* QWERTY_KEYBOARD */
+
+/*!
+    \brief      initialize the mouse function
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     none
+*/
+usbh_status usbh_hid_mouse_init (usb_core_driver *udev, usbh_host *uhost)
+{
+    usbh_hid_handler *hid = (usbh_hid_handler *)uhost->active_class->class_data;
+
+    mouse_info.x = 0U;
+    mouse_info.y = 0U;
+    mouse_info.buttons[0] = 0U;
+    mouse_info.buttons[1] = 0U;
+    mouse_info.buttons[2] = 0U;
+
+    if(hid->len > sizeof(mouse_report_data)) {
+        hid->len = sizeof(mouse_report_data);
+    }
+
+    hid->pdata = (uint8_t *)(void *)mouse_report_data;
+
+    usr_mouse_init();
+
+    return USBH_OK;
+}
+
+/*!
+    \brief      decode mouse information
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_hid_mouse_decode(uint8_t *data)
+{
+    mouse_info.buttons[0] = data[0] & MOUSE_BUTTON_1;
+    mouse_info.buttons[1] = data[0] & MOUSE_BUTTON_2;
+    mouse_info.buttons[2] = data[0] & MOUSE_BUTTON_3;
+
+    mouse_info.x = data[1];
+    mouse_info.y = data[2];
+
+    /* handle mouse data position */
+    usr_mouse_process_data(&mouse_info);
+
+    return USBH_FAIL;
+}
+
+/*!
+    \brief      initialize the keyboard function
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_hid_keybrd_init (usb_core_driver *udev, usbh_host *uhost)
+{
+    usbh_hid_handler *hid = (usbh_hid_handler *)uhost->active_class->class_data;
+
+    keybd_info.lctrl = keybd_info.lshift = 0U;
+    keybd_info.lalt  = keybd_info.lgui   = 0U;
+    keybd_info.rctrl = keybd_info.rshift = 0U;
+    keybd_info.ralt  = keybd_info.rgui   = 0U;
+
+    for (uint32_t x = 0U; x < (sizeof(keybd_report_data) / sizeof(uint32_t)); x++) {
+        keybd_report_data[x] = 0U;
+    }
+
+    if (hid->len > (sizeof(keybd_report_data) / sizeof(uint32_t))) {
+        hid->len = (sizeof(keybd_report_data) / sizeof(uint32_t));
+    }
+
+    hid->pdata = (uint8_t*)(void *)keybd_report_data;
+
+    /* call user initialization*/
+    usr_keybrd_init();
+
+    return USBH_OK;
+}
+
+/*!
+    \brief      get ascii code
+    \param[in]  info: keyboard information
+    \param[out] none
+    \retval     output
+*/
+uint8_t usbh_hid_ascii_code_get (hid_keybd_info *info)
+{
+    uint8_t output;
+    if ((1U == info->lshift) || (info->rshift)) {
+        output = kbd_key_shift[kbd_codes[info->keys[0]]];
+    } else {
+        output = kbd_key[kbd_codes[info->keys[0]]];
+    }
+
+    return output;
+}
+
+/*!
+    \brief      decode keyboard information
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_hid_keybrd_decode (uint8_t *data)
+{
+    uint8_t output;
+
+    keybd_info.lshift = data[0] & KBD_LEFT_SHIFT;
+    keybd_info.rshift = data[0] & KBD_RIGHT_SHIFT;
+
+    keybd_info.keys[0] = data[2];
+
+    if (keybd_info.lshift || keybd_info.rshift) {
+        output = kbd_key_shift[kbd_codes[keybd_info.keys[0]]];
+    } else {
+        output = kbd_key[kbd_codes[keybd_info.keys[0]]];
+    }
+
+    if (0U != output) {
+        usr_keybrd_process_data(output);
+    }
+
+    return USBH_OK;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Include/usbh_msc_bbb.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Include/usbh_msc_bbb.h
@@ -1,0 +1,152 @@
+/*!
+    \file    usbh_msc_bbb.h
+    \brief   header file for usbh_msc_bbb.c
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBH_MSC_BBB_H
+#define __USBH_MSC_BBB_H
+
+#include "usbh_enum.h"
+#include "msc_bbb.h"
+
+typedef union {
+    msc_bbb_cbw field;
+
+    uint8_t CBWArray[31];
+} usbh_cbw_pkt;
+
+typedef union {
+    msc_bbb_csw field;
+
+    uint8_t CSWArray[13];
+} usbh_csw_pkt;
+
+enum usbh_msc_state {
+    USBH_MSC_BBB_INIT_STATE = 0U,
+    USBH_MSC_BBB_RESET,
+    USBH_MSC_GET_MAX_LUN,
+    USBH_MSC_TEST_UNIT_READY,
+    USBH_MSC_READ_CAPACITY10,
+    USBH_MSC_MODE_SENSE6,
+    USBH_MSC_REQUEST_SENSE,
+    USBH_MSC_BBB_USB_TRANSFERS,
+    USBH_MSC_DEFAULT_APPLI_STATE,
+    USBH_MSC_CTRL_ERROR_STATE,
+    USBH_MSC_UNRECOVERED_STATE
+};
+
+typedef enum
+{
+    BBB_OK = 0U,
+    BBB_FAIL,
+    BBB_PHASE_ERROR,
+    BBB_BUSY
+} bbb_status;
+
+typedef enum
+{
+    BBB_CMD_IDLE = 0U,
+    BBB_CMD_SEND,
+    BBB_CMD_WAIT
+} bbb_cmd_state;
+
+/* csw status definitions */
+typedef enum
+{
+    BBB_CSW_CMD_PASSED = 0U,
+    BBB_CSW_CMD_FAILED,
+    BBB_CSW_PHASE_ERROR
+} bbb_csw_status;
+
+typedef enum
+{
+    BBB_SEND_CBW = 1U,
+    BBB_SEND_CBW_WAIT,
+    BBB_DATA_IN,
+    BBB_DATA_IN_WAIT,
+    BBB_DATA_OUT,
+    BBB_DATA_OUT_WAIT,
+    BBB_RECEIVE_CSW,
+    BBB_RECEIVE_CSW_WAIT,
+    BBB_ERROR_IN,
+    BBB_ERROR_OUT,
+    BBB_UNRECOVERED_ERROR
+} bbb_state;
+
+typedef struct
+{
+    uint8_t                *pbuf;
+    uint32_t                data[16];
+    bbb_state               state;
+    bbb_state               prev_state;
+    bbb_cmd_state           cmd_state;
+    usbh_cbw_pkt            cbw;
+    usbh_csw_pkt            csw;
+} bbb_handle;
+
+#define USBH_MSC_BBB_CBW_TAG                0x20304050U
+
+#define USBH_MSC_CSW_MAX_LENGTH             63U
+
+#define USBH_MSC_SEND_CSW_DISABLE           0U
+#define USBH_MSC_SEND_CSW_ENABLE            1U
+
+#define USBH_MSC_DIR_IN                     0U
+#define USBH_MSC_DIR_OUT                    1U
+#define USBH_MSC_BOTH_DIR                   2U
+
+#define USBH_MSC_PAGE_LENGTH                512U
+
+#define CBW_CB_LENGTH                       16U
+#define CBW_LENGTH                          10U
+#define CBW_LENGTH_TEST_UNIT_READY          0U
+
+#define MAX_BULK_STALL_COUNT_LIMIT          0x04U   /*!< If STALL is seen on Bulk 
+                                                      Endpoint continously, this means 
+                                                      that device and Host has phase error
+                                                      Hence a Reset is needed */
+
+/* function declarations */
+/* initialize the mass storage parameters */
+void usbh_msc_bbb_init (usbh_host *uhost);
+/* manage the different states of BBB transfer and updates the status to upper layer */
+usbh_status usbh_msc_bbb_process (usbh_host *uhost, uint8_t lun);
+/* manages the different error handling for stall */
+usbh_status usbh_msc_bbb_abort (usbh_host *uhost, uint8_t direction);
+/* reset MSC BBB request structure */
+usbh_status usbh_msc_bbb_reset (usbh_host *uhost);
+/* decode the CSW received by the device and updates the same to upper layer */
+bbb_csw_status usbh_msc_csw_decode (usbh_host *uhost);
+
+#endif /* __USBH_MSC_BBB_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Include/usbh_msc_core.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Include/usbh_msc_core.h
@@ -1,0 +1,126 @@
+/*!
+    \file    usbh_core.h
+    \brief   header file for the usbh_core.c
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBH_MSC_CORE_H
+#define __USBH_MSC_CORE_H
+
+#include "usb_msc.h"
+#include "usbh_msc_scsi.h"
+#include "usbh_msc_bbb.h"
+
+#define MSC_MAX_SUPPORTED_LUN                   2U
+
+typedef enum
+{
+    MSC_INIT = 0U,
+    MSC_IDLE,
+    MSC_TEST_UNIT_READY,
+    MSC_READ_CAPACITY10,
+    MSC_READ_INQUIRY,
+    MSC_REQUEST_SENSE,
+    MSC_READ,
+    MSC_WRITE,
+    MSC_UNRECOVERED_ERROR,
+    MSC_PERIODIC_CHECK,
+} msc_state;
+
+typedef enum
+{
+    MSC_OK,
+    MSC_NOT_READY,
+    MSC_ERROR,
+} msc_error;
+
+typedef enum
+{
+    MSC_REQ_IDLE = 0U,
+    MSC_REQ_RESET,
+    MSC_REQ_GET_MAX_LUN,
+    MSC_REQ_ERROR,
+} msc_req_state;
+
+/* structure for LUN */
+typedef struct
+{
+    msc_state               state;
+    msc_error               error;
+    msc_scsi_sense          sense;
+    scsi_capacity           capacity;
+    scsi_std_inquiry_data   inquiry;
+    usbh_status             prev_ready_state;
+    uint8_t                 state_changed;
+} msc_lun;
+
+/* structure for msc process */
+typedef struct _msc_process
+{
+    uint8_t         pipe_in;
+    uint8_t         pipe_out;
+    uint8_t         ep_in;
+    uint8_t         ep_out;
+    uint16_t        ep_size_in;
+    uint16_t        ep_size_out;
+    uint8_t         cur_lun;
+    uint16_t        rw_lun;
+    uint32_t        max_lun;
+    msc_state       state;
+    msc_error       error;
+    msc_req_state   req_state;
+    msc_req_state   prev_req_state;
+    bbb_handle      bbb;
+    msc_lun         unit[MSC_MAX_SUPPORTED_LUN];
+    uint32_t        timer;
+} usbh_msc_handler;
+
+extern usbh_class usbh_msc;
+
+/* function declarations */
+/* get msc logic unit information */
+usbh_status usbh_msc_lun_info_get (usbh_host *uhost, uint8_t lun, msc_lun *info);
+/* msc read interface */
+usbh_status usbh_msc_read (usbh_host *uhost,
+                           uint8_t lun,
+                           uint32_t address,
+                           uint8_t *pbuf,
+                           uint32_t length);
+/* msc write interface */
+usbh_status usbh_msc_write (usbh_host *uhost,
+                            uint8_t lun,
+                            uint32_t address,
+                            uint8_t *pbuf,
+                            uint32_t length);
+
+#endif /* __USBH_MSC_CORE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Include/usbh_msc_scsi.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Include/usbh_msc_scsi.h
@@ -1,0 +1,102 @@
+/*!
+    \file    usbh_msc_scsi.h
+    \brief   header file for usbh_msc_scsi.c
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBH_MSC_SCSI_H
+#define __USBH_MSC_SCSI_H
+
+#include "msc_scsi.h"
+#include "usbh_enum.h"
+
+/* capacity data */
+typedef struct
+{
+    uint32_t block_nbr;
+    uint16_t block_size;
+} scsi_capacity;
+
+/* inquiry data */
+typedef struct
+{
+    uint8_t peripheral_qualifier;
+    uint8_t device_type;
+    uint8_t removable_media;
+    uint8_t vendor_id[9];
+    uint8_t product_id[17];
+    uint8_t revision_id[5];
+} scsi_std_inquiry_data;
+
+typedef struct
+{
+    uint32_t msc_capacity;
+    uint32_t msc_sense_key;
+    uint16_t msc_page_len;
+    uint8_t msc_write_protect;
+} usbh_msc_parameter;
+
+#define DESC_REQUEST_SENSE                   0x00U
+#define ALLOCATION_LENGTH_REQUEST_SENSE      63U
+#define XFER_LEN_MODE_SENSE6                 63U
+
+#define MASK_MODE_SENSE_WRITE_PROTECT        0x80U
+#define MODE_SENSE_PAGE_CONTROL_FIELD        0x00U
+#define MODE_SENSE_PAGE_CODE                 0x3FU
+#define DISK_WRITE_PROTECTED                 0x01U
+
+/* function declarations */
+/* send 'Inquiry' command to the device */
+usbh_status usbh_msc_scsi_inquiry (usbh_host *uhost, uint8_t lun, scsi_std_inquiry_data *inquiry);
+/* send 'Test unit ready' command to the device */
+usbh_status usbh_msc_test_unitready (usbh_host *uhost, uint8_t lun);
+/* send the read capacity command to the device */
+usbh_status usbh_msc_read_capacity10 (usbh_host *uhost, uint8_t lun, scsi_capacity *capacity);
+/* send the mode sense6 command to the device */
+usbh_status usbh_msc_mode_sense6 (usbh_host *uhost, uint8_t lun);
+/* send the Request Sense command to the device */
+usbh_status usbh_msc_request_sense (usbh_host *uhost, uint8_t lun, msc_scsi_sense *sense_data);
+/* send the write10 command to the device */
+usbh_status usbh_msc_write10 (usbh_host *uhost,
+                              uint8_t lun,
+                              uint8_t *data_buf,
+                              uint32_t addr,
+                              uint32_t byte_num);
+/* send the read10 command to the device */
+usbh_status usbh_msc_read10 (usbh_host *uhost,
+                             uint8_t lun,
+                             uint8_t *data_buf,
+                             uint32_t addr,
+                             uint32_t byte_num);
+
+#endif /* __USBH_MSC_SCSI_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Source/usbh_msc_bbb.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Source/usbh_msc_bbb.c
@@ -1,0 +1,364 @@
+/*!
+    \file    usbh_msc_bbb.c
+    \brief   USB MSC BBB protocol related functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usbh_pipe.h"
+#include "usbh_msc_core.h"
+#include "usbh_msc_scsi.h"
+#include "usbh_msc_bbb.h"
+#include "usbh_transc.h"
+#include "drv_usbh_int.h"
+
+/*!
+    \brief      initialize the mass storage parameters
+    \param[in]  uhost: pointer to USB host handler
+    \param[out] none
+    \retval     none
+*/
+void usbh_msc_bbb_init (usbh_host *uhost)
+{
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    msc->bbb.cbw.field.dCBWSignature = BBB_CBW_SIGNATURE;
+    msc->bbb.cbw.field.dCBWTag = USBH_MSC_BBB_CBW_TAG;
+    msc->bbb.state = BBB_SEND_CBW;
+    msc->bbb.cmd_state = BBB_CMD_SEND;
+}
+
+/*!
+    \brief      manage the different states of BBB transfer and updates the status to upper layer
+    \param[in]  uhost: pointer to USB host handler
+    \param[in]  lun: logic unit number
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_msc_bbb_process (usbh_host *uhost, uint8_t lun)
+{
+    bbb_csw_status csw_status = BBB_CSW_CMD_FAILED;
+    usbh_status status = USBH_BUSY;
+    usbh_status error = USBH_BUSY;
+    usb_urb_state urb_status = URB_IDLE;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    switch (msc->bbb.state) {
+    case BBB_SEND_CBW:
+        msc->bbb.cbw.field.bCBWLUN = lun;
+        msc->bbb.state = BBB_SEND_CBW_WAIT;
+        /* send CBW */
+        usbh_data_send (uhost->data,
+                        msc->bbb.cbw.CBWArray, 
+                        msc->pipe_out, 
+                        BBB_CBW_LENGTH);
+        break;
+
+    case BBB_SEND_CBW_WAIT:
+        urb_status = usbh_urbstate_get(uhost->data, msc->pipe_out);
+
+        if (URB_DONE == urb_status) {
+            if (0U != msc->bbb.cbw.field.dCBWDataTransferLength) {
+                if (USB_TRX_IN == (msc->bbb.cbw.field.bmCBWFlags & USB_TRX_MASK)) {
+                    msc->bbb.state = BBB_DATA_IN;
+                } else {
+                    msc->bbb.state = BBB_DATA_OUT;
+                }
+            } else {
+                msc->bbb.state = BBB_RECEIVE_CSW;
+            }
+
+        } else if (URB_NOTREADY == urb_status) {
+            msc->bbb.state = BBB_SEND_CBW;
+        } else {
+            if (URB_STALL == urb_status) {
+                msc->bbb.state = BBB_ERROR_OUT;
+            }
+        }
+        break;
+
+    case BBB_DATA_IN:
+        usbh_data_recev (uhost->data, 
+                         msc->bbb.pbuf, 
+                         msc->pipe_in, 
+                         msc->ep_size_in);
+
+        msc->bbb.state = BBB_DATA_IN_WAIT;
+        break;
+
+    case BBB_DATA_IN_WAIT:
+        urb_status = usbh_urbstate_get(uhost->data, msc->pipe_in);
+
+        /* BBB DATA IN stage */
+        if (URB_DONE == urb_status) {
+            if (msc->bbb.cbw.field.dCBWDataTransferLength > msc->ep_size_in) {
+                msc->bbb.pbuf += msc->ep_size_in;
+                msc->bbb.cbw.field.dCBWDataTransferLength -= msc->ep_size_in;
+            } else {
+                msc->bbb.cbw.field.dCBWDataTransferLength = 0U;
+            }
+
+            if (msc->bbb.cbw.field.dCBWDataTransferLength > 0U) {
+                usbh_data_recev (uhost->data, 
+                                 msc->bbb.pbuf, 
+                                 msc->pipe_in, 
+                                 msc->ep_size_in);
+            } else {
+                msc->bbb.state = BBB_RECEIVE_CSW;
+            }
+        } else if(URB_STALL == urb_status) {
+            /* this is data stage stall condition */
+            msc->bbb.state = BBB_ERROR_IN;
+        } else {
+            /* no operation */
+        }
+        break;
+
+    case BBB_DATA_OUT:
+        usbh_data_send (uhost->data,
+                        msc->bbb.pbuf, 
+                        msc->pipe_out, 
+                        msc->ep_size_out);
+
+        msc->bbb.state = BBB_DATA_OUT_WAIT;
+        break;
+
+    case BBB_DATA_OUT_WAIT:
+        /* BBB DATA OUT stage */
+        urb_status = usbh_urbstate_get(uhost->data, msc->pipe_out);
+        if (URB_DONE == urb_status) {
+            if (msc->bbb.cbw.field.dCBWDataTransferLength > msc->ep_size_out) {
+                msc->bbb.pbuf += msc->ep_size_out;
+                msc->bbb.cbw.field.dCBWDataTransferLength -= msc->ep_size_out;
+            }  else {
+                msc->bbb.cbw.field.dCBWDataTransferLength = 0; /* reset this value and keep in same state */
+            }
+
+            if (msc->bbb.cbw.field.dCBWDataTransferLength > 0) {
+                usbh_data_send (uhost->data,
+                                msc->bbb.pbuf, 
+                                msc->pipe_out, 
+                                msc->ep_size_out);
+            } else {
+                msc->bbb.state = BBB_RECEIVE_CSW;
+            }
+        } else if (URB_NOTREADY == urb_status) {
+            msc->bbb.state = BBB_DATA_OUT;
+        } else if (URB_STALL == urb_status) {
+            msc->bbb.state = BBB_ERROR_OUT;
+        } else {
+            /* no operation */
+        }
+        break;
+
+    case BBB_RECEIVE_CSW:
+        /* BBB CSW stage */
+        usbh_data_recev (uhost->data,
+                         msc->bbb.csw.CSWArray, 
+                         msc->pipe_in, 
+                         BBB_CSW_LENGTH);
+
+        msc->bbb.state = BBB_RECEIVE_CSW_WAIT;
+        break;
+
+    case BBB_RECEIVE_CSW_WAIT:
+        urb_status = usbh_urbstate_get(uhost->data, msc->pipe_in);
+
+        /* decode CSW */
+        if (URB_DONE == urb_status) {
+            msc->bbb.state = BBB_SEND_CBW;
+            msc->bbb.cmd_state = BBB_CMD_SEND;
+
+            csw_status = usbh_msc_csw_decode(uhost);
+            if (BBB_CSW_CMD_PASSED == csw_status) {
+                status = USBH_OK;
+            } else {
+                status = USBH_FAIL;
+            }
+        } else if (URB_STALL == urb_status) {
+            msc->bbb.state = BBB_ERROR_IN;
+        } else {
+            /* no operation */
+        }
+        break;
+
+    case BBB_ERROR_IN:
+        error = usbh_msc_bbb_abort(uhost, USBH_MSC_DIR_IN);
+
+        if (USBH_OK == error) {
+            msc->bbb.state = BBB_RECEIVE_CSW;
+        } else if (USBH_UNRECOVERED_ERROR == status) {
+            /* this means that there is a stall error limit, do reset recovery */
+            msc->bbb.state = BBB_UNRECOVERED_ERROR;
+        } else {
+            /* no operation */
+        }
+        break;
+
+    case BBB_ERROR_OUT:
+        status = usbh_msc_bbb_abort (uhost, USBH_MSC_DIR_OUT);
+
+        if (USBH_OK == status) {
+            uint8_t toggle = usbh_pipe_toggle_get(uhost->data, msc->pipe_out);
+            usbh_pipe_toggle_set(uhost->data, msc->pipe_out, 1U - toggle);
+            usbh_pipe_toggle_set(uhost->data, msc->pipe_in, 0U);
+            msc->bbb.state = BBB_ERROR_IN;
+        } else {
+            if (USBH_UNRECOVERED_ERROR == status) {
+                msc->bbb.state = BBB_UNRECOVERED_ERROR;
+            }
+        }
+        break;
+
+    case BBB_UNRECOVERED_ERROR:
+        status = usbh_msc_bbb_reset(uhost);
+        if (USBH_OK == status) {
+            msc->bbb.state = BBB_SEND_CBW;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      manages the different error handling for stall
+    \param[in]  uhost: pointer to USB host handler
+    \param[in]  direction: data IN or OUT
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_msc_bbb_abort (usbh_host *uhost, uint8_t direction)
+{
+    usbh_status status = USBH_BUSY;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    switch (direction) {
+    case USBH_MSC_DIR_IN :
+        /* send clrfeature command on bulk IN endpoint */
+        status = usbh_clrfeature(uhost,
+                                 msc->ep_in,
+                                 msc->pipe_in);
+        break;
+
+    case USBH_MSC_DIR_OUT :
+        /*send clrfeature command on bulk OUT endpoint */
+        status = usbh_clrfeature(uhost,
+                                 msc->ep_out,
+                                 msc->pipe_out);
+        break;
+
+    default:
+        break;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      reset msc bbb transfer
+    \param[in]  uhost: pointer to USB host handler
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_msc_bbb_reset (usbh_host *uhost)
+{
+    usbh_status status = USBH_BUSY;
+
+    if (CTL_IDLE == uhost->control.ctl_state) {
+        uhost->control.setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_OUT | USB_REQTYPE_CLASS | USB_RECPTYPE_ITF,
+            .bRequest      = BBB_RESET,
+            .wValue        = 0U,
+            .wIndex        = 0U,
+            .wLength       = 0U
+        };
+
+        usbh_ctlstate_config (uhost, NULL, 0U);
+    } 
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      decode the CSW received by the device and updates the same to upper layer
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     on success USBH_MSC_OK, on failure USBH_MSC_FAIL
+    \notes
+          Refer to USB Mass-Storage Class: BBB (www.usb.org)
+          6.3.1 Valid CSW Conditions :
+          The host shall consider the CSW valid when:
+          1. dCSWSignature is equal to 53425355h
+          2. the CSW is 13 (Dh) bytes in length,
+          3. dCSWTag matches the dCBWTag from the corresponding CBW.
+*/
+bbb_csw_status usbh_msc_csw_decode (usbh_host *uhost)
+{
+    bbb_csw_status status = BBB_CSW_CMD_FAILED;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    /* checking if the transfer length is different than 13 */
+    if (BBB_CSW_LENGTH != usbh_xfercount_get (uhost->data, msc->pipe_in)) {
+        status = BBB_CSW_PHASE_ERROR;
+    } else {
+        /* CSW length is correct */
+
+        /* check validity of the CSW Signature and CSWStatus */
+        if (BBB_CSW_SIGNATURE == msc->bbb.csw.field.dCSWSignature) {
+            /* check condition 1. dCSWSignature is equal to 53425355h */
+            if (msc->bbb.csw.field.dCSWTag == msc->bbb.cbw.field.dCBWTag) {
+                /* check condition 3. dCSWTag matches the dCBWTag from the corresponding CBW */
+                if (0U == msc->bbb.csw.field.bCSWStatus) {
+                    status = BBB_CSW_CMD_PASSED;
+                } else if (1U == msc->bbb.csw.field.bCSWStatus) {
+                    status = BBB_CSW_CMD_FAILED;
+                } else if (2U == msc->bbb.csw.field.bCSWStatus) {
+                    status = BBB_CSW_PHASE_ERROR;
+                } else {
+                    /* no operation */
+                }
+            }
+        } else {
+            /* if the CSW signature is not valid, we shall return the phase error to
+               upper layers for reset recovery */
+            status = BBB_CSW_PHASE_ERROR;
+        }
+    }
+
+    return status;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Source/usbh_msc_core.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Source/usbh_msc_core.c
@@ -1,0 +1,563 @@
+/*!
+    \file    usbh_core.c
+    \brief   USB MSC(mass storage device) class driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usbh_msc_core.h"
+#include "usbh_msc_scsi.h"
+#include "usbh_msc_bbb.h"
+#include "usbh_pipe.h"
+#include "usbh_transc.h"
+#include <stdlib.h>
+#include <string.h>
+
+/* local function prototypes ('static') */
+static void usbh_msc_itf_deinit         (usbh_host *uhost);
+static usbh_status usbh_msc_itf_init    (usbh_host *uhost);
+static usbh_status usbh_msc_req         (usbh_host *uhost);
+static usbh_status usbh_msc_handle      (usbh_host *uhost);
+static usbh_status usbh_msc_maxlun_get  (usbh_host *uhost, uint8_t *maxlun);
+static usbh_status usbh_msc_rdwr_process(usbh_host *uhost, uint8_t lun);
+
+usbh_class usbh_msc = 
+{
+    USB_CLASS_MSC,
+    usbh_msc_itf_init,
+    usbh_msc_itf_deinit,
+    usbh_msc_req,
+    usbh_msc_handle,
+};
+
+/*!
+    \brief      interface initialization for MSC class
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+static usbh_status usbh_msc_itf_init (usbh_host *uhost)
+{
+    usbh_status status = USBH_OK;
+
+    uint8_t interface = usbh_interface_find(&uhost->dev_prop, MSC_CLASS, USB_MSC_SUBCLASS_SCSI, MSC_PROTOCOL);
+
+    if (0xFFU == interface) {
+        uhost->usr_cb->dev_not_supported();
+
+        status = USBH_FAIL;
+    } else {
+        static usbh_msc_handler msc_handler;
+
+        memset((void*)&msc_handler, 0U, sizeof(usbh_msc_handler));
+    
+        uhost->active_class->class_data = (void *)&msc_handler;
+
+        usbh_interface_select(&uhost->dev_prop, interface);
+
+        usb_desc_ep *ep_desc = &uhost->dev_prop.cfg_desc_set.itf_desc_set[interface][0].ep_desc[0];
+
+        if (ep_desc->bEndpointAddress & 0x80U) {
+            msc_handler.ep_in = ep_desc->bEndpointAddress;
+            msc_handler.ep_size_in = ep_desc->wMaxPacketSize;
+        } else {
+            msc_handler.ep_out = ep_desc->bEndpointAddress;
+            msc_handler.ep_size_out = ep_desc->wMaxPacketSize;
+        }
+
+        ep_desc = &uhost->dev_prop.cfg_desc_set.itf_desc_set[interface][0].ep_desc[1];
+
+        if (ep_desc->bEndpointAddress & 0x80U) {
+            msc_handler.ep_in = ep_desc->bEndpointAddress;
+            msc_handler.ep_size_in = ep_desc->wMaxPacketSize;
+        } else {
+            msc_handler.ep_out = ep_desc->bEndpointAddress;
+            msc_handler.ep_size_out = ep_desc->wMaxPacketSize;
+        }
+
+        msc_handler.state = MSC_INIT;
+        msc_handler.error = MSC_OK;
+        msc_handler.req_state = MSC_REQ_IDLE;
+        msc_handler.pipe_out = usbh_pipe_allocate(uhost->data, msc_handler.ep_out);
+        msc_handler.pipe_in = usbh_pipe_allocate(uhost->data, msc_handler.ep_in);
+
+        usbh_msc_bbb_init(uhost);
+
+        /* open the new channels */
+        usbh_pipe_create (uhost->data,
+                          &uhost->dev_prop,
+                          msc_handler.pipe_out,
+                          USB_EPTYPE_BULK,
+                          msc_handler.ep_size_out);
+
+        usbh_pipe_create (uhost->data,
+                          &uhost->dev_prop,
+                          msc_handler.pipe_in,
+                          USB_EPTYPE_BULK,
+                          msc_handler.ep_size_in);
+
+        usbh_pipe_toggle_set (uhost->data, msc_handler.pipe_out, 0U);
+        usbh_pipe_toggle_set (uhost->data, msc_handler.pipe_in, 0U);
+    }
+
+    return status;
+}
+
+/*!
+    \brief      deinitialize interface by freeing host channels allocated to interface
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+void usbh_msc_itf_deinit (usbh_host *uhost)
+{
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    if (msc->pipe_out) {
+        usb_pipe_halt (uhost->data, msc->pipe_out);
+        usbh_pipe_free (uhost->data, msc->pipe_out);
+
+        msc->pipe_out = 0U;
+    }
+
+    if (msc->pipe_in) {
+        usb_pipe_halt (uhost->data, msc->pipe_in);
+        usbh_pipe_free (uhost->data, msc->pipe_in);
+
+        msc->pipe_in = 0U;
+    }
+}
+
+/*!
+    \brief      initialize the MSC state machine
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+static usbh_status usbh_msc_req (usbh_host *uhost)
+{
+    usbh_status status = USBH_BUSY;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    switch (msc->req_state) {
+    case MSC_REQ_IDLE:
+    case MSC_REQ_GET_MAX_LUN:
+        /* issue Get_MaxLun request */
+        status = usbh_msc_maxlun_get (uhost, (uint8_t *)&msc->max_lun);
+
+        if (USBH_OK == status) {
+            msc->max_lun = ((uint8_t)msc->max_lun > MSC_MAX_SUPPORTED_LUN) ? MSC_MAX_SUPPORTED_LUN : (uint8_t)msc->max_lun + 1U;
+
+            for (uint8_t i = 0U; i < msc->max_lun; i++) {
+                msc->unit[i].prev_ready_state = USBH_FAIL;
+                msc->unit[i].state_changed = 0U;
+            }
+        } else {
+            if (USBH_NOT_SUPPORTED == status) {
+                msc->max_lun = 0U;
+                status = USBH_OK;
+            }
+        }
+        break;
+
+    case MSC_REQ_ERROR:
+        /* issue clearfeature request */
+        if (USBH_OK == usbh_clrfeature(uhost, 0x00U, uhost->control.pipe_out_num)) {
+            msc->req_state = msc->prev_req_state;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      MSC state machine handler
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+static usbh_status usbh_msc_handle (usbh_host *uhost)
+{
+    usbh_status status = USBH_BUSY;
+    uint8_t scsi_status = USBH_BUSY;
+    uint8_t ready_status = USBH_BUSY;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+
+    switch (msc->state) {
+    case MSC_INIT:
+        if (msc->cur_lun < msc->max_lun) {
+            msc->unit[msc->cur_lun].error = MSC_NOT_READY;
+
+            switch (msc->unit[msc->cur_lun].state) {
+            case MSC_INIT:
+                msc->unit[msc->cur_lun].state = MSC_READ_INQUIRY;
+                msc->timer = uhost->control.timer;
+                break;
+
+            case MSC_READ_INQUIRY:
+                scsi_status = usbh_msc_scsi_inquiry (uhost, msc->cur_lun, &msc->unit[msc->cur_lun].inquiry);
+
+                if (USBH_OK == scsi_status) {
+                    msc->unit[msc->cur_lun].state = MSC_TEST_UNIT_READY;
+                } else if (scsi_status == USBH_FAIL) {
+                    msc->unit[msc->cur_lun].state = MSC_REQUEST_SENSE;
+                } else {
+                    if (scsi_status == USBH_UNRECOVERED_ERROR) {
+                        msc->unit[msc->cur_lun].state = MSC_IDLE;
+                        msc->unit[msc->cur_lun].error = MSC_ERROR;
+                    }
+                }
+                break;
+
+            case MSC_TEST_UNIT_READY:
+                /* issue SCSI command TestUnitReady */
+                ready_status = usbh_msc_test_unitready (uhost, msc->cur_lun);
+
+                if (USBH_OK == ready_status) {
+                    if (USBH_OK != msc->unit[msc->cur_lun].prev_ready_state) {
+                        msc->unit[msc->cur_lun].state_changed = 1U;
+                    } else {
+                        msc->unit[msc->cur_lun].state_changed = 0U;
+                    }
+
+                    msc->unit[msc->cur_lun].state = MSC_READ_CAPACITY10;
+                    msc->unit[msc->cur_lun].error = MSC_OK;
+                    msc->unit[msc->cur_lun].prev_ready_state = USBH_OK;
+                } else if (USBH_FAIL == ready_status) {
+                    if (USBH_FAIL != msc->unit[msc->cur_lun].prev_ready_state) {
+                        msc->unit[msc->cur_lun].state_changed = 1U;
+                    } else {
+                        msc->unit[msc->cur_lun].state_changed = 0U;
+                    }
+
+                    msc->unit[msc->cur_lun].state = MSC_REQUEST_SENSE;
+                    msc->unit[msc->cur_lun].error = MSC_NOT_READY;
+                    msc->unit[msc->cur_lun].prev_ready_state = USBH_FAIL;
+                } else {
+                    if (USBH_UNRECOVERED_ERROR == ready_status) {
+                        msc->unit[msc->cur_lun].state = MSC_IDLE;
+                        msc->unit[msc->cur_lun].error = MSC_ERROR;
+                    }
+                }
+                break;
+
+            case MSC_READ_CAPACITY10:
+                /* issue READ_CAPACITY10 SCSI command */
+                scsi_status = usbh_msc_read_capacity10 (uhost, msc->cur_lun, &msc->unit[msc->cur_lun].capacity);
+
+                if (USBH_OK == scsi_status) {
+                    if (1U == msc->unit[msc->cur_lun].state_changed) {
+                    }
+                    msc->unit[msc->cur_lun].state = MSC_IDLE;
+                    msc->unit[msc->cur_lun].error = MSC_OK;
+                    msc->cur_lun ++;
+                } else if (USBH_FAIL == scsi_status) {
+                    msc->unit[msc->cur_lun].state = MSC_REQUEST_SENSE;
+                } else {
+                    if (USBH_UNRECOVERED_ERROR == scsi_status) {
+                        msc->unit[msc->cur_lun].state = MSC_IDLE;
+                        msc->unit[msc->cur_lun].error = MSC_ERROR;
+                    }
+                }
+                break;
+
+            case MSC_REQUEST_SENSE:
+                /* issue RequestSense SCSI command for retrieving error code */
+                scsi_status = usbh_msc_request_sense (uhost, msc->cur_lun, &msc->unit[msc->cur_lun].sense);
+                if (USBH_OK == scsi_status) {
+                    if ((msc->unit[msc->cur_lun].sense.SenseKey == UNIT_ATTENTION) || (msc->unit[msc->cur_lun].sense.SenseKey == NOT_READY)) {
+                        if (((uhost->control.timer > msc->timer) && ((uhost->control.timer - msc->timer) < 10000U)) \
+                                || ((uhost->control.timer < msc->timer) && ((uhost->control.timer + 0x3FFFU - msc->timer) < 10000U))) {
+                            msc->unit[msc->cur_lun].state = MSC_TEST_UNIT_READY;
+                            break;
+                        }
+                    }
+
+                    msc->unit[msc->cur_lun].state = MSC_IDLE;
+                    msc->cur_lun++;
+                } else if (USBH_FAIL == scsi_status) {
+                    msc->unit[msc->cur_lun].state = MSC_UNRECOVERED_ERROR;
+                } else {
+                    if (MSC_UNRECOVERED_ERROR == scsi_status) {
+                        msc->unit[msc->cur_lun].state = MSC_IDLE;
+                        msc->unit[msc->cur_lun].error = MSC_ERROR;
+                    }
+                }
+                break;
+
+            case MSC_UNRECOVERED_ERROR:
+                msc->cur_lun++;
+                break;
+
+            default:
+                break;
+            }
+        } else {
+            msc->cur_lun = 0U;
+            msc->state = MSC_IDLE;
+        }
+        break;
+
+    case MSC_IDLE:
+        uhost->usr_cb->dev_user_app();
+        status = USBH_OK;
+        break;
+
+    default:
+        break;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      get max lun of the mass storage device
+    \param[in]  uhost: pointer to USB host
+    \param[in]  maxlun: pointer to max lun
+    \param[out] none
+    \retval     operation status
+*/
+static usbh_status usbh_msc_maxlun_get (usbh_host *uhost, uint8_t *maxlun)
+{
+    usbh_status status = USBH_BUSY;
+
+    if (uhost->control.ctl_state == CTL_IDLE) {
+        uhost->control.setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_IN | USB_REQTYPE_CLASS | USB_RECPTYPE_ITF,
+            .bRequest      = BBB_GET_MAX_LUN,
+            .wValue        = 0U,
+            .wIndex        = 0U,
+            .wLength       = 1U
+        };
+
+        usbh_ctlstate_config (uhost, maxlun, 1U);
+    } 
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      get max lun of the mass storage device
+    \param[in]  uhost: pointer to USB host
+    \param[in]  lun: logic unit number
+    \param[out] none
+    \retval     operation status
+*/
+static usbh_status usbh_msc_rdwr_process(usbh_host *uhost, uint8_t lun)
+{
+    usbh_status error = USBH_BUSY;
+    usbh_status scsi_status = USBH_BUSY;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    /* switch msc req state machine */
+    switch (msc->unit[lun].state) {
+    case MSC_READ:
+        scsi_status = usbh_msc_read10(uhost, lun,  NULL, 0U, 0U);
+
+        if (USBH_OK == scsi_status) {
+            msc->unit[lun].state = MSC_IDLE;
+            error = USBH_OK;
+        } else if (USBH_FAIL == scsi_status) {
+            msc->unit[lun].state = MSC_REQUEST_SENSE;
+        } else {
+            if (USBH_UNRECOVERED_ERROR == scsi_status) {
+                msc->unit[lun].state = MSC_UNRECOVERED_ERROR;
+                error = USBH_FAIL;
+            }
+        }
+        break;
+
+    case MSC_WRITE:
+        scsi_status = usbh_msc_write10(uhost, lun, NULL, 0U, 0U);
+
+        if (USBH_OK == scsi_status) {
+            msc->unit[lun].state = MSC_IDLE;
+            error = USBH_OK;
+        } else if (USBH_FAIL == scsi_status) {
+            msc->unit[lun].state = MSC_REQUEST_SENSE;
+        } else {
+            if (USBH_UNRECOVERED_ERROR == scsi_status) {
+                msc->unit[lun].state = MSC_UNRECOVERED_ERROR;
+                error = USBH_FAIL;
+            }
+        }
+        break;
+
+    case MSC_REQUEST_SENSE:
+        scsi_status = usbh_msc_request_sense (uhost, lun, &msc->unit[lun].sense);
+
+        if (USBH_OK == scsi_status) {
+            msc->unit[lun].state = MSC_IDLE;
+            msc->unit[lun].error = MSC_ERROR;
+
+            error = USBH_FAIL;
+        }
+    
+        if (USBH_FAIL == scsi_status) {
+        } else {
+            if (USBH_UNRECOVERED_ERROR == scsi_status) {
+                msc->unit[lun].state = MSC_UNRECOVERED_ERROR;
+                error = USBH_FAIL;
+            }
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return error;
+}
+
+/*!
+    \brief      get lun information
+    \param[in]  uhost: pointer to USB host
+    \param[in]  lun: logic unit number
+    \param[in]  info: pointer to lun information
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_msc_lun_info_get (usbh_host *uhost, uint8_t lun, msc_lun *info)
+{
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    if (HOST_CLASS_HANDLER == uhost->cur_state) {
+        memcpy(info, &msc->unit[lun], sizeof(msc_lun));
+
+        return USBH_OK;
+    } else {
+        return USBH_FAIL;
+    }
+}
+
+/*!
+    \brief      handle msc read operation
+    \param[in]  uhost: pointer to USB host
+    \param[in]  lun: logic unit number
+    \param[in]  address: data address
+    \param[in]  pbuf: pointer to data buffer
+    \param[in]  length: buffer length
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_msc_read (usbh_host *uhost,
+                           uint8_t lun,
+                           uint32_t address,
+                           uint8_t *pbuf,
+                           uint32_t length)
+{
+    uint32_t timeout = 0U;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+    usb_core_driver *udev = (usb_core_driver *)uhost->data;
+
+    if ((0U == udev->host.connect_status) || 
+        (HOST_CLASS_HANDLER != uhost->cur_state) || 
+        (MSC_IDLE != msc->unit[lun].state)) {
+        return USBH_FAIL;
+    }
+
+    msc->state = MSC_READ;
+    msc->unit[lun].state = MSC_READ;
+    msc->rw_lun = lun;
+
+    usbh_msc_read10(uhost, lun, pbuf, address, length);
+
+    timeout = uhost->control.timer;
+
+    while (USBH_BUSY == usbh_msc_rdwr_process(uhost, lun)) {
+        if (((uhost->control.timer > timeout) && ((uhost->control.timer - timeout) > (1000U * length))) \
+              || ((uhost->control.timer < timeout) && ((uhost->control.timer + 0x3FFFU - timeout) > (1000U * length))) \
+              || (0U == udev->host.connect_status)){
+            msc->state = MSC_IDLE;
+            return USBH_FAIL;
+        }
+    }
+
+    msc->state = MSC_IDLE;
+
+    return USBH_OK;
+}
+
+/*!
+    \brief      handle msc write operation
+    \param[in]  uhost: pointer to USB host
+    \param[in]  lun: logic unit number
+    \param[in]  address: data address
+    \param[in]  pbuf: pointer to data buffer
+    \param[in]  length: buffer length
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_msc_write (usbh_host *uhost,
+                            uint8_t lun,
+                            uint32_t address,
+                            uint8_t *pbuf,
+                            uint32_t length)
+{
+    uint32_t timeout = 0U;
+    usb_core_driver *udev = (usb_core_driver *)uhost->data;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    if ((0U == udev->host.connect_status) || 
+        (HOST_CLASS_HANDLER != uhost->cur_state) || 
+        (MSC_IDLE != msc->unit[lun].state)) {
+        return USBH_FAIL;
+    }
+
+    msc->state = MSC_WRITE;
+    msc->unit[lun].state = MSC_WRITE;
+    msc->rw_lun = lun;
+
+    usbh_msc_write10(uhost, lun, pbuf, address, length);
+
+    timeout = uhost->control.timer;
+
+    while (USBH_BUSY == usbh_msc_rdwr_process(uhost, lun)) {
+        if (((uhost->control.timer > timeout) && ((uhost->control.timer - timeout) > (1000U * length))) \
+              || ((uhost->control.timer < timeout) && ((uhost->control.timer + 0x3FFFU - timeout) > (1000U * length))) \
+              || (0U == udev->host.connect_status)){
+            msc->state = MSC_IDLE;
+            return USBH_FAIL;
+        }
+    }
+
+    msc->state = MSC_IDLE;
+
+    return USBH_OK;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Source/usbh_msc_fatfs.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Source/usbh_msc_fatfs.c
@@ -1,0 +1,235 @@
+/*!
+    \file    usbh_msc_fatfs.c
+    \brief   USB MSC host FATFS related functions
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usb_conf.h"
+#include "diskio.h"
+#include "usbh_msc_core.h"
+
+static volatile DSTATUS state = STA_NOINIT; /* disk status */
+
+extern usbh_host usb_host_msc;
+
+/*!
+    \brief      initialize the disk drive
+    \param[in]  drv: physical drive number (0)
+    \param[out] none
+    \retval     operation status
+*/
+DSTATUS disk_initialize (BYTE drv)
+{
+    usb_core_driver *udev = (usb_core_driver *)usb_host_msc.data;
+
+    if (udev->host.connect_status) {
+        state &= ~STA_NOINIT;
+    }
+
+    return state;
+}
+
+/*!
+    \brief      get disk status
+    \param[in]  drv: physical drive number (0)
+    \param[out] none
+    \retval     operation status
+*/
+DSTATUS disk_status (BYTE drv)
+{
+    if (drv) {
+        return STA_NOINIT; /* supports only single drive */
+    }
+
+    return state;
+}
+
+/*!
+    \brief      read sectors
+    \param[in]  drv: physical drive number (0)
+    \param[in]  buff: pointer to the data buffer to store read data
+    \param[in]  sector: start sector number (LBA)
+    \param[in]  count: sector count (1..255)
+    \param[out] none
+    \retval     operation status
+*/
+DRESULT disk_read (BYTE drv, BYTE *buff, DWORD sector, UINT count)
+{
+    BYTE status = USBH_OK;
+    usb_core_driver *udev = (usb_core_driver *)usb_host_msc.data;
+
+    if (drv || (!count)) {
+        return RES_PARERR;
+    }
+
+    if (state & STA_NOINIT) {
+        return RES_NOTRDY;
+    }
+
+    if (udev->host.connect_status) {
+        do {
+            status = usbh_msc_read (&usb_host_msc, drv, sector, buff, count);
+
+            if (!udev->host.connect_status) {
+                return RES_ERROR;
+            }
+        } while(status == USBH_BUSY);
+    }
+
+    if (status == USBH_OK) {
+        return RES_OK;
+    }
+
+    return RES_ERROR;
+}
+
+#if _READONLY == 0U
+
+/*!
+    \brief      write sectors
+    \param[in]  drv: physical drive number (0)
+    \param[in]  buff: pointer to the data buffer to store read data
+    \param[in]  sector: start sector number (LBA)
+    \param[in]  count: sector count (1..255)
+    \param[out] none
+    \retval     operation status
+*/
+DRESULT disk_write (BYTE drv, const BYTE *buff, DWORD sector, UINT count)
+{
+    BYTE status = USBH_OK;
+    usb_core_driver *udev = (usb_core_driver *)usb_host_msc.data;
+
+    if ((!count) || drv) {
+        return RES_PARERR;
+    }
+
+    if (state & STA_NOINIT) {
+        return RES_NOTRDY;
+    }
+
+    if (state & STA_PROTECT) {
+        return RES_WRPRT;
+    }
+
+    if (udev->host.connect_status) {
+        do {
+            status = usbh_msc_write (&usb_host_msc, drv, sector, (BYTE*)buff, count);
+
+            if (!udev->host.connect_status) {
+                return RES_ERROR;
+            }
+        } while(status == USBH_BUSY);
+    }
+
+    if (status == USBH_OK) {
+        return RES_OK;
+    }
+
+    return RES_ERROR;
+}
+
+#endif /* _READONLY == 0 */
+
+/*!
+    \brief      I/O control function
+    \param[in]  drv: physical drive number (0)
+    \param[in]  ctrl: control code
+    \param[in]  buff: pointer to the data buffer to store read data
+    \param[out] none
+    \retval     operation status
+*/
+DRESULT disk_ioctl (BYTE drv, BYTE ctrl, void *buff)
+{
+    DRESULT res = RES_OK;
+    msc_lun info;
+
+    if (drv) {
+        return RES_PARERR;
+    }
+
+    res = RES_ERROR;
+
+    if (state & STA_NOINIT) {
+        return RES_NOTRDY;
+    }
+
+    switch (ctrl) {
+    /* make sure that no pending write process */
+    case CTRL_SYNC:
+        res = RES_OK;
+        break;
+
+    /* get number of sectors on the disk (dword) */
+    case GET_SECTOR_COUNT:
+        if (USBH_OK == usbh_msc_lun_info_get(&usb_host_msc, drv, &info)) {
+            *(DWORD*)buff = (DWORD)info.capacity.block_nbr;
+            res = RES_OK;
+        }
+        break;
+
+    /* get r/w sector size (word) */
+    case GET_SECTOR_SIZE:
+        if (USBH_OK == usbh_msc_lun_info_get(&usb_host_msc, drv, &info)) {
+            *(WORD*)buff = (DWORD)info.capacity.block_size;
+            res = RES_OK;
+        }
+        break;
+
+    /* get erase block size in unit of sector (dword) */
+    case GET_BLOCK_SIZE:
+        *(DWORD *)buff = 512U;
+        break;
+
+    default:
+        res = RES_PARERR;
+        break;
+    }
+
+    return res;
+}
+
+/*!
+    \brief      get fat time
+    \param[in]  none
+    \param[out] none
+    \retval     time value
+*/
+DWORD get_fattime (void)
+{
+    return ((DWORD)(2019U - 1980U) << 25U)     /* year 2019 */
+           | ((DWORD)1U << 21U)                /* month 1 */
+           | ((DWORD)1U << 16U)                /* day 1 */
+           | ((DWORD)0U << 11U)                /* hour 0 */
+           | ((DWORD)0U << 5U)                 /* min 0 */
+           | ((DWORD)0U >> 1U);                /* sec 0 */
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Source/usbh_msc_scsi.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/class/msc/Source/usbh_msc_scsi.c
@@ -1,0 +1,402 @@
+/*!
+    \file    usbh_msc_scsi.c
+    \brief   USB MSC SCSI commands implemention
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usbh_msc_core.h"
+#include "usbh_msc_scsi.h"
+#include "usbh_msc_bbb.h"
+
+#include <string.h>
+
+/*!
+    \brief      send 'Inquiry' command to the device
+    \param[in]  uhost: pointer to USB host handler
+    \param[in]  lun: logic unit number
+    \param[in]  inquiry: pointer to the inquiry structure
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_msc_scsi_inquiry (usbh_host *uhost, uint8_t lun, scsi_std_inquiry_data *inquiry)
+{
+    usbh_status error = USBH_FAIL;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    switch (msc->bbb.cmd_state) {
+    case BBB_CMD_SEND:
+        /* prepare the cbw and relevant field*/
+        msc->bbb.cbw.field.dCBWDataTransferLength = STANDARD_INQUIRY_DATA_LEN;
+        msc->bbb.cbw.field.bmCBWFlags = USB_TRX_IN;
+        msc->bbb.cbw.field.bCBWCBLength = CBW_LENGTH;
+
+        memset(msc->bbb.cbw.field.CBWCB, 0U, CBW_LENGTH);
+
+        msc->bbb.cbw.field.CBWCB[0] = SCSI_INQUIRY;
+        msc->bbb.cbw.field.CBWCB[1] = (lun << 5U);
+        msc->bbb.cbw.field.CBWCB[4] = 0x24U;
+
+        msc->bbb.state = BBB_SEND_CBW;
+        msc->bbb.cmd_state = BBB_CMD_WAIT;
+        msc->bbb.pbuf = (uint8_t *)(void *)msc->bbb.data;
+        error = USBH_BUSY;
+        break;
+
+    case BBB_CMD_WAIT:
+        error = usbh_msc_bbb_process(uhost, lun);
+
+        if (USBH_OK == error) {
+            memset(inquiry, 0U, sizeof(scsi_std_inquiry_data));
+
+            /* assign inquiry data */
+            inquiry->device_type = msc->bbb.pbuf[0] & 0x1FU;
+            inquiry->peripheral_qualifier = msc->bbb.pbuf[0] >> 5U;
+
+            if (0x80U == ((uint32_t)msc->bbb.pbuf[1] & 0x80U)) {
+                inquiry->removable_media = 1U;
+            } else {
+                inquiry->removable_media = 0U;
+            }
+
+            memcpy (inquiry->vendor_id, &msc->bbb.pbuf[8], 8U);
+            memcpy (inquiry->product_id, &msc->bbb.pbuf[16], 16U);
+            memcpy (inquiry->revision_id, &msc->bbb.pbuf[32], 4U);
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return error;
+}
+
+/*!
+    \brief      send 'Test unit ready' command to the device
+    \param[in]  uhost: pointer to USB host handler
+    \param[in]  lun: logic unit number
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_msc_test_unitready (usbh_host *uhost, uint8_t lun)
+{
+    usbh_status status = USBH_FAIL;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+
+    switch (msc->bbb.cmd_state) {
+    case BBB_CMD_SEND:  
+        /* prepare the CBW and relevant field */
+        msc->bbb.cbw.field.dCBWDataTransferLength = CBW_LENGTH_TEST_UNIT_READY;
+        msc->bbb.cbw.field.bmCBWFlags = USB_TRX_OUT;
+        msc->bbb.cbw.field.bCBWCBLength = CBW_LENGTH;
+
+        memset(msc->bbb.cbw.field.CBWCB, 0U, CBW_CB_LENGTH);
+
+        msc->bbb.cbw.field.CBWCB[0] = SCSI_TEST_UNIT_READY; 
+        msc->bbb.state = BBB_SEND_CBW;
+        msc->bbb.cmd_state = BBB_CMD_WAIT;
+
+        status = USBH_BUSY;
+        break;
+
+    case BBB_CMD_WAIT: 
+        status = usbh_msc_bbb_process(uhost, lun);
+        break;
+
+    default:
+        break;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      send the read capacity command to the device
+    \param[in]  uhost: pointer to USB host handler
+    \param[in]  lun: logic unit number
+    \param[in]  capacity: pointer to SCSI capacity
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_msc_read_capacity10 (usbh_host *uhost, uint8_t lun, scsi_capacity *capacity)
+{
+    usbh_status status = USBH_FAIL;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    switch (msc->bbb.cmd_state) {
+    case BBB_CMD_SEND:
+        /* prepare the CBW and relevant field */
+        msc->bbb.cbw.field.dCBWDataTransferLength = READ_CAPACITY10_DATA_LEN;
+        msc->bbb.cbw.field.bmCBWFlags = USB_TRX_IN;
+        msc->bbb.cbw.field.bCBWCBLength = CBW_LENGTH;
+
+        memset(msc->bbb.cbw.field.CBWCB, 0U, CBW_CB_LENGTH);
+
+        msc->bbb.cbw.field.CBWCB[0] = SCSI_READ_CAPACITY10;
+        msc->bbb.state = BBB_SEND_CBW;
+        msc->bbb.cmd_state = BBB_CMD_WAIT;
+        msc->bbb.pbuf = (uint8_t *)(void *)msc->bbb.data;
+
+        status = USBH_BUSY;
+        break;
+
+    case BBB_CMD_WAIT:
+        status = usbh_msc_bbb_process(uhost, lun);
+
+        if (USBH_OK == status) {
+            capacity->block_nbr = msc->bbb.pbuf[3] | \
+                                  ((uint32_t)msc->bbb.pbuf[2] << 8U) | \
+                                  ((uint32_t)msc->bbb.pbuf[1] << 16U) | \
+                                  ((uint32_t)msc->bbb.pbuf[0] << 24U);
+
+            capacity->block_size = (uint16_t)(msc->bbb.pbuf[7] | ((uint32_t)msc->bbb.pbuf[6] << 8U));
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      send the mode sense6 command to the device
+    \param[in]  uhost: pointer to USB host handler
+    \param[in]  lun: logic unit number
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_msc_mode_sense6 (usbh_host *uhost, uint8_t lun)
+{
+    usbh_status status = USBH_FAIL;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+
+    switch (msc->bbb.cmd_state) {
+    case BBB_CMD_SEND:
+        /* prepare the CBW and relevant field */
+        msc->bbb.cbw.field.dCBWDataTransferLength = XFER_LEN_MODE_SENSE6;
+        msc->bbb.cbw.field.bmCBWFlags = USB_TRX_IN;
+        msc->bbb.cbw.field.bCBWCBLength = CBW_LENGTH;
+
+        memset(msc->bbb.cbw.field.CBWCB, 0U, CBW_CB_LENGTH);
+
+        msc->bbb.cbw.field.CBWCB[0] = SCSI_MODE_SENSE6; 
+        msc->bbb.cbw.field.CBWCB[2] = MODE_SENSE_PAGE_CONTROL_FIELD | MODE_SENSE_PAGE_CODE;
+        msc->bbb.cbw.field.CBWCB[4] = XFER_LEN_MODE_SENSE6;
+        msc->bbb.state = BBB_SEND_CBW;
+        msc->bbb.cmd_state = BBB_CMD_WAIT;
+        msc->bbb.pbuf = (uint8_t *)(void *)msc->bbb.data;
+
+        status = USBH_BUSY;
+        break;
+
+    case BBB_CMD_WAIT:
+        status = usbh_msc_bbb_process(uhost, lun);
+
+        if (USBH_OK == status) {
+            if (msc->bbb.data[2] & MASK_MODE_SENSE_WRITE_PROTECT) {
+
+            } else {
+
+            }
+        }
+        break;
+
+    default:
+        break;
+    }
+
+
+    return status;
+}
+
+/*!
+    \brief      send the Request Sense command to the device
+    \param[in]  uhost: pointer to USB host handler
+    \param[in]  lun: logic unit number
+    \param[in]  sense_data: pointer to sense data
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_msc_request_sense (usbh_host *uhost, uint8_t lun, msc_scsi_sense *sense_data)
+{
+    usbh_status status = USBH_FAIL;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    switch (msc->bbb.cmd_state) {
+    case BBB_CMD_SEND:
+        /* prepare the cbw and relevant field */
+        msc->bbb.cbw.field.dCBWDataTransferLength = ALLOCATION_LENGTH_REQUEST_SENSE;
+        msc->bbb.cbw.field.bmCBWFlags = USB_TRX_IN;
+        msc->bbb.cbw.field.bCBWCBLength = CBW_LENGTH;
+
+        memset(msc->bbb.cbw.field.CBWCB, 0U, CBW_CB_LENGTH);
+
+        msc->bbb.cbw.field.CBWCB[0] = SCSI_REQUEST_SENSE; 
+        msc->bbb.cbw.field.CBWCB[1] = (lun << 5U);
+        msc->bbb.cbw.field.CBWCB[4] = ALLOCATION_LENGTH_REQUEST_SENSE;
+
+        msc->bbb.state = BBB_SEND_CBW;
+        msc->bbb.cmd_state = BBB_CMD_WAIT;
+        msc->bbb.pbuf = (uint8_t *)(void *)msc->bbb.data;
+
+        status = USBH_BUSY;
+        break;
+
+    case BBB_CMD_WAIT:
+        status = usbh_msc_bbb_process(uhost, lun);
+
+        if (status == USBH_OK) {
+            /* get sense data */
+            sense_data->SenseKey = msc->bbb.pbuf[2] & 0x0FU;
+            sense_data->ASC = msc->bbb.pbuf[12];
+            sense_data->ASCQ = msc->bbb.pbuf[13];
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      send the write10 command to the device
+    \param[in]  uhost: pointer to USB host handler
+    \param[in]  lun: logic unit number
+    \param[in]  data_buf: data buffer contains the data to write
+    \param[in]  addr: address to which the data will be written
+    \param[in]  sector_num: number of sector to be written
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_msc_write10 (usbh_host *uhost, uint8_t lun, uint8_t *data_buf, uint32_t addr, uint32_t sector_num)
+{
+    usbh_status status = USBH_FAIL;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    switch (msc->bbb.cmd_state) {
+    case BBB_CMD_SEND:
+        msc->bbb.cbw.field.dCBWDataTransferLength = sector_num * msc->unit[lun].capacity.block_size;
+        msc->bbb.cbw.field.bmCBWFlags = USB_TRX_OUT;
+        msc->bbb.cbw.field.bCBWCBLength = CBW_LENGTH;
+
+        memset(msc->bbb.cbw.field.CBWCB, 0U, CBW_CB_LENGTH);
+
+        msc->bbb.cbw.field.CBWCB[0] = SCSI_WRITE10; 
+
+        /* logical block address */
+        msc->bbb.cbw.field.CBWCB[2] = (((uint8_t*)&addr)[3]);
+        msc->bbb.cbw.field.CBWCB[3] = (((uint8_t*)&addr)[2]);
+        msc->bbb.cbw.field.CBWCB[4] = (((uint8_t*)&addr)[1]);
+        msc->bbb.cbw.field.CBWCB[5] = (((uint8_t*)&addr)[0]);
+
+        /* transfer length */
+        msc->bbb.cbw.field.CBWCB[7] = (((uint8_t *)&sector_num)[1]);
+        msc->bbb.cbw.field.CBWCB[8] = (((uint8_t *)&sector_num)[0]);
+
+        msc->bbb.state = BBB_SEND_CBW;
+        msc->bbb.cmd_state = BBB_CMD_WAIT;
+        msc->bbb.pbuf = data_buf;
+
+        status = USBH_BUSY;
+        break;
+
+    case BBB_CMD_WAIT:
+        status = usbh_msc_bbb_process(uhost, lun);
+        break;
+
+    default:
+        break;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      send the read10 command to the device
+    \param[in]  uhost: pointer to USB host handler
+    \param[in]  lun: logic unit number
+    \param[in]  data_buf: data buffer contains the data to write
+    \param[in]  addr: address to which the data will be read
+    \param[in]  sector_num: number of sector to be read
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_msc_read10 (usbh_host *uhost, uint8_t lun, uint8_t *data_buf, uint32_t addr, uint32_t sector_num)
+{
+    usbh_status status = USBH_FAIL;
+    usbh_msc_handler *msc = (usbh_msc_handler *)uhost->active_class->class_data;
+
+    switch (msc->bbb.cmd_state) {
+    case BBB_CMD_SEND:
+        /* prepare the CBW and relevant field */
+        msc->bbb.cbw.field.dCBWDataTransferLength = sector_num * msc->unit[lun].capacity.block_size;
+        msc->bbb.cbw.field.bmCBWFlags = USB_TRX_IN;
+        msc->bbb.cbw.field.bCBWCBLength = CBW_LENGTH;
+
+        memset(msc->bbb.cbw.field.CBWCB, 0U, CBW_CB_LENGTH);
+
+        msc->bbb.cbw.field.CBWCB[0] = SCSI_READ10; 
+
+        /* logical block address */
+        msc->bbb.cbw.field.CBWCB[2] = (((uint8_t*)&addr)[3]);
+        msc->bbb.cbw.field.CBWCB[3] = (((uint8_t*)&addr)[2]);
+        msc->bbb.cbw.field.CBWCB[4] = (((uint8_t*)&addr)[1]);
+        msc->bbb.cbw.field.CBWCB[5] = (((uint8_t*)&addr)[0]);
+
+        /* transfer length */
+        msc->bbb.cbw.field.CBWCB[7] = (((uint8_t *)&sector_num)[1]);
+        msc->bbb.cbw.field.CBWCB[8] = (((uint8_t *)&sector_num)[0]);
+
+        msc->bbb.state = BBB_SEND_CBW;
+        msc->bbb.cmd_state = BBB_CMD_WAIT;
+        msc->bbb.pbuf = data_buf;
+
+        status = USBH_BUSY;
+        break;
+
+    case BBB_CMD_WAIT:
+        status = usbh_msc_bbb_process(uhost, lun);
+        break;
+
+    default:
+        break;
+    }
+
+    return status;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Include/usbh_core.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Include/usbh_core.h
@@ -1,0 +1,279 @@
+/*!
+    \file    usbh_core.h
+    \brief   USB host core state machine header file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBH_CORE_H
+#define __USBH_CORE_H
+
+#include "usbh_conf.h"
+#include "drv_usb_host.h"
+
+#define MSC_CLASS                                       0x08U
+#define HID_CLASS                                       0x03U
+#define MSC_PROTOCOL                                    0x50U
+#define CBI_PROTOCOL                                    0x01U
+
+#define USBH_MAX_ERROR_COUNT                            3U
+
+#define USBH_DEV_ADDR_DEFAULT                           0U
+#define USBH_DEV_ADDR                                   1U
+
+typedef enum
+{
+    USBH_OK = 0U,
+    USBH_BUSY,
+    USBH_FAIL,
+    USBH_NOT_SUPPORTED,
+    USBH_UNRECOVERED_ERROR,
+    USBH_SPEED_UNKNOWN_ERROR,
+    USBH_APPLY_DEINIT
+} usbh_status;
+
+/* USB host global operation state */
+typedef enum
+{
+    HOST_DEFAULT = 0U,
+    HOST_DETECT_DEV_SPEED,
+    HOST_DEV_CONNECT,
+    HOST_DEV_DETACHED,
+    HOST_DEV_ENUM,
+    HOST_PWR_FEATURE_SET,
+    HOST_CLASS_CHECK,
+    HOST_CLASS_ENUM,
+    HOST_CLASS_HANDLER,
+    HOST_USER_INPUT,
+    HOST_SUSPEND,
+    HOST_WAKEUP,
+    HOST_ERROR
+} usb_host_state;
+
+/* USB host enumeration state */
+typedef enum
+{
+    ENUM_DEFAULT = 0U,
+    ENUM_GET_DEV_DESC,
+    ENUM_SET_ADDR,
+    ENUM_GET_CFG_DESC,
+    ENUM_GET_CFG_DESC_SET,
+    ENUM_GET_STR_DESC,
+#ifdef USB_MTP
+    ENUM_GET_MTP_STR,
+#endif
+    ENUM_SET_CONFIGURATION,
+    ENUM_DEV_CONFIGURED
+} usbh_enum_state;
+
+/* USB host control transfer state */
+typedef enum 
+{
+    CTL_IDLE = 0U,
+    CTL_SETUP,
+    CTL_SETUP_WAIT,
+    CTL_DATA_IN,
+    CTL_DATA_IN_WAIT,
+    CTL_DATA_OUT,
+    CTL_DATA_OUT_WAIT,
+    CTL_STATUS_IN,
+    CTL_STATUS_IN_WAIT,
+    CTL_STATUS_OUT,
+    CTL_STATUS_OUT_WAIT,
+    CTL_ERROR,
+    CTL_FINISH
+} usbh_ctl_state;
+
+/* user action state */
+typedef enum
+{
+    USR_IN_NO_RESP = 0U,
+    USR_IN_RESP_OK = 1U,
+} usbh_user_status;
+
+/* USB host wakeup mode */
+typedef enum
+{
+    NORMAL_WORK = 0U,
+    GENERAL_WAKEUP = 1U,
+    REMOTE_WAKEUP = 2,
+} usbh_wakeup_mode;
+
+/* control transfer information */
+typedef struct _usbh_control
+{
+    uint8_t               pipe_in_num;
+    uint8_t               pipe_out_num;
+    uint8_t               max_len;
+    uint8_t               error_count;
+
+    uint8_t               *buf;
+    uint16_t              ctl_len;
+    uint16_t              timer;
+
+    usb_setup             setup;
+    usbh_ctl_state        ctl_state;
+} usbh_control;
+
+/* USB interface descriptor set */
+typedef struct _usb_desc_itf_set
+{
+    usb_desc_itf itf_desc;
+    usb_desc_ep  ep_desc[USBH_MAX_EP_NUM];
+} usb_desc_itf_set;
+
+/* USB configure descriptor set */
+typedef struct _usb_desc_cfg_set
+{
+    usb_desc_config   cfg_desc;
+    usb_desc_itf_set  itf_desc_set[USBH_MAX_INTERFACES_NUM][USBH_MAX_ALT_SETTING];
+} usb_desc_cfg_set;
+
+/* USB device property */
+typedef struct
+{
+    uint8_t                   data[USBH_DATA_BUF_MAX_LEN]; /* if DMA is used, the data array must be located in the first position */
+    uint8_t                   cur_itf;
+    uint8_t                   addr;
+
+    uint32_t                  speed;
+
+    usb_desc_dev              dev_desc;
+    usb_desc_cfg_set          cfg_desc_set;
+
+#if (USBH_CFG_DESC_KEEP == 1U)
+    uint8_t                   cfgdesc_rawdata[USBH_CFGSET_MAX_LEN];
+#endif /* (USBH_CFG_DESC_KEEP == 1U) */
+} usb_dev_prop;
+
+struct _usbh_host;
+
+/* device class callbacks */
+typedef struct
+{
+    uint8_t     class_code;        /*!< USB class type */
+
+    usbh_status (*class_init)      (struct _usbh_host *phost);
+    void        (*class_deinit)    (struct _usbh_host *phost);
+    usbh_status (*class_requests)  (struct _usbh_host *phost);
+    usbh_status (*class_machine)   (struct _usbh_host *phost);
+    usbh_status (*class_sof)       (struct _usbh_host *uhost);
+
+    void         *class_data;
+} usbh_class;
+
+/* user callbacks */
+typedef struct
+{
+    void (*dev_init)                    (void);
+    void (*dev_deinit)                  (void);
+    void (*dev_attach)                  (void);
+    void (*dev_reset)                   (void);
+    void (*dev_detach)                  (void);
+    void (*dev_over_currented)          (void);
+    void (*dev_speed_detected)          (uint32_t dev_speed);
+    void (*dev_devdesc_assigned)        (void *dev_desc);
+    void (*dev_address_set)             (void);
+
+    void (*dev_cfgdesc_assigned)        (usb_desc_config *cfg_desc, 
+                                         usb_desc_itf *itf_desc,
+                                         usb_desc_ep *ep_desc);
+
+    void (*dev_mfc_str)                 (void *mfc_str);
+    void (*dev_prod_str)                (void *prod_str);
+    void (*dev_seral_str)               (void *serial_str);
+    void (*dev_enumerated)              (void);
+    usbh_user_status (*dev_user_input)  (void);
+    int  (*dev_user_app)                (void);
+    void (*dev_not_supported)           (void);
+    void (*dev_error)                   (void);
+} usbh_user_cb;
+
+/* host information */
+typedef struct _usbh_host
+{
+    usb_host_state                      cur_state;                          /*!< host state machine value */
+    usb_host_state                      backup_state;                       /*!< backup of previous state machine value */
+    usbh_enum_state                     enum_state;                         /*!< enumeration state machine */
+    usbh_control                        control;                            /*!< USB host control state machine */
+    usb_dev_prop                        dev_prop;                           /*!< USB device property */
+
+    usbh_class                          *uclass[USBH_MAX_SUPPORTED_CLASS];  /*!< USB host supported class */
+    usbh_class                          *active_class;                      /*!< USB active class */
+    usbh_user_cb                        *usr_cb;                            /*!< USB user callback */
+
+    uint8_t                             class_num;                          /*!< USB class number */
+
+    void                                *data;                              /*!< used for... */
+
+    uint8_t                             suspend_flag;                       /*!< host suspend flag */
+    uint8_t                             dev_supp_remote_wkup;               /*!< record device remote wakeup function */
+    usbh_wakeup_mode                    wakeup_mode;                        /*!< record wakeup mode */
+} usbh_host;
+
+/*!
+    \brief      get USB URB state
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  pp_num: pipe number
+    \param[out] none
+    \retval     none
+*/
+static inline usb_urb_state usbh_urbstate_get (usb_core_driver *udev, uint8_t pp_num)
+{
+    return udev->host.pipe[pp_num].urb_state;
+}
+
+/*!
+    \brief      get USB transfer data count
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  pp_num: pipe number
+    \param[out] none
+    \retval     none
+*/
+static inline uint32_t usbh_xfercount_get (usb_core_driver *udev, uint8_t pp_num)
+{
+    return udev->host.backup_xfercount[pp_num];
+}
+
+/* function declarations */
+/* USB host stack initializations */
+void usbh_init (usbh_host *uhost, usb_core_driver *udev, usb_core_enum usb_core, usbh_user_cb *user_cb);
+/* USB host register device class */
+usbh_status usbh_class_register (usbh_host *uhost, usbh_class *puclass);
+/* de-initialize USB host */
+usbh_status usbh_deinit (usbh_host *uhost);
+/* USB host core main state machine process */
+void usbh_core_task (usbh_host *uhost);
+/* handle the error on USB host side */
+void usbh_error_handler (usbh_host *uhost, usbh_status err_type);
+
+#endif /* __USBH_CORE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Include/usbh_enum.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Include/usbh_enum.h
@@ -1,0 +1,72 @@
+/*!
+    \file    usbh_enum.h
+    \brief   USB host mode USB enumeration header file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBH_ENUM_H
+#define __USBH_ENUM_H
+
+#include "usbh_core.h"
+
+/* function declarations */
+/* configure USB control status parameters */
+void usbh_ctlstate_config (usbh_host *uhost, uint8_t *buf, uint16_t len);
+/* get device descriptor from the USB device */
+usbh_status usbh_devdesc_get (usbh_host *uhost, uint8_t len);
+/* get configuration descriptor from the USB device */
+usbh_status usbh_cfgdesc_get (usbh_host *uhost, uint16_t len);
+/* get string descriptor from the USB device */
+usbh_status usbh_strdesc_get (usbh_host *uhost,uint8_t str_index, uint8_t *buf, uint16_t len);
+/* set the address to the connected device */
+usbh_status usbh_setaddress (usbh_host *uhost, uint8_t dev_addr);
+/* set the configuration value to the connected device */
+usbh_status usbh_setcfg (usbh_host *uhost, uint16_t config);
+/* set the interface value to the connected device */
+usbh_status usbh_setinterface (usbh_host *uhost, uint8_t itf_num, uint8_t alter_setting);
+/* set or enable a specific device feature */
+usbh_status usbh_setdevfeature (usbh_host *uhost, uint8_t feature_selector, uint16_t windex);
+/* clear or disable a specific device feature */
+usbh_status usbh_clrdevfeature (usbh_host *uhost, uint8_t feature_selector, uint16_t windex);
+/* clear or disable a specific feature */
+usbh_status usbh_clrfeature (usbh_host *uhost, uint8_t ep_addr, uint8_t pp_num); 
+/* get the next descriptor header */
+usb_desc_header *usbh_nextdesc_get (uint8_t *pbuf, uint16_t *ptr);
+/* select an interface */
+usbh_status usbh_interface_select (usb_dev_prop *udev, uint8_t interface);
+/* find the interface index for a specific class */
+uint8_t usbh_interface_find (usb_dev_prop *udev, uint8_t main_class, uint8_t sub_class, uint8_t protocol);
+/* find the interface index for a specific class interface and alternate setting number */
+uint8_t usbh_interfaceindex_find (usb_dev_prop *udev, uint8_t interface_number, uint8_t alt_settings);
+
+#endif /* __USBH_ENUM_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Include/usbh_pipe.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Include/usbh_pipe.h
@@ -1,0 +1,104 @@
+/*!
+    \file    usbh_pipe.h
+    \brief   USB host mode pipe header file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBH_PIPE_H
+#define __USBH_PIPE_H
+
+#include "usbh_core.h"
+
+/* host pipe maximum */
+#define HP_MAX                  8U
+
+/* host pipe status */
+#define HP_OK                   0x0000U
+#define HP_USED                 0x8000U
+#define HP_ERROR                0xFFFFU
+#define HP_USED_MASK            0x7FFFU
+
+/*!
+    \brief      set toggle for a pipe
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  pp_num: pipe number
+    \param[in]  toggle: toggle (0/1)
+    \param[out] none
+    \retval     operation status
+*/
+__STATIC_INLINE void usbh_pipe_toggle_set (usb_core_driver *udev, uint8_t pp_num, uint8_t toggle)
+{
+    if (udev->host.pipe[pp_num].ep.dir) {
+        udev->host.pipe[pp_num].data_toggle_in = toggle;
+    } else {
+        udev->host.pipe[pp_num].data_toggle_out = toggle;
+    }
+}
+
+/*!
+    \brief      get toggle flag of pipe
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  pp_num: pipe number
+    \param[out] none
+    \retval     operation status
+*/
+__STATIC_INLINE uint8_t usbh_pipe_toggle_get (usb_core_driver *udev, uint8_t pp_num)
+{
+    if (udev->host.pipe[pp_num].ep.dir) {
+        return udev->host.pipe[pp_num].data_toggle_in;
+    } else {
+        return udev->host.pipe[pp_num].data_toggle_out;
+    }
+}
+
+/* function declarations */
+/* create a pipe */
+uint8_t usbh_pipe_create (usb_core_driver *udev,
+                          usb_dev_prop *dev,
+                          uint8_t  pp_num,
+                          uint8_t  ep_type,
+                          uint16_t ep_mpl);
+/* modify a pipe */
+uint8_t usbh_pipe_update (usb_core_driver *udev,
+                          uint8_t  pp_num,
+                          uint8_t  dev_addr,
+                          uint32_t dev_speed,
+                          uint16_t ep_mpl);
+/* allocate a new pipe */
+uint8_t usbh_pipe_allocate (usb_core_driver *udev, uint8_t ep_addr);
+/* free a pipe */
+uint8_t usbh_pipe_free (usb_core_driver *udev, uint8_t pp_num);
+/* delete all USB host pipe */
+uint8_t usbh_pipe_delete (usb_core_driver *udev);
+
+#endif /* __USBH_PIPE_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Include/usbh_transc.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Include/usbh_transc.h
@@ -1,0 +1,52 @@
+/*!
+    \file    usbh_transc.h
+    \brief   USB host mode transactions header file
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USBH_TRANSC_H
+#define __USBH_TRANSC_H
+
+#include "usbh_core.h"
+
+/* function declarations */
+/* send the setup packet to the USB device */
+usbh_status usbh_ctlsetup_send (usb_core_driver *udev, uint8_t *buf, uint8_t pp_num);
+/* send a data packet to the USB device */
+usbh_status usbh_data_send (usb_core_driver *udev, uint8_t *buf, uint8_t pp_num, uint16_t len);
+/* receive a data packet from the USB device */
+usbh_status usbh_data_recev (usb_core_driver *udev, uint8_t *buf, uint8_t pp_num, uint16_t len);
+/* USB control transfer handler */
+usbh_status usbh_ctl_handler (usbh_host *uhost);
+
+#endif /* __USBH_TRANSC_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Source/usbh_core.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Source/usbh_core.c
@@ -1,0 +1,660 @@
+/*!
+    \file    usbh_core.c
+    \brief   USB host core state machine driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "drv_usb_hw.h"
+#include "usbh_pipe.h"
+#include "usbh_enum.h"
+#include "usbh_core.h"
+#include "drv_usbh_int.h"
+#include <string.h>
+
+/* local function prototypes ('static') */
+static uint8_t usb_ev_sof           (usbh_host *uhost);
+static uint8_t usb_ev_connect       (usbh_host *uhost);
+static uint8_t usb_ev_disconnect    (usbh_host *uhost);
+static usbh_status usbh_enum_task   (usbh_host *uhost);
+#if USBFS_LOW_POWER || USBHS_LOW_POWER
+static void usb_hwp_suspend         (usb_core_driver *udev);
+static void usb_hwp_resume          (usb_core_driver *udev);
+#endif /* USBFS_LOW_POWER || USBHS_LOW_POWER */
+
+usbh_ev_cb usbh_int_op = 
+{
+    usb_ev_connect,
+    usb_ev_disconnect,
+    usb_ev_sof,
+};
+
+usbh_ev_cb *usbh_int_fop = &usbh_int_op;
+
+/*!
+    \brief      USB host stack initializations
+    \param[in]  uhost: pointer to USB host
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  usb_core: USB core type
+    \param[in]  user_cb: pointer to user callback
+    \param[out] none
+    \retval     none
+*/
+void usbh_init (usbh_host *uhost, usb_core_driver *udev, usb_core_enum usb_core, usbh_user_cb *user_cb)
+{
+    /* link driver to the stack */
+    udev->host.data = (void *)uhost;
+    uhost->data = (void *)udev;
+
+    /* host deinitialization */
+    usbh_deinit(uhost);
+
+    uhost->usr_cb = user_cb;
+
+    udev->host.connect_status = 0U;
+
+    for (uint8_t i = 0U; i < USBFS_MAX_TX_FIFOS; i++) {
+        udev->host.pipe[i].err_count = 0U;
+        udev->host.pipe[i].pp_status = PIPE_IDLE;
+        udev->host.backup_xfercount[i] = 0U;
+    }
+
+    udev->host.pipe[0].ep.mps = 8U;
+
+    usb_basic_init (&udev->bp, &udev->regs, usb_core);
+
+#ifndef DUAL_ROLE_MODE_ENABLED
+    usb_globalint_disable(&udev->regs);
+
+    usb_core_init (udev->bp, &udev->regs);
+
+#ifndef USE_OTG_MODE
+    usb_curmode_set (&udev->regs, HOST_MODE);
+#endif /* USE_OTG_MODE */
+
+    usb_host_init (udev);
+
+    usb_globalint_enable(&udev->regs);
+#endif /* DUAL_ROLE_MODE_ENABLED */
+
+    /* upon initialize call usr call back */
+    uhost->usr_cb->dev_init();
+}
+
+/*!
+    \brief      USB host register device class
+    \param[in]  uhost: pointer to USB host instance
+    \param[in]  puclass: pointer to USB device class
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_class_register (usbh_host *uhost, usbh_class *puclass)
+{
+    usbh_status status = USBH_OK;
+
+    if (NULL != puclass) {
+        if (uhost->class_num < USBH_MAX_SUPPORTED_CLASS) {
+            uhost->uclass[uhost->class_num++] = puclass;
+        } else {
+            status = USBH_FAIL;
+        }
+    } else {
+        status = USBH_FAIL;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      deinitialize USB host
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_deinit(usbh_host *uhost)
+{
+    usb_core_driver *udev = (usb_core_driver *)uhost->data;
+
+    /* software initialize */
+    uhost->cur_state = HOST_DEFAULT;
+    uhost->backup_state = HOST_DEFAULT;
+    uhost->enum_state = ENUM_DEFAULT;
+
+    uhost->control.ctl_state = CTL_IDLE;
+    uhost->control.max_len = USB_FS_EP0_MAX_LEN;
+
+    uhost->dev_prop.addr = USBH_DEV_ADDR_DEFAULT;
+    uhost->dev_prop.speed = PORT_SPEED_FULL;
+    uhost->dev_prop.cur_itf = 0xFFU;
+
+    usbh_pipe_free(udev, uhost->control.pipe_in_num);
+    usbh_pipe_free(udev, uhost->control.pipe_out_num);
+
+    return USBH_OK;
+}
+
+/*!
+    \brief      USB host core main state machine process
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     none
+*/
+void usbh_core_task (usbh_host *uhost)
+{
+    volatile usbh_status status = USBH_FAIL;
+    usb_core_driver *udev = (usb_core_driver *)uhost->data;
+
+    /* check for host port events */
+    if (((0U == udev->host.connect_status) || (0U == udev->host.port_enabled)) && (HOST_DEFAULT != uhost->cur_state)) {
+        if (uhost->cur_state != HOST_DEV_DETACHED) {
+            uhost->cur_state = HOST_DEV_DETACHED;
+        }
+    }
+
+    switch (uhost->cur_state) {
+    case HOST_DEFAULT:
+        if (udev->host.connect_status) {
+            uhost->cur_state = HOST_DETECT_DEV_SPEED;
+
+            usb_mdelay (100U);
+
+            usb_port_reset (udev);
+
+            uhost->usr_cb->dev_reset();
+        }
+        break;
+
+    case HOST_DETECT_DEV_SPEED:
+        if (udev->host.port_enabled) {
+            uhost->cur_state = HOST_DEV_CONNECT;
+
+            uhost->dev_prop.speed = usb_curspeed_get (udev);
+
+            uhost->usr_cb->dev_speed_detected(uhost->dev_prop.speed);
+
+            usb_mdelay (50U);
+        }
+        break;
+
+    case HOST_DEV_CONNECT:
+        uhost->usr_cb->dev_attach();
+        uhost->control.pipe_out_num = usbh_pipe_allocate(udev, 0x00U);
+        uhost->control.pipe_in_num = usbh_pipe_allocate(udev, 0x80U);
+
+        /* open IN control pipe */
+        usbh_pipe_create (udev,
+                          &uhost->dev_prop,
+                          uhost->control.pipe_in_num,
+                          USB_EPTYPE_CTRL,
+                          (uint16_t)uhost->control.max_len);
+
+        /* open OUT control pipe */
+        usbh_pipe_create (udev,
+                          &uhost->dev_prop,
+                          uhost->control.pipe_out_num,
+                          USB_EPTYPE_CTRL,
+                          (uint16_t)uhost->control.max_len);
+
+        uhost->cur_state = HOST_DEV_ENUM;
+        break;
+
+    case HOST_DEV_ENUM:
+        /* check for enumeration status */
+        if (USBH_OK == usbh_enum_task (uhost)) {
+            /* the function shall return USBH_OK when full enumeration is complete */
+
+            /* user callback for end of device basic enumeration */
+            uhost->usr_cb->dev_enumerated();
+
+#if USBFS_LOW_POWER || USBHS_LOW_POWER
+            uhost->cur_state = HOST_SUSPEND;
+
+            /* judge device remote wakeup function */
+            if ((uhost->dev_prop.cfg_desc_set.cfg_desc.bmAttributes) & (1U << 5)) {
+                uhost->dev_supp_remote_wkup = 1;
+            }else{
+                uhost->dev_supp_remote_wkup = 0;
+            }
+#else
+            uhost->cur_state = HOST_PWR_FEATURE_SET;
+#endif /* USBFS_LOW_POWER || USBHS_LOW_POWER */
+        }
+        break;
+
+    case HOST_PWR_FEATURE_SET:
+        if ((uhost->dev_prop.cfg_desc_set.cfg_desc.bmAttributes) & (1U << 5)) {
+            if (usbh_setdevfeature(uhost, FEATURE_SELECTOR_REMOTEWAKEUP, 0U) == USBH_OK) {
+                uhost->cur_state = HOST_CLASS_CHECK;
+            }
+        } else {
+            uhost->cur_state = HOST_CLASS_CHECK;
+        }
+        break;
+
+    case HOST_CLASS_CHECK:
+        if (0U == uhost->class_num) {
+            uhost->cur_state = HOST_ERROR;
+        } else {
+            uhost->active_class = NULL;
+
+            uint8_t itf_class = uhost->dev_prop.cfg_desc_set.itf_desc_set[0][0].itf_desc.bInterfaceClass;
+
+            for (uint8_t index = 0U; index < uhost->class_num; index++) {
+                if ((uhost->uclass[index]->class_code == itf_class) || (0xFFU == itf_class)) {
+                    uhost->active_class = uhost->uclass[index];
+                }
+            }
+
+            if (uhost->active_class != NULL) {
+                uhost->cur_state = HOST_USER_INPUT;
+            } else {
+                uhost->cur_state = HOST_ERROR;
+            }
+        }
+        break;
+
+    case HOST_USER_INPUT:
+        /* the function should return user response true to move to class state */
+        if (USR_IN_RESP_OK == uhost->usr_cb->dev_user_input()) {
+            if ((USBH_OK == uhost->active_class->class_init(uhost))) {
+                uhost->cur_state = HOST_CLASS_ENUM;
+            }
+        }
+        break;
+
+#if USBFS_LOW_POWER || USBHS_LOW_POWER
+    case HOST_SUSPEND:
+        if(uhost->dev_supp_remote_wkup){
+            /* send set feature command*/
+            if (USBH_OK == usbh_setdevfeature (uhost, FEATURE_SELECTOR_REMOTEWAKEUP, 0U)) {
+
+                usb_hwp_suspend (udev);
+
+                usb_mdelay (20U);
+                uhost->suspend_flag = 1;
+                uhost->usr_cb->dev_user_input();
+
+                /* MCU enter deep-sleep*/
+                pmu_to_deepsleepmode (PMU_LDO_LOWPOWER, PMU_LOWDRIVER_DISABLE, WFI_CMD);
+                uhost->cur_state = HOST_WAKEUP;
+            }
+        } else {
+                /* host suspend */
+                usb_hwp_suspend (udev);
+
+                usb_mdelay(20U);
+                uhost->suspend_flag = 1U;
+                uhost->usr_cb->dev_user_input();
+
+                /* MCU enter deep-sleep */
+                pmu_to_deepsleepmode (PMU_LDO_LOWPOWER, PMU_LOWDRIVER_DISABLE, WFI_CMD);
+                uhost->cur_state = HOST_WAKEUP;
+        }
+        break;
+
+    case HOST_WAKEUP:
+         /* judge suspend status */
+        if (0U == uhost->suspend_flag) {
+            usb_hwp_resume(udev);
+            usb_mdelay(500U);
+    
+            if (uhost->dev_supp_remote_wkup) {
+                if (USBH_OK == usbh_clrdevfeature (uhost, FEATURE_SELECTOR_DEV, 0U)) {
+                    /* user callback for initialization */
+                    uhost->usr_cb->dev_init();
+                    uhost->cur_state = HOST_CLASS_CHECK;
+                }
+            } else {
+                    uhost->cur_state = HOST_CLASS_CHECK;
+            }
+        }
+        break;
+#endif /* USBFS_LOW_POWER || USBHS_LOW_POWER */
+
+    case HOST_CLASS_ENUM:
+        /* process class standard control requests state machine */
+        status = uhost->active_class->class_requests(uhost);
+
+        if (USBH_OK == status) {
+            uhost->cur_state = HOST_CLASS_HANDLER;
+        } else {
+            usbh_error_handler (uhost, status);
+        }
+        break;
+
+    case HOST_CLASS_HANDLER:
+        /* process class state machine */
+        status = uhost->active_class->class_machine(uhost);
+
+        usbh_error_handler (uhost, status);
+        break;
+
+    case HOST_ERROR:
+        /* deinitialize host for new enumeration */
+        usbh_deinit (uhost);
+        uhost->usr_cb->dev_deinit();
+        uhost->active_class->class_deinit(uhost);
+        break;
+
+    case HOST_DEV_DETACHED:
+        /* manage user disconnect operations*/
+        uhost->usr_cb->dev_detach();
+
+        /* re-initialize host for new enumeration */
+        usbh_deinit (uhost);
+        uhost->usr_cb->dev_deinit();
+        uhost->active_class->class_deinit(uhost);
+        usbh_pipe_delete(udev);
+        uhost->cur_state = HOST_DEFAULT;
+        break;
+
+    default:
+        break;
+    }
+}
+
+/*!
+    \brief      handle the error on USB host side
+    \param[in]  uhost: pointer to USB host
+    \param[in]  err_type: type of error or busy/OK state
+    \param[out] none
+    \retval     none
+*/
+void usbh_error_handler (usbh_host *uhost, usbh_status err_type)
+{
+    /* error unrecovered or not supported device speed */
+    if ((USBH_SPEED_UNKNOWN_ERROR == err_type) || (USBH_UNRECOVERED_ERROR == err_type)) {
+        uhost->usr_cb->dev_error();
+
+        uhost->cur_state = HOST_ERROR;
+    } else if (USBH_APPLY_DEINIT == err_type) {
+        uhost->cur_state = HOST_ERROR;
+
+        /* user callback for initialization */
+        uhost->usr_cb->dev_init();
+    } else {
+        /* no operation */
+    }
+}
+
+/*!
+    \brief      USB SOF event function from the interrupt
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+static uint8_t usb_ev_sof (usbh_host *uhost)
+{
+    usb_core_driver *udev = (usb_core_driver *)uhost->data;
+
+    /* this callback could be used to implement a scheduler process */
+    uhost->control.timer = (uint16_t)usb_curframe_get(udev);
+
+    if (uhost->active_class != NULL) {
+        if (uhost->active_class->class_sof != NULL) {
+            uhost->active_class->class_sof(uhost);
+        }
+    }
+
+    return 0U;
+}
+
+/*!
+    \brief      USB connect event function from the interrupt
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+static uint8_t usb_ev_connect (usbh_host *uhost)
+{
+    usb_core_driver *udev = (usb_core_driver *)uhost->data;
+    udev->host.connect_status = 1U;
+
+    return 0U;
+}
+
+/*!
+    \brief      USB disconnect event function from the interrupt
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+static uint8_t usb_ev_disconnect (usbh_host *uhost)
+{
+    usb_core_driver *udev = (usb_core_driver *)uhost->data;
+    udev->host.connect_status = 0U;
+
+    return 0U;
+}
+
+/*!
+    \brief      handle the USB enumeration task
+    \param[in]  uhost: pointer to host
+    \param[out] none
+    \retval     none
+*/
+static usbh_status usbh_enum_task (usbh_host *uhost)
+{
+    uint8_t str_buf[512];
+    usbh_status status = USBH_BUSY;
+    usb_core_driver *udev = (usb_core_driver *)uhost->data;
+
+    static uint8_t index_mfc_str = 0U, index_prod_str = 0U, index_serial_str = 0U;
+
+    switch (uhost->enum_state) {
+    case ENUM_DEFAULT:
+        /* get device descriptor for only 1st 8 bytes : to get ep0 max packet size */
+        if (USBH_OK == usbh_devdesc_get (uhost, 8U)) {
+            uhost->control.max_len = uhost->dev_prop.dev_desc.bMaxPacketSize0;
+
+            /* modify control channels configuration for maximum packet size */
+            usbh_pipe_update (udev,
+                              uhost->control.pipe_out_num,
+                              0U, 0U,
+                              (uint16_t)uhost->control.max_len);
+
+            usbh_pipe_update (udev,
+                              uhost->control.pipe_in_num,
+                              0U, 0U,
+                              (uint16_t)uhost->control.max_len);
+
+            uhost->enum_state = ENUM_GET_DEV_DESC;
+        }
+        break;
+
+    case ENUM_GET_DEV_DESC:
+        /* get full device descriptor */
+        if (USBH_OK == usbh_devdesc_get (uhost, USB_DEV_DESC_LEN)) {
+            uhost->usr_cb->dev_devdesc_assigned(&uhost->dev_prop.dev_desc);
+
+            index_mfc_str = uhost->dev_prop.dev_desc.iManufacturer;
+            index_prod_str = uhost->dev_prop.dev_desc.iProduct;
+            index_serial_str = uhost->dev_prop.dev_desc.iSerialNumber;
+
+            uhost->enum_state = ENUM_SET_ADDR;
+        }
+        break;
+
+    case ENUM_SET_ADDR: 
+        /* set address */
+        if (USBH_OK == usbh_setaddress (uhost, USBH_DEV_ADDR)) {
+            usb_mdelay (2U);
+
+            uhost->dev_prop.addr = USBH_DEV_ADDR;
+
+            /* user callback for device address assigned */
+            uhost->usr_cb->dev_address_set();
+
+            /* modify control channels to update device address */
+            usbh_pipe_update (udev,
+                              uhost->control.pipe_in_num,
+                              uhost->dev_prop.addr,
+                              0U, 0U);
+
+            usbh_pipe_update (udev,
+                              uhost->control.pipe_out_num,
+                              uhost->dev_prop.addr,
+                              0U, 0U);
+
+            uhost->enum_state = ENUM_GET_CFG_DESC;
+        }
+        break;
+
+    case ENUM_GET_CFG_DESC:
+        /* get standard configuration descriptor */
+        if (USBH_OK == usbh_cfgdesc_get (uhost, USB_CFG_DESC_LEN)) {
+            uhost->enum_state = ENUM_GET_CFG_DESC_SET;
+        }
+        break;
+
+    case ENUM_GET_CFG_DESC_SET:
+        /* get full configure descriptor (config, interface, endpoints) */
+        if (USBH_OK == usbh_cfgdesc_get (uhost, uhost->dev_prop.cfg_desc_set.cfg_desc.wTotalLength)) {
+            /* user callback for configuration descriptors available */
+            uhost->usr_cb->dev_cfgdesc_assigned (&uhost->dev_prop.cfg_desc_set.cfg_desc,
+                                                  &uhost->dev_prop.cfg_desc_set.itf_desc_set[0][0].itf_desc,
+                                                  &uhost->dev_prop.cfg_desc_set.itf_desc_set[0][0].ep_desc[0]);
+
+            uhost->enum_state = ENUM_GET_STR_DESC;
+        }
+        break;
+
+    case ENUM_GET_STR_DESC:
+        if (index_mfc_str) {
+            if (USBH_OK == usbh_strdesc_get (uhost, 
+                                             uhost->dev_prop.dev_desc.iManufacturer, 
+                                             str_buf,
+                                             0xFFU)) {
+                /* user callback for manufacturing string */
+                uhost->usr_cb->dev_mfc_str(str_buf);
+
+                index_mfc_str = 0U;
+            }
+        } else {
+            if (index_prod_str) {
+                /* check that product string is available */
+                if (USBH_OK == usbh_strdesc_get (uhost, 
+                                                 uhost->dev_prop.dev_desc.iProduct, 
+                                                 str_buf, 
+                                                 0xFFU)) {
+                    uhost->usr_cb->dev_prod_str(str_buf);
+
+                    index_prod_str = 0U;
+                }
+            } else {
+                if (index_serial_str) {
+                    if (USBH_OK == usbh_strdesc_get (uhost, 
+                                                     uhost->dev_prop.dev_desc.iSerialNumber,
+                                                     str_buf, 
+                                                     0xFFU)) {
+                        uhost->usr_cb->dev_seral_str(str_buf);
+                        uhost->enum_state = ENUM_SET_CONFIGURATION;
+                        index_serial_str = 0U;
+                    }
+                } else {
+                    uhost->enum_state = ENUM_SET_CONFIGURATION;
+                }
+            }
+        }
+        break;
+
+    case ENUM_SET_CONFIGURATION:
+        if (USBH_OK == usbh_setcfg (uhost, (uint16_t)uhost->dev_prop.cfg_desc_set.cfg_desc.bConfigurationValue)) {
+            uhost->enum_state = ENUM_DEV_CONFIGURED;
+        }
+        break;
+
+    case ENUM_DEV_CONFIGURED:
+        status = USBH_OK;
+        break;
+
+    default:
+        break;
+    }
+
+    return status;
+}
+
+#if USBFS_LOW_POWER || USBHS_LOW_POWER
+
+/*!
+    \brief      handles the USB resume from suspend mode
+    \param[in]  udev: pointer to selected USB device
+    \param[out] none
+    \retval     none
+*/
+static void usb_hwp_resume(usb_core_driver *udev)
+{
+    __IO uint32_t hprt = 0U;
+
+    /*  switch-on the clocks */
+    *udev->regs.PWRCLKCTL &= ~PWRCLKCTL_SUCLK;
+
+    *udev->regs.PWRCLKCTL &= ~PWRCLKCTL_SHCLK;
+
+    hprt = usb_port_read(udev);
+
+    hprt &= ~HPCS_PSP;
+    hprt |= HPCS_PREM;
+
+    *udev->regs.HPCS = hprt;
+
+    usb_mdelay (20U);
+
+    hprt &= ~HPCS_PREM;
+
+    *udev->regs.HPCS = hprt;
+}
+
+/*!
+    \brief      handles the USB enter to suspend mode
+    \param[in]  udev: pointer to selected USB device
+    \param[out] none
+    \retval     none
+*/
+static void usb_hwp_suspend(usb_core_driver *udev)
+{
+    __IO uint32_t hprt = 0U;
+
+    hprt = usb_port_read(udev);
+
+    hprt |= HPCS_PSP;
+
+    *udev->regs.HPCS = hprt;
+
+    /*  switch-off the clocks */
+    *udev->regs.PWRCLKCTL |= PWRCLKCTL_SUCLK;
+
+    *udev->regs.PWRCLKCTL |= PWRCLKCTL_SHCLK;
+}
+
+#endif /* USBFS_LOW_POWER || USBHS_LOW_POWER */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Source/usbh_enum.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Source/usbh_enum.c
@@ -1,0 +1,695 @@
+/*!
+    \file    usbh_enum.c
+    \brief   USB host mode enumeration driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usbh_pipe.h"
+#include "usbh_transc.h"
+#include "usbh_enum.h"
+
+/* local function prototypes ('static') */
+static void usbh_devdesc_parse (usb_desc_dev *dev_desc, uint8_t *buf, uint16_t len);
+static void usbh_cfgdesc_parse (usb_desc_config *cfg_desc, uint8_t *buf);
+static void usbh_cfgset_parse  (usb_dev_prop *udev, uint8_t *buf);
+static void usbh_itfdesc_parse (usb_desc_itf *itf_desc, uint8_t *buf);
+static void usbh_epdesc_parse  (usb_desc_ep *ep_desc, uint8_t *buf);
+static void usbh_strdesc_parse (uint8_t *psrc, uint8_t *pdest, uint16_t len);
+
+/*!
+    \brief      configure USB control status parameters
+    \param[in]  uhost: pointer to USB host
+    \param[in]  buf: control transfer data buffer pointer
+    \param[in]  len: length of the data buffer
+    \param[out] none
+    \retval     none
+*/
+void usbh_ctlstate_config (usbh_host *uhost, uint8_t *buf, uint16_t len)
+{
+    /* prepare the transactions */
+    uhost->control.buf = buf;
+    uhost->control.ctl_len = len;
+
+    uhost->control.ctl_state = CTL_SETUP;
+}
+
+/*!
+    \brief      get device descriptor from the USB device
+    \param[in]  uhost: pointer to USB host
+    \param[in]  len: length of the descriptor
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_devdesc_get (usbh_host *uhost, uint8_t len)
+{
+    usbh_status status = USBH_BUSY;
+
+    usbh_control *usb_ctl = &uhost->control;
+
+    if (CTL_IDLE == usb_ctl->ctl_state) {
+        usb_ctl->setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_IN | USB_RECPTYPE_DEV | USB_REQTYPE_STRD,
+            .bRequest      = USB_GET_DESCRIPTOR,
+            .wValue        = USBH_DESC(USB_DESCTYPE_DEV),
+            .wIndex        = 0U,
+            .wLength       = len
+        };
+
+        usbh_ctlstate_config (uhost, uhost->dev_prop.data, (uint16_t)len);
+    }
+
+    status = usbh_ctl_handler (uhost);
+
+    if (USBH_OK == status) {
+        /* commands successfully sent and response received */
+        usbh_devdesc_parse (&uhost->dev_prop.dev_desc, uhost->dev_prop.data, (uint16_t)len);
+    }
+
+    return status;
+}
+
+/*!
+    \brief      get configuration descriptor from the USB device
+    \param[in]  uhost: pointer to USB host
+    \param[in]  len: length of the descriptor
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_cfgdesc_get (usbh_host *uhost, uint16_t len)
+{
+    uint8_t *pdata = NULL;
+
+    usbh_status status = USBH_BUSY;
+
+    usbh_control *usb_ctl = &uhost->control;
+
+#if (USBH_CFG_DESC_KEEP == 1U)
+    pdata = uhost->dev_prop.cfgdesc_rawdata;
+#else
+    pdata = uhost->dev_prop.data;
+#endif /* (USBH_CFG_DESC_KEEP == 1U) */
+
+    if (CTL_IDLE == usb_ctl->ctl_state) {
+        usb_ctl->setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_IN | USB_RECPTYPE_DEV | USB_REQTYPE_STRD,
+            .bRequest      = USB_GET_DESCRIPTOR,
+            .wValue        = USBH_DESC(USB_DESCTYPE_CONFIG),
+            .wIndex        = 0U,
+            .wLength       = len
+        };
+
+        usbh_ctlstate_config (uhost, pdata, len);
+    }
+
+    status = usbh_ctl_handler (uhost);
+
+    if (USBH_OK == status) {
+        if (len <= USB_CFG_DESC_LEN) {
+            usbh_cfgdesc_parse (&uhost->dev_prop.cfg_desc_set.cfg_desc, pdata);
+        } else {
+            usbh_cfgset_parse (&uhost->dev_prop, pdata);
+        }
+    }
+
+    return status;
+}
+
+/*!
+    \brief      get string descriptor from the USB device
+    \param[in]  uhost: pointer to USB host
+    \param[in]  str_index: index for the string descriptor
+    \param[in]  buf: buffer pointer to the string descriptor
+    \param[in]  len: length of the descriptor
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_strdesc_get (usbh_host *uhost,
+                              uint8_t str_index, 
+                              uint8_t *buf, 
+                              uint16_t len)
+{
+    usbh_status status = USBH_BUSY;
+
+    usbh_control *usb_ctl = &uhost->control;
+
+    if (CTL_IDLE == usb_ctl->ctl_state) {
+        usb_ctl->setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_IN | USB_RECPTYPE_DEV | USB_REQTYPE_STRD,
+            .bRequest      = USB_GET_DESCRIPTOR,
+            .wValue        = USBH_DESC(USB_DESCTYPE_STR) | str_index,
+            .wIndex        = 0x0409U,
+            .wLength       = len
+        };
+
+        usbh_ctlstate_config (uhost, uhost->dev_prop.data, len);
+    }
+
+    status = usbh_ctl_handler (uhost);
+
+    if (USBH_OK == status) {
+        /* commands successfully sent and response received */
+        usbh_strdesc_parse (uhost->dev_prop.data, buf, len);
+    }
+
+    return status;
+}
+
+/*!
+    \brief      set the address to the connected device
+    \param[in]  uhost: pointer to USB host
+    \param[in]  dev_addr: device address to assign
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_setaddress (usbh_host *uhost, uint8_t dev_addr)
+{
+    usbh_status status = USBH_BUSY;
+
+    usbh_control *usb_ctl = &uhost->control;
+
+    if (CTL_IDLE == usb_ctl->ctl_state) {
+        usb_ctl->setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_OUT | USB_RECPTYPE_DEV | USB_REQTYPE_STRD,
+            .bRequest      = USB_SET_ADDRESS,
+            .wValue        = (uint16_t)dev_addr,
+            .wIndex        = 0U,
+            .wLength       = 0U
+        };
+
+        usbh_ctlstate_config (uhost, NULL, 0U);
+    }
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      set the configuration value to the connected device
+    \param[in]  uhost: pointer to USB host
+    \param[in]  config_index: configuration value
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_setcfg (usbh_host *uhost, uint16_t config_index)
+{
+    usbh_status status = USBH_BUSY;
+
+    usbh_control *usb_ctl = &uhost->control;
+
+    if (CTL_IDLE == usb_ctl->ctl_state) {
+        usb_ctl->setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_OUT | USB_RECPTYPE_DEV | USB_REQTYPE_STRD,
+            .bRequest      = USB_SET_CONFIGURATION,
+            .wValue        = config_index,
+            .wIndex        = 0U,
+            .wLength       = 0U
+        };
+
+        usbh_ctlstate_config (uhost, NULL, 0U);
+    }
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      set the interface value to the connected device
+    \param[in]  uhost: pointer to USB host
+    \param[in]  itf_num: interface number
+    \param[in]  set: alternated setting value
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_setinterface (usbh_host *uhost, uint8_t itf_num, uint8_t set)
+{
+    usbh_status status = USBH_BUSY;
+
+    usbh_control *usb_ctl = &uhost->control;
+
+    if (CTL_IDLE == usb_ctl->ctl_state) {
+        usb_ctl->setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_OUT | USB_RECPTYPE_ITF | USB_REQTYPE_STRD,
+            .bRequest      = USB_SET_INTERFACE,
+            .wValue        = set,
+            .wIndex        = itf_num,
+            .wLength       = 0U
+        };
+
+        usbh_ctlstate_config (uhost, NULL, 0U);
+    }
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      set the interface value to the connected device
+    \param[in]  uhost: pointer to USB host
+    \param[in]  feature_selector: feature selector
+    \param[in]  windex: index value
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_setdevfeature (usbh_host *uhost, uint8_t feature_selector, uint16_t windex)
+{
+    usbh_status status = USBH_BUSY;
+
+    usbh_control *usb_ctl = &uhost->control;
+
+    if (CTL_IDLE == usb_ctl->ctl_state) {
+        usb_ctl->setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_OUT | USB_RECPTYPE_DEV | USB_REQTYPE_STRD,
+            .bRequest      = USB_SET_FEATURE,
+            .wValue        = feature_selector,
+            .wIndex        = windex,
+            .wLength       = 0U
+        };
+
+        usbh_ctlstate_config (uhost, NULL, 0U);
+    } 
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      clear the interface value to the connected device
+    \param[in]  uhost: pointer to USB host
+    \param[in]  feature_selector: feature selector
+    \param[in]  windex: index value
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_clrdevfeature (usbh_host *uhost, uint8_t feature_selector, uint16_t windex)
+{
+    usbh_status status = USBH_BUSY;
+
+    usbh_control *usb_ctl = &uhost->control;
+
+    if (CTL_IDLE == usb_ctl->ctl_state) {
+        usb_ctl->setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_OUT | USB_RECPTYPE_DEV | USB_REQTYPE_STRD,
+            .bRequest      = USB_CLEAR_FEATURE,
+            .wValue        = feature_selector,
+            .wIndex        = windex,
+            .wLength       = 0U
+        };
+
+        usbh_ctlstate_config (uhost, NULL, 0U);
+    } 
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      clear or disable a specific feature
+    \param[in]  uhost: pointer to USB host
+    \param[in]  ep_addr: endpoint address
+    \param[in]  pp_num: pipe number
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_clrfeature (usbh_host *uhost, uint8_t ep_addr, uint8_t pp_num) 
+{
+    usbh_status status = USBH_BUSY;
+    usbh_control *usb_ctl = &uhost->control;
+    usb_core_driver *udev = (usb_core_driver *)uhost->data;
+
+    if (CTL_IDLE == usb_ctl->ctl_state) {
+        usb_ctl->setup.req = (usb_req) {
+            .bmRequestType = USB_TRX_OUT | USB_RECPTYPE_EP | USB_REQTYPE_STRD,
+            .bRequest      = USB_CLEAR_FEATURE,
+            .wValue        = FEATURE_SELECTOR_EP,
+            .wIndex        = ep_addr,
+            .wLength       = 0U
+        };
+
+        if (EP_ID(ep_addr) == udev->host.pipe[pp_num].ep.num) {
+            usbh_pipe_toggle_set(udev, pp_num, 0U);
+        } else {
+            return USBH_FAIL;
+        }
+
+        usbh_ctlstate_config (uhost, NULL, 0U);
+    } 
+
+    status = usbh_ctl_handler (uhost);
+
+    return status;
+}
+
+/*!
+    \brief      get the next descriptor header
+    \param[in]  pbuf: pointer to buffer where the configuration descriptor set is available
+    \param[in]  ptr: data pointer inside the configuration descriptor set
+    \param[out] none
+    \retval     return descriptor header
+*/
+usb_desc_header *usbh_nextdesc_get (uint8_t *pbuf, uint16_t *ptr)
+{
+    usb_desc_header *pnext;
+
+    *ptr += ((usb_desc_header *)pbuf)->bLength;
+
+    pnext = (usb_desc_header *)((uint8_t *)pbuf + ((usb_desc_header *)pbuf)->bLength);
+
+    return (pnext);
+}
+
+/*!
+    \brief      get the next descriptor header
+    \param[in]  udev: pointer to device property
+    \param[in]  interface: interface number
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_interface_select (usb_dev_prop *udev, uint8_t interface)
+{
+    usbh_status status = USBH_OK;
+
+    if (interface < udev->cfg_desc_set.cfg_desc.bNumInterfaces) {
+        udev->cur_itf = interface;
+    } else {
+        status = USBH_FAIL;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      find the interface index for a specific class
+    \param[in]  udev: pointer to device property
+    \param[in]  main_class: class code
+    \param[in]  sub_class: subclass code
+    \param[in]  protocol: Protocol code
+    \param[out] none
+    \retval     interface index in the configuration structure
+    \note       interface index 0xFF means interface index not found
+*/
+uint8_t usbh_interface_find (usb_dev_prop *udev, uint8_t main_class, uint8_t sub_class, uint8_t protocol)
+{
+    usb_desc_itf *pif;
+
+    uint8_t if_ix = 0U;
+
+    pif = (usb_desc_itf *)0;
+
+    while (if_ix < udev->cfg_desc_set.cfg_desc.bNumInterfaces) {
+        pif = &udev->cfg_desc_set.itf_desc_set[if_ix][0].itf_desc;
+
+        if (((pif->bInterfaceClass == main_class) || (main_class == 0xFFU))&&
+             ((pif->bInterfaceSubClass == sub_class) || (sub_class == 0xFFU))&&
+               ((pif->bInterfaceProtocol == protocol) || (protocol == 0xFFU))) {
+            return if_ix;
+        }
+
+        if_ix++;
+    }
+
+    return 0xFFU;
+}
+
+/*!
+    \brief      find the interface index for a specific class interface and alternate setting number
+    \param[in]  udev: pointer to device property
+    \param[in]  interface_number: interface number
+    \param[in]  alt_settings: alternate setting number
+    \param[out] none
+    \retval     interface index in the configuration structure
+    \note       interface index 0xFF means interface index not found
+*/
+uint8_t usbh_interfaceindex_find (usb_dev_prop *udev, uint8_t interface_number, uint8_t alt_settings)
+{
+    usb_desc_itf *pif;
+
+    uint8_t if_ix = 0U;
+
+    pif = (usb_desc_itf *)0;
+
+    while (if_ix < USBH_MAX_INTERFACES_NUM) {
+        pif = &udev->cfg_desc_set.itf_desc_set[if_ix][alt_settings].itf_desc;
+
+        if ((pif->bInterfaceNumber == interface_number) && (pif->bAlternateSetting == alt_settings)) {
+            return if_ix;
+        }
+
+        if_ix++;
+    }
+
+    return 0xFFU;
+}
+
+/*!
+    \brief      parse the device descriptor
+    \param[in]  dev_desc: pointer to USB device descriptor buffer
+    \param[in]  buf: pointer to the source descriptor buffer
+    \param[in]  len: length of the descriptor
+    \param[out] none
+    \retval     none
+*/
+static void usbh_devdesc_parse (usb_desc_dev *dev_desc, uint8_t *buf, uint16_t len)
+{
+    *dev_desc = (usb_desc_dev) {
+        .header = {
+            .bLength         = *(uint8_t *)(buf + 0U),
+            .bDescriptorType = *(uint8_t *)(buf + 1U)
+        },
+
+        .bcdUSB              = BYTE_SWAP(buf + 2U),
+        .bDeviceClass        = *(uint8_t *)(buf + 4U),
+        .bDeviceSubClass     = *(uint8_t *)(buf + 5U),
+        .bDeviceProtocol     = *(uint8_t *)(buf + 6U),
+        .bMaxPacketSize0     = *(uint8_t *)(buf + 7U)
+    };
+
+    if (len > 8U) {
+        /* for 1st time after device connection, host may issue only 8 bytes for device descriptor length  */
+        dev_desc->idVendor              = BYTE_SWAP(buf + 8U);
+        dev_desc->idProduct             = BYTE_SWAP(buf + 10U);
+        dev_desc->bcdDevice             = BYTE_SWAP(buf + 12U);
+        dev_desc->iManufacturer         = *(uint8_t *)(buf + 14U);
+        dev_desc->iProduct              = *(uint8_t *)(buf + 15U);
+        dev_desc->iSerialNumber         = *(uint8_t *)(buf + 16U);
+        dev_desc->bNumberConfigurations = *(uint8_t *)(buf + 17U);
+    }
+}
+
+/*!
+    \brief      parse the configuration descriptor
+    \param[in]  cfg_desc: pointer to USB configuration descriptor buffer
+    \param[in]  buf: pointer to the source descriptor buffer
+    \param[out] none
+    \retval     none
+*/
+static void usbh_cfgdesc_parse (usb_desc_config *cfg_desc, uint8_t *buf)
+{
+    /* parse configuration descriptor */
+    *cfg_desc = (usb_desc_config) {
+        .header = {
+            .bLength         = *(uint8_t *)(buf + 0U),
+            .bDescriptorType = *(uint8_t *)(buf + 1U),
+        },
+
+        .wTotalLength        = BYTE_SWAP(buf + 2U),
+        .bNumInterfaces      = *(uint8_t *)(buf + 4U),
+        .bConfigurationValue = *(uint8_t *)(buf + 5U),
+        .iConfiguration      = *(uint8_t *)(buf + 6U),
+        .bmAttributes        = *(uint8_t *)(buf + 7U),
+        .bMaxPower           = *(uint8_t *)(buf + 8U)
+    };
+}
+
+/*!
+    \brief      parse the configuration descriptor set
+    \param[in]  udev:  pointer to device property
+    \param[in]  buf: pointer to the source descriptor buffer
+    \param[out] none
+    \retval     none
+*/
+static void  usbh_cfgset_parse (usb_dev_prop *udev, uint8_t *buf)
+{
+    usb_desc_ep *ep = NULL;
+    usb_desc_itf_set *itf = NULL;
+    usb_desc_itf itf_value;
+    usb_desc_config *cfg = NULL;
+
+    usb_desc_header *pdesc = (usb_desc_header *)buf;
+
+    uint8_t itf_index = 0U, ep_index = 0U, alt_setting = 0U;
+    uint8_t pre_itf_index = 0U;
+    uint16_t ptr;
+
+    /* parse configuration descriptor */
+    usbh_cfgdesc_parse (&udev->cfg_desc_set.cfg_desc, buf);
+    cfg = &udev->cfg_desc_set.cfg_desc;
+    ptr = USB_CFG_DESC_LEN;
+
+    if (cfg->bNumInterfaces > USBH_MAX_INTERFACES_NUM) {
+        return;
+    }
+
+    while (ptr < cfg->wTotalLength) {
+        pdesc = usbh_nextdesc_get ((uint8_t *)pdesc, &ptr);
+
+        if (pdesc->bDescriptorType == USB_DESCTYPE_ITF) {
+            itf_index = *(((uint8_t *)pdesc) + 2U);
+
+            if (pre_itf_index != itf_index) {
+                alt_setting = 0U;
+            }
+
+            itf = &udev->cfg_desc_set.itf_desc_set[itf_index][alt_setting];
+
+            alt_setting++;
+
+            if ((*((uint8_t *)pdesc + 3U)) < 3U) {
+                usbh_itfdesc_parse (&itf_value, (uint8_t *)pdesc);
+
+                /* parse endpoint descriptors relative to the current interface */
+                if (itf_value.bNumEndpoints > USBH_MAX_EP_NUM) {
+                    return;
+                }
+
+                usbh_itfdesc_parse (&itf->itf_desc, (uint8_t *)&itf_value);
+
+                /* store the previous interface index */
+                pre_itf_index = itf_index;
+
+                if (0U == itf_value.bNumEndpoints) {
+                    continue;
+                }
+
+                for (ep_index = 0U; ep_index < itf_value.bNumEndpoints; ) {
+                    pdesc = usbh_nextdesc_get ((void*)pdesc, &ptr);
+
+                    if (pdesc->bDescriptorType == USB_DESCTYPE_EP) {
+                        ep = &itf->ep_desc[ep_index];
+
+                        usbh_epdesc_parse (ep, (uint8_t *)pdesc);
+
+                        ep_index++;
+                    }
+                }
+            }
+        }
+    }
+}
+
+/*!
+    \brief      parse the interface descriptor
+    \param[in]  itf_desc: pointer to USB interface descriptor buffer
+    \param[in]  buf: pointer to the source descriptor buffer
+    \param[out] none
+    \retval     none
+*/
+static void  usbh_itfdesc_parse (usb_desc_itf *itf_desc, uint8_t *buf)
+{
+    *itf_desc = (usb_desc_itf) {
+        .header = {
+            .bLength         = *(uint8_t *)(buf + 0U),
+            .bDescriptorType = *(uint8_t *)(buf + 1U),
+        },
+
+        .bInterfaceNumber    = *(uint8_t *)(buf + 2U),
+        .bAlternateSetting   = *(uint8_t *)(buf + 3U),
+        .bNumEndpoints       = *(uint8_t *)(buf + 4U),
+        .bInterfaceClass     = *(uint8_t *)(buf + 5U),
+        .bInterfaceSubClass  = *(uint8_t *)(buf + 6U),
+        .bInterfaceProtocol  = *(uint8_t *)(buf + 7U),
+        .iInterface          = *(uint8_t *)(buf + 8U)
+    };
+}
+
+/*!
+    \brief      parse the endpoint descriptor
+    \param[in]  ep_desc: pointer to USB endpoint descriptor buffer
+    \param[in]  buf: pointer to the source descriptor buffer
+    \param[out] none
+    \retval     none
+*/
+static void  usbh_epdesc_parse (usb_desc_ep *ep_desc, uint8_t *buf)
+{
+    *ep_desc = (usb_desc_ep) {
+        .header = {
+            .bLength         = *(uint8_t *)(buf + 0U),
+            .bDescriptorType = *(uint8_t *)(buf + 1U)
+        },
+
+        .bEndpointAddress    = *(uint8_t *)(buf + 2U),
+        .bmAttributes        = *(uint8_t *)(buf + 3U),
+        .wMaxPacketSize      = BYTE_SWAP(buf + 4U),
+        .bInterval           = *(uint8_t *)(buf + 6U)
+    };
+}
+
+/*!
+    \brief      parse the string descriptor
+    \param[in]  psrc: source pointer containing the descriptor data
+    \param[in]  pdest: destination address pointer
+    \param[in]  len: length of the descriptor
+    \param[out] none
+    \retval     none
+*/
+static void usbh_strdesc_parse (uint8_t *psrc, uint8_t *pdest, uint16_t len)
+{
+    uint16_t str_len = 0U, index = 0U;
+
+    /* the unicode string descriptor is not NULL-terminated. The string length is
+     * computed by substracting two from the value of the first byte of the descriptor.
+     */
+
+    /* check which is lower size, the size of string or the length of bytes read from the device */
+    if (USB_DESCTYPE_STR == psrc[1]) {
+        /* make sure the descriptor is string type */
+
+        /* psrc[0] contains size of descriptor, subtract 2 to get the length of string */
+        str_len = USB_MIN((uint16_t)psrc[0] - 2U, len);
+
+        psrc += 2U; /* adjust the offset ignoring the string length and descriptor type */
+
+        for(index = 0U; index < str_len; index += 2U) {
+            /* copy only the string and ignore the unicode id, hence add the source */
+            *pdest = psrc[index];
+
+            pdest++;
+        }
+
+        *pdest = 0U; /* mark end of string */
+    }
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Source/usbh_pipe.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Source/usbh_pipe.c
@@ -1,0 +1,183 @@
+/*!
+    \file    usbh_pipe.c
+    \brief   USB host mode pipe operation driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "usbh_pipe.h"
+
+/* local function prototypes ('static') */
+static uint16_t usbh_freepipe_get (usb_core_driver *udev);
+
+/*!
+    \brief      create a pipe
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  dev: USB device
+    \param[in]  pp_num: pipe number
+    \param[in]  ep_type: endpoint type
+    \param[in]  ep_mpl: endpoint max packet length
+    \param[out] none
+    \retval     operation status
+*/
+uint8_t usbh_pipe_create (usb_core_driver *udev,
+                          usb_dev_prop *dev,
+                          uint8_t  pp_num,
+                          uint8_t  ep_type,
+                          uint16_t ep_mpl)
+{
+    usb_pipe *pp = &udev->host.pipe[pp_num];
+
+    pp->dev_addr = dev->addr;
+    pp->dev_speed = dev->speed;
+    pp->ep.type = ep_type;
+    pp->ep.mps = ep_mpl;
+
+    if ((USB_USE_DMA != udev->bp.transfer_mode) && ((USB_EPTYPE_BULK == pp->ep.type) || (USB_EPTYPE_CTRL == pp->ep.type))) {
+        pp->supp_ping = (uint8_t)(pp->dev_speed == PORT_SPEED_HIGH);
+    }
+
+    usb_pipe_init (udev, pp_num);
+
+    return HP_OK;
+}
+
+/*!
+    \brief      modify a pipe
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  pp_num: pipe number
+    \param[in]  dev_addr: device address
+    \param[in]  dev_speed: device speed
+    \param[in]  ep_mpl: endpoint max packet length
+    \param[out] none
+    \retval     operation status
+*/
+uint8_t usbh_pipe_update (usb_core_driver *udev,
+                          uint8_t  pp_num,
+                          uint8_t  dev_addr,
+                          uint32_t dev_speed,
+                          uint16_t ep_mpl)
+{
+    usb_pipe *pp = &udev->host.pipe[pp_num];
+
+    if ((pp->dev_addr != dev_addr) && (dev_addr)) {
+        pp->dev_addr = dev_addr;
+    }
+
+    if ((pp->dev_speed != dev_speed) && (dev_speed)) {
+        pp->dev_speed = dev_speed;
+
+        if ((USB_USE_DMA != udev->bp.transfer_mode) && ((USB_EPTYPE_BULK == pp->ep.type) || (USB_EPTYPE_CTRL == pp->ep.type))) {
+            pp->supp_ping = (uint8_t)(pp->dev_speed == PORT_SPEED_HIGH);
+        }
+    }
+
+    if ((pp->ep.mps != ep_mpl) && (ep_mpl)) {
+        pp->ep.mps = ep_mpl; 
+    }
+
+    usb_pipe_init (udev, pp_num);
+
+    return HP_OK;
+}
+
+/*!
+    \brief      allocate a new pipe
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  ep_addr: endpoint address
+    \param[out] none
+    \retval     operation status
+*/
+uint8_t usbh_pipe_allocate (usb_core_driver *udev, uint8_t ep_addr)
+{
+    uint16_t pp_num = usbh_freepipe_get (udev);
+
+    if (HP_ERROR != pp_num) {
+        udev->host.pipe[pp_num].in_used = 1U;
+        udev->host.pipe[pp_num].ep.dir = EP_DIR(ep_addr);
+        udev->host.pipe[pp_num].ep.num = EP_ID(ep_addr);
+    }
+
+    return (uint8_t)pp_num;
+}
+
+/*!
+    \brief      free a pipe
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  pp_num: pipe number
+    \param[out] none
+    \retval     operation status
+*/
+uint8_t usbh_pipe_free (usb_core_driver *udev, uint8_t pp_num)
+{
+    if (pp_num < HP_MAX) {
+        udev->host.pipe[pp_num].in_used = 0U;
+    }
+
+    return USBH_OK;
+}
+
+/*!
+    \brief      delete all USB host pipe
+    \param[in]  udev: pointer to USB core instance
+    \param[out] none
+    \retval     operation status
+*/
+uint8_t usbh_pipe_delete (usb_core_driver *udev)
+{
+    uint8_t pp_num = 0U;
+
+    for (pp_num = 2U; pp_num < HP_MAX; pp_num++) {
+        udev->host.pipe[pp_num] = (usb_pipe) {0};
+    }
+
+    return USBH_OK;
+}
+
+/*!
+    \brief      get a free pipe number for allocation
+    \param[in]  udev: pointer to USB core instance
+    \param[out] none
+    \retval     operation status
+*/
+static uint16_t usbh_freepipe_get (usb_core_driver *udev)
+{
+    uint8_t pp_num = 0U;
+
+    for (pp_num = 0U; pp_num < HP_MAX; pp_num++) {
+        if (0U == udev->host.pipe[pp_num].in_used) {
+            return (uint16_t)pp_num;
+        }
+    }
+
+    return HP_ERROR;
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Source/usbh_transc.c
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/host/core/Source/usbh_transc.c
@@ -1,0 +1,377 @@
+/*!
+    \file    usbh_transc.c
+    \brief   USB host mode transactions driver
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#include "drv_usb_hw.h"
+#include "usbh_pipe.h"
+#include "usbh_transc.h"
+
+/* local function prototypes ('static') */
+static usb_urb_state usbh_urb_wait  (usbh_host *uhost, uint8_t pp_num, uint32_t wait_time);
+static void usbh_setup_transc       (usbh_host *uhost);
+static void usbh_data_in_transc     (usbh_host *uhost);
+static void usbh_data_out_transc    (usbh_host *uhost);
+static void usbh_status_in_transc   (usbh_host *uhost);
+static void usbh_status_out_transc  (usbh_host *uhost);
+static uint32_t usbh_request_submit (usb_core_driver *udev, uint8_t pp_num);
+
+/*!
+    \brief      send the setup packet to the USB device
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  buf: data buffer which will be sent to USB device
+    \param[in]  pp_num: pipe number
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_ctlsetup_send (usb_core_driver *udev, uint8_t *buf, uint8_t pp_num)
+{
+    usb_pipe *pp = &udev->host.pipe[pp_num];
+
+    pp->DPID = PIPE_DPID_SETUP;
+    pp->xfer_buf = buf;
+    pp->xfer_len = USB_SETUP_PACKET_LEN;
+
+    return (usbh_status)usbh_request_submit (udev, pp_num);
+}
+
+/*!
+    \brief      send a data packet to the USB device
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  buf: data buffer which will be sent to USB device
+    \param[in]  pp_num: pipe number
+    \param[in]  len: length of the data to be sent
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_data_send (usb_core_driver *udev, uint8_t *buf, uint8_t pp_num, uint16_t len)
+{
+    usb_pipe *pp = &udev->host.pipe[pp_num];
+
+    pp->xfer_buf = buf;
+    pp->xfer_len = len;
+
+    switch (pp->ep.type) {
+    case USB_EPTYPE_CTRL:
+        if (0U == len) {
+            pp->data_toggle_out = 1U;
+        }
+
+        pp->DPID = PIPE_DPID[pp->data_toggle_out];
+        break;
+
+    case USB_EPTYPE_INTR:
+        pp->DPID = PIPE_DPID[pp->data_toggle_out];
+
+        pp->data_toggle_out ^= 1U;
+        break;
+
+    case USB_EPTYPE_BULK:
+        pp->DPID = PIPE_DPID[pp->data_toggle_out];
+        break;
+
+    case USB_EPTYPE_ISOC:
+        pp->DPID = PIPE_DPID[0];
+        break;
+
+    default:
+        break;
+    }
+
+    usbh_request_submit (udev, pp_num);
+
+    return USBH_OK;
+}
+
+/*!
+    \brief      receive a data packet from the USB device
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  buf: data buffer which will be received from USB device
+    \param[in]  pp_num: pipe number
+    \param[in]  len: length of the data to be received
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_data_recev (usb_core_driver *udev, uint8_t *buf, uint8_t pp_num, uint16_t len)
+{
+    usb_pipe *pp = &udev->host.pipe[pp_num];
+
+    pp->xfer_buf = buf;
+    pp->xfer_len = len;
+
+    switch (pp->ep.type) {
+    case USB_EPTYPE_CTRL:
+        pp->DPID = PIPE_DPID[1];
+        break;
+
+    case USB_EPTYPE_INTR:
+        pp->DPID = PIPE_DPID[pp->data_toggle_in];
+
+        /* toggle DATA PID */
+        pp->data_toggle_in ^= 1U;
+        break;
+
+    case USB_EPTYPE_BULK:
+        pp->DPID = PIPE_DPID[pp->data_toggle_in];
+        break;
+
+    case USB_EPTYPE_ISOC:
+        pp->DPID = PIPE_DPID[0];
+        break;
+
+    default:
+        break;
+    }
+
+    usbh_request_submit (udev, pp_num);
+
+    return USBH_OK;
+}
+
+/*!
+    \brief      USB control transfer handler
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     operation status
+*/
+usbh_status usbh_ctl_handler (usbh_host *uhost)
+{
+    usbh_status status = USBH_BUSY;
+
+    switch (uhost->control.ctl_state) {
+    case CTL_SETUP:
+        usbh_setup_transc (uhost);
+        break;
+
+    case CTL_DATA_IN:
+        usbh_data_in_transc (uhost);
+        break;
+
+    case CTL_DATA_OUT:
+        usbh_data_out_transc (uhost);
+        break;
+
+    case CTL_STATUS_IN:
+        usbh_status_in_transc (uhost);
+        break;
+
+    case CTL_STATUS_OUT:
+        usbh_status_out_transc (uhost);
+        break;
+
+    case CTL_FINISH:
+        uhost->control.ctl_state = CTL_IDLE;
+
+        status = USBH_OK;
+        break;
+
+    case CTL_ERROR:
+        if (++uhost->control.error_count <= USBH_MAX_ERROR_COUNT) {
+            /* do the transmission again, starting from SETUP packet */
+            uhost->control.ctl_state = CTL_SETUP;
+        } else {
+            status = USBH_FAIL;
+        }
+        break;
+
+    default:
+        break;
+    }
+
+    return status;
+}
+
+/*!
+    \brief      wait for USB URB(USB request block) state
+    \param[in]  uhost: pointer to USB host
+    \param[in]  pp_num: pipe number
+    \param[in]  wait_time: wait time
+    \param[out] none
+    \retval     USB URB state
+*/
+static usb_urb_state usbh_urb_wait (usbh_host *uhost, uint8_t pp_num, uint32_t wait_time)
+{
+    uint32_t timeout = 0U;
+    usb_urb_state urb_status = URB_IDLE;
+    timeout = uhost->control.timer;
+
+    while (URB_DONE != (urb_status = usbh_urbstate_get(uhost->data, pp_num))) {
+        if (URB_NOTREADY == urb_status) {
+            break;
+        } else if (URB_STALL == urb_status) {
+            uhost->control.ctl_state = CTL_SETUP;
+            break;
+        } else if (URB_ERROR == urb_status) {
+            uhost->control.ctl_state = CTL_ERROR;
+            break;
+        } else if ((wait_time > 0U) && (((usb_curframe_get(uhost->data) > timeout) && ((usb_curframe_get(uhost->data) - timeout) > wait_time)) \
+              || ((usb_curframe_get(uhost->data) < timeout) && ((usb_curframe_get(uhost->data) + 0x3FFFU - timeout) > wait_time)))){
+            /* timeout for in transfer */
+            uhost->control.ctl_state = CTL_ERROR;
+            break;
+        } else {
+            /* no operation, just wait */
+        }
+    }
+
+    return urb_status;
+}
+
+/*!
+    \brief      USB setup transaction
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     none
+*/
+static void usbh_setup_transc (usbh_host *uhost)
+{
+    /* send a SETUP packet */
+    usbh_ctlsetup_send (uhost->data, 
+                        uhost->control.setup.data, 
+                        uhost->control.pipe_out_num);
+
+    if (URB_DONE == usbh_urb_wait (uhost, uhost->control.pipe_out_num, 0U)) {
+        uint8_t dir = (uhost->control.setup.req.bmRequestType & USB_TRX_MASK);
+
+        if (uhost->control.setup.req.wLength) {
+            if (USB_TRX_IN == dir) {
+                uhost->control.ctl_state = CTL_DATA_IN;
+            } else {
+                uhost->control.ctl_state = CTL_DATA_OUT;
+            }
+        } else {
+            if (USB_TRX_IN == dir) {
+                uhost->control.ctl_state = CTL_STATUS_OUT;
+            } else {
+                uhost->control.ctl_state = CTL_STATUS_IN;
+            }
+        }
+
+        /* set the delay timer to enable timeout for data stage completion */
+        uhost->control.timer = (uint16_t)usb_curframe_get(uhost->data);
+    }
+}
+
+/*!
+    \brief      USB data IN transaction
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     none
+*/
+static void usbh_data_in_transc (usbh_host *uhost)
+{
+    usbh_data_recev (uhost->data,
+                     uhost->control.buf,
+                     uhost->control.pipe_in_num,
+                     uhost->control.ctl_len);
+
+    if (URB_DONE == usbh_urb_wait (uhost, uhost->control.pipe_in_num, DATA_STAGE_TIMEOUT)) {
+        uhost->control.ctl_state = CTL_STATUS_OUT;
+
+    }
+}
+
+/*!
+    \brief      USB data OUT transaction
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     none
+*/
+static void usbh_data_out_transc (usbh_host *uhost)
+{
+    usbh_pipe_toggle_set(uhost->data, uhost->control.pipe_out_num, 1U);
+
+    usbh_data_send (uhost->data,
+                    uhost->control.buf,
+                    uhost->control.pipe_out_num,
+                    uhost->control.ctl_len);
+
+    if (URB_DONE == usbh_urb_wait (uhost, uhost->control.pipe_out_num, DATA_STAGE_TIMEOUT)) {
+        uhost->control.ctl_state = CTL_STATUS_IN;
+    }
+}
+
+/*!
+    \brief      USB status IN transaction
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     none
+*/
+static void usbh_status_in_transc (usbh_host *uhost)
+{
+    uint8_t pp_num = uhost->control.pipe_in_num;
+
+    usbh_data_recev (uhost->data, NULL, pp_num, 0U);
+
+    if (URB_DONE == usbh_urb_wait (uhost, pp_num, NODATA_STAGE_TIMEOUT)) {
+        uhost->control.ctl_state = CTL_FINISH;
+    }
+}
+
+/*!
+    \brief      USB status OUT transaction
+    \param[in]  uhost: pointer to USB host
+    \param[out] none
+    \retval     none
+*/
+static void usbh_status_out_transc (usbh_host *uhost)
+{
+    uint8_t pp_num = uhost->control.pipe_out_num;
+
+    usbh_data_send (uhost->data, NULL, pp_num, 0U);
+
+    if (URB_DONE == usbh_urb_wait (uhost, pp_num, NODATA_STAGE_TIMEOUT)) {
+        uhost->control.ctl_state = CTL_FINISH;
+    }
+}
+
+/*!
+    \brief      prepare a pipe and start a transfer
+    \param[in]  udev: pointer to USB core instance
+    \param[in]  pp_num: pipe number
+    \param[out] none
+    \retval     operation status
+*/
+static uint32_t usbh_request_submit (usb_core_driver *udev, uint8_t pp_num) 
+{
+    udev->host.pipe[pp_num].urb_state = URB_IDLE;
+    udev->host.pipe[pp_num].xfer_count = 0U;
+
+    if (1U == udev->host.pipe[pp_num].do_ping) {
+        (void)usb_pipe_ping (udev, (uint8_t)pp_num);
+        return USB_OK;
+    }
+
+    return (uint32_t)usb_pipe_xfer (udev, pp_num);
+}

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/ustd/class/cdc/usb_cdc.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/ustd/class/cdc/usb_cdc.h
@@ -1,0 +1,182 @@
+/*!
+    \file    usb_cdc.h
+    \brief   the header file of communication device class standard
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USB_CDC_H
+#define __USB_CDC_H
+
+#include "usb_ch9_std.h"
+
+/* communications device class code */
+#define USB_CLASS_CDC                                       0x02U
+
+/* communications interface class control protocol codes */
+#define USB_CDC_PROTOCOL_NONE                               0x00U
+#define USB_CDC_PROTOCOL_AT                                 0x01U
+#define USB_CDC_PROTOCOL_VENDOR                             0xFFU
+
+/* data interface class code */
+#define USB_CLASS_DATA                                      0x0AU
+
+#define USB_DESCTYPE_CDC_ACM                                0x21U
+#define USB_DESCTYPE_CS_INTERFACE                           0x24U
+
+#define USB_CDC_ACM_CONFIG_DESC_SIZE                        0x43U
+
+/* class-specific notification codes for pstn subclasses */
+#define USB_CDC_NOTIFY_SERIAL_STATE                         0x20U
+
+/* class-specific request codes */
+#define SEND_ENCAPSULATED_COMMAND                           0x00U
+#define GET_ENCAPSULATED_RESPONSE                           0x01U
+#define SET_COMM_FEATURE                                    0x02U
+#define GET_COMM_FEATURE                                    0x03U
+#define CLEAR_COMM_FEATURE                                  0x04U
+
+#define SET_AUX_LINE_STATE                                  0x10U
+#define SET_HOOK_STATE                                      0x11U
+#define PULSE_SETUP                                         0x12U
+#define SEND_PULSE                                          0x13U
+#define SET_PULSE_TIME                                      0x14U
+#define RING_AUX_JACK                                       0x15U
+
+#define SET_LINE_CODING                                     0x20U
+#define GET_LINE_CODING                                     0x21U
+#define SET_CONTROL_LINE_STATE                              0x22U
+#define SEND_BREAK                                          0x23U
+#define NO_CMD                                              0xFFU
+
+#define SET_RINGER_PARMS                                    0x30U
+#define GET_RINGER_PARMS                                    0x31U
+#define SET_OPERATION_PARMS                                 0x32U
+#define GET_OPERATION_PARMS                                 0x33U
+#define SET_LINE_PARMS                                      0x34U
+#define GET_LINE_PARMS                                      0x35U
+#define DIAL_DIGITS                                         0x36U
+#define SET_UNIT_PARAMETER                                  0x37U
+#define GET_UNIT_PARAMETER                                  0x38U
+#define CLEAR_UNIT_PARAMETER                                0x39U
+#define GET_PROFILE                                         0x3AU
+
+#define SET_ETHERNET_MULTICAST_FILTERS                      0x40U
+#define SET_ETHERNET_POWER_MANAGEMENT_PATTERN FILTER        0x41U
+#define GET_ETHERNET_POWER_MANAGEMENT_PATTERN FILTER        0x42U
+#define SET_ETHERNET_PACKET_FILTER                          0x43U
+#define GET_ETHERNET_STATISTIC                              0x44U
+
+#define SET_ATM_DATA_FORMAT                                 0x50U
+#define GET_ATM_DEVICE_STATISTICS                           0x51U
+#define SET_ATM_DEFAULT_VC                                  0x52U
+#define GET_ATM_VC_STATISTICS                               0x53U
+
+/* wValue for set control line state */
+#define CDC_ACTIVATE_CARRIER_SIGNAL_RTS                     0x0002U
+#define CDC_DEACTIVATE_CARRIER_SIGNAL_RTS                   0x0000U
+#define CDC_ACTIVATE_SIGNAL_DTR                             0x0001U
+#define CDC_DEACTIVATE_SIGNAL_DTR                           0x0000U
+
+/* CDC subclass code */
+enum usb_cdc_subclass {
+    USB_CDC_SUBCLASS_RESERVED = 0U,  /*!< reserved */
+    USB_CDC_SUBCLASS_DLCM,           /*!< direct line control mode */
+    USB_CDC_SUBCLASS_ACM,            /*!< abstract control mode */
+    USB_CDC_SUBCLASS_TCM,            /*!< telephone control mode */
+    USB_CDC_SUBCLASS_MCM,            /*!< multichannel control model */
+    USB_CDC_SUBCLASS_CCM,            /*!< CAPI control model */
+    USB_CDC_SUBCLASS_ENCM,           /*!< ethernet networking control model */
+    USB_CDC_SUBCLASS_ANCM            /*!< ATM networking control model */
+};
+
+#pragma pack(1)
+
+/* cdc acm line coding structure */
+typedef struct {
+    uint32_t dwDTERate;                   /*!< data terminal rate */
+    uint8_t  bCharFormat;                 /*!< stop bits */
+    uint8_t  bParityType;                 /*!< parity */
+    uint8_t  bDataBits;                   /*!< data bits */
+} acm_line;
+
+/* notification structure */
+typedef struct {
+    uint8_t bmRequestType;                /*!< type of request */
+    uint8_t bNotification;                /*!< communication interface class notifications */
+    uint16_t wValue;                      /*!< value of notification */
+    uint16_t wIndex;                      /*!< index of interface */
+    uint16_t wLength;                     /*!< length of notification data */
+} acm_notification;
+
+typedef struct {
+    usb_desc_header header;               /*!< descriptor header, including type and size. */
+    uint8_t   bDescriptorSubtype;         /*!< bDescriptorSubtype: header function descriptor */
+    uint16_t  bcdCDC;                     /*!< bcdCDC: low byte of spec release number (CDC1.10) */
+} usb_desc_header_func;
+
+typedef struct {
+    usb_desc_header header;               /*!< descriptor header, including type and size. */
+    uint8_t  bDescriptorSubtype;          /*!< bDescriptorSubtype:  call management function descriptor */
+    uint8_t  bmCapabilities;              /*!< bmCapabilities: D0 is reset, D1 is ignored */
+    uint8_t  bDataInterface;              /*!< bDataInterface: 1 interface used for call management */
+} usb_desc_call_managment_func;
+
+typedef struct {
+    usb_desc_header header;               /*!< descriptor header, including type and size. */
+    uint8_t  bDescriptorSubtype;          /*!< bDescriptorSubtype: abstract control management descriptor */
+    uint8_t  bmCapabilities;              /*!< bmCapabilities: D1 */
+} usb_desc_acm_func;
+
+typedef struct {
+    usb_desc_header header;               /*!< descriptor header, including type and size. */
+    uint8_t  bDescriptorSubtype;          /*!< bDescriptorSubtype: union function descriptor */
+    uint8_t  bMasterInterface;            /*!< bMasterInterface: communication class interface */
+    uint8_t  bSlaveInterface0;            /*!< bSlaveInterface0: data class interface */
+} usb_desc_union_func;
+
+#pragma pack()
+
+typedef struct {
+    usb_desc_config                  config;
+    usb_desc_itf                     cmd_itf;
+    usb_desc_header_func             cdc_header;
+    usb_desc_call_managment_func     cdc_call_managment;
+    usb_desc_acm_func                cdc_acm;
+    usb_desc_union_func              cdc_union;
+    usb_desc_ep                      cdc_cmd_endpoint;
+    usb_desc_itf                     cdc_data_interface;
+    usb_desc_ep                      cdc_out_endpoint;
+    usb_desc_ep                      cdc_in_endpoint;
+} usb_cdc_desc_config_set;
+
+#endif /* __USB_CDC_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/ustd/class/hid/usb_hid.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/ustd/class/hid/usb_hid.h
@@ -1,0 +1,85 @@
+/*!
+    \file    usb_hid.h
+    \brief   definitions for the USB HID class
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USB_HID_H
+#define __USB_HID_H
+
+#include "usb_ch9_std.h"
+
+#define USB_HID_CLASS               0x03U
+
+#define USB_DESCTYPE_HID            0x21U
+#define USB_DESCTYPE_REPORT         0x22U
+
+/* HID subclass code */
+#define USB_HID_SUBCLASS_BOOT_ITF   0x01U
+
+/* HID protocol codes */
+#define USB_HID_PROTOCOL_KEYBOARD   0x01U
+#define USB_HID_PROTOCOL_MOUSE      0x02U
+
+#define GET_REPORT                  0x01U
+#define GET_IDLE                    0x02U
+#define GET_PROTOCOL                0x03U
+#define SET_REPORT                  0x09U
+#define SET_IDLE                    0x0AU
+#define SET_PROTOCOL                0x0BU
+
+#pragma pack(1)
+
+typedef struct
+{
+    usb_desc_header header;     /*!< regular descriptor header containing the descriptor's type and length */
+
+    uint16_t bcdHID;            /*!< BCD encoded version that the HID descriptor and device complies to */
+    uint8_t  bCountryCode;      /*!< country code of the localized device, or zero if universal */
+    uint8_t  bNumDescriptors;   /*!< total number of HID report descriptors for the interface */
+    uint8_t  bDescriptorType;   /*!< type of HID report */
+    uint16_t wDescriptorLength; /*!< length of the associated HID report descriptor, in bytes */
+} usb_desc_hid;
+
+#pragma pack()
+
+typedef struct
+{
+    usb_desc_config         config;
+    usb_desc_itf            hid_itf;
+    usb_desc_hid            hid_vendor;
+    usb_desc_ep             hid_epin;
+    usb_desc_ep             hid_epout;
+} usb_hid_desc_config_set;
+
+#endif /* __USB_HID_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/ustd/class/msc/msc_bbb.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/ustd/class/msc/msc_bbb.h
@@ -1,0 +1,71 @@
+/*!
+    \file    msc_bbb.h
+    \brief   definitions for the USB MSC BBB(bulk/bulk/bulk) protocol
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __MSC_BBB_H
+#define __MSC_BBB_H
+
+#include "usb_ch9_std.h"
+
+#define BBB_CBW_SIGNATURE                 0x43425355U
+#define BBB_CSW_SIGNATURE                 0x53425355U
+#define BBB_CBW_LENGTH                    31U
+#define BBB_CSW_LENGTH                    13U
+
+typedef struct {
+    uint32_t dCBWSignature;
+    uint32_t dCBWTag;
+    uint32_t dCBWDataTransferLength;
+    uint8_t  bmCBWFlags;
+    uint8_t  bCBWLUN;
+    uint8_t  bCBWCBLength;
+    uint8_t  CBWCB[16];
+} msc_bbb_cbw;
+
+typedef struct {
+    uint32_t dCSWSignature;
+    uint32_t dCSWTag;
+    uint32_t dCSWDataResidue;
+    uint8_t  bCSWStatus;
+} msc_bbb_csw;
+
+/* CSW command status */
+enum msc_csw_status {
+    CSW_CMD_PASSED = 0,
+    CSW_CMD_FAILED,
+    CSW_PHASE_ERROR
+};
+
+#endif /* __MSC_BBB_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/ustd/class/msc/msc_scsi.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/ustd/class/msc/msc_scsi.h
@@ -1,0 +1,119 @@
+/*!
+    \file    msc_scsi.h
+    \brief   definitions for the USB MSC SCSI commands
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __MSC_SCSI_H
+#define __MSC_SCSI_H
+
+#include "usb_ch9_std.h"
+
+/* SCSI commands */
+#define SCSI_FORMAT_UNIT                            0x04U
+#define SCSI_INQUIRY                                0x12U
+#define SCSI_MODE_SELECT6                           0x15U
+#define SCSI_MODE_SELECT10                          0x55U
+#define SCSI_MODE_SENSE6                            0x1AU
+#define SCSI_READ_TOC_DATA                          0x43U
+#define SCSI_MODE_SENSE10                           0x5AU
+#define SCSI_ALLOW_MEDIUM_REMOVAL                   0x1EU
+#define SCSI_READ6                                  0x08U
+#define SCSI_READ10                                 0x28U
+#define SCSI_READ12                                 0xA8U
+#define SCSI_READ16                                 0x88U
+
+#define SCSI_READ_CAPACITY10                        0x25U
+#define SCSI_READ_CAPACITY16                        0x9EU
+
+#define SCSI_REQUEST_SENSE                          0x03U
+#define SCSI_START_STOP_UNIT                        0x1BU
+#define SCSI_TEST_UNIT_READY                        0x00U
+#define SCSI_WRITE6                                 0x0AU
+#define SCSI_WRITE10                                0x2AU
+#define SCSI_WRITE12                                0xAAU
+#define SCSI_WRITE16                                0x8AU
+
+#define SCSI_VERIFY10                               0x2FU
+#define SCSI_VERIFY12                               0xAFU
+#define SCSI_VERIFY16                               0x8FU
+
+#define SCSI_SEND_DIAGNOSTIC                        0x1DU
+#define SCSI_READ_FORMAT_CAPACITIES                 0x23U
+
+#define INVALID_CDB                                 0x20U
+#define INVALID_FIELED_IN_COMMAND                   0x24U
+#define PARAMETER_LIST_LENGTH_ERROR                 0x1AU
+#define INVALID_FIELD_IN_PARAMETER_LIST             0x26U
+#define ADDRESS_OUT_OF_RANGE                        0x21U
+#define MEDIUM_NOT_PRESENT                          0x3AU
+#define MEDIUM_HAVE_CHANGED                         0x28U
+#define WRITE_PROTECTED                             0x27U
+#define UNRECOVERED_READ_ERROR                      0x11U
+#define WRITE_FAULT                                 0x03U
+
+#define READ_FORMAT_CAPACITY_DATA_LEN               0x0CU
+#define READ_CAPACITY10_DATA_LEN                    0x08U
+#define MODE_SENSE10_DATA_LEN                       0x08U
+#define MODE_SENSE6_DATA_LEN                        0x04U
+#define READ_TOC_CMD_LEN                            0x14U
+#define REQUEST_SENSE_DATA_LEN                      0x12U
+#define STANDARD_INQUIRY_DATA_LEN                   0x24U
+#define BLKVFY                                      0x04U
+
+enum sense_state {
+    NO_SENSE = 0U,
+    RECOVERED_ERROR,
+    NOT_READY,
+    MEDIUM_ERROR,
+    HARDWARE_ERROR,
+    ILLEGAL_REQUEST,
+    UNIT_ATTENTION,
+    DATA_PROTECT,
+    BLANK_CHECK,
+    VENDOR_SPECIFIC,
+    COPY_ABORTED,
+    ABORTED_COMMAND,
+    RESERVED,
+    VOLUME_OVERFLOW,
+    MISCOMPARE
+};
+
+typedef struct {
+    uint8_t  SenseKey;
+    uint32_t Information;
+    uint8_t  ASC;
+    uint8_t  ASCQ;
+} msc_scsi_sense;
+
+#endif /* __MSC_SCSI_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/ustd/class/msc/usb_msc.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/ustd/class/msc/usb_msc.h
@@ -1,0 +1,70 @@
+/*!
+    \file    usb_msc.h
+    \brief   definitions for the USB MSC class
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USB_MSC_H
+#define __USB_MSC_H
+
+#include "usb_ch9_std.h"
+
+/* mass storage device class code */
+#define USB_CLASS_MSC                     0x08U
+
+/* mass storage subclass code */
+#define USB_MSC_SUBCLASS_RBC              0x01U
+#define USB_MSC_SUBCLASS_ATAPI            0x02U
+#define USB_MSC_SUBCLASS_UFI              0x04U
+#define USB_MSC_SUBCLASS_SCSI             0x06U
+#define USB_MSC_SUBCLASS_LOCKABLE         0x07U
+#define USB_MSC_SUBCLASS_IEEE1667         0x08U
+
+/* mass storage interface class control protocol codes */
+#define USB_MSC_PROTOCOL_CBI              0x00U
+#define USB_MSC_PROTOCOL_CBI_ALT          0x01U
+#define USB_MSC_PROTOCOL_BBB              0x50U
+
+/* mass storage request codes */
+#define USB_MSC_REQ_CODES_ADSC            0x00U
+#define USB_MSC_REQ_CODES_GET             0xFCU
+#define USB_MSC_REQ_CODES_PUT             0xFDU
+#define USB_MSC_REQ_CODES_GML             0xFEU
+#define USB_MSC_REQ_CODES_BOMSR           0xFFU
+
+#define BBB_GET_MAX_LUN                   0xFEU
+#define BBB_RESET                         0xFFU
+
+#define SCSI_CMD_LENGTH                   16U
+
+#endif /* __USB_MSC_H */

--- a/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/ustd/common/usb_ch9_std.h
+++ b/contrib/GD32F4xx_Firmware_Library/GD32F4xx_usb_library/ustd/common/usb_ch9_std.h
@@ -1,0 +1,250 @@
+/*!
+    \file    usb_ch9_std.h
+    \brief   USB 2.0 standard defines
+
+    \version 2020-08-01, V3.0.0, firmware for GD32F4xx
+    \version 2022-03-09, V3.1.0, firmware for GD32F4xx
+    \version 2022-06-30, V3.2.0, firmware for GD32F4xx
+*/
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without modification, 
+are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this 
+       list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice, 
+       this list of conditions and the following disclaimer in the documentation 
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its contributors 
+       may be used to endorse or promote products derived from this software without 
+       specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" 
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. 
+IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, 
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT 
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR 
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, 
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) 
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY 
+OF SUCH DAMAGE.
+*/
+
+#ifndef __USB_CH9_STD_H
+#define __USB_CH9_STD_H
+
+#include "usb_conf.h"
+
+#define USB_DEV_QUALIFIER_DESC_LEN   0x0AU       /*!< USB device qualifier descriptor length */
+#define USB_DEV_DESC_LEN             0x12U       /*!< USB device descriptor length */
+#define USB_CFG_DESC_LEN             0x09U       /*!< USB configuration descriptor length */
+#define USB_ITF_DESC_LEN             0x09U       /*!< USB interface descriptor length */
+#define USB_EP_DESC_LEN              0x07U       /*!< USB endpoint descriptor length */
+#define USB_IAD_DESC_LEN             0x08U       /*!< USB IAD descriptor length */
+#define USB_OTG_DESC_LEN             0x03U       /*!< USB device OTG descriptor length */
+
+#define USB_SETUP_PACKET_LEN         0x08U       /*!< USB setup packet length */
+
+/* bit 7 of bmRequestType: data phase transfer direction */
+#define USB_TRX_MASK                 0x80U       /*!< USB transfer direction mask */
+#define USB_TRX_OUT                  0x00U       /*!< USB transfer OUT direction */
+#define USB_TRX_IN                   0x80U       /*!< USB transfer IN direction */
+
+/* bit 6..5 of bmRequestType: request type */
+#define USB_REQTYPE_STRD             0x00U       /*!< USB standard request */
+#define USB_REQTYPE_CLASS            0x20U       /*!< USB class request */
+#define USB_REQTYPE_VENDOR           0x40U       /*!< USB vendor request */
+#define USB_REQTYPE_MASK             0x60U       /*!< USB request mask */
+
+#define USBD_BUS_POWERED             0x00U       /*!< USB bus power supply */
+#define USBD_SELF_POWERED            0x01U       /*!< USB self power supply */
+
+#define USB_STATUS_REMOTE_WAKEUP     2U          /*!< USB is in remote wakeup status */
+#define USB_STATUS_SELF_POWERED      1U          /*!< USB is in self powered status */
+
+/* bit 4..0 of bmRequestType: recipient type */
+enum _usb_recp_type {
+    USB_RECPTYPE_DEV  = 0x0U,                    /*!< USB device request type */
+    USB_RECPTYPE_ITF  = 0x1U,                    /*!< USB interface request type */
+    USB_RECPTYPE_EP   = 0x2U,                    /*!< USB endpoint request type */
+    USB_RECPTYPE_MASK = 0x3U                     /*!< USB request type mask */
+};
+
+/* bRequest value */
+enum _usb_request {
+    USB_GET_STATUS        = 0x0U,                /*!< USB get status request */
+    USB_CLEAR_FEATURE     = 0x1U,                /*!< USB clear feature request */
+    USB_RESERVED2         = 0x2U,
+    USB_SET_FEATURE       = 0x3U,                /*!< USB set feature request */
+    USB_RESERVED4         = 0x4U,
+    USB_SET_ADDRESS       = 0x5U,                /*!< USB set address request */
+    USB_GET_DESCRIPTOR    = 0x6U,                /*!< USB get descriptor request */
+    USB_SET_DESCRIPTOR    = 0x7U,                /*!< USB set descriptor request */
+    USB_GET_CONFIGURATION = 0x8U,                /*!< USB get configuration request */
+    USB_SET_CONFIGURATION = 0x9U,                /*!< USB set configuration request */
+    USB_GET_INTERFACE     = 0xAU,                /*!< USB get interface request */
+    USB_SET_INTERFACE     = 0xBU,                /*!< USB set interface request */
+    USB_SYNCH_FRAME       = 0xCU                 /*!< USB synchronize frame request */
+};
+
+/* descriptor types of USB specifications */
+enum _usb_desctype {
+    USB_DESCTYPE_DEV              = 0x1U,        /*!< USB device descriptor type */
+    USB_DESCTYPE_CONFIG           = 0x2U,        /*!< USB configuration descriptor type */
+    USB_DESCTYPE_STR              = 0x3U,        /*!< USB string descriptor type */
+    USB_DESCTYPE_ITF              = 0x4U,        /*!< USB interface descriptor type */
+    USB_DESCTYPE_EP               = 0x5U,        /*!< USB endpoint descriptor type */
+    USB_DESCTYPE_DEV_QUALIFIER    = 0x6U,        /*!< USB device qualifier descriptor type */
+    USB_DESCTYPE_OTHER_SPD_CONFIG = 0x7U,        /*!< USB other speed configuration descriptor type */
+    USB_DESCTYPE_ITF_POWER        = 0x8U,        /*!< USB interface power descriptor type */
+    USB_DESCTYPE_IAD              = 0xBU,        /*!< USB interface association descriptor type */
+    USB_DESCTYPE_BOS              = 0xFU         /*!< USB BOS descriptor type  */
+};
+
+/* USB Endpoint Descriptor bmAttributes bit definitions */
+/* bits 1..0 : transfer type */
+enum _usbx_type {
+    USB_EP_ATTR_CTL  = 0x0U,                     /*!< USB control transfer type */
+    USB_EP_ATTR_ISO  = 0x1U,                     /*!< USB Isochronous transfer type */
+    USB_EP_ATTR_BULK = 0x2U,                     /*!< USB Bulk transfer type */
+    USB_EP_ATTR_INT  = 0x3U                      /*!< USB Interrupt transfer type */
+};
+
+/* bits 3..2 : Sync type (only if ISOCHRONOUS) */
+#define USB_EP_ATTR_NOSYNC                  0x00U     /*!< No Synchronization */
+#define USB_EP_ATTR_ASYNC                   0x04U     /*!< Asynchronous */
+#define USB_EP_ATTR_ADAPTIVE                0x08U     /*!< Adaptive */
+#define USB_EP_ATTR_SYNC                    0x0CU     /*!< Synchronous */
+#define USB_EP_ATTR_SYNCTYPE                0x0CU     /*!< Synchronous type */
+
+/* bits 5..4 : usage type (only if ISOCHRONOUS) */
+#define USB_EP_ATTR_DATA                    0x00U     /*!< Data endpoint */
+#define USB_EP_ATTR_FEEDBACK                0x10U     /*!< Feedback endpoint */
+#define USB_EP_ATTR_IMPLICIT_FEEDBACK_DATA  0x20U     /*!< Implicit feedback Data endpoint */
+#define USB_EP_ATTR_USAGETYPE               0x30U     /*!< Usage type */
+
+/* endpoint max packet size bits12..11 */
+#define USB_EP_MPS_ADD_0                    (0x00 << 11) /*!< None(1 transaction per microframe */
+#define USB_EP_MPS_ADD_1                    (0x01 << 11) /*!< 1 additional(2 transaction per microframe */
+#define USB_EP_MPS_ADD_2                    (0x02 << 11) /*!< 2 additional(3 transaction per microframe */
+
+#define FEATURE_SELECTOR_EP                 0x00U        /*!< USB endpoint feature selector */
+#define FEATURE_SELECTOR_DEV                0x01U        /*!< USB device feature selector */
+#define FEATURE_SELECTOR_REMOTEWAKEUP       0x01U        /*!< USB feature selector remote wakeup */
+
+#define BYTE_SWAP(addr)      (((uint16_t)(*((uint8_t *)(addr)))) + \
+                             (uint16_t)(((uint16_t)(*(((uint8_t *)(addr)) + 1U))) << 8U))
+
+#define BYTE_LOW(x)          ((uint8_t)((x) & 0x00FFU))
+#define BYTE_HIGH(x)         ((uint8_t)(((x) & 0xFF00U) >> 8U))
+
+#define USB_MIN(a, b)        (((a) < (b)) ? (a) : (b))
+
+#define USB_DEFAULT_CONFIG                  0U
+
+/* USB classes */
+#define USB_CLASS_HID                       0x03U       /*!< USB HID class */
+#define USB_CLASS_MSC                       0x08U       /*!< USB MSC class */
+
+/* use the following values when USB host need to get descriptor  */
+#define USBH_DESC(x)                        (((x)<< 8U) & 0xFF00U)
+
+/* as per USB specs 9.2.6.4 :standard request with data request timeout: 5sec
+   standard request with no data stage timeout : 50ms */
+#define DATA_STAGE_TIMEOUT                  5000U       /*!< USB data stage timeout*/
+#define NODATA_STAGE_TIMEOUT                50U         /*!< USB no data stage timeout*/
+
+#pragma pack(1)
+
+/* USB standard device request structure */
+typedef struct _usb_req {
+    uint8_t           bmRequestType;  /*!< type of request */
+    uint8_t           bRequest;       /*!< request of setup packet */
+    uint16_t          wValue;         /*!< value of setup packet */
+    uint16_t          wIndex;         /*!< index of setup packet */
+    uint16_t          wLength;        /*!< length of setup packet */
+} usb_req;
+
+/* USB setup packet define */
+typedef union _usb_setup {
+    uint8_t data[8];
+
+    usb_req req;
+} usb_setup;
+
+/* USB descriptor defines */
+
+typedef struct _usb_desc_header {
+    uint8_t bLength;                      /*!< size of the descriptor */
+    uint8_t bDescriptorType;              /*!< type of the descriptor */
+} usb_desc_header;
+
+typedef struct _usb_desc_dev {
+    usb_desc_header header;               /*!< descriptor header, including type and size */
+
+    uint16_t bcdUSB;                      /*!< BCD of the supported USB specification */
+    uint8_t  bDeviceClass;                /*!< USB device class */
+    uint8_t  bDeviceSubClass;             /*!< USB device subclass */
+    uint8_t  bDeviceProtocol;             /*!< USB device protocol */
+    uint8_t  bMaxPacketSize0;             /*!< size of the control (address 0) endpoint's bank in bytes */
+    uint16_t idVendor;                    /*!< vendor ID for the USB product */
+    uint16_t idProduct;                   /*!< unique product ID for the USB product */
+    uint16_t bcdDevice;                   /*!< product release (version) number */
+    uint8_t  iManufacturer;               /*!< string index for the manufacturer's name */
+    uint8_t  iProduct;                    /*!< string index for the product name/details */
+    uint8_t  iSerialNumber;               /*!< string index for the product's globally unique hexadecimal serial number */
+    uint8_t  bNumberConfigurations;       /*!< total number of configurations supported by the device */
+} usb_desc_dev;
+
+typedef struct _usb_desc_config {
+    usb_desc_header header;               /*!< descriptor header, including type and size */
+
+    uint16_t wTotalLength;                /*!< size of the configuration descriptor header,and all sub descriptors inside the configuration */
+    uint8_t  bNumInterfaces;              /*!< total number of interfaces in the configuration */
+    uint8_t  bConfigurationValue;         /*!< configuration index of the current configuration */
+    uint8_t  iConfiguration;              /*!< index of a string descriptor describing the configuration */
+    uint8_t  bmAttributes;                /*!< configuration attributes */
+    uint8_t  bMaxPower;                   /*!< maximum power consumption of the device while in the current configuration */
+} usb_desc_config;
+
+typedef struct _usb_desc_itf {
+    usb_desc_header header;               /*!< descriptor header, including type and size */
+
+    uint8_t bInterfaceNumber;             /*!< index of the interface in the current configuration */
+    uint8_t bAlternateSetting;            /*!< alternate setting for the interface number */
+    uint8_t bNumEndpoints;                /*!< total number of endpoints in the interface */
+    uint8_t bInterfaceClass;              /*!< interface class ID */
+    uint8_t bInterfaceSubClass;           /*!< interface subclass ID */
+    uint8_t bInterfaceProtocol;           /*!< interface protocol ID */
+    uint8_t iInterface;                   /*!< index of the string descriptor describing the interface */
+} usb_desc_itf;
+
+typedef struct _usb_desc_ep {
+    usb_desc_header header;               /*!< descriptor header, including type and size. */
+
+    uint8_t  bEndpointAddress;            /*!< logical address of the endpoint */
+    uint8_t  bmAttributes;                /*!< endpoint attributes */
+    uint16_t wMaxPacketSize;              /*!< size of the endpoint bank, in bytes */
+    uint8_t  bInterval;                   /*!< polling interval in milliseconds for the endpoint if it is an INTERRUPT or ISOCHRONOUS type */
+} usb_desc_ep;
+
+typedef struct _usb_desc_LANGID {
+    usb_desc_header header;               /*!< descriptor header, including type and size. */
+    uint16_t wLANGID;                     /*!< LANGID code */
+} usb_desc_LANGID;
+
+typedef struct _usb_desc_str {
+    usb_desc_header header;               /*!< descriptor header, including type and size. */
+    uint16_t unicode_string[128];          /*!< unicode string data */
+} usb_desc_str;
+
+#pragma pack()
+
+/* compute string descriptor length */
+#define USB_STRING_LEN(unicode_chars) (sizeof(usb_desc_header) + ((unicode_chars) << 1U))
+
+#endif /* __USB_CH9_STD_H */

--- a/src/benchmark.c
+++ b/src/benchmark.c
@@ -19,8 +19,7 @@ static void do_fuel_calculation_bench() {
   uint64_t start = cycle_count();
   calculate_fueling();
   uint64_t end = cycle_count();
-  printf("calculate_fueling: %llu ns\r\n",
-         (unsigned long long)cycles_to_ns(end - start));
+  printf("calculate_fueling: %d ns\r\n", (int)cycles_to_ns(end - start));
 }
 
 static void do_schedule_ignition_event_bench() {
@@ -39,24 +38,22 @@ static void do_schedule_ignition_event_bench() {
   uint64_t end = cycle_count();
   assert(config.events[0].start.state == SCHED_SCHEDULED);
 
-  printf("fresh ignition schedule_event: %llu ns\r\n",
-         (unsigned long long)cycles_to_ns(end - start));
+  printf("fresh ignition schedule_event: %d ns\r\n",
+         (int)cycles_to_ns(end - start));
 
   calculated_values.timing_advance = 25.0f;
   start = cycle_count();
   schedule_event(&config.events[0]);
   end = cycle_count();
 
-  printf("backward schedule_event: %llu ns\r\n",
-         (unsigned long long)cycles_to_ns(end - start));
+  printf("backward schedule_event: %d ns\r\n", (int)cycles_to_ns(end - start));
 
   calculated_values.timing_advance = 15.0f;
   start = cycle_count();
   schedule_event(&config.events[0]);
   end = cycle_count();
 
-  printf("forward schedule_event: %llu ns\r\n",
-         (unsigned long long)cycles_to_ns(end - start));
+  printf("forward schedule_event: %d ns\r\n", (int)cycles_to_ns(end - start));
 }
 
 static void do_sensor_adc_calcs() {
@@ -68,8 +65,7 @@ static void do_sensor_adc_calcs() {
   sensors_process(SENSOR_ADC);
   uint64_t end = cycle_count();
 
-  printf("process_sensor(adc): %llu ns\r\n",
-         (unsigned long long)cycles_to_ns(end - start));
+  printf("process_sensor(adc): %d ns\r\n", (int)cycles_to_ns(end - start));
 }
 
 static void do_sensor_single_therm() {
@@ -97,8 +93,8 @@ static void do_sensor_single_therm() {
   sensors_process(SENSOR_ADC);
   uint64_t end = cycle_count();
 
-  printf("process_sensor(single-therm): %llu ns\r\n",
-         (unsigned long long)cycles_to_ns(end - start));
+  printf("process_sensor(single-therm): %d ns\r\n",
+         (int)cycles_to_ns(end - start));
 }
 
 int main() {

--- a/src/console.c
+++ b/src/console.c
@@ -337,11 +337,11 @@ static size_t console_try_read() {
   }
   /* If we have the start of a valid object (as per the cbor_value_is_map check
    * above, but not enough to decode the whole object, return but do not reset
-   * unless 1s has passed. This is a balance between allowing time for messages
+   * unless 5s has passed. This is a balance between allowing time for messages
    * to arrive but not locking up communications due to some garbage */
   case CborErrorAdvancePastEOF:
   case CborErrorUnexpectedEOF:
-    if (current_time() - rx_start_time > time_from_us(1000000)) {
+    if (current_time() - rx_start_time > time_from_us(5000000)) {
       rx_buffer_size = 0;
     }
     /* Alternatively, if we've filled up, waiting longer will not work, reset */

--- a/src/platforms/common/max11632_adc.h
+++ b/src/platforms/common/max11632_adc.h
@@ -1,0 +1,65 @@
+#ifndef _COMMON_MAX11632_ADC_H
+#define _COMMON_MAX11632_ADC_H
+
+#include <stdint.h>
+
+#define NUM_SPI_TX 24
+#define SPI_SETUP 0x7400 /* Clock mode 11, external reference */
+#define SPI_INPUT(X) (0x8600 | ((X) << 11)) /* No scan */
+
+/* Query the 16 inputs in a pattern that causes input 0 and 1 to get sampled at
+ * 4x the rate of the rest, over a total of 24 spi commands.  The first command
+ * sets the setup register. The order allows the last command to be a NOP, and
+ * thus sample results don't cross buffer boundaries
+ * */
+static const uint16_t max11632_transmit_sequence[NUM_SPI_TX] = {
+  SPI_SETUP,     SPI_INPUT(2), SPI_INPUT(3),  SPI_INPUT(0),  SPI_INPUT(1),
+  SPI_INPUT(4),  SPI_INPUT(5), SPI_INPUT(6),  SPI_INPUT(7),  SPI_INPUT(0),
+  SPI_INPUT(1),  SPI_INPUT(8), SPI_INPUT(9),  SPI_INPUT(10), SPI_INPUT(11),
+  SPI_INPUT(0),  SPI_INPUT(1), SPI_INPUT(12), SPI_INPUT(13), SPI_INPUT(14),
+  SPI_INPUT(15), SPI_INPUT(0), SPI_INPUT(1),  0x1000,
+};
+
+static inline uint16_t read_raw_from_position(const uint16_t *values,
+                                              int position) {
+  uint16_t first = values[position];
+  uint16_t second = values[position + 1];
+  return ((first & 0x0F) << 8) | (second >> 8);
+}
+
+static inline uint16_t read_adc_pin(const uint16_t *values, int pin) {
+  switch (pin) {
+  case 2:
+    return read_raw_from_position(values, 1);
+  case 3:
+    return read_raw_from_position(values, 2);
+  case 4:
+    return read_raw_from_position(values, 5);
+  case 5:
+    return read_raw_from_position(values, 6);
+  case 6:
+    return read_raw_from_position(values, 7);
+  case 7:
+    return read_raw_from_position(values, 8);
+  case 8:
+    return read_raw_from_position(values, 11);
+  case 9:
+    return read_raw_from_position(values, 12);
+  case 10:
+    return read_raw_from_position(values, 13);
+  case 11:
+    return read_raw_from_position(values, 14);
+  case 12:
+    return read_raw_from_position(values, 17);
+  case 13:
+    return read_raw_from_position(values, 18);
+  case 14:
+    return read_raw_from_position(values, 19);
+  case 15:
+    return read_raw_from_position(values, 20);
+  default:
+    return 0;
+  }
+}
+
+#endif

--- a/src/platforms/common/stm32_sched_buffers.c
+++ b/src/platforms/common/stm32_sched_buffers.c
@@ -1,0 +1,108 @@
+#include "config.h"
+#include "decoder.h"
+#include "platform.h"
+
+#include "stm32_sched_buffers.h"
+
+__attribute__((
+  section(".dmadata"))) struct output_buffer output_buffers[2] = { 0 };
+static uint32_t current_buffer = 0;
+
+uint32_t stm32_current_buffer() {
+  return current_buffer;
+}
+
+static void platform_output_slot_unset(struct output_slot *slots,
+                                       uint32_t index,
+                                       uint32_t pin,
+                                       bool value) {
+  if (value) {
+    slots[index].on &= ~(1 << pin);
+  } else {
+    slots[index].off &= ~(1 << pin);
+  }
+}
+
+static void platform_output_slot_set(struct output_slot *slots,
+                                     uint32_t index,
+                                     uint32_t pin,
+                                     bool value) {
+  if (value) {
+    slots[index].on |= (1 << pin);
+  } else {
+    slots[index].off |= (1 << pin);
+  }
+}
+
+/* Return the first time that is gauranteed to be changable.  We use a circular
+ * pair of buffers: We can't change the current buffer, and its likely the next
+ * buffer's time range is already submitted, so use the time after that.
+ */
+timeval_t platform_output_earliest_schedulable_time() {
+  return output_buffers[current_buffer].first_time + NUM_SLOTS * 2;
+}
+
+/* Retire all stop/stop events that are in the time range of our "completed"
+ * buffer and were previously submitted by setting them to "fired" and clearing
+ * out the dma bits */
+static void retire_output_buffer(struct output_buffer *buf) {
+  timeval_t offset_from_start;
+  for (int i = 0; i < MAX_EVENTS; i++) {
+    struct output_event *oev = &config.events[i];
+
+    offset_from_start = oev->start.time - buf->first_time;
+    if (sched_entry_get_state(&oev->start) == SCHED_SUBMITTED &&
+        offset_from_start < NUM_SLOTS) {
+      platform_output_slot_unset(
+        buf->slots, offset_from_start, oev->start.pin, oev->start.val);
+      sched_entry_set_state(&oev->start, SCHED_FIRED);
+    }
+
+    offset_from_start = oev->stop.time - buf->first_time;
+    if (sched_entry_get_state(&oev->stop) == SCHED_SUBMITTED &&
+        offset_from_start < NUM_SLOTS) {
+      platform_output_slot_unset(
+        buf->slots, offset_from_start, oev->stop.pin, oev->stop.val);
+      sched_entry_set_state(&oev->stop, SCHED_FIRED);
+    }
+  }
+}
+
+/* Any scheduled start/stop event in the time range for the new buffer can be
+ * "submitted" and the dma bits set */
+static void populate_output_buffer(struct output_buffer *buf) {
+  timeval_t offset_from_start;
+  for (int i = 0; i < MAX_EVENTS; i++) {
+    struct output_event *oev = &config.events[i];
+    offset_from_start = oev->start.time - buf->first_time;
+    if (sched_entry_get_state(&oev->start) == SCHED_SCHEDULED &&
+        offset_from_start < NUM_SLOTS) {
+      platform_output_slot_set(
+        buf->slots, offset_from_start, oev->start.pin, oev->start.val);
+      sched_entry_set_state(&oev->start, SCHED_SUBMITTED);
+    }
+    offset_from_start = oev->stop.time - buf->first_time;
+    if (sched_entry_get_state(&oev->stop) == SCHED_SCHEDULED &&
+        offset_from_start < NUM_SLOTS) {
+      platform_output_slot_set(
+        buf->slots, offset_from_start, oev->stop.pin, oev->stop.val);
+      sched_entry_set_state(&oev->stop, SCHED_SUBMITTED);
+    }
+  }
+}
+
+static timeval_t round_time_to_buffer_start(timeval_t time) {
+  timeval_t time_since_buffer_start = time % NUM_SLOTS;
+  return time - time_since_buffer_start;
+}
+
+void stm32_buffer_swap(void) {
+  struct output_buffer *buf = &output_buffers[current_buffer];
+  current_buffer = (current_buffer + 1) % 2;
+
+  retire_output_buffer(buf);
+
+  buf->first_time = round_time_to_buffer_start(current_time()) + NUM_SLOTS;
+
+  populate_output_buffer(buf);
+}

--- a/src/platforms/common/stm32_sched_buffers.h
+++ b/src/platforms/common/stm32_sched_buffers.h
@@ -1,0 +1,35 @@
+#ifndef _COMMON_STM32_SCHED_BUFFERS_H
+#define _COMMON_STM32_SCHED_BUFFERS_H
+
+#include "platform.h"
+#include <stdint.h>
+#define NUM_SLOTS 128
+
+/* Implement STM32 and GD32 support for output buffer handling.  Currently this
+ * includes the STM32F4, STM32H7, and GD32F4.
+ */
+
+/* GPIO BSRR is 16 bits of "on" mask and 16 bits of "off" mask */
+struct output_slot {
+  uint16_t on;
+  uint16_t off;
+} __attribute__((packed)) __attribute((aligned(4)));
+
+struct output_buffer {
+  timeval_t first_time; /* First time represented by the range */
+  struct output_slot slots[NUM_SLOTS];
+};
+
+extern struct output_buffer output_buffers[2];
+
+/* Perform a buffer swap for STM32-like hardware.  First find all sched_entryS
+ * that have fired in the most recently completed buffer and mark them as fired.
+ * Then find all the sched_entryS that are to be scheduled and set up the next
+ * DMA buffer for them.
+ */
+void stm32_buffer_swap(void);
+
+/* Returns the current buffer being used for outputs */
+uint32_t stm32_current_buffer(void);
+
+#endif

--- a/src/platforms/gd32f470/README.md
+++ b/src/platforms/gd32f470/README.md
@@ -1,0 +1,31 @@
+## GD32F470
+
+This chip is pin compatible with the STM32F407, but with a 240 MHz clock and 
+0-cycle "flash", it is significantly faster chip than the STM32F4.  More
+importantly, it is available, whereas STM32 chips are currently unavailable.
+
+The only notable difference is the lack of the DMA errata, allowing us to use 
+the second DMA for multiple things.
+
+### Pins
+Use | Pins
+--- | ---
+Trigger 0 | `PA0`
+Trigger 1 | `PA1`
+ADC | `PA5`, `PA6`, `PA7`, and `PA8`
+USB | `PA9`, `PA11`, and `PA12`
+OUT | `PD0`-`PD15`
+GPIO | `PE0`-`PE15`
+PWM | `PC6`-`PC9`
+
+### Resources
+System | Use
+--- | ---
+SPI0 | MAX11632 ADC
+TIMER0 | SPI(ADC) sample timer
+TIMER1 | Main CPU Clock, event timer, and capture units for trigger inputs
+TIMER2 | PWM driver, fixed at 30 Hz
+TIMER7 | TIM2 4 MHz tick driver, triggers TIM2 on update
+USBFS | Console
+SYSTICK | 100 Hz task driver
+

--- a/src/platforms/gd32f470/gd32f470.ld
+++ b/src/platforms/gd32f470/gd32f470.ld
@@ -1,0 +1,97 @@
+/* Define memory regions for GD32F470VE. */
+MEMORY
+{
+	rom(rx) : ORIGIN = 0x08000000, LENGTH = 512K
+	configrom(rx) : ORIGIN = 0x08100000, LENGTH = 512K
+	ram (rwx) : ORIGIN = 0x20000000, LENGTH = 256K
+	ccm (rwx) : ORIGIN = 0x10000000, LENGTH = 64K
+}
+
+EXTERN (vector_table)
+ENTRY(reset_handler)
+
+SECTIONS {
+
+	.text : {
+		*(.vectors)
+		*(.text*)	/* Program code */
+		. = ALIGN(4);
+		*(.rodata*)	/* Read-only data */
+		. = ALIGN(4);
+	} >rom
+
+	/* C++ Static constructors/destructors, also used for __attribute__
+	 * ((constructor)) and the likes */
+	.preinit_array : {
+		. = ALIGN(4);
+		__preinit_array_start = .;
+		KEEP (*(.preinit_array))
+		__preinit_array_end = .;
+	} >rom
+	.init_array : {
+		. = ALIGN(4);
+		__init_array_start = .;
+		KEEP (*(SORT(.init_array.*)))
+		KEEP (*(.init_array))
+		__init_array_end = .;
+	} >rom
+	.fini_array : {
+		. = ALIGN(4);
+		__fini_array_start = .;
+		KEEP (*(.fini_array))
+		KEEP (*(SORT(.fini_array.*)))
+		__fini_array_end = .;
+	} >rom
+
+	/*
+	 * Another section used by C++ stuff, appears when using newlib with
+	 * 64bit (long long) printf support
+	 */
+	.ARM.extab : {
+		*(.ARM.extab*)
+	} >rom
+	.ARM.exidx : {
+		__exidx_start = .;
+		*(.ARM.exidx*)
+		__exidx_end = .;
+	} >rom
+
+	. = ALIGN(4);
+	_etext = .;
+
+	.data : {
+		_sdata = .;
+		*(.data*)	/* Read-write initialized data */
+		*(.dmadata*)
+		. = ALIGN(4);
+		_edata = .;
+	} >ram AT >rom
+	_data_loadaddr = LOADADDR(.data);
+
+	.configdata : {
+		_sconfigdata = .;
+		*(.configdata*)
+		. = ALIGN(4);
+		_econfigdata = .;
+	} >ram AT >configrom
+	_configdata_loadaddr = LOADADDR(.configdata);
+
+	.bss : {
+		*(.bss*)	/* Read-write zero initialized data */
+		*(COMMON)
+		. = ALIGN(4);
+		_ebss = .;
+	} >ram
+
+	/*
+	 * The .eh_frame section appears to be used for C++ exception handling.
+	 * You may need to fix this if you're using C++.
+	 */
+	/DISCARD/ : { *(.eh_frame) }
+
+	. = ALIGN(4);
+	end = .;
+}
+
+PROVIDE(_stack = ORIGIN(ram) + LENGTH(ram));
+

--- a/src/platforms/gd32f470/gd32f470_init.c
+++ b/src/platforms/gd32f470/gd32f470_init.c
@@ -1,0 +1,249 @@
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "gd32f4xx_fwdgt.h"
+#include "gd32f4xx_rcu.h"
+#include "platform.h"
+#include "tasks.h"
+
+#include "gd32f4xx.h"
+
+void platform_enable_event_logging() {}
+
+void platform_disable_event_logging() {}
+
+uint64_t cycles_to_ns(uint64_t cycles) {
+  return cycles * 1000 / 240;
+}
+
+uint64_t cycle_count() {
+  return DWT->CYCCNT;
+}
+
+static void setup_dwt() {
+  CoreDebug->DEMCR |= CoreDebug_DEMCR_TRCENA_Msk;
+  DWT->CTRL |= DWT_CTRL_CYCCNTENA_Msk;
+  DWT->CYCCNT = 0;
+}
+
+void disable_interrupts() {
+  __disable_irq();
+}
+
+void enable_interrupts() {
+  __enable_irq();
+}
+
+bool interrupts_enabled() {
+  return __get_PRIMASK() == 0;
+}
+
+void set_output(int output, char value) {
+  if (value) {
+    GPIO_OCTL(GPIOD) |= (1 << output);
+  } else {
+    GPIO_OCTL(GPIOD) &= ~(1 << output);
+  }
+}
+
+void set_gpio(int output, char value) {
+  if (value) {
+    GPIO_OCTL(GPIOE) |= (1 << output);
+  } else {
+    GPIO_OCTL(GPIOE) &= ~(1 << output);
+  }
+}
+
+int __attribute__((externally_visible))
+_write(int fd, const char *buf, size_t count) {
+  (void)fd;
+  size_t pos = 0;
+  while (pos < count) {
+    pos += console_write(buf + pos, count - pos);
+  }
+  return count;
+}
+
+static void reset_watchdog() {
+  FWDGT_CTL = 0x0000AAAA;
+}
+
+static void setup_watchdog() {
+  DBG_CTL1 |= DBG_CTL1_FWDGT_HOLD;
+
+  FWDGT_CTL = 0x0000CCCC; /* Start watchdog */
+  FWDGT_CTL = 0x00005555; /* Magic unlock sequence */
+  FWDGT_RLD = 1000;       /* Approx 30 mS */
+  reset_watchdog();
+}
+
+void systick_handler(void) {
+  run_tasks();
+  reset_watchdog();
+}
+
+static void setup_systick() {
+  DBG_CTL1 |= DBG_CTL1_FWDGT_HOLD;
+
+  /* Systick is driven by AHB / 8 = 30 MHz
+   * Reload value 300000 for 30 MHz Systick and 10 ms period */
+  SysTick->LOAD = 300000;
+  SysTick->CTRL = SysTick_CTRL_ENABLE_Msk |
+                  SysTick_CTRL_TICKINT_Msk; /* Enable interrupt and systick */
+
+  NVIC_SetPriority(SysTick_IRQn,
+                   NVIC_EncodePriority(NVIC_GetPriorityGrouping(), 4, 0));
+}
+
+static void setup_gpios(void) {
+  GPIO_CTL(GPIOE) = 0x55555555;  /* All of GPIOD is output */
+  GPIO_OSPD(GPIOE) = 0xffffffff; /* All GPIOD set to High speed*/
+}
+
+static void platform_disable_periphs(void) {
+  rcu_periph_clock_disable(RCU_PMU);
+  rcu_periph_clock_disable(RCU_SYSCFG);
+
+  rcu_periph_clock_disable(RCU_TIMER0);
+  rcu_periph_clock_disable(RCU_TIMER1);
+  rcu_periph_clock_disable(RCU_TIMER2);
+  rcu_periph_clock_disable(RCU_TIMER7);
+
+  rcu_periph_clock_disable(RCU_GPIOA);
+  rcu_periph_clock_disable(RCU_GPIOC);
+  rcu_periph_clock_disable(RCU_GPIOD);
+  rcu_periph_clock_disable(RCU_GPIOE);
+
+  rcu_periph_clock_disable(RCU_SPI0);
+
+  rcu_periph_clock_disable(RCU_DMA1);
+  rcu_periph_clock_disable(RCU_USBFS);
+}
+
+static void platform_enable_periphs(void) {
+  rcu_periph_clock_enable(RCU_PMU);
+  rcu_periph_clock_enable(RCU_SYSCFG);
+
+  rcu_periph_clock_enable(RCU_TIMER0);
+  rcu_periph_clock_enable(RCU_TIMER1);
+  rcu_periph_clock_enable(RCU_TIMER2);
+  rcu_periph_clock_enable(RCU_TIMER7);
+
+  rcu_periph_clock_enable(RCU_GPIOA);
+  rcu_periph_clock_enable(RCU_GPIOC);
+  rcu_periph_clock_enable(RCU_GPIOD);
+  rcu_periph_clock_enable(RCU_GPIOE);
+
+  rcu_periph_clock_enable(RCU_SPI0);
+
+  rcu_periph_clock_enable(RCU_DMA1);
+  rcu_periph_clock_enable(RCU_USBFS);
+}
+
+static void system_init(void) {
+  SCB->CPACR |=
+    ((3UL << 10 * 2) | (3UL << 11 * 2)); /* set CP10 and CP11 Full Access */
+
+  rcu_deinit();
+  platform_enable_periphs();
+
+  /* Enable 8 MHz Crystal and wait for it to stablize */
+  rcu_osci_on(RCU_HXTAL);
+  rcu_osci_stab_wait(RCU_HXTAL);
+
+  pmu_ldo_output_select(PMU_LDOVS_HIGH);
+
+  rcu_ahb_clock_config(RCU_AHB_CKSYS_DIV1);   /* 240 MHz */
+  rcu_apb1_clock_config(RCU_APB1_CKAHB_DIV4); /* 60 MHz */
+  rcu_apb2_clock_config(RCU_APB2_CKAHB_DIV2); /* 120 MHz */
+
+  /* Configure the main PLL, PSC = 8, PLL_N = 480, PLL_P = 2, PLL_Q = 10 */
+  rcu_pll_config(RCU_PLLSRC_HXTAL, 8, 480, 2, 10);
+
+  rcu_osci_on(RCU_PLL_CK);
+  rcu_osci_stab_wait(RCU_PLL_CK);
+
+  /* Enable the high-drive to extend the clock frequency to 240 Mhz */
+  pmu_highdriver_mode_enable();
+  pmu_highdriver_switch_select(PMU_HIGHDR_SWITCH_EN);
+
+  rcu_system_clock_source_config(RCU_CKSYSSRC_PLLP);
+}
+
+/* Common symbols exported by the linker script(s): */
+extern uint32_t _data_loadaddr, _sdata, _edata, _ebss;
+
+void reset_handler(void) {
+  volatile uint32_t *src, *dest;
+  for (src = &_data_loadaddr, dest = &_sdata; dest < &_edata; src++, dest++) {
+    *dest = *src;
+  }
+
+  while (dest < &_ebss) {
+    *dest++ = 0;
+  }
+
+  system_init();
+
+  int main();
+  (void)main();
+}
+extern uint32_t _configdata_loadaddr, _sconfigdata, _econfigdata;
+void platform_load_config() {
+  uint32_t *src, *dest;
+  for (src = &_configdata_loadaddr, dest = &_sconfigdata; dest < &_econfigdata;
+       src++, dest++) {
+    *dest = *src;
+  }
+}
+
+void platform_save_config() {
+  disable_interrupts();
+  handle_emergency_shutdown();
+  platform_disable_periphs();
+
+  /* Ensure watchdog won't stop us from flashing */
+  FWDGT_CTL = 0x00005555;
+  FWDGT_PSC = FWDGT_PSC_DIV256;
+
+  fmc_unlock();
+  /* Erase sectors 12-15, first 64K of second bank */
+  fmc_sector_erase(CTL_SECTOR_NUMBER_12);
+  fmc_sector_erase(CTL_SECTOR_NUMBER_13);
+  fmc_sector_erase(CTL_SECTOR_NUMBER_14);
+  fmc_sector_erase(CTL_SECTOR_NUMBER_15);
+
+  uint32_t *src, *dest;
+  for (dest = &_configdata_loadaddr, src = &_sconfigdata; src < &_econfigdata;
+       src++, dest++) {
+    fmc_word_program((uint32_t)dest, *src);
+  }
+
+  fmc_lock();
+  reset_handler();
+}
+
+void platform_reset_into_bootloader() {
+  /* TODO: unimplemented */
+}
+
+extern void gd32f470_configure_scheduler(void);
+extern void gd32f470_console_init(void);
+extern void gd32f470_configure_adc(void);
+extern void gd32f470_configure_pwm(void);
+
+void platform_init() {
+  NVIC_SetPriorityGrouping(3); /* 16 priority preemption levels */
+
+  gd32f470_configure_scheduler();
+  gd32f470_console_init();
+  gd32f470_configure_adc();
+  gd32f470_configure_pwm();
+
+  setup_gpios();
+  setup_systick();
+  setup_watchdog();
+  setup_dwt();
+}
+
+void platform_benchmark_init() {}

--- a/src/platforms/gd32f470/gd32f470_pwm.c
+++ b/src/platforms/gd32f470/gd32f470_pwm.c
@@ -1,0 +1,60 @@
+#include "platform.h"
+#include "tasks.h"
+
+#include "gd32f4xx.h"
+
+/* Use TIMER2 as a fixed-frequency 4-output PWM timer.  This has the downside of
+ * requiring all four PWM outputs to be the same frequency, but uses a
+ * contiguous port-C block that isn't used elsewhere.  In the future we can also
+ * use TIMER8 and TIMER11 to add more frequency selections.  Other
+ * considerations were TIMER9, 10, and 12, but their outputs overlap with CAN0
+ * and SPI.
+ */
+
+/* For now, only set up TIMER2 hardcoded to 30 Hz, and configure PC6-PC9 as the
+ * four outputs */
+void gd32f470_configure_pwm(void) {
+  uint32_t pins = GPIO_PIN_6 | GPIO_PIN_7 | GPIO_PIN_8 | GPIO_PIN_9;
+  gpio_mode_set(GPIOC, GPIO_MODE_AF, GPIO_PUPD_NONE, pins);
+  gpio_af_set(GPIOC, GPIO_AF_2, pins);
+
+  /* TIMER2 is 2x APB1's clock = 120 MHz, divide by 60 results in a period of 30
+   * Hz when counting to 65536 */
+  TIMER_CAR(TIMER2) = 65535;
+  TIMER_PSC(TIMER2) = 60;
+
+  /* Set all outputs to zero */
+  TIMER_CH0CV(TIMER2) = 0;
+  TIMER_CH1CV(TIMER2) = 0;
+  TIMER_CH2CV(TIMER2) = 0;
+  TIMER_CH3CV(TIMER2) = 0;
+
+  /* All four outputs as PWM0 with shadow preload enabled */
+  TIMER_CHCTL0(TIMER2) = TIMER_OC_MODE_PWM0 | TIMER_CHCTL0_CH0COMSEN |
+                         (TIMER_OC_MODE_PWM0 << 8) | TIMER_CHCTL0_CH1COMSEN;
+  TIMER_CHCTL1(TIMER2) = TIMER_OC_MODE_PWM0 | TIMER_CHCTL1_CH2COMSEN |
+                         (TIMER_OC_MODE_PWM0 << 8) | TIMER_CHCTL1_CH3COMSEN;
+  /* Enable output compares */
+  TIMER_CHCTL2(TIMER2) = TIMER_CHCTL2_CH0EN | TIMER_CHCTL2_CH1EN |
+                         TIMER_CHCTL2_CH2EN | TIMER_CHCTL2_CH3EN;
+
+  TIMER_CTL0(TIMER2) = TIMER_CTL0_CEN;
+}
+
+void set_pwm(int output, float percent) {
+  uint16_t duty = (percent / 100.0f) * 65535;
+  switch (output) {
+  case 1:
+    TIMER_CH0CV(TIMER2) = duty;
+    break;
+  case 2:
+    TIMER_CH1CV(TIMER2) = duty;
+    break;
+  case 3:
+    TIMER_CH2CV(TIMER2) = duty;
+    break;
+  case 4:
+    TIMER_CH3CV(TIMER2) = duty;
+    break;
+  }
+}

--- a/src/platforms/gd32f470/gd32f470_sched.c
+++ b/src/platforms/gd32f470/gd32f470_sched.c
@@ -1,0 +1,203 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "config.h"
+#include "decoder.h"
+#include "gd32f4xx.h"
+#include "platform.h"
+#include "sensors.h"
+#include "util.h"
+
+#include "stm32_sched_buffers.h"
+
+/* The primary outputs are driven by the DMA copying from a circular
+ * double-buffer to the GPIO's BSRR register.  TIMER7 is configured to generate
+ * an update even at 4 MHz, and that update event triggers the DMA.  The same
+ * update event also triggers TIMER1, which keeps track of the current time.
+ *
+ * Each DMA buffer represents 32 uS of time (128 time points at 4 MHz), and each
+ * 32 bit word in the DMA buffer is directly written to BSRR.  The high 16 bits
+ * of this word cause the GPIO for that bit to go high, the low 16 bits cause it
+ * to go low.
+ *
+ * The DMA buffers are updated and modified only in the DMA ISR, which is
+ * triggered once the DMA has finished the buffer and is currently executing on
+ * the other buffer. At this time, we iterate through all events that would have
+ * been in the time range of the completed buffer and set them to FIRED.  We
+ * then enumerate all events that are scheduled for the next time range and set
+ * the bits appropriately.
+ *
+ * Since TIMER1 is the main time base and also has input captures, we use the
+ * first two capture units as the trigger inputs.  These inputs trigger a
+ * capture interrupt, the captured time is used to directly call the decoder,
+ * which optionally may do fuel/ignition calculations and reschedule events.
+ */
+
+static void setup_timer7(void) {
+  TIMER_CTL1(TIMER7) =
+    TIMER_TRI_OUT_SRC_UPDATE; /* Master Mode: TRGO on counter update */
+  TIMER_CAR(TIMER7) =
+    59; /* Period of (59+1) with 240 MHz Clock produces 4 MHz */
+  TIMER_DMAINTEN(TIMER7) = TIMER_DMAINTEN_UPDEN; /* Enable DMA event on update*/
+  TIMER_CTL0(TIMER7) = TIMER_CTL0_CEN;           /* Start */
+
+  DBG_CTL2 |= DBG_CTL2_TIMER7_HOLD;
+}
+
+static void configure_trigger_inputs(void) {
+  trigger_edge cc0_edge = config.freq_inputs[0].edge;
+  trigger_edge cc1_edge = config.freq_inputs[1].edge;
+  bool cc0_en = (config.freq_inputs[0].type == TRIGGER);
+  bool cc1_en = (config.freq_inputs[1].type == TRIGGER);
+
+  bool cc0p = (cc0_edge == FALLING_EDGE) || (cc0_edge == BOTH_EDGES);
+  bool cc0np = (cc0_edge == BOTH_EDGES);
+  bool cc1p = (cc1_edge == FALLING_EDGE) || (cc1_edge == BOTH_EDGES);
+  bool cc1np = (cc1_edge == BOTH_EDGES);
+
+  /* Ensure CH0 and CH1 are off */
+  TIMER_CHCTL2(TIMER1) &= ~(TIMER_CHCTL2_CH0EN | TIMER_CHCTL2_CH1EN);
+
+  /* Configure 2 input captures for trigger inputs */
+  TIMER_CHCTL0(TIMER1) = TIMER_CHCTL0_CH0CAPFLT | /* DTS/32 filter */
+                         0x1 | /* CH0MS Mode 01 -- CH0 input */
+                         TIMER_CHCTL0_CH1CAPFLT | /* DTS/32 filter */
+                         (0x1 << 8); /* CH1MS Mode 01 -- CH1 input */
+
+  TIMER_CHCTL2(TIMER1) =
+    (cc0p ? TIMER_CHCTL2_CH0P : 0) | (cc0np ? TIMER_CHCTL2_CH0NP : 0) |
+    (cc1p ? TIMER_CHCTL2_CH1P : 0) | (cc1np ? TIMER_CHCTL2_CH2NP : 0) |
+    TIMER_CHCTL2_CH3EN | /* Setup output compare for callbacks */
+    (cc0_en ? TIMER_CHCTL2_CH0EN : 0) | (cc1_en ? TIMER_CHCTL2_CH1EN : 0);
+}
+
+static void setup_timer1(void) {
+
+  /* Enable the trigger input GPIOs */
+  gpio_mode_set(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO_PIN_0 | GPIO_PIN_1);
+  gpio_af_set(GPIOA, GPIO_AF_1, GPIO_PIN_0 | GPIO_PIN_1);
+
+  /* Timer is driven by ITI1, the output of TIMER7 */
+  TIMER_SMCFG(TIMER1) = TIMER_SLAVE_MODE_EXTERNAL0 | TIMER_SMCFG_TRGSEL_ITI1;
+  TIMER_CAR(TIMER1) = 0xffffffff;
+
+  configure_trigger_inputs();
+
+  nvic_irq_enable(TIMER1_IRQn, 1, 0);
+  TIMER_DMAINTEN(TIMER1) = TIMER_DMAINTEN_CH0IE | TIMER_DMAINTEN_CH1IE;
+
+  TIMER_CTL0(TIMER1) |= TIMER_CTL0_CEN;
+
+  DBG_CTL1 |= DBG_CTL1_TIMER1_HOLD;
+}
+
+timeval_t current_time() {
+  return TIMER_CNT(TIMER1);
+}
+
+void TIMER1_IRQHandler(void) {
+  bool cc0_fired = false;
+  bool cc1_fired = false;
+  timeval_t cc0;
+  timeval_t cc1;
+
+  if (TIMER_INTF(TIMER1) & TIMER_INTF_CH0IF) {
+    TIMER_INTF(TIMER1) &= ~TIMER_INTF_CH0IF;
+    cc0_fired = true;
+    cc0 = TIMER_CH0CV(TIMER1);
+  }
+
+  if (TIMER_INTF(TIMER1) & TIMER_INTF_CH1IF) {
+    TIMER_INTF(TIMER1) &= ~TIMER_INTF_CH1IF;
+    cc1_fired = true;
+    cc1 = TIMER_CH1CV(TIMER1);
+  }
+
+  if (cc0_fired && cc1_fired && time_before(cc1, cc0)) {
+    decoder_update_scheduling(1, cc1);
+    decoder_update_scheduling(0, cc0);
+  } else {
+    if (cc0_fired) {
+      decoder_update_scheduling(0, cc0);
+    }
+    if (cc1_fired) {
+      decoder_update_scheduling(1, cc1);
+    }
+  }
+
+  if (TIMER_INTF(TIMER1) & TIMER_INTF_CH3IF) {
+    TIMER_INTF(TIMER1) &= ~TIMER_INTF_CH3IF;
+    scheduler_callback_timer_execute();
+  }
+}
+
+void schedule_event_timer(timeval_t time) {
+
+  TIMER_DMAINTEN(TIMER1) &= ~TIMER_DMAINTEN_CH3IE;
+  TIMER_INTF(TIMER1) &= ~TIMER_INTF_CH3IF;
+
+  TIMER_CH3CV(TIMER1) = time;
+  TIMER_DMAINTEN(TIMER1) |= TIMER_DMAINTEN_CH3IE;
+
+  /* If time is prior to now, we may have missed it, set the interrupt pending
+   * just in case */
+  if (time_before_or_equal(time, current_time())) {
+    TIMER_SWEVG(TIMER1) = TIMER_SWEVG_CH3G;
+  }
+}
+
+void DMA1_Channel1_IRQHandler(void) {
+  if (dma_interrupt_flag_get(DMA1, DMA_CH1, DMA_INT_FLAG_FTF) == SET) {
+    dma_interrupt_flag_clear(DMA1, DMA_CH1, DMA_INT_FLAG_FTF);
+    stm32_buffer_swap();
+  }
+
+  /* If we overran, abort */
+  if (dma_using_memory_get(DMA1, DMA_CH1) != stm32_current_buffer()) {
+    abort();
+  }
+
+  /* In the event of a transfer error, abort */
+  if (dma_interrupt_flag_get(DMA1, DMA_CH1, DMA_INT_FLAG_TAE)) {
+    abort();
+  }
+}
+
+static void setup_scheduled_outputs(void) {
+
+  /* While still in hi-z, set outputs that are active-low */
+  for (int i = 0; i < MAX_EVENTS; ++i) {
+    if (config.events[i].inverted && config.events[i].type != DISABLED_EVENT) {
+      GPIO_OCTL(GPIOD) |= (1 << config.events[i].pin);
+    }
+  }
+
+  GPIO_CTL(GPIOD) = 0x55555555;  /* All of GPIOD is output */
+  GPIO_OSPD(GPIOD) = 0xffffffff; /* All GPIOD set to High speed*/
+
+  /* Enable Interrupt on buffer swap at highest priority */
+  nvic_irq_enable(DMA1_Channel1_IRQn, 0, 0);
+
+  /* Use DMA1's Channel 1 to write to GPIOD's OCTL whenever TIMER7 updates */
+  DMA_CH1PADDR(DMA1) = (uint32_t)&GPIO_BOP(GPIOD);
+  DMA_CH1M0ADDR(DMA1) = (uint32_t)&output_buffers[0].slots;
+  DMA_CH1M1ADDR(DMA1) = (uint32_t)&output_buffers[1].slots;
+  DMA_CH1CNT(DMA1) = NUM_SLOTS;
+
+  DMA_CH1CTL(DMA1) = DMA_PERIPH_7_SELECT | /* TIMER7 Update */
+                     DMA_CHXCTL_SBMEN |    /* Switch-buffer mode */
+                     DMA_PRIORITY_HIGH | DMA_MEMORY_WIDTH_32BIT |
+                     DMA_PERIPH_WIDTH_32BIT |
+                     DMA_CHXCTL_MNAGA | /* Memory-increment */
+                     DMA_MEMORY_TO_PERIPH |
+                     DMA_CHXCTL_FTFIE | /* Enable interrupt on buffer swap */
+                     DMA_CHXCTL_TAEIE | /* Enable interrupt on transfer error */
+                     DMA_CHXCTL_CHEN;   /* Enable DMA */
+}
+
+void gd32f470_configure_scheduler() {
+  setup_scheduled_outputs();
+  setup_timer1();
+  setup_timer7();
+}

--- a/src/platforms/gd32f470/gd32f470_sensors.c
+++ b/src/platforms/gd32f470/gd32f470_sensors.c
@@ -1,0 +1,119 @@
+#include "config.h"
+#include "sensors.h"
+
+#include "gd32f4xx.h"
+#include "max11632_adc.h"
+
+/* Query a MAX11632 ADC on SPI0 at a fixed sampling rate of 192 KHz and a SPI
+ * clock of 3.75 MHz.  SPI0 is on APB2 with a clock frequency of 120 MHz.
+ * Prescale down to 3.75 (divide by 32) to keep under the maximum clock
+ * frequency of the MAX11632.
+ */
+
+/* Configure TIMER0 to update at 192 KHz and generate a DMA request. We use
+ * TIMER0's output compare functionality to drive CS high and low once per
+ * sample. */
+
+static void setup_timer0(void) {
+  gpio_mode_set(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO_PIN_8);
+  gpio_af_set(GPIOA, GPIO_AF_1, GPIO_PIN_8);
+  /* set AF for gpio */
+
+  /* TIMER0 is on APB2's CK_TIMER, driven at 240 MHz (2x APB2's clock). Divide
+   * by 1250 */
+  TIMER_CAR(TIMER0) = 1250 - 1;
+
+  TIMER_DMAINTEN(TIMER0) = TIMER_DMAINTEN_UPDEN;
+
+  /* Configure TIMER0's CH0 as a PWM output to act as CS.  On each cycle start
+     low and after the duty% is reached, go high */
+  TIMER_CH0CV(TIMER0) = 1125; /* 90% duty cycle */
+  TIMER_CHCTL0(TIMER0) = (TIMER_OC_MODE_PWM1 << 4) | TIMER_CHCTL0_CH0COMSEN;
+  TIMER_CHCTL2(TIMER0) = TIMER_CHCTL2_CH0EN;
+  TIMER_CCHP(TIMER0) = TIMER_CCHP_POEN | TIMER_CCHP_ROS;
+
+  TIMER_CTL0(TIMER0) = TIMER_CTL0_CEN;
+
+  DBG_CTL1 |= DBG_CTL2_TIMER0_HOLD;
+}
+
+/* Configure SPI0 for a SPI clock of 3.75 MHz in master mode with hardware NSS
+ */
+static void setup_spi0(void) {
+
+  const uint32_t spi_pins = GPIO_PIN_5 | GPIO_PIN_6 | GPIO_PIN_7;
+  gpio_mode_set(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, spi_pins);
+  gpio_af_set(GPIOA, GPIO_AF_5, spi_pins);
+
+  GPIO_OSPD(GPIOA) |= GPIO_OSPEED_SET(5, GPIO_OSPEED_25MHZ) |
+                      GPIO_OSPEED_SET(6, GPIO_OSPEED_25MHZ) |
+                      GPIO_OSPEED_SET(7, GPIO_OSPEED_25MHZ) |
+                      GPIO_OSPEED_SET(8, GPIO_OSPEED_25MHZ);
+
+  SPI_CTL0(SPI0) = SPI_CTL0_FF16 |  /* 16 bit data format */
+                   SPI_PSC_32 |     /* Divide to 3.75 MHz */
+                   SPI_CTL0_MSTMOD; /* Master Mode */
+
+  SPI_CTL1(SPI0) = SPI_CTL1_NSSDRV | /* Manage NSS Output */
+                   SPI_CTL1_DMAREN;  /* Enable RX DMA */
+
+  SPI_CTL0(SPI0) |= SPI_CTL0_SPIEN; /* Enable */
+}
+
+/* Use TIMER0 to trigger the DMA to write SPI0.  Use circular mode to transmit
+ * the SPI commands.  TIMER0_UP can be driven with DMA1, Channel 5 Periph 6. */
+void setup_spi0_tx_dma(void) {
+  DMA_CH5PADDR(DMA1) = (uint32_t)&SPI_DATA(SPI0);
+  DMA_CH5M0ADDR(DMA1) = (uint32_t)&max11632_transmit_sequence[0];
+  DMA_CH5CNT(DMA1) = NUM_SPI_TX;
+
+  DMA_CH5CTL(DMA1) = DMA_PERIPH_6_SELECT | DMA_MEMORY_WIDTH_16BIT |
+                     DMA_PERIPH_WIDTH_16BIT | DMA_MEMORY_TO_PERIPH |
+                     DMA_CHXCTL_MNAGA | DMA_CHXCTL_CMEN | DMA_CHXCTL_CHEN;
+}
+
+static volatile uint16_t __attribute__((aligned(4)))
+__attribute__((section(".dmadata"))) spi_rx_buffer[2][NUM_SPI_TX] = { 0 };
+
+/* DMA is driven by SPI's RX and transfers the SPI result into a double buffer
+ * of results.  The interrupt is also used for the ADC calculations */
+void setup_spi0_rx_dma(void) {
+
+  /* Enable interrupt for dma completion */
+  nvic_irq_enable(DMA1_Channel0_IRQn, 3, 0);
+
+  DMA_CH0PADDR(DMA1) = (uint32_t)&SPI_DATA(SPI0);
+  DMA_CH0M0ADDR(DMA1) = (uint32_t)&spi_rx_buffer[0][0];
+  DMA_CH0M1ADDR(DMA1) = (uint32_t)&spi_rx_buffer[1][0];
+  DMA_CH0CNT(DMA1) = NUM_SPI_TX;
+
+  DMA_CH0CTL(DMA1) =
+    DMA_PERIPH_3_SELECT | DMA_MEMORY_WIDTH_16BIT | DMA_PERIPH_WIDTH_16BIT |
+    DMA_PERIPH_TO_MEMORY | DMA_CHXCTL_MNAGA | DMA_CHXCTL_SBMEN |
+    DMA_CHXCTL_FTFIE | /* Enable interrupt on buffer completion */
+    DMA_CHXCTL_CHEN;
+}
+
+void DMA1_Channel0_IRQHandler(void) {
+  if (dma_interrupt_flag_get(DMA1, DMA_CH0, DMA_INT_FLAG_FTF) == SET) {
+    dma_interrupt_flag_clear(DMA1, DMA_CH0, DMA_INT_FLAG_FTF);
+    const uint16_t *sequence = (dma_using_memory_get(DMA1, DMA_CH0) == 0)
+                                 ? (const uint16_t *)spi_rx_buffer[1]
+                                 : (const uint16_t *)spi_rx_buffer[0];
+    for (int i = 0; i < NUM_SENSORS; ++i) {
+      if (config.sensors[i].source == SENSOR_ADC) {
+        config.sensors[i].fault = FAULT_NONE;
+        config.sensors[i].raw_value =
+          read_adc_pin(sequence, config.sensors[i].pin);
+      }
+    }
+    sensors_process(SENSOR_ADC);
+  }
+}
+
+void gd32f470_configure_adc(void) {
+  setup_spi0();
+  setup_spi0_tx_dma();
+  setup_spi0_rx_dma();
+  setup_timer0();
+}

--- a/src/platforms/gd32f470/gd32f470_usb.c
+++ b/src/platforms/gd32f470/gd32f470_usb.c
@@ -1,0 +1,529 @@
+
+/*
+    Copyright (c) 2022, GigaDevice Semiconductor Inc.
+
+    Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holder nor the names of its
+contributors may be used to endorse or promote products derived from this
+software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+
+/* This file is derived from the GD32F4xx Usb library, with modifications
+  support the viaems usb use case */
+
+#include <assert.h>
+#include <stdatomic.h>
+#include <string.h>
+
+#include "gd32f4xx.h"
+#include "platform.h"
+#include "util.h"
+
+#include "drv_usb_hw.h"
+#include "drv_usbd_int.h"
+#include "usb_cdc.h"
+#include "usb_ch9_std.h"
+#include "usbd_enum.h"
+
+usb_core_driver cdc_acm;
+
+#define USBD_VID 0x1209
+#define USBD_PID 0x2041
+
+struct cdc_state {
+  _Atomic bool pending_write;
+  _Atomic bool pending_read;
+  uint8_t cmd[8];
+
+  acm_line line_coding;
+};
+
+struct cdc_state state;
+
+/* note:it should use the C99 standard when compiling the below codes */
+/* USB standard device descriptor */
+const usb_desc_dev cdc_dev_desc  =
+{
+    .header = 
+     {
+         .bLength          = USB_DEV_DESC_LEN, 
+         .bDescriptorType  = USB_DESCTYPE_DEV,
+     },
+    .bcdUSB                = 0x0200U,
+    .bDeviceClass          = USB_CLASS_CDC,
+    .bDeviceSubClass       = 0x00U,
+    .bDeviceProtocol       = 0x00U,
+    .bMaxPacketSize0       = USB_FS_EP0_MAX_LEN,
+    .idVendor              = USBD_VID,
+    .idProduct             = USBD_PID,
+    .bcdDevice             = 0x0100U,
+    .iManufacturer         = STR_IDX_MFC,
+    .iProduct              = STR_IDX_PRODUCT,
+    .iSerialNumber         = STR_IDX_SERIAL,
+    .bNumberConfigurations = USBD_CFG_MAX_NUM,
+};
+
+/* USB device configuration descriptor */
+const usb_cdc_desc_config_set cdc_config_desc  = 
+{
+    .config = 
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_config),
+            .bDescriptorType = USB_DESCTYPE_CONFIG,
+        },
+        .wTotalLength         = USB_CDC_ACM_CONFIG_DESC_SIZE,
+        .bNumInterfaces       = 0x02U,
+        .bConfigurationValue  = 0x01U,
+        .iConfiguration       = 0x00U,
+        .bmAttributes         = 0x80U,
+        .bMaxPower            = 0x32U
+    },
+
+    .cmd_itf = 
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_itf),
+            .bDescriptorType = USB_DESCTYPE_ITF
+        },
+        .bInterfaceNumber     = 0x00U,
+        .bAlternateSetting    = 0x00U,
+        .bNumEndpoints        = 0x01U,
+        .bInterfaceClass      = USB_CLASS_CDC,
+        .bInterfaceSubClass   = USB_CDC_SUBCLASS_ACM,
+        .bInterfaceProtocol   = USB_CDC_PROTOCOL_AT,
+        .iInterface           = 0x00U
+    },
+
+    .cdc_header =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_header_func),
+            .bDescriptorType = USB_DESCTYPE_CS_INTERFACE
+        },
+        .bDescriptorSubtype  = 0x00U,
+        .bcdCDC              = 0x0110U
+    },
+
+    .cdc_call_managment =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_call_managment_func),
+            .bDescriptorType = USB_DESCTYPE_CS_INTERFACE
+        },
+        .bDescriptorSubtype  = 0x01U,
+        .bmCapabilities      = 0x00U,
+        .bDataInterface      = 0x01U
+    },
+
+    .cdc_acm =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_acm_func),
+            .bDescriptorType = USB_DESCTYPE_CS_INTERFACE
+        },
+        .bDescriptorSubtype  = 0x02U,
+        .bmCapabilities      = 0x02U,
+    },
+
+    .cdc_union =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_union_func),
+            .bDescriptorType = USB_DESCTYPE_CS_INTERFACE
+        },
+        .bDescriptorSubtype  = 0x06U,
+        .bMasterInterface    = 0x00U,
+        .bSlaveInterface0    = 0x01U,
+    },
+
+    .cdc_cmd_endpoint =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_ep),
+            .bDescriptorType = USB_DESCTYPE_EP,
+        },
+        .bEndpointAddress    = CDC_CMD_EP,
+        .bmAttributes        = USB_EP_ATTR_INT,
+        .wMaxPacketSize      = USB_CDC_CMD_PACKET_SIZE,
+        .bInterval           = 0x0AU
+    },
+
+    .cdc_data_interface =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_itf),
+            .bDescriptorType = USB_DESCTYPE_ITF,
+        },
+        .bInterfaceNumber    = 0x01U,
+        .bAlternateSetting   = 0x00U,
+        .bNumEndpoints       = 0x02U,
+        .bInterfaceClass     = USB_CLASS_DATA,
+        .bInterfaceSubClass  = 0x00U,
+        .bInterfaceProtocol  = USB_CDC_PROTOCOL_NONE,
+        .iInterface          = 0x00U
+    },
+
+    .cdc_out_endpoint =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_ep),
+            .bDescriptorType = USB_DESCTYPE_EP,
+        },
+        .bEndpointAddress     = CDC_DATA_OUT_EP,
+        .bmAttributes         = USB_EP_ATTR_BULK,
+        .wMaxPacketSize       = USB_CDC_DATA_PACKET_SIZE,
+        .bInterval            = 0x00U
+    },
+
+    .cdc_in_endpoint =
+    {
+        .header =
+        {
+            .bLength         = sizeof(usb_desc_ep),
+            .bDescriptorType = USB_DESCTYPE_EP
+        },
+        .bEndpointAddress     = CDC_DATA_IN_EP,
+        .bmAttributes         = USB_EP_ATTR_BULK,
+        .wMaxPacketSize       = USB_CDC_DATA_PACKET_SIZE,
+        .bInterval            = 0x00U
+    }
+};
+
+/* USB language ID Descriptor */
+static const usb_desc_LANGID usbd_language_id_desc = 
+{
+    .header =
+    {
+        .bLength         = sizeof(usb_desc_LANGID),
+        .bDescriptorType = USB_DESCTYPE_STR,
+    },
+    .wLANGID              = ENG_LANGID
+};
+
+/* USB manufacture string */
+static usb_desc_str manufacturer_string;
+
+/* USB product string */
+static usb_desc_str product_string;
+
+/* USBD serial string */
+static usb_desc_str serial_string;
+
+/* USB string descriptor set */
+void *const usbd_cdc_strings[] = {
+  [STR_IDX_LANGID] = (uint8_t *)&usbd_language_id_desc,
+  [STR_IDX_MFC] = (uint8_t *)&manufacturer_string,
+  [STR_IDX_PRODUCT] = (uint8_t *)&product_string,
+  [STR_IDX_SERIAL] = (uint8_t *)&serial_string
+};
+
+usb_desc cdc_desc = { .dev_desc = (uint8_t *)&cdc_dev_desc,
+                      .config_desc = (uint8_t *)&cdc_config_desc,
+                      .strings = usbd_cdc_strings };
+
+/* local function prototypes ('static') */
+static uint8_t cdc_acm_init(usb_dev *udev, uint8_t config_index);
+static uint8_t cdc_acm_deinit(usb_dev *udev, uint8_t config_index);
+static uint8_t cdc_acm_req(usb_dev *udev, usb_req *req);
+static uint8_t cdc_acm_ctlx_out(usb_dev *udev);
+static uint8_t cdc_acm_in(usb_dev *udev, uint8_t ep_num);
+static uint8_t cdc_acm_out(usb_dev *udev, uint8_t ep_num);
+
+/* USB CDC device class callbacks structure */
+usb_class_core cdc_class = { .command = NO_CMD,
+                             .alter_set = 0U,
+
+                             .init = cdc_acm_init,
+                             .deinit = cdc_acm_deinit,
+                             .req_proc = cdc_acm_req,
+                             .ctlx_out = cdc_acm_ctlx_out,
+                             .data_in = cdc_acm_in,
+                             .data_out = cdc_acm_out };
+
+/*!
+    \brief      initialize the CDC ACM device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t cdc_acm_init(usb_dev *udev, uint8_t config_index) {
+  (void)config_index;
+  /* initialize the data Tx endpoint */
+  usbd_ep_setup(udev, &(cdc_config_desc.cdc_in_endpoint));
+
+  /* initialize the data Rx endpoint */
+  usbd_ep_setup(udev, &(cdc_config_desc.cdc_out_endpoint));
+
+  /* initialize the command Tx endpoint */
+  usbd_ep_setup(udev, &(cdc_config_desc.cdc_cmd_endpoint));
+
+  /* initialize CDC handler structure */
+  state.pending_read = false;
+  state.pending_write = false;
+
+  state.line_coding = (acm_line){ .dwDTERate = 115200U,
+                                  .bCharFormat = 0U,
+                                  .bParityType = 0U,
+                                  .bDataBits = 0x08U };
+
+  return USBD_OK;
+}
+
+/*!
+    \brief      deinitialize the CDC ACM device
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  config_index: configuration index
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t cdc_acm_deinit(usb_dev *udev, uint8_t config_index) {
+  (void)config_index;
+
+  /* deinitialize the data Tx/Rx endpoint */
+  usbd_ep_clear(udev, CDC_DATA_IN_EP);
+  usbd_ep_clear(udev, CDC_DATA_OUT_EP);
+
+  /* deinitialize the command Tx endpoint */
+  usbd_ep_clear(udev, CDC_CMD_EP);
+
+  return USBD_OK;
+}
+
+/*!
+    \brief      handle the CDC ACM class-specific requests
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  req: device class-specific request
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t cdc_acm_req(usb_dev *udev, usb_req *req) {
+  usb_transc *transc = NULL;
+
+  switch (req->bRequest) {
+  case SEND_ENCAPSULATED_COMMAND:
+    /* no operation for this driver */
+    break;
+
+  case GET_ENCAPSULATED_RESPONSE:
+    /* no operation for this driver */
+    break;
+
+  case SET_COMM_FEATURE:
+    /* no operation for this driver */
+    break;
+
+  case GET_COMM_FEATURE:
+    /* no operation for this driver */
+    break;
+
+  case CLEAR_COMM_FEATURE:
+    /* no operation for this driver */
+    break;
+
+  case SET_LINE_CODING:
+    transc = &udev->dev.transc_out[0];
+
+    /* set the value of the current command to be processed */
+    udev->dev.class_core->alter_set = req->bRequest;
+
+    /* enable EP0 prepare to receive command data packet */
+    transc->remain_len = req->wLength;
+    transc->xfer_buf = state.cmd;
+    break;
+
+  case GET_LINE_CODING:
+    transc = &udev->dev.transc_in[0];
+
+    state.cmd[0] = (uint8_t)(state.line_coding.dwDTERate);
+    state.cmd[1] = (uint8_t)(state.line_coding.dwDTERate >> 8);
+    state.cmd[2] = (uint8_t)(state.line_coding.dwDTERate >> 16);
+    state.cmd[3] = (uint8_t)(state.line_coding.dwDTERate >> 24);
+    state.cmd[4] = state.line_coding.bCharFormat;
+    state.cmd[5] = state.line_coding.bParityType;
+    state.cmd[6] = state.line_coding.bDataBits;
+
+    transc->xfer_buf = state.cmd;
+    transc->remain_len = 7U;
+    break;
+
+  case SET_CONTROL_LINE_STATE:
+    /* no operation for this driver */
+    break;
+
+  case SEND_BREAK:
+    /* no operation for this driver */
+    break;
+
+  default:
+    break;
+  }
+
+  return USBD_OK;
+}
+
+/*!
+    \brief      command data received on control endpoint
+    \param[in]  udev: pointer to USB device instance
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t cdc_acm_ctlx_out(usb_dev *udev) {
+
+  if (udev->dev.class_core->alter_set != NO_CMD) {
+    /* process the command data */
+    state.line_coding.dwDTERate =
+      (uint32_t)((uint32_t)state.cmd[0] | ((uint32_t)state.cmd[1] << 8U) |
+                 ((uint32_t)state.cmd[2] << 16U) |
+                 ((uint32_t)state.cmd[3] << 24U));
+
+    state.line_coding.bCharFormat = state.cmd[4];
+    state.line_coding.bParityType = state.cmd[5];
+    state.line_coding.bDataBits = state.cmd[6];
+
+    udev->dev.class_core->alter_set = NO_CMD;
+  }
+
+  return USBD_OK;
+}
+
+/*!
+    \brief      handle CDC ACM data in
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint identifier
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t cdc_acm_in(usb_dev *udev, uint8_t ep_num) {
+  usb_transc *transc = &udev->dev.transc_in[EP_ID(ep_num)];
+
+  if ((0U == transc->xfer_len % transc->max_len) && (0U != transc->xfer_len)) {
+    usbd_ep_send(udev, ep_num, NULL, 0U);
+  } else {
+    state.pending_write = false;
+  }
+
+  return USBD_OK;
+}
+
+static uint8_t rxbuffer[64];
+static uint32_t rx_len = 0;
+/*!
+    \brief      handle CDC ACM data out
+    \param[in]  udev: pointer to USB device instance
+    \param[in]  ep_num: endpoint identifier
+    \param[out] none
+    \retval     USB device operation status
+*/
+static uint8_t cdc_acm_out(usb_dev *udev, uint8_t ep_num) {
+  rx_len = ((usb_core_driver *)udev)->dev.transc_out[ep_num].xfer_count;
+  state.pending_read = true;
+  return USBD_OK;
+}
+
+size_t console_read(void *ptr, size_t max) {
+
+  if (state.pending_read) {
+    disable_interrupts();
+    assert(rx_len <= max);
+    memcpy(ptr, rxbuffer, rx_len);
+    state.pending_read = false;
+    enable_interrupts();
+    return rx_len;
+  }
+
+  if (max >= sizeof(rxbuffer)) {
+    usbd_ep_recev(&cdc_acm, CDC_DATA_OUT_EP, rxbuffer, sizeof(rxbuffer));
+  }
+  return 0;
+}
+
+size_t console_write(const void *ptr, size_t max) {
+  if (state.pending_write) {
+    return 0;
+  }
+
+  disable_interrupts();
+  state.pending_write = true;
+  usbd_ep_send(&cdc_acm, CDC_DATA_IN_EP, ptr, max);
+  enable_interrupts();
+
+  /* Block until sent */
+  while (state.pending_write)
+    ;
+
+  return max;
+}
+
+void usb_udelay(uint32_t d) {
+  timeval_t before = current_time();
+  while ((current_time() - before) < time_from_us(d))
+    ;
+}
+
+void usb_mdelay(uint32_t d) {
+  usb_udelay(d * 1000);
+}
+
+void USBFS_IRQHandler(void) {
+  usbd_isr(&cdc_acm);
+}
+
+static void usb_initialize_string(usb_desc_str *desc, const char *str) {
+  desc->header.bDescriptorType = USB_DESCTYPE_STR;
+  size_t len = 0;
+  while (str[len] != 0) {
+    desc->unicode_string[len] = str[len];
+    len++;
+  }
+  desc->header.bLength = USB_STRING_LEN(len);
+}
+
+void gd32f470_console_init() {
+  rcu_pll48m_clock_config(RCU_PLL48MSRC_PLLQ);
+  rcu_ck48m_clock_config(RCU_CK48MSRC_PLL48M);
+
+  /* USBFS_DM(PA11) and USBFS_DP(PA12) GPIO pin configuration */
+  gpio_mode_set(GPIOA, GPIO_MODE_AF, GPIO_PUPD_NONE, GPIO_PIN_11 | GPIO_PIN_12);
+  gpio_output_options_set(
+    GPIOA, GPIO_OTYPE_PP, GPIO_OSPEED_MAX, GPIO_PIN_11 | GPIO_PIN_12);
+
+  gpio_af_set(GPIOA, GPIO_AF_10, GPIO_PIN_11 | GPIO_PIN_12);
+
+  nvic_irq_enable(USBFS_IRQn, 4, 0);
+
+  usb_initialize_string(cdc_desc.strings[STR_IDX_MFC],
+                        "https://github.com/via/viaems");
+  usb_initialize_string(cdc_desc.strings[STR_IDX_PRODUCT], "ViaEMS Console");
+  usb_initialize_string(cdc_desc.strings[STR_IDX_SERIAL], "0");
+
+  usbd_init(&cdc_acm, USB_CORE_ENUM_FS, &cdc_desc, &cdc_class);
+}

--- a/src/platforms/gd32f470/gd32f470_vectors.c
+++ b/src/platforms/gd32f470/gd32f470_vectors.c
@@ -1,0 +1,262 @@
+#include "gd32f4xx.h"
+#include <stdint.h>
+
+/* Must be provided by linker script */
+extern uint32_t _stack;
+
+struct vector_table {
+  uint32_t *stack_pointer;
+  void (*reset)(void);
+  void (*nmi)(void);
+  void (*hard_fault)(void);
+  void (*memory_manage_fault)(void);
+  void (*bus_fault)(void);
+  void (*usage_fault)(void);
+  void (*reserved_x001c[4])(void);
+  void (*sv_call)(void);
+  void (*debug_monitor)(void);
+  void (*reserved_x0034)(void);
+  void (*pend_sv)(void);
+  void (*systick)(void);
+  void (*irqs[91])(void);
+};
+
+void blocking_handler(void) {
+  while (1)
+    ;
+}
+
+void null_handler(void) {}
+
+void reset_handler(void) __attribute__((weak, alias("blocking_handler")));
+void nmi_handler(void) __attribute__((weak, alias("null_handler")));
+void hard_fault_handler(void) __attribute__((weak, alias("null_handler")));
+void memory_manage_fault_handler(void)
+  __attribute__((weak, alias("null_handler")));
+void bus_fault_handler(void) __attribute__((weak, alias("null_handler")));
+void usage_fault_handler(void) __attribute__((weak, alias("null_handler")));
+void debug_monitor_handler(void) __attribute__((weak, alias("null_handler")));
+void sv_call_handler(void) __attribute__((weak, alias("null_handler")));
+void pend_sv_handler(void) __attribute__((weak, alias("null_handler")));
+void systick_handler(void) __attribute__((weak, alias("null_handler")));
+
+void WWDGT_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void LVD_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void TAMPER_STAMP_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void RTC_WKUP_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void FMC_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void RCU_CTC_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void EXTI0_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void EXTI1_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void EXTI2_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void EXTI3_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void EXTI4_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void DMA0_Channel0_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void DMA0_Channel1_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void DMA0_Channel2_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void DMA0_Channel3_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void DMA0_Channel4_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void DMA0_Channel5_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void DMA0_Channel6_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void ADC_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void CAN0_TX_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void CAN0_RX0_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void CAN0_RX1_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void CAN0_EWMC_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void EXTI5_9_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void TIMER0_BRK_TIMER8_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void TIMER0_UP_TIMER9_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void TIMER0_TRG_CMT_TIMER10_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void TIMER0_Channel_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void TIMER1_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void TIMER2_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void TIMER3_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void I2C0_EV_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void I2C0_ER_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void I2C1_EV_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void I2C1_ER_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void SPI0_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void SPI1_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void USART0_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void USART1_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void USART2_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void EXTI10_15_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void RTC_Alarm_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void USBFS_WKUP_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void TIMER7_BRK_TIMER11_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void TIMER7_UP_TIMER12_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void TIMER7_TRG_CMT_TIMER13_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void TIMER7_Channel_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void DMA0_Channel7_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void EXMC_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void SDIO_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void TIMER4_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void SPI2_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void UART3_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void UART4_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void TIMER5_DAC_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void TIMER6_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void DMA1_Channel0_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void DMA1_Channel1_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void DMA1_Channel2_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void DMA1_Channel3_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void DMA1_Channel4_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void ENET_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void ENET_WKUP_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void CAN1_TX_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void CAN1_RX0_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void CAN1_RX1_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void CAN1_EWMC_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void USBFS_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void DMA1_Channel5_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void DMA1_Channel6_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void DMA1_Channel7_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void USART5_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void I2C2_EV_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void I2C2_ER_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void USBHS_EP1_Out_IRQHandler(void)
+  __attribute__((weak, alias("null_handler")));
+void USBHS_EP1_In_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void USBHS_WKUP_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void USBHS_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void DCI_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void TRNG_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void FPU_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void UART6_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void UART7_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void SPI3_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void SPI4_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void SPI5_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void TLI_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void TLI_ER_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+void IPA_IRQHandler(void) __attribute__((weak, alias("null_handler")));
+
+__attribute__ ((section(".vectors")))
+struct vector_table vector_table = {
+	.stack_pointer = &_stack,
+	.reset = reset_handler,
+	.nmi = nmi_handler,
+	.hard_fault = hard_fault_handler,
+	.memory_manage_fault = memory_manage_fault_handler,
+	.bus_fault = bus_fault_handler,
+	.usage_fault = usage_fault_handler,
+	.debug_monitor = debug_monitor_handler,
+	.sv_call = sv_call_handler,
+	.pend_sv = pend_sv_handler,
+	.systick = systick_handler,
+  .irqs = {
+    [WWDGT_IRQn] = WWDGT_IRQHandler,
+    [LVD_IRQn] = LVD_IRQHandler,
+    [TAMPER_STAMP_IRQn] = TAMPER_STAMP_IRQHandler,
+    [RTC_WKUP_IRQn] = RTC_WKUP_IRQHandler,
+    [FMC_IRQn] = FMC_IRQHandler,
+    [RCU_CTC_IRQn] = RCU_CTC_IRQHandler,
+    [EXTI0_IRQn] = EXTI0_IRQHandler,
+    [EXTI1_IRQn] = EXTI1_IRQHandler,
+    [EXTI2_IRQn] = EXTI2_IRQHandler,
+    [EXTI3_IRQn] = EXTI3_IRQHandler,
+    [EXTI4_IRQn] = EXTI4_IRQHandler,
+    [DMA0_Channel0_IRQn] = DMA0_Channel0_IRQHandler,
+    [DMA0_Channel1_IRQn] = DMA0_Channel1_IRQHandler,
+    [DMA0_Channel2_IRQn] = DMA0_Channel2_IRQHandler,
+    [DMA0_Channel3_IRQn] = DMA0_Channel3_IRQHandler,
+    [DMA0_Channel4_IRQn] = DMA0_Channel4_IRQHandler,
+    [DMA0_Channel5_IRQn] = DMA0_Channel5_IRQHandler,
+    [DMA0_Channel6_IRQn] = DMA0_Channel6_IRQHandler,
+    [ADC_IRQn] = ADC_IRQHandler,
+    [CAN0_TX_IRQn] = CAN0_TX_IRQHandler,
+    [CAN0_RX0_IRQn] = CAN0_RX0_IRQHandler,
+    [CAN0_RX1_IRQn] = CAN0_RX1_IRQHandler,
+    [CAN0_EWMC_IRQn] = CAN0_EWMC_IRQHandler,
+    [EXTI5_9_IRQn] = EXTI5_9_IRQHandler,
+    [TIMER0_BRK_TIMER8_IRQn] = TIMER0_BRK_TIMER8_IRQHandler,
+    [TIMER0_UP_TIMER9_IRQn] = TIMER0_UP_TIMER9_IRQHandler,
+    [TIMER0_TRG_CMT_TIMER10_IRQn] = TIMER0_TRG_CMT_TIMER10_IRQHandler,
+    [TIMER0_Channel_IRQn] = TIMER0_Channel_IRQHandler,
+    [TIMER1_IRQn] = TIMER1_IRQHandler,
+    [TIMER2_IRQn] = TIMER2_IRQHandler,
+    [TIMER3_IRQn] = TIMER3_IRQHandler,
+    [I2C0_EV_IRQn] = I2C0_EV_IRQHandler,
+    [I2C0_ER_IRQn] = I2C0_ER_IRQHandler,
+    [I2C1_EV_IRQn] = I2C1_EV_IRQHandler,
+    [I2C1_ER_IRQn] = I2C1_ER_IRQHandler,
+    [SPI0_IRQn] = SPI0_IRQHandler,
+    [SPI1_IRQn] = SPI1_IRQHandler,
+    [USART0_IRQn] = USART0_IRQHandler,
+    [USART1_IRQn] = USART1_IRQHandler,
+    [USART2_IRQn] = USART2_IRQHandler,
+    [EXTI10_15_IRQn] = EXTI10_15_IRQHandler,
+    [RTC_Alarm_IRQn] = RTC_Alarm_IRQHandler,
+    [USBFS_WKUP_IRQn] = USBFS_WKUP_IRQHandler,
+    [TIMER7_BRK_TIMER11_IRQn] = TIMER7_BRK_TIMER11_IRQHandler,
+    [TIMER7_UP_TIMER12_IRQn] = TIMER7_UP_TIMER12_IRQHandler,
+    [TIMER7_TRG_CMT_TIMER13_IRQn] = TIMER7_TRG_CMT_TIMER13_IRQHandler,
+    [TIMER7_Channel_IRQn] = TIMER7_Channel_IRQHandler,
+    [DMA0_Channel7_IRQn] = DMA0_Channel7_IRQHandler,
+    [EXMC_IRQn] = EXMC_IRQHandler,
+    [SDIO_IRQn] = SDIO_IRQHandler,
+    [TIMER4_IRQn] = TIMER4_IRQHandler,
+    [SPI2_IRQn] = SPI2_IRQHandler,
+    [UART3_IRQn] = UART3_IRQHandler,
+    [UART4_IRQn] = UART4_IRQHandler,
+    [TIMER5_DAC_IRQn] = TIMER5_DAC_IRQHandler,
+    [TIMER6_IRQn] = TIMER6_IRQHandler,
+    [DMA1_Channel0_IRQn] = DMA1_Channel0_IRQHandler,
+    [DMA1_Channel1_IRQn] = DMA1_Channel1_IRQHandler,
+    [DMA1_Channel2_IRQn] = DMA1_Channel2_IRQHandler,
+    [DMA1_Channel3_IRQn] = DMA1_Channel3_IRQHandler,
+    [DMA1_Channel4_IRQn] = DMA1_Channel4_IRQHandler,
+    [ENET_IRQn] = ENET_IRQHandler,
+    [ENET_WKUP_IRQn] = ENET_WKUP_IRQHandler,
+    [CAN1_TX_IRQn] = CAN1_TX_IRQHandler,
+    [CAN1_RX0_IRQn] = CAN1_RX0_IRQHandler,
+    [CAN1_RX1_IRQn] = CAN1_RX1_IRQHandler,
+    [CAN1_EWMC_IRQn] = CAN1_EWMC_IRQHandler,
+    [USBFS_IRQn] = USBFS_IRQHandler,
+    [DMA1_Channel5_IRQn] = DMA1_Channel5_IRQHandler,
+    [DMA1_Channel6_IRQn] = DMA1_Channel6_IRQHandler,
+    [DMA1_Channel7_IRQn] = DMA1_Channel7_IRQHandler,
+    [USART5_IRQn] = USART5_IRQHandler,
+    [I2C2_EV_IRQn] = I2C2_EV_IRQHandler,
+    [I2C2_ER_IRQn] = I2C2_ER_IRQHandler,
+    [USBHS_EP1_Out_IRQn] = USBHS_EP1_Out_IRQHandler,
+    [USBHS_EP1_In_IRQn] = USBHS_EP1_In_IRQHandler,
+    [USBHS_WKUP_IRQn] = USBHS_WKUP_IRQHandler,
+    [USBHS_IRQn] = USBHS_IRQHandler,
+    [DCI_IRQn] = DCI_IRQHandler,
+    [TRNG_IRQn] = TRNG_IRQHandler,
+    [FPU_IRQn] = FPU_IRQHandler,
+    [UART6_IRQn] = UART6_IRQHandler,
+    [UART7_IRQn] = UART7_IRQHandler,
+    [SPI3_IRQn] = SPI3_IRQHandler,
+    [SPI4_IRQn] = SPI4_IRQHandler,
+    [SPI5_IRQn] = SPI5_IRQHandler,
+    [TLI_IRQn] = TLI_IRQHandler,
+    [TLI_ER_IRQn] = TLI_ER_IRQHandler,
+    [IPA_IRQn] = IPA_IRQHandler,
+  },
+};

--- a/src/platforms/gd32f470/usb_conf.h
+++ b/src/platforms/gd32f470/usb_conf.h
@@ -1,0 +1,21 @@
+#ifndef _USB_CONF_H
+#define _USB_CONF_H
+
+#include "gd32f4xx.h"
+#define USB_FS_CORE
+
+#define RX_FIFO_FS_SIZE 128
+#define TX0_FIFO_FS_SIZE 64
+#define TX1_FIFO_FS_SIZE 64
+#define TX2_FIFO_FS_SIZE 64
+#define TX3_FIFO_FS_SIZE 0
+
+#define USBFS_SOF_OUTPUT 0
+#define USBFS_LOW_POWER 0
+
+#define USE_DEVICE_MODE
+
+#define __ALIGN_BEGIN
+#define __ALIGN_END
+
+#endif

--- a/src/platforms/gd32f470/usbd_conf.h
+++ b/src/platforms/gd32f470/usbd_conf.h
@@ -1,0 +1,21 @@
+#ifndef __USBD_CONF_H
+#define __USBD_CONF_H
+
+#include "usb_conf.h"
+#define USBD_CFG_MAX_NUM 1
+#define USBD_ITF_MAX_NUM 1
+
+#define CDC_COM_INTERFACE 0
+
+#define USB_STR_DESC_MAX_SIZE 255
+
+#define CDC_DATA_IN_EP EP1_IN   /* EP1 for data IN */
+#define CDC_DATA_OUT_EP EP3_OUT /* EP3 for data OUT */
+#define CDC_CMD_EP EP2_IN       /* EP2 for CDC commands */
+
+#define USB_STRING_COUNT 4
+
+#define USB_CDC_CMD_PACKET_SIZE 8   /* Control Endpoint Packet size */
+#define USB_CDC_DATA_PACKET_SIZE 64 /* Endpoint IN & OUT Packet size */
+
+#endif /* __USBD_CONF_H */

--- a/src/platforms/stm32f4-discovery.ld
+++ b/src/platforms/stm32f4-discovery.ld
@@ -87,6 +87,7 @@ SECTIONS {
 	.data : {
 		_data = .;
 		*(.data*)	/* Read-write initialized data */
+		*(.dmadata*)	/* DMA regions, no different from normal data on stm32f4 */
 		. = ALIGN(4);
 		_edata = .;
 	} >ram AT >rom

--- a/src/platforms/test.c
+++ b/src/platforms/test.c
@@ -62,6 +62,10 @@ uint64_t cycle_count() {
   return 0;
 }
 
+uint64_t cycles_to_ns(uint64_t cycles) {
+  return cycles;
+}
+
 timeval_t platform_output_earliest_schedulable_time() {
   /* Round/floor to nearest 128-time buffer start, then use next one */
   return curtime + 1;

--- a/src/scheduler.c
+++ b/src/scheduler.c
@@ -226,7 +226,8 @@ static int schedule_fuel_event(struct output_event *ev,
    * time for the event, lets also schedule a callback to reschedule it when it
    * fires immediately.  This allows fuel events to use close to 100% duty cycle
    * without having to wait until the next trigger for rescheduling */
-  if (ev->stop.state == SCHED_SCHEDULED) {
+  if (ev->stop.state == SCHED_SCHEDULED &&
+      !time_before(ev->stop.time, current_time())) {
     ev->callback.callback = (void (*)(void *))schedule_event;
     ev->callback.data = ev;
     schedule_callback(&ev->callback, ev->stop.time);

--- a/src/sim.c
+++ b/src/sim.c
@@ -61,7 +61,7 @@ void set_test_trigger_rpm(uint32_t rpm) {
   test_trigger_rpm = rpm;
   test_trigger_callback.callback = execute_test_trigger;
   test_trigger_callback.data = NULL;
-  schedule_callback(&test_trigger_callback, current_time());
+  schedule_callback(&test_trigger_callback, current_time() + 10000);
 }
 
 uint32_t get_test_trigger_rpm() {

--- a/targets/gd32f470.mk
+++ b/targets/gd32f470.mk
@@ -1,0 +1,93 @@
+AS=arm-none-eabi-as
+CC=arm-none-eabi-gcc
+AR=arm-none-eabi-ar
+LD=arm-none-eabi-ld
+OBJCOPY=arm-none-eabi-objcopy
+
+CMSIS=contrib/CMSIS_5
+GDLIB=contrib/GD32F4xx_Firmware_Library
+
+OBJS+= gd32f470_init.o \
+       gd32f470_vectors.o \
+       gd32f470_pwm.o \
+       gd32f470_usb.o \
+       gd32f470_sched.o \
+       gd32f470_sensors.o \
+       stm32_sched_buffers.o
+
+GD32PERIPH= \
+      gd32f4xx_adc.o \
+      gd32f4xx_can.o \
+      gd32f4xx_crc.o \
+      gd32f4xx_ctc.o \
+      gd32f4xx_dac.o \
+      gd32f4xx_dbg.o \
+      gd32f4xx_dci.o \
+      gd32f4xx_dma.o \
+      gd32f4xx_enet.o \
+      gd32f4xx_exmc.o \
+      gd32f4xx_exti.o \
+      gd32f4xx_fmc.o \
+      gd32f4xx_fwdgt.o \
+      gd32f4xx_gpio.o \
+      gd32f4xx_i2c.o \
+      gd32f4xx_ipa.o \
+      gd32f4xx_iref.o \
+      gd32f4xx_misc.o \
+      gd32f4xx_pmu.o \
+      gd32f4xx_rcu.o \
+      gd32f4xx_rtc.o \
+      gd32f4xx_sdio.o \
+      gd32f4xx_spi.o \
+      gd32f4xx_syscfg.o \
+      gd32f4xx_timer.o \
+      gd32f4xx_tli.o \
+      gd32f4xx_trng.o \
+      gd32f4xx_usart.o \
+      gd32f4xx_wwdgt.o
+
+GD32USB=\
+      drv_usb_core.o \
+      drv_usb_dev.o \
+      drv_usbd_int.o \
+      usbd_core.o \
+      usbd_enum.o \
+      usbd_transc.o
+
+OBJS+= ${GD32USB} ${GD32PERIPH}
+
+VPATH=src/platforms/${PLATFORM} \
+      ${GDLIB}/GD32F4xx_usb_library/device/core/Source \
+      ${GDLIB}/GD32F4xx_usb_library/driver/Source \
+      ${GDLIB}/GD32F4xx_standard_peripheral/Source
+
+OBJS+= libssp.a libssp_nonshared.a
+
+CFLAGS= -DNDEBUG -ffunction-sections -fdata-sections -O3 -ggdb \
+            -mfloat-abi=hard -mfpu=fpv4-sp-d16 -mthumb -mcpu=cortex-m4
+
+CFLAGS+= -Isrc/platforms/gd32f470
+CFLAGS+= -I${CMSIS}/CMSIS/Core/Include
+CFLAGS+= -I${GDLIB}/GD32F4xx/Include
+CFLAGS+= -I${GDLIB}/GD32F4xx_standard_peripheral/Include
+CFLAGS+= -I${GDLIB}/GD32F4xx_usb_library/driver/Include
+CFLAGS+= -I${GDLIB}/GD32F4xx_usb_library/device/core/Include
+CFLAGS+= -I${GDLIB}/GD32F4xx_usb_library/device/class/cdc/Include
+CFLAGS+= -I${GDLIB}/GD32F4xx_usb_library/ustd/common
+CFLAGS+= -I${GDLIB}/GD32F4xx_usb_library/ustd/class/cdc
+CFLAGS+= -DGD32F470 -D TICKRATE=4000000
+
+LDFLAGS+= -lc -lnosys -nostartfiles -L ${OBJDIR} -Wl,--gc-sections
+LDFLAGS+= -T src/platforms/gd32f470/gd32f470.ld
+
+${OBJDIR}/libssp.a:
+	${AR} rcs ${OBJDIR}/libssp.a
+
+${OBJDIR}/libssp_nonshared.a:
+	${AR} rcs ${OBJDIR}/libssp_nonshared.a
+
+${OBJDIR}/viaems.dfu: ${OBJDIR}/viaems
+	${OBJCOPY} -O binary ${OBJDIR}/viaems ${OBJDIR}/viaems.dfu
+
+program: ${OBJDIR}/viaems.dfu
+	dfu-util -D ${OBJDIR}/viaems.dfu -a 0 -s 0x8000000:leave

--- a/targets/stm32f4.mk
+++ b/targets/stm32f4.mk
@@ -6,7 +6,7 @@ OBJCOPY=arm-none-eabi-objcopy
 CM3_LIB=libopencm3_stm32f4.a
 
 OBJS+= ${CM3_LIB}
-OBJS+= stm32f4-discovery.o
+OBJS+= stm32f4-discovery.o stm32_sched_buffers.o
 OBJS+= libssp.a libssp_nonshared.a
 
 CFLAGS+= -D TICKRATE=4000000 -DNDEBUG -ffunction-sections -fdata-sections


### PR DESCRIPTION
The GD32F470 is pin-compatible with the stm32f4 series, but has a 240 MHz clock and 0-wait-state flash for code access.  More importantly, it is possible to get one, whereas the stm32 F4 and H7's seem impossible to find.

Todo:
- [x] Misc cleanups
- [x] PWM outputs
- [x] USB issues debugging
- [ ] ~"reboot into bootloader" implementation~ My first pass at this didn't work, but i'm happy to just keep using swd to program for now